### PR TITLE
test: correct a skip check that accidentally disables lots of tests

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -258,7 +258,7 @@ jobs:
           ]
         shard: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
         node: [20]
-        previewFeatures: ['', ',relationJoins']
+        previewFeatures: ['', 'relationJoins']
     steps:
       - uses: actions/checkout@v4
 
@@ -277,7 +277,7 @@ jobs:
           engine-hash: ${{ inputs.engineHash }}
           skip-tsc: false
 
-      - run: pnpm run test:functional ${{ env.FUNCTIONAL_TEST_OPTIONS }} --adapter ${{ matrix.flavor }} --shard ${{ matrix.shard }} --client-runtime ${{ matrix.clientRuntime }} --preview-features ${{ matrix.previewFeatures }} --runInBand
+      - run: pnpm run test:functional ${{ env.FUNCTIONAL_TEST_OPTIONS }} --adapter ${{ matrix.flavor }} --shard ${{ matrix.shard }} --client-runtime ${{ matrix.clientRuntime }} --preview-features "${{ matrix.previewFeatures }}" --runInBand
         working-directory: packages/client
         env:
           PRISMA_DISABLE_QUAINT_EXECUTORS: true, # ensures quaint runs no queries

--- a/packages/client/helpers/functional-test/run-tests.ts
+++ b/packages/client/helpers/functional-test/run-tests.ts
@@ -127,6 +127,10 @@ const args = arg(
   true,
 )
 
+if (args instanceof Error) {
+  throw args
+}
+
 async function main(): Promise<number | void> {
   let miniProxyProcess: ExecaChildProcess | undefined
 

--- a/packages/client/tests/functional/_utils/getTestSuiteInfo.ts
+++ b/packages/client/tests/functional/_utils/getTestSuiteInfo.ts
@@ -40,9 +40,10 @@ const schemaRelationModeRegex = /relationMode\s*=\s*".*"/
  */
 export function getTestSuiteFullName(suiteMeta: TestSuiteMeta, suiteConfig: NamedTestSuiteConfig) {
   let name = `${suiteMeta.testName.replace(/\\|\//g, '.')}`
-
   let parametersString = suiteConfig.parametersString
-  if (suiteConfig.matrixOptions.clientEngineExecutor === 'remote') {
+
+  const { clientEngineExecutor, clientRuntime } = suiteConfig.matrixOptions
+  if (clientRuntime === 'client' && clientEngineExecutor === 'remote') {
     parametersString += ', qpe=remote'
   }
 

--- a/packages/client/tests/functional/_utils/getTestSuitePlan.ts
+++ b/packages/client/tests/functional/_utils/getTestSuitePlan.ts
@@ -42,6 +42,7 @@ export function getTestSuitePlan(
     config.matrixOptions.clientRuntime ??= testCliMeta.runtime
     config.matrixOptions.previewFeatures ??= testCliMeta.previewFeatures
     config.matrixOptions.generatorType ??= testCliMeta.generatorType
+    config.matrixOptions.clientEngineExecutor ??= testCliMeta.clientEngineExecutor
   })
 
   return expandedSuiteConfigs.map((namedConfig, configIndex) => ({

--- a/packages/client/tests/functional/_utils/getTestSuitePlan.ts
+++ b/packages/client/tests/functional/_utils/getTestSuitePlan.ts
@@ -94,9 +94,22 @@ function getExpandedTestSuitePlanWithRemoteQpe(suiteConfig: NamedTestSuiteConfig
     suiteConfig.matrixOptions.clientEngineExecutor = 'local'
     return [suiteConfig]
   } else {
+    // For each suite config that doesn't use driver adapters, we need
+    // to clone it and create two separate configs:
+    //  - one which doesn't require `ClientEngine` specifically and can
+    //    be run with any engine type, but requires specifically a local
+    //    executor in the event it is executed using `ClientEngine`;
+    //  - another one which is only ever used with remote executor of
+    //    `ClientEngine` and never runs with either a local exeuctor
+    //    of the client engine nor any other engine type.
+    // This is required to separate the snapshots between them.
+
+    suiteConfig.matrixOptions.clientEngineExecutor = 'local'
+
     const remoteExecutorSuiteConfig = klona(suiteConfig)
-    suiteConfig.matrixOptions.clientRuntime = 'client'
-    suiteConfig.matrixOptions.clientEngineExecutor = 'remote'
+    remoteExecutorSuiteConfig.matrixOptions.clientRuntime = 'client'
+    remoteExecutorSuiteConfig.matrixOptions.clientEngineExecutor = 'remote'
+
     return [suiteConfig, remoteExecutorSuiteConfig]
   }
 }

--- a/packages/client/tests/functional/_utils/getTestSuitePlan.ts
+++ b/packages/client/tests/functional/_utils/getTestSuitePlan.ts
@@ -195,7 +195,7 @@ function shouldSkipSuiteConfig(
     return true
   }
 
-  if (clientEngineExecutor !== cliMeta.clientEngineExecutor) {
+  if (clientEngineExecutor !== undefined && clientEngineExecutor !== cliMeta.clientEngineExecutor) {
     return true
   }
 

--- a/packages/client/tests/functional/_utils/getTestSuitePlan.ts
+++ b/packages/client/tests/functional/_utils/getTestSuitePlan.ts
@@ -94,6 +94,7 @@ function getExpandedTestSuitePlanWithRemoteQpe(suiteConfig: NamedTestSuiteConfig
     return [suiteConfig]
   } else {
     const remoteExecutorSuiteConfig = klona(suiteConfig)
+    suiteConfig.matrixOptions.clientRuntime = 'client'
     suiteConfig.matrixOptions.clientEngineExecutor = 'remote'
     return [suiteConfig, remoteExecutorSuiteConfig]
   }


### PR DESCRIPTION
- Fix client tests being incorrectly skipped after introducing QPE tests
- Fix broken driver adapter tests CLI arguments due to missing quotes around the preview features variable
- Fix incorrect error handling in `run-tests.ts` that led to tests being executed with completely wrong arguments (specifically, always with default arguments regardless of what was passed) in the above case