### PR TITLE
fix(adapter-pg): error event listener leak

### DIFF
--- a/packages/adapter-pg/src/__tests__/pg.test.ts
+++ b/packages/adapter-pg/src/__tests__/pg.test.ts
@@ -51,11 +51,25 @@ describe('PrismaPgAdapterFactory', () => {
     const config: pg.PoolConfig = { user: 'test', password: 'test', database: 'test', port: 5432, host: 'localhost' }
     const factory = new PrismaPgAdapterFactory(config)
     const adapter = await factory.connect()
+
+    const mockConnection = {
+      on: vi.fn(),
+      removeListener: vi.fn(),
+      query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+      release: vi.fn(),
+      listenerCount: vi.fn().mockReturnValue(1),
+    }
+
+    adapter['client'].connect = vi.fn().mockResolvedValue(mockConnection)
+
     const transaction = await adapter.startTransaction()
-    const connection = transaction['client']
-    expect(connection.listenerCount('error')).toEqual(1)
+    expect(mockConnection.listenerCount('error')).toEqual(1)
+
+    mockConnection.listenerCount.mockReturnValue(0)
     await transaction.commit()
-    expect(connection.listenerCount('error')).toEqual(0)
+    expect(mockConnection.removeListener).toHaveBeenCalledWith('error', expect.any(Function))
+    expect(mockConnection.listenerCount('error')).toEqual(0)
+
     await adapter.dispose()
   })
 
@@ -63,11 +77,25 @@ describe('PrismaPgAdapterFactory', () => {
     const config: pg.PoolConfig = { user: 'test', password: 'test', database: 'test', port: 5432, host: 'localhost' }
     const factory = new PrismaPgAdapterFactory(config)
     const adapter = await factory.connect()
+
+    const mockConnection = {
+      on: vi.fn(),
+      removeListener: vi.fn(),
+      query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+      release: vi.fn(),
+      listenerCount: vi.fn().mockReturnValue(1),
+    }
+
+    adapter['client'].connect = vi.fn().mockResolvedValue(mockConnection)
+
     const transaction = await adapter.startTransaction()
-    const connection = transaction['client']
-    expect(connection.listenerCount('error')).toEqual(1)
+    expect(mockConnection.listenerCount('error')).toEqual(1)
+
+    mockConnection.listenerCount.mockReturnValue(0)
     await transaction.rollback()
-    expect(connection.listenerCount('error')).toEqual(0)
+    expect(mockConnection.removeListener).toHaveBeenCalledWith('error', expect.any(Function))
+    expect(mockConnection.listenerCount('error')).toEqual(0)
+
     await adapter.dispose()
   })
 })

--- a/packages/adapter-pg/src/__tests__/pg.test.ts
+++ b/packages/adapter-pg/src/__tests__/pg.test.ts
@@ -46,4 +46,28 @@ describe('PrismaPgAdapterFactory', () => {
     expect(pool.listenerCount('error')).toEqual(1)
     await pool.end()
   })
+
+  it('should remove connection error listener after transaction commit', async () => {
+    const config: pg.PoolConfig = { user: 'test', password: 'test', database: 'test', port: 5432, host: 'localhost' }
+    const factory = new PrismaPgAdapterFactory(config)
+    const adapter = await factory.connect()
+    const transaction = await adapter.startTransaction()
+    const connection = transaction['client']
+    expect(connection.listenerCount('error')).toEqual(1)
+    await transaction.commit()
+    expect(connection.listenerCount('error')).toEqual(0)
+    await adapter.dispose()
+  })
+
+  it('should remove connection error listener after transaction rollback', async () => {
+    const config: pg.PoolConfig = { user: 'test', password: 'test', database: 'test', port: 5432, host: 'localhost' }
+    const factory = new PrismaPgAdapterFactory(config)
+    const adapter = await factory.connect()
+    const transaction = await adapter.startTransaction()
+    const connection = transaction['client']
+    expect(connection.listenerCount('error')).toEqual(1)
+    await transaction.rollback()
+    expect(connection.listenerCount('error')).toEqual(0)
+    await adapter.dispose()
+  })
 })


### PR DESCRIPTION
Fixes an issue where when executing enough transactions in quick succession and pg-pool starts to reuse clients, error handlers are re-attached to them but old ones aren't removed, causing the `MaxListenersExceededWarning` and supposedly a memory leak.

Closes #28037