### PR TITLE
chore: bump wrangler to latest 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "turbo": "2.5.6",
     "typescript": "5.4.5",
     "vitest": "3.2.4",
+    "wrangler": "3.114.14",
     "zx": "8.4.1"
   },
   "lint-staged": {

--- a/packages/adapter-d1/package.json
+++ b/packages/adapter-d1/package.json
@@ -40,7 +40,7 @@
   "license": "Apache-2.0",
   "sideEffects": false,
   "dependencies": {
-    "@cloudflare/workers-types": "^4.20250214.0",
+    "@cloudflare/workers-types": "^4.20250408.0",
     "@prisma/driver-adapter-utils": "workspace:*",
     "ky": "1.7.5"
   }

--- a/packages/bundle-size/package.json
+++ b/packages/bundle-size/package.json
@@ -21,7 +21,6 @@
     "@prisma/adapter-mariadb": "workspace:*",
     "@prisma/client": "workspace:*",
     "pg": "8.14.1",
-    "prisma": "workspace:*",
-    "wrangler": "3.114.14"
+    "prisma": "workspace:*"
   }
 }

--- a/packages/bundle-size/package.json
+++ b/packages/bundle-size/package.json
@@ -22,6 +22,6 @@
     "@prisma/client": "workspace:*",
     "pg": "8.14.1",
     "prisma": "workspace:*",
-    "wrangler": "3.111.0"
+    "wrangler": "3.114.14"
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -209,7 +209,7 @@
     "sql.mjs"
   ],
   "devDependencies": {
-    "@cloudflare/workers-types": "4.20250214.0",
+    "@cloudflare/workers-types": "^4.20250408.0",
     "@codspeed/benchmark.js-plugin": "4.0.0",
     "@faker-js/faker": "9.6.0",
     "@fast-check/jest": "2.0.3",
@@ -305,7 +305,6 @@
     "tsd": "0.31.2",
     "typescript": "5.4.5",
     "undici": "7.4.0",
-    "wrangler": "3.114.14",
     "zx": "8.4.1"
   },
   "peerDependencies": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -305,7 +305,7 @@
     "tsd": "0.31.2",
     "typescript": "5.4.5",
     "undici": "7.4.0",
-    "wrangler": "3.111.0",
+    "wrangler": "3.114.14",
     "zx": "8.4.1"
   },
   "peerDependencies": {

--- a/packages/client/tests/e2e/enum-import-in-edge/package.json
+++ b/packages/client/tests/e2e/enum-import-in-edge/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "@types/jest": "29.5.12",
     "@types/node": "18.19.76",
-    "prisma": "/tmp/prisma-0.0.0.tgz"
+    "prisma": "/tmp/prisma-0.0.0.tgz",
+    "wrangler": "3.114.14"
   }
 }

--- a/packages/client/tests/e2e/enum-import-in-edge/package.json
+++ b/packages/client/tests/e2e/enum-import-in-edge/package.json
@@ -10,7 +10,6 @@
   "devDependencies": {
     "@types/jest": "29.5.12",
     "@types/node": "18.19.76",
-    "prisma": "/tmp/prisma-0.0.0.tgz",
-    "wrangler": "3.114.14"
+    "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/enum-import-in-edge/package.json
+++ b/packages/client/tests/e2e/enum-import-in-edge/package.json
@@ -5,7 +5,7 @@
   "scripts": {},
   "dependencies": {
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz",
-    "wrangler": "3.109.3"
+    "wrangler": "3.114.14"
   },
   "devDependencies": {
     "@types/jest": "29.5.12",

--- a/packages/client/tests/e2e/enum-import-unused/package.json
+++ b/packages/client/tests/e2e/enum-import-unused/package.json
@@ -10,6 +10,7 @@
     "@types/jest": "29.5.12",
     "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz",
-    "typescript": "5.6.3"
+    "typescript": "5.6.3",
+    "wrangler": "3.114.14"
   }
 }

