### PR TITLE
chore: add Codex CLI detection to ai-safety check

### DIFF
--- a/packages/migrate/src/utils/ai-safety.ts
+++ b/packages/migrate/src/utils/ai-safety.ts
@@ -54,6 +54,7 @@ function detectAiAgent(): string | undefined {
     Cursor: process.env.CURSOR_AGENT,
     Aider: process.env.OR_APP_NAME === 'Aider',
     Replit: process.env.REPLIT_CLI,
+    'Codex CLI': process.env.CODEX_SANDBOX === 'seatbelt',
   }
 
   for (const [agentName, marker] of Object.entries(agentMarkers)) {


### PR DESCRIPTION
This PR adds detection logic for Codex CLI via `CODEX_SANDBOX` environment variable
to `aiAgentConfirmationCheckpoint()`, ensuring dangerous Prisma operations are
not executed by Codex without explicit user consent.

Detected variable:
- `CODEX_SANDBOX` (present when running in Codex CLI sandbox mode)