### PR TITLE
test: correct a skip check that accidentally disables lots of tests

### DIFF
--- a/packages/client/tests/functional/_utils/getTestSuitePlan.ts
+++ b/packages/client/tests/functional/_utils/getTestSuitePlan.ts
@@ -195,7 +195,7 @@ function shouldSkipSuiteConfig(
     return true
   }
 
-  if (clientEngineExecutor !== cliMeta.clientEngineExecutor) {
+  if (clientEngineExecutor !== undefined && clientEngineExecutor !== cliMeta.clientEngineExecutor) {
     return true
   }
 


### PR DESCRIPTION
We've been entirely skipping some test suites like TS-Client, because of a missing `undefined` check.
See [🧪 / TS-Client postgresql [v18] 1/6](https://github.com/prisma/prisma/actions/runs/17589075490/job/49977617030#logs) from yesterday:
```
Test Suites: 43 skipped, 0 of 43 total
Tests:       2052 skipped, 2052 total
```