### PR TITLE
fix(generator-js): don't break QC with `--no-engine`

### DIFF
--- a/packages/client-generator-js/src/TSClient/TSClient.ts
+++ b/packages/client-generator-js/src/TSClient/TSClient.ts
@@ -159,7 +159,7 @@ const config = ${JSON.stringify(config, null, 2)}
 ${buildDirname(edge, relativeOutdir)}
 ${buildRuntimeDataModel(this.dmmf.datamodel, runtimeNameJs)}
 ${buildQueryEngineWasmModule(wasm, copyEngine, runtimeNameJs)}
-${buildQueryCompilerWasmModule(wasm, copyEngine, runtimeNameJs)}
+${buildQueryCompilerWasmModule(wasm, runtimeNameJs)}
 ${buildInjectableEdgeEnv(edge, datasources)}
 ${buildWarnEnvConflicts(edge, runtimeBase, runtimeNameJs)}
 ${buildDebugInitialization(edge)}

--- a/packages/client-generator-js/src/generateClient.ts
+++ b/packages/client-generator-js/src/generateClient.ts
@@ -490,13 +490,11 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
   const schemaTargetPath = path.join(outputDir, 'schema.prisma')
   await fs.writeFile(schemaTargetPath, datamodel, { encoding: 'utf-8' })
 
+  const runtimeNeedsWasmEngine =
+    clientEngineType === ClientEngineType.Client || (generator.previewFeatures.includes('driverAdapters') && copyEngine)
+
   // copy the necessary engine files needed for the wasm/driver-adapter engine
