### PR TITLE
fix(qpe): flip condition when choosing whether to enable itx manager

### DIFF
--- a/packages/client/tests/functional/batch-transaction/tests.ts
+++ b/packages/client/tests/functional/batch-transaction/tests.ts
@@ -1,6 +1,5 @@
 import { faker } from '@faker-js/faker'
 
-import { Providers } from '../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type { PrismaClient } from './generated/prisma/client'
@@ -66,14 +65,6 @@ testMatrix.setupTestSuite(
     skipDriverAdapter: {
       from: ['js_d1'],
       reason: 'D1 does not support transactions',
-    },
-    skip(when, { clientEngineExecutor, provider }) {
-      when(
-        clientEngineExecutor === 'remote' && provider === Providers.MYSQL,
-        `
-        Tracked in https://linear.app/prisma-company/issue/ORM-1415/interactive-transaction-tests-fail-with-mysqlqcaccelerate
-        `,
-      )
     },
   },
 )

--- a/packages/client/tests/functional/extensions/itx.ts
+++ b/packages/client/tests/functional/extensions/itx.ts
@@ -318,13 +318,5 @@ testMatrix.setupTestSuite(
         'js_d1: iTx are not possible. There is no Transaction API for D1 yet: https://github.com/cloudflare/workers-sdk/issues/2733; ' +
         'js_libsql: SIGABRT due to panic in libsql (not yet implemented: array)', // TODO: ORM-867
     },
-    skip(when, { clientEngineExecutor, provider }) {
-      when(
-        clientEngineExecutor === 'remote' && provider === Providers.MYSQL,
-        `
-        Tracked in https://linear.app/prisma-company/issue/ORM-1415/interactive-transaction-tests-fail-with-mysqlqcaccelerate
-        `,
-      )
-    },
   },
 )

--- a/packages/client/tests/functional/extensions/tx.ts
+++ b/packages/client/tests/functional/extensions/tx.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 import { copycat } from '@snaplet/copycat'
 import { expectTypeOf } from 'expect-type'
 
-import { AdapterProviders, Providers } from '../_utils/providers'
+import { AdapterProviders } from '../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type { PrismaClient } from './generated/prisma/client'
@@ -222,14 +222,6 @@ testMatrix.setupTestSuite(
       reason:
         'js_d1: batch transaction needs to be implemented. Unskip once https://github.com/prisma/team-orm/issues/997 is done; ' +
         'js_libsql: SIGABRT due to panic in libsql (not yet implemented: array)', // TODO: ORM-867
-    },
-    skip(when, { clientEngineExecutor, provider }) {
-      when(
-        clientEngineExecutor === 'remote' && provider === Providers.MYSQL,
-        `
-        Tracked in https://linear.app/prisma-company/issue/ORM-1415/interactive-transaction-tests-fail-with-mysqlqcaccelerate
-        `,
-      )
     },
   },
 )

--- a/packages/client/tests/functional/interactive-transactions/tests.ts
+++ b/packages/client/tests/functional/interactive-transactions/tests.ts
@@ -827,13 +827,5 @@ testMatrix.setupTestSuite(
         'js_d1: iTx are not possible. There is no Transaction API for D1 yet: https://github.com/cloudflare/workers-sdk/issues/2733; ' +
         'js_libsql: SIGABRT crash occurs on having the first transaction with at least two create statements, panic inside `statement.rs` inside libsql',
     },
-    skip(when, { clientEngineExecutor }) {
-      when(
-        clientEngineExecutor === 'remote',
-        `
-        Tracked in https://linear.app/prisma-company/issue/ORM-1415/interactive-transaction-tests-fail-with-mysqlqcaccelerate
-        `,
-      )
-    },
   },
 )

--- a/packages/client/tests/functional/issues/15044/tests.ts
+++ b/packages/client/tests/functional/issues/15044/tests.ts
@@ -65,13 +65,5 @@ testMatrix.setupTestSuite(
       from: [AdapterProviders.JS_LIBSQL],
       reason: 'js_libsql: SIGABRT due to panic in libsql (not yet implemented: array)', // TODO: ORM-867
     },
-    skip(when, { clientEngineExecutor }) {
-      when(
-        clientEngineExecutor === 'remote',
-        `
-        Tracked in https://linear.app/prisma-company/issue/ORM-1394/investigate-failing-regression-test-for-gh-15044
-        `,
-      )
-    },
   },
 )