--- a/packages/client/tests/e2e/enum-import-unused/package.json
+++ b/packages/client/tests/e2e/enum-import-unused/package.json
@@ -10,7 +10,6 @@
     "@types/jest": "29.5.12",
     "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz",
-    "typescript": "5.6.3",
-    "wrangler": "3.114.14"
+    "typescript": "5.6.3"
   }
 }

--- a/packages/client/tests/e2e/prisma-client-imports-sqlite/package.json
+++ b/packages/client/tests/e2e/prisma-client-imports-sqlite/package.json
@@ -6,7 +6,7 @@
     "test": "jest --verbose"
   },
   "dependencies": {
-    "@cloudflare/workers-types": "4.20250214.0",
+    "@cloudflare/workers-types": "^4.20250408.0",
     "@libsql/client": "0.8.1",
     "@prisma/adapter-d1": "/tmp/prisma-adapter-d1-0.0.0.tgz",
     "@prisma/adapter-libsql": "/tmp/prisma-adapter-libsql-0.0.0.tgz",

--- a/packages/client/tests/e2e/unsupported-browser-error/package.json
+++ b/packages/client/tests/e2e/unsupported-browser-error/package.json
@@ -10,6 +10,6 @@
     "@types/jest": "29.5.12",
     "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz",
-    "wrangler": "3.109.3"
+    "wrangler": "3.114.14"
   }
 }

--- a/packages/client/tests/e2e/unsupported-edge-error/package.json
+++ b/packages/client/tests/e2e/unsupported-edge-error/package.json
@@ -10,6 +10,6 @@
     "@types/jest": "29.5.12",
     "@types/node": "18.19.76",
     "prisma": "/tmp/prisma-0.0.0.tgz",
-    "wrangler": "3.109.3"
+    "wrangler": "3.114.14"
   }
 }

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -44,8 +44,7 @@
     "strip-indent": "4.0.0",
     "tempy": "1.0.1",
     "ts-pattern": "5.6.2",
