### PR TITLE
chore: bump get-port to 7.1.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -139,7 +139,7 @@
     "fast-glob": "3.3.3",
     "fs-extra": "11.3.0",
     "fs-jetpack": "5.1.0",
-    "get-port": "5.1.1",
+    "get-port": "7.1.0",
     "get-tsconfig": "4.10.0",
     "jest": "29.7.0",
     "jest-junit": "16.0.0",

--- a/packages/cli/src/Studio.ts
+++ b/packages/cli/src/Studio.ts
@@ -14,7 +14,7 @@ import {
   resolveUrl,
 } from '@prisma/internals'
 import { StudioServer } from '@prisma/studio-server'
-import getPort from 'get-port'
+import getPort, { portNumbers } from 'get-port'
 import { bold, dim, red } from 'kleur/colors'
 import open from 'open'
 import path from 'path'
@@ -110,7 +110,7 @@ ${bold('Examples')}
     })
 
     const hostname = args['--hostname']
-    const port = args['--port'] || (await getPort({ port: getPort.makeRange(5555, 5600) }))
+    const port = args['--port'] || (await getPort({ port: portNumbers(5555, 5600) }))
     const browser = args['--browser'] || process.env.BROWSER
 
     const staticAssetDir = path.resolve(__dirname, '../build/public')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -494,8 +494,8 @@ importers:
         specifier: 5.1.0
         version: 5.1.0
       get-port:
-        specifier: 5.1.1
-        version: 5.1.1
+        specifier: 7.1.0
+        version: 7.1.0
       get-tsconfig:
         specifier: 4.10.0
         version: 4.10.0
@@ -5254,9 +5254,9 @@ packages:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
 
-  get-port@5.1.1:
-    resolution: {integrity: sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==}
-    engines: {node: '>=8'}
+  get-port@7.1.0:
+    resolution: {integrity: sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==}
+    engines: {node: '>=16'}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -11856,7 +11856,7 @@ snapshots:
 
   get-package-type@0.1.0: {}
 
-  get-port@5.1.1: {}
+  get-port@7.1.0: {}
 
   get-proto@1.0.1:
     dependencies:


### PR DESCRIPTION
This PR bumps get-port version to 7.1.0.