### PR TITLE
fix(adapter-pg): convert dates before 1000-01-01 to valid date strings

### DIFF
--- a/packages/adapter-pg/src/__tests__/conversion.test.ts
+++ b/packages/adapter-pg/src/__tests__/conversion.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { mapArg } from '../conversion'
+
+describe('mapArg', () => {
+  it('converts a date with a 4-digit year (value >= 1000-01-01) to the correct date', () => {
+    const date = new Date('1999-12-31T23:59:59.999Z')
+    const result = mapArg(date, { dbType: 'DATE', scalarType: 'datetime', arity: 'scalar' })
+    expect(result).toBe('1999-12-31')
+  })
+
+  it('converts a date with a 3-digit year (0100-01-01 <= value < 1000-01-01) to the correct date', () => {
+    const date = new Date('0999-12-31T23:59:59.999Z')
+    const result = mapArg(date, { dbType: 'DATE', scalarType: 'datetime', arity: 'scalar' })
+    expect(result).toBe('0999-12-31')
+  })
+
+  it('converts a date with a 2-digit year (0000-01-01 <= value < 0100-01-01) to the correct date', () => {
+    const date = new Date('0099-12-31T23:59:59.999Z')
+    const result = mapArg(date, { dbType: 'DATE', scalarType: 'datetime', arity: 'scalar' })
+    expect(result).toBe('0099-12-31')
+  })
+
+  it('converts a date with a 4-digit year (value >= 1000-01-01) to the correct datetime', () => {
+    const date = new Date('1999-12-31T23:59:59.999Z')
+    const result = mapArg(date, { dbType: 'DATETIME', scalarType: 'datetime', arity: 'scalar' })
+    expect(result).toBe('1999-12-31 23:59:59.999')
+  })
+
+  it('converts a date with a 3-digit year (0100-01-01 <= value < 1000-01-01) to the correct datetime', () => {
+    const date = new Date('0999-12-31T23:59:59.999Z')
+    const result = mapArg(date, { dbType: 'DATETIME', scalarType: 'datetime', arity: 'scalar' })
+    expect(result).toBe('0999-12-31 23:59:59.999')
+  })
+
+  it('converts a date with a 2-digit year (0000-01-01 <= value < 0100-01-01) to the correct datetime', () => {
+    const date = new Date('0099-12-31T23:59:59.999Z')
+    const result = mapArg(date, { dbType: 'DATETIME', scalarType: 'datetime', arity: 'scalar' })
+    expect(result).toBe('0099-12-31 23:59:59.999')
+  })
+})

--- a/packages/adapter-pg/src/conversion.ts
+++ b/packages/adapter-pg/src/conversion.ts
@@ -466,7 +466,7 @@ function formatDateTime(date: Date): string {
   const pad = (n: number, z = 2) => String(n).padStart(z, '0')
   const ms = date.getUTCMilliseconds()
   return (
-    date.getUTCFullYear() +
+    pad(date.getUTCFullYear(), 4) +
     '-' +
     pad(date.getUTCMonth() + 1) +
     '-' +
@@ -483,7 +483,7 @@ function formatDateTime(date: Date): string {
 
 function formatDate(date: Date): string {
   const pad = (n: number, z = 2) => String(n).padStart(z, '0')
-  return date.getUTCFullYear() + '-' + pad(date.getUTCMonth() + 1) + '-' + pad(date.getUTCDate())
+  return pad(date.getUTCFullYear(), 4) + '-' + pad(date.getUTCMonth() + 1) + '-' + pad(date.getUTCDate())
 }
 
 function formatTime(date: Date): string {


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma/issues/28038

While fixing the above, I saw that this also happens for datetimes, so I went ahead and fixed i there as well.

Another thing that I could take care of, if desired, is to extract the `pad` function that gets redefined multiple times as a private (non-exported) method within the file itself. Let me know if you want me to do that or if the inlining and repetition is intentional.