### PR TITLE
fix: correct accelerate validation

### DIFF
--- a/packages/client/src/runtime/core/init/validateEngineInstanceConfig.ts
+++ b/packages/client/src/runtime/core/init/validateEngineInstanceConfig.ts
@@ -98,22 +98,21 @@ export function validateEngineInstanceConfig({
 
   const isAccelerateConfigured = isAccelerateUrlScheme || !copyEngine
 
-  // Note: we're explicitly allowing the `isUsingDriverAdapters && isUsingPrismaPostgres` case to pass through.
   if (isUsingDriverAdapters && (isAccelerateConfigured || targetBuildType === 'edge')) {
     if (targetBuildType === 'edge') {
       pushError([
         `Prisma Client was configured to use the \`adapter\` option but it was imported via its \`/edge\` endpoint.`,
         `Please either remove the \`/edge\` endpoint or remove the \`adapter\` from the Prisma Client constructor.`,
       ])
+    } else if (isAccelerateUrlScheme) {
+      pushError([
+        `You've provided both a driver adapter and an Accelerate database URL. Driver adapters currently cannot connect to Accelerate.`,
+        `Please provide either a driver adapter with a direct database URL or an Accelerate URL and no driver adapter.`,
+      ])
     } else if (!copyEngine) {
       pushError([
         `Prisma Client was configured to use the \`adapter\` option but \`prisma generate\` was run with \`--no-engine\`.`,
         `Please run \`prisma generate\` without \`--no-engine\` to be able to use Prisma Client with the adapter.`,
-      ])
-    } else if (isUsingPrismaAccelerate) {
-      pushError([
-        `Prisma Client was configured to use the \`adapter\` option but the URL was a \`prisma://\` URL.`,
-        `Please either use the \`prisma://\` URL or remove the \`adapter\` from the Prisma Client constructor.`,
       ])
     }
   }

--- a/packages/client/tests/e2e/driver-adapters-accelerate/tests/url.ts
+++ b/packages/client/tests/e2e/driver-adapters-accelerate/tests/url.ts
@@ -22,8 +22,8 @@ describe('driver adapters cannot be used with accelerate', () => {
         })
 
       expect(newClient).toThrowErrorMatchingInlineSnapshot(`
-  "Prisma Client was configured to use the \`adapter\` option but the URL was a \`prisma://\` URL.
-  Please either use the \`prisma://\` URL or remove the \`adapter\` from the Prisma Client constructor."
+  "You've provided both a driver adapter and an Accelerate database URL. Driver adapters currently cannot connect to Accelerate.
+  Please provide either a driver adapter with a direct database URL or an Accelerate URL and no driver adapter."
   `)
     })
   })
@@ -38,8 +38,8 @@ describe('driver adapters cannot be used with accelerate', () => {
         })
 
       expect(newClient).toThrowErrorMatchingInlineSnapshot(`
-  "Prisma Client was configured to use the \`adapter\` option but the URL was a \`prisma://\` URL.
-  Please either use the \`prisma://\` URL or remove the \`adapter\` from the Prisma Client constructor."
+  "You've provided both a driver adapter and an Accelerate database URL. Driver adapters currently cannot connect to Accelerate.
+  Please provide either a driver adapter with a direct database URL or an Accelerate URL and no driver adapter."
   `)
     })
   })


### PR DESCRIPTION
[ORM-1433](https://linear.app/prisma-company/issue/ORM-1433/output-more-informative-error-when-driver-adapters-accelerate-are-used)

Modifies validation to show an error for PPG URLs. Also slightly modifies error messages and displays the adapter error before the `no-engine` error.