-    "typescript": "5.4.5",
-    "wrangler": "3.114.14"
+    "typescript": "5.4.5"
   },
   "peerDependencies": {
     "@prisma/internals": "*"

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -45,7 +45,7 @@
     "tempy": "1.0.1",
     "ts-pattern": "5.6.2",
     "typescript": "5.4.5",
-    "wrangler": "3.111.0"
+    "wrangler": "3.114.14"
   },
   "peerDependencies": {
     "@prisma/internals": "*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,9 @@ importers:
       vitest:
         specifier: 3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
+      wrangler:
+        specifier: 3.114.14
+        version: 3.114.14(@cloudflare/workers-types@4.20250903.0)
       zx:
         specifier: 8.4.1
         version: 8.4.1
@@ -229,8 +232,8 @@ importers:
   packages/adapter-d1:
     dependencies:
       '@cloudflare/workers-types':
-        specifier: ^4.20250214.0
-        version: 4.20250214.0
+        specifier: ^4.20250408.0
+        version: 4.20250903.0
       '@prisma/driver-adapter-utils':
         specifier: workspace:*
         version: link:../driver-adapter-utils
@@ -363,9 +366,6 @@ importers:
       prisma:
         specifier: workspace:*
         version: link:../cli
-      wrangler:
-        specifier: 3.114.14
-        version: 3.114.14(@cloudflare/workers-types@4.20250214.0)
 
   packages/bundled-js-drivers:
     dependencies:
@@ -557,8 +557,8 @@ importers:
   packages/client:
     devDependencies:
       '@cloudflare/workers-types':
-        specifier: 4.20250214.0
-        version: 4.20250214.0
+        specifier: ^4.20250408.0
+        version: 4.20250903.0
       '@codspeed/benchmark.js-plugin':
         specifier: 4.0.0
         version: 4.0.0(benchmark@2.1.4)
@@ -844,9 +844,6 @@ importers:
       undici:
         specifier: 7.4.0
         version: 7.4.0
-      wrangler:
-        specifier: 3.114.14
-        version: 3.114.14(@cloudflare/workers-types@4.20250214.0)
       zx:
         specifier: 8.4.1
         version: 8.4.1
@@ -1739,9 +1736,6 @@ importers:
       typescript:
         specifier: 5.4.5
         version: 5.4.5
-      wrangler:
-        specifier: 3.114.14
-        version: 3.114.14(@cloudflare/workers-types@4.20250214.0)
 
   packages/nextjs-monorepo-workaround-plugin:
     devDependencies:
@@ -2108,8 +2102,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-types@4.20250214.0':
-    resolution: {integrity: sha512-+M8oOFVbyXT5GeJrYLWMUGyPf5wGB4+k59PPqdedtOig7NjZ5r4S79wMdaZ/EV5IV8JPtZBSNjTKpDnNmfxjaQ==}
+  '@cloudflare/workers-types@4.20250903.0':
+    resolution: {integrity: sha512-F6G3MG7EZxsJ2Fgsy3eed+U2fU/XGfKqDlyY/vCL/zUqI8KuaNx8GVnxttqzktBY55HK3xe82Zpj8xujW6PfXw==}
 
   '@codspeed/benchmark.js-plugin@4.0.0':
     resolution: {integrity: sha512-1nzkRfvsA2rI1NsqYmkXEnQ/P3NL2JlAqRs/RLWLyeGtmE+4JN8w4ndgUpeb3g9Q+Kki/njmPUf7YsHUAQpUXA==}
@@ -8416,7 +8410,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20250718.0':
     optional: true
 
-  '@cloudflare/workers-types@4.20250214.0': {}
+  '@cloudflare/workers-types@4.20250903.0': {}
 
   '@codspeed/benchmark.js-plugin@4.0.0(benchmark@2.1.4)':
     dependencies:
@@ -14815,7 +14809,7 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20250718.0
       '@cloudflare/workerd-windows-64': 1.20250718.0
 
-  wrangler@3.114.14(@cloudflare/workers-types@4.20250214.0):
+  wrangler@3.114.14(@cloudflare/workers-types@4.20250903.0):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.4
       '@cloudflare/unenv-preset': 2.0.2(unenv@2.0.0-rc.14)(workerd@1.20250718.0)
@@ -14828,7 +14822,7 @@ snapshots:
       unenv: 2.0.0-rc.14
       workerd: 1.20250718.0
     optionalDependencies:
-      '@cloudflare/workers-types': 4.20250214.0
+      '@cloudflare/workers-types': 4.20250903.0
       fsevents: 2.3.3
       sharp: 0.33.5
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -364,8 +364,8 @@ importers:
         specifier: workspace:*
         version: link:../cli
       wrangler:
-        specifier: 3.111.0
-        version: 3.111.0(@cloudflare/workers-types@4.20250214.0)
+        specifier: 3.114.14
+        version: 3.114.14(@cloudflare/workers-types@4.20250214.0)
 
   packages/bundled-js-drivers:
     dependencies:
@@ -845,8 +845,8 @@ importers:
         specifier: 7.4.0
         version: 7.4.0
       wrangler:
-        specifier: 3.111.0
-        version: 3.111.0(@cloudflare/workers-types@4.20250214.0)
+        specifier: 3.114.14
+        version: 3.114.14(@cloudflare/workers-types@4.20250214.0)
       zx:
         specifier: 8.4.1
         version: 8.4.1
@@ -1740,8 +1740,8 @@ importers:
         specifier: 5.4.5
         version: 5.4.5
       wrangler:
-        specifier: 3.111.0
-        version: 3.111.0(@cloudflare/workers-types@4.20250214.0)
+        specifier: 3.114.14
+        version: 3.114.14(@cloudflare/workers-types@4.20250214.0)
 
   packages/nextjs-monorepo-workaround-plugin:
     devDependencies:
@@ -2069,32 +2069,41 @@ packages:
     resolution: {integrity: sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==}
     engines: {node: '>=16.13'}
 
-  '@cloudflare/workerd-darwin-64@1.20250214.0':
-    resolution: {integrity: sha512-cDvvedWDc5zrgDnuXe2qYcz/TwBvzmweO55C7XpPuAWJ9Oqxv81PkdekYxD8mH989aQ/GI5YD0Fe6fDYlM+T3Q==}
+  '@cloudflare/unenv-preset@2.0.2':
+    resolution: {integrity: sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg==}
+    peerDependencies:
+      unenv: 2.0.0-rc.14
+      workerd: ^1.20250124.0
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20250718.0':
+    resolution: {integrity: sha512-FHf4t7zbVN8yyXgQ/r/GqLPaYZSGUVzeR7RnL28Mwj2djyw2ZergvytVc7fdGcczl6PQh+VKGfZCfUqpJlbi9g==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20250214.0':
-    resolution: {integrity: sha512-NytCvRveVzu0mRKo+tvZo3d/gCUway3B2ZVqSi/TS6NXDGBYIJo7g6s3BnTLS74kgyzeDOjhu9j/RBJBS809qw==}
+  '@cloudflare/workerd-darwin-arm64@1.20250718.0':
+    resolution: {integrity: sha512-fUiyUJYyqqp4NqJ0YgGtp4WJh/II/YZsUnEb6vVy5Oeas8lUOxnN+ZOJ8N/6/5LQCVAtYCChRiIrBbfhTn5Z8Q==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-linux-64@1.20250214.0':
-    resolution: {integrity: sha512-pQ7+aHNHj8SiYEs4d/6cNoimE5xGeCMfgU1yfDFtA9YGN9Aj2BITZgOWPec+HW7ZkOy9oWlNrO6EvVjGgB4tbQ==}
+  '@cloudflare/workerd-linux-64@1.20250718.0':
+    resolution: {integrity: sha512-5+eb3rtJMiEwp08Kryqzzu8d1rUcK+gdE442auo5eniMpT170Dz0QxBrqkg2Z48SFUPYbj+6uknuA5tzdRSUSg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20250214.0':
-    resolution: {integrity: sha512-Vhlfah6Yd9ny1npNQjNgElLIjR6OFdEbuR3LCfbLDCwzWEBFhIf7yC+Tpp/a0Hq7kLz3sLdktaP7xl3PJhyOjA==}
+  '@cloudflare/workerd-linux-arm64@1.20250718.0':
+    resolution: {integrity: sha512-Aa2M/DVBEBQDdATMbn217zCSFKE+ud/teS+fFS+OQqKABLn0azO2qq6ANAHYOIE6Q3Sq4CxDIQr8lGdaJHwUog==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-windows-64@1.20250214.0':
-    resolution: {integrity: sha512-GMwMyFbkjBKjYJoKDhGX8nuL4Gqe3IbVnVWf2Q6086CValyIknupk5J6uQWGw2EBU3RGO3x4trDXT5WphQJZDQ==}
+  '@cloudflare/workerd-windows-64@1.20250718.0':
+    resolution: {integrity: sha512-dY16RXKffmugnc67LTbyjdDHZn5NoTF1yHEf2fN4+OaOnoGSp3N1x77QubTDwqZ9zECWxgQfDLjddcH8dWeFhg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -4348,9 +4357,6 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  confbox@0.1.8:
-    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
-
   confbox@0.2.2:
     resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
 
@@ -4391,10 +4397,6 @@ packages:
 
   cookie@0.4.1:
     resolution: {integrity: sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==}
-    engines: {node: '>= 0.6'}
-
-  cookie@0.5.0:
-    resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
     engines: {node: '>= 0.6'}
 
   cookie@0.7.2:
@@ -6104,8 +6106,8 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
-  miniflare@3.20250214.1:
-    resolution: {integrity: sha512-NE66QV+2n9ZndaP5jgPlcVref3Arvizb+l2QqhgeXtKM5Orhi8UU2mijoiN3mHEUexKaBES2S1VubT4LDPqkxQ==}
+  miniflare@3.20250718.1:
+    resolution: {integrity: sha512-9QAOHVKIVHmnQ1dJT9Fls8aVA8R5JjEizzV889Dinq/+bEPltqIepCvm9Z+fbNUgLvV7D/H1NUk8VdlLRgp9Wg==}
     engines: {node: '>=16.13'}
     hasBin: true
 
@@ -6185,9 +6187,6 @@ packages:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
     hasBin: true
-
-  mlly@1.7.4:
-    resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==}
 
   mock-stdin@1.0.0:
     resolution: {integrity: sha512-tukRdb9Beu27t6dN+XztSRHq9J0B/CoAOySGzHfn8UTfmqipA5yNT/sDUEyYdAV3Hpka6Wx6kOMxuObdOex60Q==}
@@ -6397,9 +6396,6 @@ packages:
   obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
 
-  ohash@1.1.5:
-    resolution: {integrity: sha512-AtXrG/lMFjPBWj3uhWYFwYVZQqutPYRsv6nnPLTipnC+gJuMFc+WFzf/jx+94Ebray1vxfQfEFDtpIpppOe4xQ==}
-
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
@@ -6565,9 +6561,6 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
-  pathe@1.1.2:
-    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
-
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -6657,9 +6650,6 @@ packages:
   pkg-dir@7.0.0:
     resolution: {integrity: sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==}
     engines: {node: '>=14.16'}
-
-  pkg-types@1.3.1:
-    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
   pkg-types@2.2.0:
     resolution: {integrity: sha512-2SM/GZGAEkPp3KWORxQZns4M+WSeXbC2HEvmOIJe3Cmiv6ieAJvdVhDldtHqM5J1Y7MrR1XhkBT/rMlhh9FdqQ==}
@@ -7655,8 +7645,8 @@ packages:
     resolution: {integrity: sha512-PUQM3/es3noM24oUn10u3kNNap0AbxESOmnssmW+dOi9yGwlUSi5nTNYl3bNbTkWOF8YZDkx2tCmj9OtQ3iGGw==}
     engines: {node: '>=20.18.1'}
 
-  unenv@2.0.0-rc.1:
-    resolution: {integrity: sha512-PU5fb40H8X149s117aB4ytbORcCvlASdtF97tfls4BPIyj4PeVxvpSuy1jAptqYHqB0vb2w2sHvzM0XWcp2OKg==}
+  unenv@2.0.0-rc.14:
+    resolution: {integrity: sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==}
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -7870,17 +7860,17 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
-  workerd@1.20250214.0:
-    resolution: {integrity: sha512-QWcqXZLiMpV12wiaVnb3nLmfs/g4ZsFQq2mX85z546r3AX4CTIkXl0VP50W3CwqLADej3PGYiRDOTelDOwVG1g==}
+  workerd@1.20250718.0:
+    resolution: {integrity: sha512-kqkIJP/eOfDlUyBzU7joBg+tl8aB25gEAGqDap+nFWb+WHhnooxjGHgxPBy3ipw2hnShPFNOQt5lFRxbwALirg==}
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@3.111.0:
-    resolution: {integrity: sha512-3j/Wq5aj/sCQRSmkjBLxbkIH7LCx0h2UnaxmhOplDjJmZty10lGRs/jGgaG/M/GEsDg5TJ7UHvBh3hSldgjfKg==}
+  wrangler@3.114.14:
+    resolution: {integrity: sha512-zytHJn5+S47sqgUHi71ieSSP44yj9mKsj0sTUCsY+Tw5zbH8EzB1d9JbRk2KHg7HFM1WpoTI7518EExPGenAmg==}
     engines: {node: '>=16.17.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^4.20250214.0
+      '@cloudflare/workers-types': ^4.20250408.0
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -7987,8 +7977,8 @@ packages:
     resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
     engines: {node: '>=18'}
 
-  youch@3.2.3:
-    resolution: {integrity: sha512-ZBcWz/uzZaQVdCvfV4uk616Bbpf2ee+F/AvuKDR5EwX/Y4v06xWdtMluqTD7+KlZdM93lLm9gMZYo0sKBS0pgw==}
+  youch@3.3.4:
+    resolution: {integrity: sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==}
 
   zip-stream@5.0.1:
     resolution: {integrity: sha512-UfZ0oa0C8LI58wJ+moL46BDIMgCQbnsb+2PoiJYtonhBsMh2bq1eRBVkvjfVsqbEHd9/EgKPUuL9saSSsec8OA==}
@@ -8405,19 +8395,25 @@ snapshots:
     dependencies:
       mime: 3.0.0
 
-  '@cloudflare/workerd-darwin-64@1.20250214.0':
+  '@cloudflare/unenv-preset@2.0.2(unenv@2.0.0-rc.14)(workerd@1.20250718.0)':
+    dependencies:
+      unenv: 2.0.0-rc.14
+    optionalDependencies:
+      workerd: 1.20250718.0
+
+  '@cloudflare/workerd-darwin-64@1.20250718.0':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20250214.0':
+  '@cloudflare/workerd-darwin-arm64@1.20250718.0':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20250214.0':
+  '@cloudflare/workerd-linux-64@1.20250718.0':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20250214.0':
+  '@cloudflare/workerd-linux-arm64@1.20250718.0':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20250214.0':
+  '@cloudflare/workerd-windows-64@1.20250718.0':
     optional: true
 
   '@cloudflare/workers-types@4.20250214.0': {}
@@ -10845,8 +10841,6 @@ snapshots:
 
   concat-map@0.0.1: {}
 
-  confbox@0.1.8: {}
-
   confbox@0.2.2: {}
 
   consola@3.4.2: {}
@@ -10875,8 +10869,6 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.4.1: {}
-
-  cookie@0.5.0: {}
 
   cookie@0.7.2: {}
 
@@ -12896,7 +12888,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  miniflare@3.20250214.1:
+  miniflare@3.20250718.1:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       acorn: 8.14.0
@@ -12905,9 +12897,9 @@ snapshots:
       glob-to-regexp: 0.4.1
       stoppable: 1.1.0
       undici: 5.28.5
-      workerd: 1.20250214.0
+      workerd: 1.20250718.0
       ws: 8.18.0
-      youch: 3.2.3
+      youch: 3.3.4
       zod: 3.22.3
     transitivePeerDependencies:
       - bufferutil
@@ -12994,13 +12986,6 @@ snapshots:
   mkdirp-classic@0.5.3: {}
 
   mkdirp@1.0.4: {}
-
-  mlly@1.7.4:
-    dependencies:
-      acorn: 8.14.1
-      pathe: 2.0.3
-      pkg-types: 1.3.1
-      ufo: 1.5.4
 
   mock-stdin@1.0.0: {}
 
@@ -13198,8 +13183,6 @@ snapshots:
 
   obuf@1.1.2: {}
 
-  ohash@1.1.5: {}
-
   ohash@2.0.11: {}
 
   on-finished@2.3.0:
@@ -13370,8 +13353,6 @@ snapshots:
 
   path-type@4.0.0: {}
 
-  pathe@1.1.2: {}
-
   pathe@2.0.3: {}
 
   pathval@2.0.0: {}
@@ -13448,12 +13429,6 @@ snapshots:
   pkg-dir@7.0.0:
     dependencies:
       find-up: 6.3.0
-
-  pkg-types@1.3.1:
-    dependencies:
-      confbox: 0.1.8
-      mlly: 1.7.4
-      pathe: 2.0.3
 
   pkg-types@2.2.0:
     dependencies:
@@ -14525,12 +14500,12 @@ snapshots:
 
   undici@7.4.0: {}
 
-  unenv@2.0.0-rc.1:
+  unenv@2.0.0-rc.14:
     dependencies:
       defu: 6.1.4
-      mlly: 1.7.4
-      ohash: 1.1.5
-      pathe: 1.1.2
+      exsolve: 1.0.7
+      ohash: 2.0.11
+      pathe: 2.0.3
       ufo: 1.5.4
 
   unicorn-magic@0.1.0: {}
@@ -14832,25 +14807,26 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  workerd@1.20250214.0:
+  workerd@1.20250718.0:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20250214.0
-      '@cloudflare/workerd-darwin-arm64': 1.20250214.0
-      '@cloudflare/workerd-linux-64': 1.20250214.0
-      '@cloudflare/workerd-linux-arm64': 1.20250214.0
-      '@cloudflare/workerd-windows-64': 1.20250214.0
+      '@cloudflare/workerd-darwin-64': 1.20250718.0
+      '@cloudflare/workerd-darwin-arm64': 1.20250718.0
+      '@cloudflare/workerd-linux-64': 1.20250718.0
+      '@cloudflare/workerd-linux-arm64': 1.20250718.0
+      '@cloudflare/workerd-windows-64': 1.20250718.0
 
-  wrangler@3.111.0(@cloudflare/workers-types@4.20250214.0):
+  wrangler@3.114.14(@cloudflare/workers-types@4.20250214.0):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.4
+      '@cloudflare/unenv-preset': 2.0.2(unenv@2.0.0-rc.14)(workerd@1.20250718.0)
       '@esbuild-plugins/node-globals-polyfill': 0.2.3(esbuild@0.17.19)
       '@esbuild-plugins/node-modules-polyfill': 0.2.2(esbuild@0.17.19)
       blake3-wasm: 2.1.5
       esbuild: 0.17.19
-      miniflare: 3.20250214.1
+      miniflare: 3.20250718.1
       path-to-regexp: 6.3.0
-      unenv: 2.0.0-rc.1
-      workerd: 1.20250214.0
+      unenv: 2.0.0-rc.14
+      workerd: 1.20250718.0
     optionalDependencies:
       '@cloudflare/workers-types': 4.20250214.0
       fsevents: 2.3.3
@@ -14950,9 +14926,9 @@ snapshots:
 
   yoctocolors-cjs@2.1.2: {}
 
-  youch@3.2.3:
+  youch@3.3.4:
     dependencies:
-      cookie: 0.5.0
+      cookie: 0.7.2
       mustache: 4.2.0
       stacktracey: 2.1.8
 

--- a/sandbox/d1/package.json
+++ b/sandbox/d1/package.json
@@ -21,6 +21,6 @@
     "prisma": "../../packages/cli",
     "tsx": "4.7.1",
     "typescript": "5.4.2",
-    "wrangler": "3.109.3"
+    "wrangler": "3.114.14"
   }
 }

--- a/sandbox/d1/package.json
+++ b/sandbox/d1/package.json
@@ -17,7 +17,7 @@
     "db": "link:./node_modules/.prisma/client"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "4.20250214.0",
+    "@cloudflare/workers-types": "^4.20250408.0",
     "prisma": "../../packages/cli",
     "tsx": "4.7.1",
     "typescript": "5.4.2",


### PR DESCRIPTION
this PR bumps wrangler to 3.114.14 or latest 3.x version. Also, adds wranger to workspace root then remove from packages to consolidate version management.

Initially I was planning to bump wrangler to 4.x, but it required Node.js 20 or above. I hope that Prisma would bump Node.js requirement to 20 with a next major version.