### PR TITLE
feat(client): remove node_modules caching check when generator has custom output

### DIFF
--- a/packages/client/src/runtime/core/init/checkPlatformCaching.test.ts
+++ b/packages/client/src/runtime/core/init/checkPlatformCaching.test.ts
@@ -1,3 +1,5 @@
+import type { GeneratorConfig } from '@prisma/generator'
+
 import { PrismaClientInitializationError } from '../errors/PrismaClientInitializationError'
 import { checkPlatformCaching } from './checkPlatformCaching'
 
@@ -26,6 +28,52 @@ test('generated via postinstall on vercel', () => {
 
 test('generated on vercel', () => {
   expect(() => checkPlatformCaching({ postinstall: false, ciName: 'Vercel', clientVersion: '0.0.0' })).not.toThrow()
+
+  expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`undefined`)
+})
+
+test('generated on vercel with `prisma-client-js` + custom output', () => {
+  const generator = {
+    provider: {
+      value: 'prisma-client-js',
+      fromEnvVar: null,
+    },
+    output: {
+      value: './custom-output',
+      fromEnvVar: null,
+    },
+    name: 'prisma-client-js',
+    previewFeatures: [],
+    binaryTargets: [],
+    config: {},
+    sourceFilePath: '',
+  } satisfies GeneratorConfig
+  expect(() =>
+    checkPlatformCaching({ postinstall: false, ciName: 'Vercel', clientVersion: '0.0.0', generator }),
+  ).not.toThrow()
+
+  expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`undefined`)
+})
+
+test('generated on vercel with `prisma-client` + custom output', () => {
+  const generator = {
+    provider: {
+      value: 'prisma-client',
+      fromEnvVar: null,
+    },
+    output: {
+      value: './custom-output',
+      fromEnvVar: null,
+    },
+    name: 'prisma-client',
+    previewFeatures: [],
+    binaryTargets: [],
+    config: {},
+    sourceFilePath: '',
+  } satisfies GeneratorConfig
+  expect(() =>
+    checkPlatformCaching({ postinstall: false, ciName: 'Vercel', clientVersion: '0.0.0', generator }),
+  ).not.toThrow()
 
   expect(consoleMock.mock.calls[0]).toMatchInlineSnapshot(`undefined`)
 })

--- a/packages/client/src/runtime/core/init/checkPlatformCaching.ts
+++ b/packages/client/src/runtime/core/init/checkPlatformCaching.ts
@@ -34,7 +34,7 @@ export function checkPlatformCaching({ postinstall, ciName, clientVersion, gener
   if (postinstall !== true) return
 
   // check if a custom output directory is used
-  if (generator && generator.output) {
+  if (generator?.output) {
     const output = generator.output.fromEnvVar ?? generator.output.value
 
     if (typeof output === 'string') {


### PR DESCRIPTION
This PR:
- skips the `node_modules` cache check when `generator { output = "<path>" }` is used
- solves [ORM-1429](https://linear.app/prisma-company/issue/ORM-1429/remove-node-modules-caching-check-when-generator-has-custom-output)
- Closes: https://linear.app/prisma-company/issue/ORM-1428/remove-vercel-cached-client-validation-with-custom-output-path