### PR TITLE
chore: CI - build - reusable workflow artifacts

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -20,6 +20,15 @@ runs:
   using: composite
   steps:
     - uses: pnpm/action-setup@v4.0.0
+
+    - name: Cache turbo build setup
+      uses: actions/cache@v4
+      with:
+        path: .turbo
+        key: ${{ runner.os }}-node-${{ inputs.node-version }}-turbo-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-node-${{ inputs.node-version }}-turbo-
+
     - name: Use Node.js ${{ inputs.node-version }}
       uses: actions/setup-node@v4
       with:
@@ -29,7 +38,7 @@ runs:
         # The NPM_TOKEN secret needs to be defined in the job
         registry-url: 'https://registry.npmjs.org'
 
-    - run: pnpm install
+    - run: pnpm install --prefer-offline
       shell: bash
 
     - run: pnpm -r run dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: Build
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: ['18', '20', '22', '24']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install & build
+        uses: ./.github/actions/setup
+        with:
+          node-version: ${{ matrix.node-version }}
+          skip-tsc: false
+          skip-build: false

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,7 +1,10 @@
 name: Bundle size
 
 on:
-  pull_request:
+  workflow_run:
+    workflows: [Build]
+    types:
+      - completed
     paths-ignore:
       # Any update here needs to be done for all files
       # (test.yml, benchmark.yml, release-ci.yml, bundle-size.yml, ci-aux-files.yml)
@@ -25,6 +28,7 @@ concurrency:
 jobs:
   size:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -33,8 +37,8 @@ jobs:
         uses: ./.github/actions/setup
         with:
           node-version: 18
-          skip-tsc: true
-          skip-build: true
+          skip-tsc: false
+          skip-build: false
 
       - uses: andresz1/size-limit-action@v1
         with:

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -5,21 +5,6 @@ on:
     workflows: [Build]
     types:
       - completed
-    paths-ignore:
-      # Any update here needs to be done for all files
-      # (test.yml, benchmark.yml, release-ci.yml, bundle-size.yml, ci-aux-files.yml)
-      - '*.md'
-      - '*.bench.ts'
-      - 'LICENSE'
-      - '.dockerignore'
-      - 'scripts/ci/publish.ts'
-      - '.github/CODEOWNERS'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/DISCUSSION_TEMPLATE/**'
-      - '.devcontainer/**'
-      - '.vscode/**'
-      - 'graphs/**'
-      - 'sandbox/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This PR introduces build workflow that other workflows should depend to re-use build artifacts as cache to save time. Once this PR lands confirming that we can save time using build artifacts, I'll work on CI optimization utilizing turbo caching.