-  if (
-    generator.previewFeatures.includes('driverAdapters') &&
-    isWasmEngineSupported(provider) &&
-    copyEngine &&
-    !testMode
-  ) {
+  if (runtimeNeedsWasmEngine && isWasmEngineSupported(provider) && !testMode) {
     const suffix = provider === 'postgres' ? 'postgresql' : provider
     const filename = clientEngineType === ClientEngineType.Client ? 'query_compiler_bg' : 'query_engine_bg'
 

--- a/packages/client-generator-js/src/utils/buildGetQueryCompilerWasmModule.ts
+++ b/packages/client-generator-js/src/utils/buildGetQueryCompilerWasmModule.ts
@@ -5,11 +5,10 @@ import { TSClientOptions } from '../TSClient/TSClient'
  * @returns
  */
 export function buildQueryCompilerWasmModule(
-  wasm: boolean,
-  copyCompiler: boolean,
+  forceEdgeWasmLoader: boolean,
   runtimeNameJs: TSClientOptions['runtimeNameJs'],
 ) {
-  if (copyCompiler && runtimeNameJs === 'client') {
+  if (runtimeNameJs === 'client' && !forceEdgeWasmLoader) {
     return `config.compilerWasm = {
       getRuntime: async () => require('./query_compiler_bg.js'),
       getQueryCompilerWasmModule: async () => {
@@ -29,7 +28,7 @@ export function buildQueryCompilerWasmModule(
   // isn't able to handle dynamic imports with `import(#MODULE_NAME)`, which used
   // to lead to a runtime "No such module .prisma/client/#wasm-compiler-loader" error.
   // Related issue: https://github.com/vitest-dev/vitest/issues/5486.
-  if (copyCompiler && ((runtimeNameJs === 'client' && wasm === true) || runtimeNameJs === 'wasm-compiler-edge')) {
+  if ((runtimeNameJs === 'client' && forceEdgeWasmLoader) || runtimeNameJs === 'wasm-compiler-edge') {
     return `config.compilerWasm = {
   getRuntime: async () => require('./query_compiler_bg.js'),
   getQueryCompilerWasmModule: async () => {

--- a/packages/client/tests/e2e/issues/orm-1310-generator-js-qc-no-engine/.gitignore
+++ b/packages/client/tests/e2e/issues/orm-1310-generator-js-qc-no-engine/.gitignore
@@ -1,0 +1,1 @@
+/generated

--- a/packages/client/tests/e2e/issues/orm-1310-generator-js-qc-no-engine/_steps.ts
+++ b/packages/client/tests/e2e/issues/orm-1310-generator-js-qc-no-engine/_steps.ts
@@ -1,0 +1,17 @@
+import { $ } from 'zx'
+
+import { executeSteps } from '../../_utils/executeSteps'
+
+void executeSteps({
+  setup: async () => {
+    await $`pnpm install`
+    await $`pnpm prisma generate --no-engine`
+  },
+  test: async () => {
+    await $`pnpm exec prisma -v`
+    await $`ts-node src/index.ts`
+  },
+  finish: async () => {
+    await $`echo "done"`
+  },
+})

--- a/packages/client/tests/e2e/issues/orm-1310-generator-js-qc-no-engine/package.json
+++ b/packages/client/tests/e2e/issues/orm-1310-generator-js-qc-no-engine/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js",
+  "scripts": {},
+  "dependencies": {
+    "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
+  },
+  "devDependencies": {
+    "@types/node": "18.19.76",
+    "prisma": "/tmp/prisma-0.0.0.tgz"
+  }
+}

--- a/packages/client/tests/e2e/issues/orm-1310-generator-js-qc-no-engine/pnpm-lock.yaml
+++ b/packages/client/tests/e2e/issues/orm-1310-generator-js-qc-no-engine/pnpm-lock.yaml
@@ -1,0 +1,312 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@prisma/client':
+        specifier: /tmp/prisma-client-0.0.0.tgz
+        version: file:../../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../../tmp/prisma-0.0.0.tgz)
+    devDependencies:
+      '@types/node':
+        specifier: 18.19.76
+        version: 18.19.76
+      prisma:
+        specifier: /tmp/prisma-0.0.0.tgz
+        version: file:../../../tmp/prisma-0.0.0.tgz
+
+packages:
+
+  '@prisma/client@file:../../../tmp/prisma-client-0.0.0.tgz':
+    resolution: {integrity: sha512-d3GcLWovLie45BZAbL800WEX7jYk57ZNJb0AVmvy9w3EhFXU8n/6nnXFVZ5RJJpKrLKWAFMFofj95YXWHS8mMQ==, tarball: file:../../../tmp/prisma-client-0.0.0.tgz}
+    version: 0.0.0
+    engines: {node: '>=18.18'}
+    peerDependencies:
+      prisma: '*'
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      prisma:
+        optional: true
+      typescript:
+        optional: true
+
+  '@prisma/config@file:../../../tmp/prisma-config-0.0.0.tgz':
+    resolution: {integrity: sha512-Yb1GIIHQgbVLJWP1L0cgy0kxcSbfm2bPzVvo8q4NFVOcYMKSumA9ggOJWR1Be0t9UbOK6MLDiusaY+sqXxZAsw==, tarball: file:../../../tmp/prisma-config-0.0.0.tgz}
+    version: 0.0.0
+
+  '@prisma/debug@file:../../../tmp/prisma-debug-0.0.0.tgz':
+    resolution: {integrity: sha512-DUB0sxdVBWGXnSdrB5Qy5KTCIhst7TZIg0QenHyEDk6lUHdAQICzx2xjzPWvWWLJdt2sRdCxB6FRqR83JI5TrQ==, tarball: file:../../../tmp/prisma-debug-0.0.0.tgz}
+    version: 0.0.0
+
+  '@prisma/engines-version@6.16.0-5.66f07015fb4a0f9195e6e97dca56186a2f4cad17':
+    resolution: {integrity: sha512-lwol4MR83LQ9hJRyGrc0mnx+LsZynxTb7BHyCnJ6yR6AFuu4jcwhZUQdUsOo18F107g4kepa7Zv8+h1xjzp1vA==}
+
+  '@prisma/engines@file:../../../tmp/prisma-engines-0.0.0.tgz':
+    resolution: {integrity: sha512-aYns0Y3RJL/xrjmepHSMjuFVHR++uue5Pjr03wHG2/rQSpfZCTBdUwOiTLwEcFi0er/kMsVtmRfRirIDfAPksw==, tarball: file:../../../tmp/prisma-engines-0.0.0.tgz}
+    version: 0.0.0
+
+  '@prisma/fetch-engine@file:../../../tmp/prisma-fetch-engine-0.0.0.tgz':
+    resolution: {integrity: sha512-VF8RhKfZ0RTpHNwteqHh3JrFJGfsfBK+hyauYsB31jpeo/uth39dhUp0skynYM9VezNM3nH8u4J0qjQinhP1jg==, tarball: file:../../../tmp/prisma-fetch-engine-0.0.0.tgz}
+    version: 0.0.0
+
+  '@prisma/get-platform@file:../../../tmp/prisma-get-platform-0.0.0.tgz':
+    resolution: {integrity: sha512-x2/cs4t7cu7n4gUfXU9F1wnHVM1UdunC0XBKY1W1IuC7BAKz4QprfHbC5sox8aeTH4gxDdLNLTtBoRJnjqoOcA==, tarball: file:../../../tmp/prisma-get-platform-0.0.0.tgz}
+    version: 0.0.0
+
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
+  '@types/node@18.19.76':
+    resolution: {integrity: sha512-yvR7Q9LdPz2vGpmpJX5LolrgRdWvB67MJKDPSgIIzpFbaf9a1j/f5DnLp5VDyHGMR0QZHlTr1afsD87QCXFHKw==}
+
+  c12@3.1.0:
+    resolution: {integrity: sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==}
+    peerDependencies:
+      magicast: ^0.3.5
+    peerDependenciesMeta:
+      magicast:
+        optional: true
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  citty@0.1.6:
+    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
+  confbox@0.2.2:
+    resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  deepmerge-ts@7.1.5:
+    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
+    engines: {node: '>=16.0.0'}
+
+  defu@6.1.4:
+    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  destr@2.0.5:
+    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  effect@3.16.12:
+    resolution: {integrity: sha512-N39iBk0K71F9nb442TLbTkjl24FLUzuvx2i1I2RsEAQsdAdUTuUoW0vlfUXgkMTUOnYqKnWcFfqw4hK4Pw27hg==}
+
+  empathic@2.0.0:
+    resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
+    engines: {node: '>=14'}
+
+  exsolve@1.0.7:
+    resolution: {integrity: sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==}
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
+
+  giget@2.0.0:
+    resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
+    hasBin: true
+
+  jiti@2.5.1:
+    resolution: {integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==}
+    hasBin: true
+
+  node-fetch-native@1.6.7:
+    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  nypm@0.6.1:
+    resolution: {integrity: sha512-hlacBiRiv1k9hZFiphPUkfSQ/ZfQzZDzC+8z0wL3lvDAOUu/2NnChkKuMoMjNur/9OpKuz2QsIeiPVN0xM5Q0w==}
+    engines: {node: ^14.16.0 || >=16.10.0}
+    hasBin: true
+
+  ohash@2.0.11:
+    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  perfect-debounce@1.0.0:
+    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+
+  pkg-types@2.3.0:
+    resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  prisma@file:../../../tmp/prisma-0.0.0.tgz:
+    resolution: {integrity: sha512-PhFJYamQebyYJStYQaDYULK5AZ0f++j1SLgGsBNOhoP0b/fTsy01/zKZ2LNZt7xAtBlf1yjUBeFnfp5S2LhKMA==, tarball: file:../../../tmp/prisma-0.0.0.tgz}
+    version: 0.0.0
+    engines: {node: '>=18.18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  rc9@2.1.2:
+    resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  tinyexec@1.0.1:
+    resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+snapshots:
+
+  '@prisma/client@file:../../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../../tmp/prisma-0.0.0.tgz)':
+    optionalDependencies:
+      prisma: file:../../../tmp/prisma-0.0.0.tgz
+
+  '@prisma/config@file:../../../tmp/prisma-config-0.0.0.tgz':
+    dependencies:
+      c12: 3.1.0
+      deepmerge-ts: 7.1.5
+      effect: 3.16.12
+      empathic: 2.0.0
+    transitivePeerDependencies:
+      - magicast
+
+  '@prisma/debug@file:../../../tmp/prisma-debug-0.0.0.tgz': {}
+
+  '@prisma/engines-version@6.16.0-5.66f07015fb4a0f9195e6e97dca56186a2f4cad17': {}
+
+  '@prisma/engines@file:../../../tmp/prisma-engines-0.0.0.tgz':
+    dependencies:
+      '@prisma/debug': file:../../../tmp/prisma-debug-0.0.0.tgz
+      '@prisma/engines-version': 6.16.0-5.66f07015fb4a0f9195e6e97dca56186a2f4cad17
+      '@prisma/fetch-engine': file:../../../tmp/prisma-fetch-engine-0.0.0.tgz
+      '@prisma/get-platform': file:../../../tmp/prisma-get-platform-0.0.0.tgz
+
+  '@prisma/fetch-engine@file:../../../tmp/prisma-fetch-engine-0.0.0.tgz':
+    dependencies:
+      '@prisma/debug': file:../../../tmp/prisma-debug-0.0.0.tgz
+      '@prisma/engines-version': 6.16.0-5.66f07015fb4a0f9195e6e97dca56186a2f4cad17
+      '@prisma/get-platform': file:../../../tmp/prisma-get-platform-0.0.0.tgz
+
+  '@prisma/get-platform@file:../../../tmp/prisma-get-platform-0.0.0.tgz':
+    dependencies:
+      '@prisma/debug': file:../../../tmp/prisma-debug-0.0.0.tgz
+
+  '@standard-schema/spec@1.0.0': {}
+
+  '@types/node@18.19.76':
+    dependencies:
+      undici-types: 5.26.5
+
+  c12@3.1.0:
+    dependencies:
+      chokidar: 4.0.3
+      confbox: 0.2.2
+      defu: 6.1.4
+      dotenv: 16.6.1
+      exsolve: 1.0.7
+      giget: 2.0.0
+      jiti: 2.5.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 1.0.0
+      pkg-types: 2.3.0
+      rc9: 2.1.2
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
+
+  confbox@0.2.2: {}
+
+  consola@3.4.2: {}
+
+  deepmerge-ts@7.1.5: {}
+
+  defu@6.1.4: {}
+
+  destr@2.0.5: {}
+
+  dotenv@16.6.1: {}
+
+  effect@3.16.12:
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      fast-check: 3.23.2
+
+  empathic@2.0.0: {}
+
+  exsolve@1.0.7: {}
+
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
+
+  giget@2.0.0:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.2
+      defu: 6.1.4
+      node-fetch-native: 1.6.7
+      nypm: 0.6.1
+      pathe: 2.0.3
+
+  jiti@2.5.1: {}
+
+  node-fetch-native@1.6.7: {}
+
+  nypm@0.6.1:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.2
+      pathe: 2.0.3
+      pkg-types: 2.3.0
+      tinyexec: 1.0.1
+
+  ohash@2.0.11: {}
+
+  pathe@2.0.3: {}
+
+  perfect-debounce@1.0.0: {}
+
+  pkg-types@2.3.0:
+    dependencies:
+      confbox: 0.2.2
+      exsolve: 1.0.7
+      pathe: 2.0.3
+
+  prisma@file:../../../tmp/prisma-0.0.0.tgz:
+    dependencies:
+      '@prisma/config': file:../../../tmp/prisma-config-0.0.0.tgz
+      '@prisma/engines': file:../../../tmp/prisma-engines-0.0.0.tgz
+    transitivePeerDependencies:
+      - magicast
+
+  pure-rand@6.1.0: {}
+
+  rc9@2.1.2:
+    dependencies:
+      defu: 6.1.4
+      destr: 2.0.5
+
+  readdirp@4.1.2: {}
+
+  tinyexec@1.0.1: {}
+
+  undici-types@5.26.5: {}

--- a/packages/client/tests/e2e/issues/orm-1310-generator-js-qc-no-engine/prisma/schema.prisma
+++ b/packages/client/tests/e2e/issues/orm-1310-generator-js-qc-no-engine/prisma/schema.prisma
@@ -1,0 +1,26 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+generator client1 {
+  provider        = "prisma-client-js"
+  previewFeatures = ["queryCompiler"]
+  engineType      = "client"
+}
+
+generator client2 {
+  provider        = "prisma-client-js"
+  previewFeatures = ["queryCompiler"]
+  engineType      = "client"
+  output          = "../generated/prisma"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = "prisma://localhost:50000/?api_key=1"
+}
+
+model User {
+  id    Int     @id @default(autoincrement())
+  email String  @unique
+  name  String?
+}

--- a/packages/client/tests/e2e/issues/orm-1310-generator-js-qc-no-engine/readme.md
+++ b/packages/client/tests/e2e/issues/orm-1310-generator-js-qc-no-engine/readme.md
@@ -1,0 +1,1 @@
+Regression test for https://linear.app/prisma-company/issue/ORM-1310/prisma-client-js-with-qc-broken-with-no-engine

--- a/packages/client/tests/e2e/issues/orm-1310-generator-js-qc-no-engine/src/index.ts
+++ b/packages/client/tests/e2e/issues/orm-1310-generator-js-qc-no-engine/src/index.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict'
+
+import { PrismaClient as PrismaClient1 } from '@prisma/client'
+
+import { PrismaClient as PrismaClient2 } from '../generated/prisma/client'
+
+async function main() {
+  for (const PrismaClient of [PrismaClient1, PrismaClient2]) {
+    const prisma = new PrismaClient()
+
+    // Check that it should fail with the expected error and not crash with
+    // "WASM query compiler was unexpectedly `undefined`".
+    await assert.rejects(async () => {
+      await prisma.user.create({
+        data: { email: 'john@doe.io' },
+      })
+    }, /fetch failed/)
+  }
+}
+
+void main()

--- a/packages/client/tests/e2e/issues/orm-1310-generator-js-qc-no-engine/tsconfig.json
+++ b/packages/client/tests/e2e/issues/orm-1310-generator-js-qc-no-engine/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "exclude": ["_steps.ts"]
+}


### PR DESCRIPTION
Fixes: https://linear.app/prisma-company/issue/ORM-1310/prisma-client-js-with-qc-broken-with-no-engine