### PR TITLE
feat(client-generator-ts): removed "Prisma.Validator" from "prisma-client" generator

### DIFF
--- a/packages/client-generator-ts/src/TSClient/common.ts
+++ b/packages/client-generator-ts/src/TSClient/common.ts
@@ -6,11 +6,6 @@ export const commonCodeTS = ({ clientVersion, engineVersion, generator }: TSClie
 export type PrismaPromise<T> = runtime.Types.Public.PrismaPromise<T>
 
 /**
- * Validator
- */
-export const validator = runtime.Public.validator
-
-/**
  * Prisma Errors
  */
 

--- a/packages/client/tests/functional/validator/tests.ts
+++ b/packages/client/tests/functional/validator/tests.ts
@@ -8,8 +8,8 @@ declare let prisma: PrismaClient
 declare let Prisma: typeof PrismaNamespace
 
 testMatrix.setupTestSuite(
-  () => {
-    test('validation via non-extended client', () => {
+  ({ generatorType }) => {
+    testIf(generatorType === 'prisma-client-js')('validation via non-extended client', () => {
       const data1 = Prisma.validator<PrismaNamespace.UserSelect>()({
         id: true,
       })

--- a/packages/client/tests/functional/validator/tests.ts
+++ b/packages/client/tests/functional/validator/tests.ts
@@ -83,7 +83,7 @@ testMatrix.setupTestSuite(
       })
     })
 
-    test('validation via extended client', () => {
+    testIf(generatorType === 'prisma-client-js')('validation via extended client', () => {
       const xprisma = prisma.$extends({
         result: {
           user: {


### PR DESCRIPTION
This PR:
- closes [ORM-1376](https://linear.app/prisma-company/issue/ORM-1376/drop-prismavalidator-in-new-generator)