### PR TITLE
fix(client): add apiKey method for Accelerate extension

### DIFF
--- a/packages/client/src/runtime/core/engines/client/ClientEngine.ts
+++ b/packages/client/src/runtime/core/engines/client/ClientEngine.ts
@@ -592,6 +592,14 @@ export class ClientEngine implements Engine {
     throw new Error('Method not implemented.')
   }
 
+  /**
+   * Used by `@prisma/extension-accelerate`
+   */
+  async apiKey(): Promise<string | null> {
+    const { executor } = await this.#ensureStarted()
+    return executor.apiKey()
+  }
+
   #convertIsolationLevel(clientIsolationLevel: Tx.IsolationLevel | undefined): SqlIsolationLevel | undefined {
     switch (clientIsolationLevel) {
       case undefined:

--- a/packages/client/src/runtime/core/engines/client/Executor.ts
+++ b/packages/client/src/runtime/core/engines/client/Executor.ts
@@ -31,4 +31,6 @@ export interface Executor {
   rollbackTransaction(transaction: InteractiveTransactionInfo): Promise<void>
 
   disconnect(): Promise<void>
+
+  apiKey(): string | null
 }

--- a/packages/client/src/runtime/core/engines/client/LocalExecutor.ts
+++ b/packages/client/src/runtime/core/engines/client/LocalExecutor.ts
@@ -94,4 +94,8 @@ export class LocalExecutor implements Executor {
       await this.#driverAdapter.dispose()
     }
   }
+
+  apiKey(): string | null {
+    return null
+  }
 }

--- a/packages/client/src/runtime/core/engines/client/RemoteExecutor.ts
+++ b/packages/client/src/runtime/core/engines/client/RemoteExecutor.ts
@@ -118,6 +118,10 @@ export class RemoteExecutor implements Executor {
     return Promise.resolve()
   }
 
+  apiKey(): string | null {
+    return this.#headerBuilder.apiKey
+  }
+
   async #request({
     path,
     method,


### PR DESCRIPTION
This should unblock or even completely fix https://linear.app/prisma-company/issue/FT-3865/invalidate-and-invalidateall-accelerate-extension-methods-dont-work

`@prisma/extension-accelerate` relies on `apiKey` method exposed by `DataProxyEngine` for some of its functionality. This method was missing in the new `ClientEngine`.

See
https://github.com/prisma/prisma-extension-accelerate/blob/b6ffa853f038780f5ab2fc01bff584ca251f645b/src/extension.ts#L539 and https://prisma-company.slack.com/archives/C058VM009HT/p1756741911469959?thread_ts=1756741881.462559&cid=C058VM009HT

This will be covered by tests in the Accelerate client extension repo.