--- a/packages/client/tests/functional/logging/tests.ts
+++ b/packages/client/tests/functional/logging/tests.ts
@@ -55,89 +55,85 @@ testMatrix.setupTestSuite(({ provider, driverAdapter, clientEngineExecutor }) =>
   })
 
   // D1: iTx are not available.
-  // MySQL+QPE: tracked in https://linear.app/prisma-company/issue/ORM-1416/extra-commit-query-in-logs-with-mysqlqcaccelerate
-  skipTestIf(driverAdapter === 'js_d1' || (clientEngineExecutor === 'remote' && provider === Providers.MYSQL))(
-    'should log queries inside a ITX',
-    async () => {
-      client = newPrismaClient({
-        log: [
-          {
-            emit: 'event',
-            level: 'query',
-          },
-        ],
-      })
+  skipTestIf(driverAdapter === 'js_d1')('should log queries inside a ITX', async () => {
+    client = newPrismaClient({
+      log: [
+        {
+          emit: 'event',
+          level: 'query',
+        },
+      ],
+    })
 
-      const queryLogs = new Promise<Prisma.QueryEvent[]>((resolve) => {
-        const logs: Prisma.QueryEvent[] = []
+    const queryLogs = new Promise<Prisma.QueryEvent[]>((resolve) => {
+      const logs: Prisma.QueryEvent[] = []
 
-        client.$on('query', (data) => {
-          if ('query' in data) {
-            logs.push(data)
+      client.$on('query', (data) => {
+        if ('query' in data) {
+          logs.push(data)
 
-            if (isMongoDb && logs.length === 3) {
-              resolve(logs)
-            }
-
-            if ((data.query as string).includes('COMMIT')) {
-              resolve(logs)
-            }
+          if (isMongoDb && logs.length === 3) {
+            resolve(logs)
           }
-        })
+
+          if ((data.query as string).includes('COMMIT')) {
+            resolve(logs)
+          }
+        }
+      })
+    })
+
+    await client.$transaction(async (tx) => {
+      const id = isMongoDb ? faker.database.mongodbObjectId() : faker.string.numeric()
+
+      await tx.user.create({
+        data: {
+          id,
+        },
       })
 
-      await client.$transaction(async (tx) => {
-        const id = isMongoDb ? faker.database.mongodbObjectId() : faker.string.numeric()
-
-        await tx.user.create({
-          data: {
-            id,
-          },
-        })
-
-        return tx.user.findMany({
-          where: {
-            id,
-          },
-        })
+      return tx.user.findMany({
+        where: {
+          id,
+        },
       })
+    })
 
-      const logs = await queryLogs
+    const logs = await queryLogs
 
-      if (isMongoDb) {
-        expect(logs).toHaveLength(3)
+    if (isMongoDb) {
+      expect(logs).toHaveLength(3)
 
-        expect(logs[0].query).toContain('User.insertOne')
-        expect(logs[1].query).toContain('User.aggregate')
-        expect(logs[2].query).toContain('User.aggregate')
-      } else {
-        // - Since https://github.com/prisma/prisma-engines/pull/4041,
-        //   we skip a read when possible, on CockroachDB and PostgreSQL.
-        // - Since https://github.com/prisma/prisma-engines/pull/4640,
-        //   we also skip a read when possible, on SQLite.
+      expect(logs[0].query).toContain('User.insertOne')
+      expect(logs[1].query).toContain('User.aggregate')
+      expect(logs[2].query).toContain('User.aggregate')
+    } else {
+      // - Since https://github.com/prisma/prisma-engines/pull/4041,
+      //   we skip a read when possible, on CockroachDB and PostgreSQL.
+      // - Since https://github.com/prisma/prisma-engines/pull/4640,
+      //   we also skip a read when possible, on SQLite.
 
-        if (isSqlServer && !usesJsDrivers) {
-          expect(logs.shift()?.query).toContain('SET TRANSACTION')
-        }
-        if (!usesJsDrivers) {
-          // Driver adapters do not issue BEGIN through the query engine.
-          expect(logs.shift()?.query).toContain('BEGIN')
-        }
-        if (['postgresql', 'cockroachdb', 'sqlite'].includes(provider)) {
-          expect(logs).toHaveLength(3)
-          expect(logs.shift()?.query).toContain('INSERT')
-          expect(logs.shift()?.query).toContain('SELECT')
-          expect(logs.shift()?.query).toContain('COMMIT')
-        } else {
-          expect(logs).toHaveLength(4)
-          expect(logs.shift()?.query).toContain('INSERT')
-          expect(logs.shift()?.query).toContain('SELECT')
-          expect(logs.shift()?.query).toContain('SELECT')
-          expect(logs.shift()?.query).toContain('COMMIT')
-        }
+      if (isSqlServer && !usesJsDrivers) {
+        expect(logs.shift()?.query).toContain('SET TRANSACTION')
       }
-    },
-  )
+      if (!usesJsDrivers) {
+        // Driver adapters do not issue BEGIN through the query engine.
+        expect(logs.shift()?.query).toContain('BEGIN')
+      }
+      if (['postgresql', 'cockroachdb', 'sqlite'].includes(provider)) {
+        expect(logs).toHaveLength(3)
+        expect(logs.shift()?.query).toContain('INSERT')
+        expect(logs.shift()?.query).toContain('SELECT')
+        expect(logs.shift()?.query).toContain('COMMIT')
+      } else {
+        expect(logs).toHaveLength(4)
+        expect(logs.shift()?.query).toContain('INSERT')
+        expect(logs.shift()?.query).toContain('SELECT')
+        expect(logs.shift()?.query).toContain('SELECT')
+        expect(logs.shift()?.query).toContain('COMMIT')
+      }
+    }
+  })
 
   // D1: iTx are not available.
   skipTestIf(driverAdapter === 'js_d1')('should log batched queries inside a ITX', async () => {

--- a/packages/client/tests/functional/methods/findFirstOrThrow/tests.ts
+++ b/packages/client/tests/functional/methods/findFirstOrThrow/tests.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker'
 import { expectTypeOf } from 'expect-type'
 
-import { AdapterProviders, Providers } from '../../_utils/providers'
+import { AdapterProviders } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type { PrismaClient } from './generated/prisma/client'
@@ -101,14 +101,6 @@ testMatrix.setupTestSuite(
     skipDriverAdapter: {
       from: [AdapterProviders.JS_LIBSQL],
       reason: 'js_libsql: SIGABRT due to panic in libsql (not yet implemented: array)', // TODO: ORM-867
-    },
-    skip(when, { clientEngineExecutor, provider }) {
-      when(
-        clientEngineExecutor === 'remote' && provider === Providers.MYSQL,
-        `
-        Tracked in https://linear.app/prisma-company/issue/ORM-1415/interactive-transaction-tests-fail-with-mysqlqcaccelerate
-        `,
-      )
     },
   },
 )

--- a/packages/client/tests/functional/methods/findUniqueOrThrow/tests.ts
+++ b/packages/client/tests/functional/methods/findUniqueOrThrow/tests.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker'
 import { expectTypeOf } from 'expect-type'
 
-import { AdapterProviders, Providers } from '../../_utils/providers'
+import { AdapterProviders } from '../../_utils/providers'
 import testMatrix from './_matrix'
 // @ts-ignore
 import type { PrismaClient } from './generated/prisma/client'
@@ -100,14 +100,6 @@ testMatrix.setupTestSuite(
     skipDriverAdapter: {
       from: [AdapterProviders.JS_LIBSQL],
       reason: 'js_libsql: SIGABRT due to panic in libsql (not yet implemented: array)', // TODO: ORM-867
-    },
-    skip(when, { clientEngineExecutor, provider }) {
-      when(
-        clientEngineExecutor === 'remote' && provider === Providers.MYSQL,
-        `
-        Tracked in https://linear.app/prisma-company/issue/ORM-1415/interactive-transaction-tests-fail-with-mysqlqcaccelerate
-        `,
-      )
     },
   },
 )

--- a/packages/query-plan-executor/src/logic/app.ts
+++ b/packages/query-plan-executor/src/logic/app.ts
@@ -86,7 +86,7 @@ export class App {
         placeholderValues,
         tracingHelper: this.#tracingHandler,
         transactionManager:
-          transactionId !== null ? { enabled: true, manager: this.#transactionManager } : { enabled: false },
+          transactionId === null ? { enabled: true, manager: this.#transactionManager } : { enabled: false },
         onQuery: logQuery,
       })
 


### PR DESCRIPTION
Fix the incorrectly flipped condition when deciding whether to enable the transaction manager for the query interpreter. The transaction manager must be enabled if `transactionId === null` (thus allowing the query interpreter to start new transactions), not the other way around.

Fixes: https://linear.app/prisma-company/issue/ORM-1394/investigate-failing-regression-test-for-gh-15044
Fixes: https://linear.app/prisma-company/issue/ORM-1415/interactive-transaction-tests-fail-with-mysqlqcaccelerate
Fixes: https://linear.app/prisma-company/issue/ORM-1416/extra-commit-query-in-logs-with-mysqlqcaccelerate