### PR TITLE
fix: handle missing timer unref

### DIFF
--- a/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
+++ b/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
@@ -101,7 +101,7 @@ export class TransactionManager {
     // Start timeout to wait for transaction to be started.
     let hasTimedOut = false
     const startTimer = setTimeout(() => (hasTimedOut = true), validatedOptions.maxWait!)
-    startTimer.unref()
+    startTimer.unref?.()
 
     transaction.transaction = await this.driverAdapter
       .startTransaction(validatedOptions.isolationLevel)
@@ -215,7 +215,7 @@ export class TransactionManager {
       }
     }, timeout)
 
-    timer.unref()
+    timer.unref?.()
     return timer
   }
 


### PR DESCRIPTION
timer.unref is not available in some environments like CF workers

[ORM-1431](https://linear.app/prisma-company/issue/ORM-1431/fix-transaction-manager-in-workerd-environment)

Fixes http://github.com/prisma/prisma/issues/28089