### PR TITLE
feat(adapter-mssql): support Entra ID (ActiveDirectory) authentication parameters

### DIFF
--- a/packages/adapter-mssql/README.md
+++ b/packages/adapter-mssql/README.md
@@ -16,7 +16,7 @@ Install the Prisma ORM's driver adapter:
 npm install @prisma/adapter-mssql
 ```
 
-### 3. Instantiate Prisma Client using the driver adapter
+### 2. Instantiate Prisma Client using the driver adapter
 
 Finally, when you instantiate Prisma Client, you need to pass an instance of Prisma ORM's driver adapter to the `PrismaClient` constructor:
 
@@ -39,3 +39,58 @@ const config = {
 const adapter = new PrismaMssql(config)
 const prisma = new PrismaClient({ adapter })
 ```
+
+You can also instantiate the adapter with a [JDBC](https://learn.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver15) connection string:
+
+```ts
+import { PrismaMssql } from '@prisma/adapter-mssql'
+import { PrismaClient } from '@prisma/client'
+
+const adapter = new PrismaMssql('sqlserver://localhost:1433;database=testdb;user=sa;password=mypassword;encrypt=true')
+const prisma = new PrismaClient({ adapter })
+```
+
+### 3. Entra ID Authentication (formerly Azure Active Directory)
+
+Entra ID authentication is supported by the mssql driver used by this adapter.
+
+For options using the config object, see the options documentation for the [Tedious driver](https://github.com/tediousjs/node-mssql?tab=readme-ov-file#tedious).
+
+For example, using the config object to configure [DefaultAzureCredential](https://learn.microsoft.com/en-gb/azure/developer/javascript/sdk/authentication/credential-chains#use-defaultazurecredential-for-flexibility):
+
+```ts
+import { PrismaMssql } from '@prisma/adapter-mssql'
+import { PrismaClient } from '@prisma/client'
+
+const config = {
+  server: 'localhost',
+  port: 1433,
+  database: 'mydb',
+  authentication: {
+    type: 'azure-active-directory-default',
+  },
+  options: {
+    encrypt: true,
+  },
+}
+
+const adapter = new PrismaMssql(config)
+const prisma = new PrismaClient({ adapter })
+```
+
+Connection string parsing also supports authentication options, as per below:
+
+- to use [DefaultAzureCredential](https://learn.microsoft.com/en-gb/azure/developer/javascript/sdk/authentication/credential-chains#use-defaultazurecredential-for-flexibility), set:
+  - `authentication=DefaultAzureCredential` in your connection string
+- to use an Entra username/password, set:
+  - `authentication=ActiveDirectoryPassword`
+  - `userName=<value>`
+  - `password=<value>`
+  - `clientId=<value>`
+- to use an Entra managed identity, set:
+  - `authentication=ActiveDirectoryManagedIdentity`
+  - `clientId=<value>` (optional)
+- to use a Service Principal with clientId and secret, set:
+  - `authentication=ActiveDirectoryServicePrincipal`
+  - `userName=<client id>`
+  - `password=<client secret>`

--- a/packages/adapter-mssql/package.json
+++ b/packages/adapter-mssql/package.json
@@ -41,6 +41,6 @@
     "async-mutex": "0.5.0"
   },
   "devDependencies": {
-    "@types/mssql": "9.1.7"
+    "@types/mssql": "9.1.8"
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -270,7 +270,7 @@
     "@types/fs-extra": "11.0.4",
     "@types/jest": "29.5.14",
     "@types/js-levenshtein": "1.1.3",
-    "@types/mssql": "9.1.5",
+    "@types/mssql": "9.1.8",
     "@types/node": "18.19.76",
     "@types/pg": "8.11.11",
     "arg": "5.0.2",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -19,7 +19,7 @@
     "@swc/core": "1.11.5",
     "@swc/jest": "0.2.37",
     "@types/jest": "29.5.14",
-    "@types/mssql": "9.1.5",
+    "@types/mssql": "9.1.8",
     "@types/node": "18.19.76",
     "@types/pg": "8.11.11",
     "@types/sqlite3": "3.1.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,8 +275,8 @@ importers:
         version: 11.0.1
     devDependencies:
       '@types/mssql':
-        specifier: 9.1.7
-        version: 9.1.7
+        specifier: 9.1.8
+        version: 9.1.8
 
   packages/adapter-neon:
     dependencies:
@@ -695,8 +695,8 @@ importers:
         specifier: 1.1.3
         version: 1.1.3
       '@types/mssql':
-        specifier: 9.1.5
-        version: 9.1.5
+        specifier: 9.1.8
+        version: 9.1.8
       '@types/node':
         specifier: 18.19.76
         version: 18.19.76
@@ -1342,8 +1342,8 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/mssql':
-        specifier: 9.1.5
-        version: 9.1.5
+        specifier: 9.1.8
+        version: 9.1.8
       '@types/node':
         specifier: 18.19.76
         version: 18.19.76
@@ -3627,17 +3627,11 @@ packages:
   '@types/ms@0.7.31':
     resolution: {integrity: sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==}
 
-  '@types/mssql@9.1.5':
-    resolution: {integrity: sha512-Q9EsgXwuRoX5wvUSu24YfbKMbFChv7pZ/jeCzPkj47ehcuXYsBcfogwrtVFosSjinD4Q/MY2YPGk9Yy1cM2Ywg==}
-
-  '@types/mssql@9.1.7':
-    resolution: {integrity: sha512-eIOEe78nuSW5KctDHImDhLZ9a+jV/z/Xs5RBhcG/jrk+YWqhdNmzBmHVWV7aWQ5fW+jbIGtX6Ph+bbVqfhzafg==}
+  '@types/mssql@9.1.8':
+    resolution: {integrity: sha512-mt9h5jWj+DYE5jxnKaWSV/GqDf9FV52XYVk6T3XZF69noEe+JJV6MKirii48l81+cjmAkSq+qeKX+k61fHkYrQ==}
 
   '@types/node@18.19.76':
     resolution: {integrity: sha512-yvR7Q9LdPz2vGpmpJX5LolrgRdWvB67MJKDPSgIIzpFbaf9a1j/f5DnLp5VDyHGMR0QZHlTr1afsD87QCXFHKw==}
-
-  '@types/node@20.12.7':
-    resolution: {integrity: sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==}
 
   '@types/node@24.3.0':
     resolution: {integrity: sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==}
@@ -3677,9 +3671,6 @@ packages:
 
   '@types/stack-utils@2.0.1':
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
-
-  '@types/tedious@4.0.9':
-    resolution: {integrity: sha512-ipwFvfy9b2m0gjHsIX0D6NAAwGCKokzf5zJqUZHUGt+7uWVlBIy6n2eyMgiKQ8ChLFVxic/zwQUhjLYNzbHDRA==}
 
   '@types/webidl-conversions@7.0.3':
     resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
@@ -9925,13 +9916,7 @@ snapshots:
 
   '@types/ms@0.7.31': {}
 
-  '@types/mssql@9.1.5':
-    dependencies:
-      '@types/node': 20.12.7
-      '@types/tedious': 4.0.9
-      tarn: 3.0.2
-
-  '@types/mssql@9.1.7':
+  '@types/mssql@9.1.8':
     dependencies:
       '@types/node': 18.19.76
       tarn: 3.0.2
@@ -9940,10 +9925,6 @@ snapshots:
       - supports-color
 
   '@types/node@18.19.76':
-    dependencies:
-      undici-types: 5.26.5
-
-  '@types/node@20.12.7':
     dependencies:
       undici-types: 5.26.5
 
@@ -9992,10 +9973,6 @@ snapshots:
       '@types/node': 18.19.76
 
   '@types/stack-utils@2.0.1': {}
-
-  '@types/tedious@4.0.9':
-    dependencies:
-      '@types/node': 18.19.76
 
   '@types/webidl-conversions@7.0.3': {}
 


### PR DESCRIPTION
Currently it is possible to use `adapter-mssql` to connect using Entra ID/Active Directory via the config object, since it is support by mssql/tedious. This PR updates `parseConnectionString` to support the `authentication` config parameters from a connection string. Tests and documentation have been added. I have tested this locally (via npm link) with one of our projects, but only using DefaultAzureCredential.

I wasn't sure if we needed to only stick to values defined in [JDBC Driver properties](https://learn.microsoft.com/en-us/sql/connect/jdbc/setting-the-connection-properties?view=sql-server-ver15#properties), or whether we are just adhering to the format itself. This is a bit of a hybrid, of most the `authentication` values are defined in that spec, but not `DefaultAzureCredential`.

The first commit updates `@types/mssql` package since the latest version was needed for the `authentication` config options.

Relates to:
- [PR#27969](https://github.com/prisma/prisma/pull/27969)
- [Issue #13853](https://github.com/prisma/prisma/issues/13853)
- [Issue #7673](https://github.com/prisma/prisma/issues/7673)
- [Issue #7673](https://github.com/prisma/prisma/issues/7673)

