### PR TITLE
feat(client): Map `Bytes` to generic `Uint8Array` depending on TypeScript version

### DIFF
--- a/packages/client-generator-js/src/TSClient/common.ts
+++ b/packages/client-generator-js/src/TSClient/common.ts
@@ -199,6 +199,7 @@ export const prismaVersion: PrismaVersion
  */
 
 
+export import Bytes = runtime.Bytes
 export import JsonObject = runtime.JsonObject
 export import JsonArray = runtime.JsonArray
 export import JsonValue = runtime.JsonValue

--- a/packages/client-generator-js/src/typedSql/mapTypes.ts
+++ b/packages/client-generator-js/src/typedSql/mapTypes.ts
@@ -10,7 +10,7 @@ type TypeMappingConfig = {
 }
 
 const decimal = ts.namedType('$runtime.Decimal')
-const uint8Array = ts.namedType('Uint8Array')
+const uint8Array = ts.namedType('$runtime.Bytes')
 const date = ts.namedType('Date')
 const inputJsonValue = ts.namedType('$runtime.InputJsonObject')
 const jsonValue = ts.namedType('$runtime.JsonValue')

--- a/packages/client-generator-js/src/utils/common.ts
+++ b/packages/client-generator-js/src/utils/common.ts
@@ -3,6 +3,7 @@ import type * as DMMF from '@prisma/dmmf'
 export const needNamespace = {
   Json: 'JsonValue',
   Decimal: 'Decimal',
+  Bytes: 'Bytes',
 }
 
 export function needsNamespace(field: DMMF.Field): boolean {
@@ -11,7 +12,7 @@ export function needsNamespace(field: DMMF.Field): boolean {
   }
 
   if (field.kind === 'scalar') {
-    return field.type === 'Json' || field.type === 'Decimal'
+    return field.type === 'Json' || field.type === 'Decimal' || field.type === 'Bytes'
   }
   return false
 }
@@ -26,7 +27,7 @@ export const GraphQLScalarToJSTypeTable = {
   ID: 'string',
   UUID: 'string',
   Json: 'JsonValue',
-  Bytes: 'Uint8Array',
+  Bytes: 'Bytes',
   Decimal: ['Decimal', 'DecimalJsLike', 'number', 'string'],
   BigInt: ['bigint', 'number'],
 }

