### PR TITLE
chore: add `turbo dev` task

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "packageManager": "pnpm@10.15.1",
   "scripts": {
     "build": "turbo build",
+    "dev": "turbo dev",
     "watch": "pnpm -r run dev && WATCH=true pnpm -r --parallel --stream run dev",
     "publish-all-dryrun": "tsx scripts/ci/publish.ts --publish --dry-run",
     "publish-all": "tsx scripts/ci/publish.ts --publish",

--- a/packages/type-benchmark-tests/test.ts
+++ b/packages/type-benchmark-tests/test.ts
@@ -99,7 +99,7 @@ function getTestFilter() {
 function getTestDirectories() {
   return readdirSync(parentDir).filter((item) => {
     const fullPath = join(parentDir, item)
-    return statSync(fullPath).isDirectory() && !directoryBlockList.includes(item)
+    return statSync(fullPath).isDirectory() && !item.startsWith('.') && !directoryBlockList.includes(item)
   })
 }
 

--- a/turbo.json
+++ b/turbo.json
@@ -6,6 +6,14 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**", "generator-build/**", "runtime/**"],
       "env": ["DEV", "MINIFY"]
+    },
+    "dev": {
+      "dependsOn": ["^dev"],
+      "outputs": ["dist/**", "generator-build/**", "runtime/**"],
+      "env": ["DEV", "MINIFY"]
+    },
+    "@prisma/type-benchmark-tests#dev": {
+      "outputs": ["**/generated"]
     }
   }
 }


### PR DESCRIPTION
Add a `pnpm dev`/`turbo dev` task as an alternative to `pnpm -r dev` that uses Turborepo.