### PR TITLE
fix: remove incorrect driver adapter flag check

### DIFF
--- a/packages/client-generator-ts/src/generateClient.ts
+++ b/packages/client-generator-ts/src/generateClient.ts
@@ -103,7 +103,7 @@ export function buildClient({
   // we define the basic options for the client generation
   const clientEngineType = getClientEngineType(generator)
 
-  const runtimeName = getRuntimeNameForTarget(target, clientEngineType, generator.previewFeatures)
+  const runtimeName = getRuntimeNameForTarget(target, clientEngineType)
 
   const outputName = generatedFileNameMapper(generatedFileExtension)
   const importName = importFileNameMapper(importFileExtension)
@@ -404,11 +404,7 @@ async function getGenerationDirs({ runtimeBase, outputDir }: GenerateClientOptio
   }
 }
 
-function getRuntimeNameForTarget(
-  target: RuntimeTargetInternal,
-  engineType: ClientEngineType,
-  previewFeatures: string[],
-): RuntimeName {
+function getRuntimeNameForTarget(target: RuntimeTargetInternal, engineType: ClientEngineType): RuntimeName {
   switch (target) {
     case 'nodejs':
     case 'deno':
@@ -416,11 +412,7 @@ function getRuntimeNameForTarget(
 
     case 'workerd':
     case 'vercel-edge':
-      if (previewFeatures.includes('driverAdapters')) {
-        return engineType === ClientEngineType.Client ? 'wasm-compiler-edge' : 'wasm-engine-edge'
-      } else {
-        return 'edge'
-      }
+      return engineType === ClientEngineType.Client ? 'wasm-compiler-edge' : 'wasm-engine-edge'
 
     case 'react-native':
       return 'react-native'

--- a/packages/client-generator-ts/tests/workerd.prisma
+++ b/packages/client-generator-ts/tests/workerd.prisma
@@ -1,0 +1,16 @@
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+generator client {
+  provider = "prisma-client-ts"
+  engineType = "client"
+  runtime = "workerd"
+  output = "./generated"
+}
+
+model User {
+  id   Int    @id
+  name String
+}


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma/issues/28073

This PR removes a leftover check for the `driverAdapters` feature, we should no longer be checking for it since it's been stabilized. This has led to an issue where the runtime gets defaulted to `edge` and we generate no `adapter` property.

Also adds a generator test case that looks for the adapter property. It's a crude way of testing this behavior, but unfortunately a client test can't be written for this without significantly refactoring the test setup, because the tests hardcode some properties including `target`.

I've also done a manual test via an integration NPM version `6.17.0-integration-remove-driver-adapter-flag-check.1`.