--- a/packages/client-generator-ts/src/TSClient/common.ts
+++ b/packages/client-generator-ts/src/TSClient/common.ts
@@ -80,6 +80,7 @@ export const prismaVersion: PrismaVersion = {
  * Utility Types
  */
 
+export type Bytes = runtime.Bytes
 export type JsonObject = runtime.JsonObject
 export type JsonArray = runtime.JsonArray
 export type JsonValue = runtime.JsonValue

--- a/packages/client-generator-ts/src/typedSql/mapTypes.ts
+++ b/packages/client-generator-ts/src/typedSql/mapTypes.ts
@@ -9,7 +9,7 @@ type TypeMappingConfig = {
 }
 
 const decimal = ts.namedType('$runtime.Decimal')
-const uint8Array = ts.namedType('Uint8Array')
+const uint8Array = ts.namedType('$runtime.Bytes')
 const date = ts.namedType('Date')
 const inputJsonValue = ts.namedType('$runtime.InputJsonObject')
 const jsonValue = ts.namedType('$runtime.JsonValue')

--- a/packages/client-generator-ts/src/utils/common.ts
+++ b/packages/client-generator-ts/src/utils/common.ts
@@ -8,7 +8,7 @@ export const GraphQLScalarToJSTypeTable = {
   ID: 'string',
   UUID: 'string',
   Json: 'runtime.JsonValue',
-  Bytes: 'Uint8Array',
+  Bytes: 'runtime.Bytes',
   Decimal: ['runtime.Decimal', 'runtime.DecimalJsLike', 'number', 'string'],
   BigInt: ['bigint', 'number'],
 }

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/binary.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/binary.test.ts.snap
@@ -768,6 +768,7 @@ export namespace Prisma {
    */
 
 
+  export import Bytes = runtime.Bytes
   export import JsonObject = runtime.JsonObject
   export import JsonArray = runtime.JsonArray
   export import JsonValue = runtime.JsonValue
@@ -15542,14 +15543,14 @@ export namespace Prisma {
   export type DMinAggregateOutputType = {
     id: string | null
     bool: boolean | null
-    byteA: Uint8Array | null
+    byteA: Bytes | null
     xml: string | null
   }
 
   export type DMaxAggregateOutputType = {
     id: string | null
     bool: boolean | null
-    byteA: Uint8Array | null
+    byteA: Bytes | null
     xml: string | null
   }
 
@@ -15687,7 +15688,7 @@ export namespace Prisma {
   export type DGroupByOutputType = {
     id: string
     bool: boolean
-    byteA: Uint8Array
+    byteA: Bytes
     xml: string
     json: JsonValue
     jsonb: JsonValue
@@ -15743,7 +15744,7 @@ export namespace Prisma {
     scalars: $Extensions.GetPayloadResult<{
       id: string
       bool: boolean
-      byteA: Uint8Array
+      byteA: Prisma.Bytes
       xml: string
       json: Prisma.JsonValue
       jsonb: Prisma.JsonValue
@@ -18776,7 +18777,7 @@ export namespace Prisma {
     NOT?: DWhereInput | DWhereInput[]
     id?: StringFilter<"D"> | string
     bool?: BoolFilter<"D"> | boolean
-    byteA?: BytesFilter<"D"> | Uint8Array
+    byteA?: BytesFilter<"D"> | Bytes
     xml?: StringFilter<"D"> | string
     json?: JsonFilter<"D">
     jsonb?: JsonFilter<"D">
@@ -18799,7 +18800,7 @@ export namespace Prisma {
     OR?: DWhereInput[]
     NOT?: DWhereInput | DWhereInput[]
     bool?: BoolFilter<"D"> | boolean
-    byteA?: BytesFilter<"D"> | Uint8Array
+    byteA?: BytesFilter<"D"> | Bytes
     xml?: StringFilter<"D"> | string
     json?: JsonFilter<"D">
     jsonb?: JsonFilter<"D">
@@ -18827,7 +18828,7 @@ export namespace Prisma {
     NOT?: DScalarWhereWithAggregatesInput | DScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter<"D"> | string
     bool?: BoolWithAggregatesFilter<"D"> | boolean
-    byteA?: BytesWithAggregatesFilter<"D"> | Uint8Array
+    byteA?: BytesWithAggregatesFilter<"D"> | Bytes
     xml?: StringWithAggregatesFilter<"D"> | string
     json?: JsonWithAggregatesFilter<"D">
     jsonb?: JsonWithAggregatesFilter<"D">
@@ -19984,7 +19985,7 @@ export namespace Prisma {
   export type DCreateInput = {
     id?: string
     bool: boolean
-    byteA: Uint8Array
+    byteA: Bytes
     xml: string
     json: InputJsonValue
     jsonb: InputJsonValue
@@ -19994,7 +19995,7 @@ export namespace Prisma {
   export type DUncheckedCreateInput = {
     id?: string
     bool: boolean
-    byteA: Uint8Array
+    byteA: Bytes
     xml: string
     json: InputJsonValue
     jsonb: InputJsonValue
@@ -20003,7 +20004,7 @@ export namespace Prisma {
 
   export type DUpdateInput = {
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
+    byteA?: BytesFieldUpdateOperationsInput | Bytes
     xml?: StringFieldUpdateOperationsInput | string
     json?: InputJsonValue | InputJsonValue
     jsonb?: InputJsonValue | InputJsonValue
@@ -20012,7 +20013,7 @@ export namespace Prisma {
 
   export type DUncheckedUpdateInput = {
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
+    byteA?: BytesFieldUpdateOperationsInput | Bytes
     xml?: StringFieldUpdateOperationsInput | string
     json?: InputJsonValue | InputJsonValue
     jsonb?: InputJsonValue | InputJsonValue
@@ -20022,7 +20023,7 @@ export namespace Prisma {
   export type DCreateManyInput = {
     id?: string
     bool: boolean
-    byteA: Uint8Array
+    byteA: Bytes
     xml: string
     json: InputJsonValue
     jsonb: InputJsonValue
@@ -20031,7 +20032,7 @@ export namespace Prisma {
 
   export type DUpdateManyMutationInput = {
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
+    byteA?: BytesFieldUpdateOperationsInput | Bytes
     xml?: StringFieldUpdateOperationsInput | string
     json?: InputJsonValue | InputJsonValue
     jsonb?: InputJsonValue | InputJsonValue
@@ -20040,7 +20041,7 @@ export namespace Prisma {
 
   export type DUncheckedUpdateManyInput = {
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
+    byteA?: BytesFieldUpdateOperationsInput | Bytes
     xml?: StringFieldUpdateOperationsInput | string
     json?: InputJsonValue | InputJsonValue
     jsonb?: InputJsonValue | InputJsonValue
@@ -21133,10 +21134,10 @@ export namespace Prisma {
   }
 
   export type BytesFilter<$PrismaModel = never> = {
-    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
-    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesFilter<$PrismaModel> | Uint8Array
+    equals?: Bytes | BytesFieldRefInput<$PrismaModel>
+    in?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesFilter<$PrismaModel> | Bytes
   }
 
   export type IntNullableListFilter<$PrismaModel = never> = {
@@ -21180,10 +21181,10 @@ export namespace Prisma {
   }
 
   export type BytesWithAggregatesFilter<$PrismaModel = never> = {
-    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
-    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Uint8Array
+    equals?: Bytes | BytesFieldRefInput<$PrismaModel>
+    in?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Bytes
     _count?: NestedIntFilter<$PrismaModel>
     _min?: NestedBytesFilter<$PrismaModel>
     _max?: NestedBytesFilter<$PrismaModel>
@@ -21639,7 +21640,7 @@ export namespace Prisma {
   }
 
   export type BytesFieldUpdateOperationsInput = {
-    set?: Uint8Array
+    set?: Bytes
   }
 
   export type DUpdatelistInput = {
@@ -21989,17 +21990,17 @@ export namespace Prisma {
   }
 
   export type NestedBytesFilter<$PrismaModel = never> = {
-    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
-    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesFilter<$PrismaModel> | Uint8Array
+    equals?: Bytes | BytesFieldRefInput<$PrismaModel>
+    in?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesFilter<$PrismaModel> | Bytes
   }
 
   export type NestedBytesWithAggregatesFilter<$PrismaModel = never> = {
-    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
-    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Uint8Array
+    equals?: Bytes | BytesFieldRefInput<$PrismaModel>
+    in?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Bytes
     _count?: NestedIntFilter<$PrismaModel>
     _min?: NestedBytesFilter<$PrismaModel>
     _max?: NestedBytesFilter<$PrismaModel>

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/library.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/__snapshots__/library.test.ts.snap
@@ -768,6 +768,7 @@ export namespace Prisma {
    */
 
 
+  export import Bytes = runtime.Bytes
   export import JsonObject = runtime.JsonObject
   export import JsonArray = runtime.JsonArray
   export import JsonValue = runtime.JsonValue
@@ -15542,14 +15543,14 @@ export namespace Prisma {
   export type DMinAggregateOutputType = {
     id: string | null
     bool: boolean | null
-    byteA: Uint8Array | null
+    byteA: Bytes | null
     xml: string | null
   }
 
   export type DMaxAggregateOutputType = {
     id: string | null
     bool: boolean | null
-    byteA: Uint8Array | null
+    byteA: Bytes | null
     xml: string | null
   }
 
@@ -15687,7 +15688,7 @@ export namespace Prisma {
   export type DGroupByOutputType = {
     id: string
     bool: boolean
-    byteA: Uint8Array
+    byteA: Bytes
     xml: string
     json: JsonValue
     jsonb: JsonValue
@@ -15743,7 +15744,7 @@ export namespace Prisma {
     scalars: $Extensions.GetPayloadResult<{
       id: string
       bool: boolean
-      byteA: Uint8Array
+      byteA: Prisma.Bytes
       xml: string
       json: Prisma.JsonValue
       jsonb: Prisma.JsonValue
@@ -18776,7 +18777,7 @@ export namespace Prisma {
     NOT?: DWhereInput | DWhereInput[]
     id?: StringFilter<"D"> | string
     bool?: BoolFilter<"D"> | boolean
-    byteA?: BytesFilter<"D"> | Uint8Array
+    byteA?: BytesFilter<"D"> | Bytes
     xml?: StringFilter<"D"> | string
     json?: JsonFilter<"D">
     jsonb?: JsonFilter<"D">
@@ -18799,7 +18800,7 @@ export namespace Prisma {
     OR?: DWhereInput[]
     NOT?: DWhereInput | DWhereInput[]
     bool?: BoolFilter<"D"> | boolean
-    byteA?: BytesFilter<"D"> | Uint8Array
+    byteA?: BytesFilter<"D"> | Bytes
     xml?: StringFilter<"D"> | string
     json?: JsonFilter<"D">
     jsonb?: JsonFilter<"D">
@@ -18827,7 +18828,7 @@ export namespace Prisma {
     NOT?: DScalarWhereWithAggregatesInput | DScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter<"D"> | string
     bool?: BoolWithAggregatesFilter<"D"> | boolean
-    byteA?: BytesWithAggregatesFilter<"D"> | Uint8Array
+    byteA?: BytesWithAggregatesFilter<"D"> | Bytes
     xml?: StringWithAggregatesFilter<"D"> | string
     json?: JsonWithAggregatesFilter<"D">
     jsonb?: JsonWithAggregatesFilter<"D">
@@ -19984,7 +19985,7 @@ export namespace Prisma {
   export type DCreateInput = {
     id?: string
     bool: boolean
-    byteA: Uint8Array
+    byteA: Bytes
     xml: string
     json: InputJsonValue
     jsonb: InputJsonValue
@@ -19994,7 +19995,7 @@ export namespace Prisma {
   export type DUncheckedCreateInput = {
     id?: string
     bool: boolean
-    byteA: Uint8Array
+    byteA: Bytes
     xml: string
     json: InputJsonValue
     jsonb: InputJsonValue
@@ -20003,7 +20004,7 @@ export namespace Prisma {
 
   export type DUpdateInput = {
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
+    byteA?: BytesFieldUpdateOperationsInput | Bytes
     xml?: StringFieldUpdateOperationsInput | string
     json?: InputJsonValue | InputJsonValue
     jsonb?: InputJsonValue | InputJsonValue
@@ -20012,7 +20013,7 @@ export namespace Prisma {
 
   export type DUncheckedUpdateInput = {
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
+    byteA?: BytesFieldUpdateOperationsInput | Bytes
     xml?: StringFieldUpdateOperationsInput | string
     json?: InputJsonValue | InputJsonValue
     jsonb?: InputJsonValue | InputJsonValue
@@ -20022,7 +20023,7 @@ export namespace Prisma {
   export type DCreateManyInput = {
     id?: string
     bool: boolean
-    byteA: Uint8Array
+    byteA: Bytes
     xml: string
     json: InputJsonValue
     jsonb: InputJsonValue
@@ -20031,7 +20032,7 @@ export namespace Prisma {
 
   export type DUpdateManyMutationInput = {
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
+    byteA?: BytesFieldUpdateOperationsInput | Bytes
     xml?: StringFieldUpdateOperationsInput | string
     json?: InputJsonValue | InputJsonValue
     jsonb?: InputJsonValue | InputJsonValue
@@ -20040,7 +20041,7 @@ export namespace Prisma {
 
   export type DUncheckedUpdateManyInput = {
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
+    byteA?: BytesFieldUpdateOperationsInput | Bytes
     xml?: StringFieldUpdateOperationsInput | string
     json?: InputJsonValue | InputJsonValue
     jsonb?: InputJsonValue | InputJsonValue
@@ -21133,10 +21134,10 @@ export namespace Prisma {
   }
 
   export type BytesFilter<$PrismaModel = never> = {
-    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
-    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesFilter<$PrismaModel> | Uint8Array
+    equals?: Bytes | BytesFieldRefInput<$PrismaModel>
+    in?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesFilter<$PrismaModel> | Bytes
   }
 
   export type IntNullableListFilter<$PrismaModel = never> = {
@@ -21180,10 +21181,10 @@ export namespace Prisma {
   }
 
   export type BytesWithAggregatesFilter<$PrismaModel = never> = {
-    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
-    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Uint8Array
+    equals?: Bytes | BytesFieldRefInput<$PrismaModel>
+    in?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Bytes
     _count?: NestedIntFilter<$PrismaModel>
     _min?: NestedBytesFilter<$PrismaModel>
     _max?: NestedBytesFilter<$PrismaModel>
@@ -21639,7 +21640,7 @@ export namespace Prisma {
   }
 
   export type BytesFieldUpdateOperationsInput = {
-    set?: Uint8Array
+    set?: Bytes
   }
 
   export type DUpdatelistInput = {
@@ -21989,17 +21990,17 @@ export namespace Prisma {
   }
 
   export type NestedBytesFilter<$PrismaModel = never> = {
-    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
-    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesFilter<$PrismaModel> | Uint8Array
+    equals?: Bytes | BytesFieldRefInput<$PrismaModel>
+    in?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesFilter<$PrismaModel> | Bytes
   }
 
   export type NestedBytesWithAggregatesFilter<$PrismaModel = never> = {
-    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
-    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Uint8Array
+    equals?: Bytes | BytesFieldRefInput<$PrismaModel>
+    in?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Bytes
     _count?: NestedIntFilter<$PrismaModel>
     _min?: NestedBytesFilter<$PrismaModel>
     _max?: NestedBytesFilter<$PrismaModel>

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/binary.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/binary.test.ts.snap
@@ -797,6 +797,7 @@ export namespace Prisma {
    */
 
 
+  export import Bytes = runtime.Bytes
   export import JsonObject = runtime.JsonObject
   export import JsonArray = runtime.JsonArray
   export import JsonValue = runtime.JsonValue
@@ -15337,14 +15338,14 @@ export namespace Prisma {
   export type DMinAggregateOutputType = {
     id: string | null
     bool: boolean | null
-    byteA: Uint8Array | null
+    byteA: Bytes | null
     xml: string | null
   }
 
   export type DMaxAggregateOutputType = {
     id: string | null
     bool: boolean | null
-    byteA: Uint8Array | null
+    byteA: Bytes | null
     xml: string | null
   }
 
@@ -15482,7 +15483,7 @@ export namespace Prisma {
   export type DGroupByOutputType = {
     id: string
     bool: boolean
-    byteA: Uint8Array
+    byteA: Bytes
     xml: string
     json: JsonValue
     jsonb: JsonValue
@@ -15556,7 +15557,7 @@ export namespace Prisma {
     scalars: $Extensions.GetPayloadResult<{
       id: string
       bool: boolean
-      byteA: Uint8Array
+      byteA: Prisma.Bytes
       xml: string
       json: Prisma.JsonValue
       jsonb: Prisma.JsonValue
@@ -18704,7 +18705,7 @@ export namespace Prisma {
     NOT?: DWhereInput | DWhereInput[]
     id?: StringFilter<"D"> | string
     bool?: BoolFilter<"D"> | boolean
-    byteA?: BytesFilter<"D"> | Uint8Array
+    byteA?: BytesFilter<"D"> | Bytes
     xml?: StringFilter<"D"> | string
     json?: JsonFilter<"D">
     jsonb?: JsonFilter<"D">
@@ -18727,7 +18728,7 @@ export namespace Prisma {
     OR?: DWhereInput[]
     NOT?: DWhereInput | DWhereInput[]
     bool?: BoolFilter<"D"> | boolean
-    byteA?: BytesFilter<"D"> | Uint8Array
+    byteA?: BytesFilter<"D"> | Bytes
     xml?: StringFilter<"D"> | string
     json?: JsonFilter<"D">
     jsonb?: JsonFilter<"D">
@@ -18755,7 +18756,7 @@ export namespace Prisma {
     NOT?: DScalarWhereWithAggregatesInput | DScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter<"D"> | string
     bool?: BoolWithAggregatesFilter<"D"> | boolean
-    byteA?: BytesWithAggregatesFilter<"D"> | Uint8Array
+    byteA?: BytesWithAggregatesFilter<"D"> | Bytes
     xml?: StringWithAggregatesFilter<"D"> | string
     json?: JsonWithAggregatesFilter<"D">
     jsonb?: JsonWithAggregatesFilter<"D">
@@ -19883,7 +19884,7 @@ export namespace Prisma {
   export type DCreateInput = {
     id?: string
     bool: boolean
-    byteA: Uint8Array
+    byteA: Bytes
     xml: string
     json: JsonNullValueInput | InputJsonValue
     jsonb: JsonNullValueInput | InputJsonValue
@@ -19893,7 +19894,7 @@ export namespace Prisma {
   export type DUncheckedCreateInput = {
     id?: string
     bool: boolean
-    byteA: Uint8Array
+    byteA: Bytes
     xml: string
     json: JsonNullValueInput | InputJsonValue
     jsonb: JsonNullValueInput | InputJsonValue
@@ -19903,7 +19904,7 @@ export namespace Prisma {
   export type DUpdateInput = {
     id?: StringFieldUpdateOperationsInput | string
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
+    byteA?: BytesFieldUpdateOperationsInput | Bytes
     xml?: StringFieldUpdateOperationsInput | string
     json?: JsonNullValueInput | InputJsonValue
     jsonb?: JsonNullValueInput | InputJsonValue
@@ -19913,7 +19914,7 @@ export namespace Prisma {
   export type DUncheckedUpdateInput = {
     id?: StringFieldUpdateOperationsInput | string
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
+    byteA?: BytesFieldUpdateOperationsInput | Bytes
     xml?: StringFieldUpdateOperationsInput | string
     json?: JsonNullValueInput | InputJsonValue
     jsonb?: JsonNullValueInput | InputJsonValue
@@ -19923,7 +19924,7 @@ export namespace Prisma {
   export type DCreateManyInput = {
     id?: string
     bool: boolean
-    byteA: Uint8Array
+    byteA: Bytes
     xml: string
     json: JsonNullValueInput | InputJsonValue
     jsonb: JsonNullValueInput | InputJsonValue
@@ -19933,7 +19934,7 @@ export namespace Prisma {
   export type DUpdateManyMutationInput = {
     id?: StringFieldUpdateOperationsInput | string
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
+    byteA?: BytesFieldUpdateOperationsInput | Bytes
     xml?: StringFieldUpdateOperationsInput | string
     json?: JsonNullValueInput | InputJsonValue
     jsonb?: JsonNullValueInput | InputJsonValue
@@ -19943,7 +19944,7 @@ export namespace Prisma {
   export type DUncheckedUpdateManyInput = {
     id?: StringFieldUpdateOperationsInput | string
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
+    byteA?: BytesFieldUpdateOperationsInput | Bytes
     xml?: StringFieldUpdateOperationsInput | string
     json?: JsonNullValueInput | InputJsonValue
     jsonb?: JsonNullValueInput | InputJsonValue
@@ -21095,10 +21096,10 @@ export namespace Prisma {
   }
 
   export type BytesFilter<$PrismaModel = never> = {
-    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
-    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesFilter<$PrismaModel> | Uint8Array
+    equals?: Bytes | BytesFieldRefInput<$PrismaModel>
+    in?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesFilter<$PrismaModel> | Bytes
   }
 
   export type IntNullableListFilter<$PrismaModel = never> = {
@@ -21142,10 +21143,10 @@ export namespace Prisma {
   }
 
   export type BytesWithAggregatesFilter<$PrismaModel = never> = {
-    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
-    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Uint8Array
+    equals?: Bytes | BytesFieldRefInput<$PrismaModel>
+    in?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Bytes
     _count?: NestedIntFilter<$PrismaModel>
     _min?: NestedBytesFilter<$PrismaModel>
     _max?: NestedBytesFilter<$PrismaModel>
@@ -21491,7 +21492,7 @@ export namespace Prisma {
   }
 
   export type BytesFieldUpdateOperationsInput = {
-    set?: Uint8Array
+    set?: Bytes
   }
 
   export type DUpdatelistInput = {
@@ -21880,17 +21881,17 @@ export namespace Prisma {
   }
 
   export type NestedBytesFilter<$PrismaModel = never> = {
-    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
-    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesFilter<$PrismaModel> | Uint8Array
+    equals?: Bytes | BytesFieldRefInput<$PrismaModel>
+    in?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesFilter<$PrismaModel> | Bytes
   }
 
   export type NestedBytesWithAggregatesFilter<$PrismaModel = never> = {
-    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
-    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Uint8Array
+    equals?: Bytes | BytesFieldRefInput<$PrismaModel>
+    in?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Bytes
     _count?: NestedIntFilter<$PrismaModel>
     _min?: NestedBytesFilter<$PrismaModel>
     _max?: NestedBytesFilter<$PrismaModel>

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/library.test.ts.snap
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/__snapshots__/library.test.ts.snap
@@ -797,6 +797,7 @@ export namespace Prisma {
    */
 
 
+  export import Bytes = runtime.Bytes
   export import JsonObject = runtime.JsonObject
   export import JsonArray = runtime.JsonArray
   export import JsonValue = runtime.JsonValue
@@ -15341,14 +15342,14 @@ export namespace Prisma {
   export type DMinAggregateOutputType = {
     id: string | null
     bool: boolean | null
-    byteA: Uint8Array | null
+    byteA: Bytes | null
     xml: string | null
   }
 
   export type DMaxAggregateOutputType = {
     id: string | null
     bool: boolean | null
-    byteA: Uint8Array | null
+    byteA: Bytes | null
     xml: string | null
   }
 
@@ -15486,7 +15487,7 @@ export namespace Prisma {
   export type DGroupByOutputType = {
     id: string
     bool: boolean
-    byteA: Uint8Array
+    byteA: Bytes
     xml: string
     json: JsonValue
     jsonb: JsonValue
@@ -15560,7 +15561,7 @@ export namespace Prisma {
     scalars: $Extensions.GetPayloadResult<{
       id: string
       bool: boolean
-      byteA: Uint8Array
+      byteA: Prisma.Bytes
       xml: string
       json: Prisma.JsonValue
       jsonb: Prisma.JsonValue
@@ -18708,7 +18709,7 @@ export namespace Prisma {
     NOT?: DWhereInput | DWhereInput[]
     id?: StringFilter<"D"> | string
     bool?: BoolFilter<"D"> | boolean
-    byteA?: BytesFilter<"D"> | Uint8Array
+    byteA?: BytesFilter<"D"> | Bytes
     xml?: StringFilter<"D"> | string
     json?: JsonFilter<"D">
     jsonb?: JsonFilter<"D">
@@ -18731,7 +18732,7 @@ export namespace Prisma {
     OR?: DWhereInput[]
     NOT?: DWhereInput | DWhereInput[]
     bool?: BoolFilter<"D"> | boolean
-    byteA?: BytesFilter<"D"> | Uint8Array
+    byteA?: BytesFilter<"D"> | Bytes
     xml?: StringFilter<"D"> | string
     json?: JsonFilter<"D">
     jsonb?: JsonFilter<"D">
@@ -18759,7 +18760,7 @@ export namespace Prisma {
     NOT?: DScalarWhereWithAggregatesInput | DScalarWhereWithAggregatesInput[]
     id?: StringWithAggregatesFilter<"D"> | string
     bool?: BoolWithAggregatesFilter<"D"> | boolean
-    byteA?: BytesWithAggregatesFilter<"D"> | Uint8Array
+    byteA?: BytesWithAggregatesFilter<"D"> | Bytes
     xml?: StringWithAggregatesFilter<"D"> | string
     json?: JsonWithAggregatesFilter<"D">
     jsonb?: JsonWithAggregatesFilter<"D">
@@ -19887,7 +19888,7 @@ export namespace Prisma {
   export type DCreateInput = {
     id?: string
     bool: boolean
-    byteA: Uint8Array
+    byteA: Bytes
     xml: string
     json: JsonNullValueInput | InputJsonValue
     jsonb: JsonNullValueInput | InputJsonValue
@@ -19897,7 +19898,7 @@ export namespace Prisma {
   export type DUncheckedCreateInput = {
     id?: string
     bool: boolean
-    byteA: Uint8Array
+    byteA: Bytes
     xml: string
     json: JsonNullValueInput | InputJsonValue
     jsonb: JsonNullValueInput | InputJsonValue
@@ -19907,7 +19908,7 @@ export namespace Prisma {
   export type DUpdateInput = {
     id?: StringFieldUpdateOperationsInput | string
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
+    byteA?: BytesFieldUpdateOperationsInput | Bytes
     xml?: StringFieldUpdateOperationsInput | string
     json?: JsonNullValueInput | InputJsonValue
     jsonb?: JsonNullValueInput | InputJsonValue
@@ -19917,7 +19918,7 @@ export namespace Prisma {
   export type DUncheckedUpdateInput = {
     id?: StringFieldUpdateOperationsInput | string
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
+    byteA?: BytesFieldUpdateOperationsInput | Bytes
     xml?: StringFieldUpdateOperationsInput | string
     json?: JsonNullValueInput | InputJsonValue
     jsonb?: JsonNullValueInput | InputJsonValue
@@ -19927,7 +19928,7 @@ export namespace Prisma {
   export type DCreateManyInput = {
     id?: string
     bool: boolean
-    byteA: Uint8Array
+    byteA: Bytes
     xml: string
     json: JsonNullValueInput | InputJsonValue
     jsonb: JsonNullValueInput | InputJsonValue
@@ -19937,7 +19938,7 @@ export namespace Prisma {
   export type DUpdateManyMutationInput = {
     id?: StringFieldUpdateOperationsInput | string
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
+    byteA?: BytesFieldUpdateOperationsInput | Bytes
     xml?: StringFieldUpdateOperationsInput | string
     json?: JsonNullValueInput | InputJsonValue
     jsonb?: JsonNullValueInput | InputJsonValue
@@ -19947,7 +19948,7 @@ export namespace Prisma {
   export type DUncheckedUpdateManyInput = {
     id?: StringFieldUpdateOperationsInput | string
     bool?: BoolFieldUpdateOperationsInput | boolean
-    byteA?: BytesFieldUpdateOperationsInput | Uint8Array
+    byteA?: BytesFieldUpdateOperationsInput | Bytes
     xml?: StringFieldUpdateOperationsInput | string
     json?: JsonNullValueInput | InputJsonValue
     jsonb?: JsonNullValueInput | InputJsonValue
@@ -21099,10 +21100,10 @@ export namespace Prisma {
   }
 
   export type BytesFilter<$PrismaModel = never> = {
-    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
-    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesFilter<$PrismaModel> | Uint8Array
+    equals?: Bytes | BytesFieldRefInput<$PrismaModel>
+    in?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesFilter<$PrismaModel> | Bytes
   }
 
   export type IntNullableListFilter<$PrismaModel = never> = {
@@ -21146,10 +21147,10 @@ export namespace Prisma {
   }
 
   export type BytesWithAggregatesFilter<$PrismaModel = never> = {
-    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
-    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Uint8Array
+    equals?: Bytes | BytesFieldRefInput<$PrismaModel>
+    in?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Bytes
     _count?: NestedIntFilter<$PrismaModel>
     _min?: NestedBytesFilter<$PrismaModel>
     _max?: NestedBytesFilter<$PrismaModel>
@@ -21495,7 +21496,7 @@ export namespace Prisma {
   }
 
   export type BytesFieldUpdateOperationsInput = {
-    set?: Uint8Array
+    set?: Bytes
   }
 
   export type DUpdatelistInput = {
@@ -21884,17 +21885,17 @@ export namespace Prisma {
   }
 
   export type NestedBytesFilter<$PrismaModel = never> = {
-    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
-    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesFilter<$PrismaModel> | Uint8Array
+    equals?: Bytes | BytesFieldRefInput<$PrismaModel>
+    in?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesFilter<$PrismaModel> | Bytes
   }
 
   export type NestedBytesWithAggregatesFilter<$PrismaModel = never> = {
-    equals?: Uint8Array | BytesFieldRefInput<$PrismaModel>
-    in?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    notIn?: Uint8Array[] | ListBytesFieldRefInput<$PrismaModel>
-    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Uint8Array
+    equals?: Bytes | BytesFieldRefInput<$PrismaModel>
+    in?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    notIn?: Bytes[] | ListBytesFieldRefInput<$PrismaModel>
+    not?: NestedBytesWithAggregatesFilter<$PrismaModel> | Bytes
     _count?: NestedIntFilter<$PrismaModel>
     _min?: NestedBytesFilter<$PrismaModel>
     _max?: NestedBytesFilter<$PrismaModel>

--- a/packages/client/src/runtime/core/types/exported/Bytes.ts
+++ b/packages/client/src/runtime/core/types/exported/Bytes.ts
@@ -1,0 +1,4 @@
+/**
+ * Equivalent to `Uint8Array` before TypeScript 5.7, and `Uint8Array<ArrayBuffer>` in TypeScript 5.7 and beyond.
+ */
+export type Bytes = ReturnType<Uint8Array['slice']>

--- a/packages/client/src/runtime/core/types/exported/index.ts
+++ b/packages/client/src/runtime/core/types/exported/index.ts
@@ -1,4 +1,5 @@
 export * from './BackwardCompat'
+export * from './Bytes'
 export * from './DecimalJsLike'
 export * from './ExtensionArgs'
 export * from './Extensions'


### PR DESCRIPTION
Add a new runtime helper type `Bytes`, that either maps to `Uint8Array` or `Uint8Array<ArrayBuffer>`. Both `client-generator-ts` and `client-generator-js` now map `Bytes` to the new `runtime.Bytes` type.

I verified these changes manually in a sandbox with different TypeScript versions, but I would be happy to add tests if I get some pointers where/how to test this.

For `client-generator-js` I followed `Prisma.Decimal` and `Prisma.JsonX` and added a `Prisma.Bytes`. Instead of exposing this as `Prisma.Bytes`, this could maybe just life internally in the generated client without being exported. I also exported it from the `client-generator-ts` to align it with `client-generator-js`, even though it is not used there (`runtime.Bytes` is used directly).

## Context

TypeScript 5.9 changed `ArrayBuffer` to be no longer a super type of `Uint8Array<ArrayBufferLike>` ([src](https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/#lib.d.ts-changes)), which is the default for `Uint8Array` without generics. This makes it difficult to pass `Bytes` received from prisma to APIs that expect `ArrayBuffer`.

`Uint8Array` is generic since TypeScript 5.7 ([src](https://devblogs.microsoft.com/typescript/announcing-typescript-5-7/#typedarrays-are-now-generic-over-arraybufferlike)).

Fixes prisma/prisma#27854