### PR TITLE
fix(client ts): TML-1442 fix missing json null types in browser.ts

### DIFF
--- a/packages/client-generator-ts/src/TSClient/NullTypes.ts
+++ b/packages/client-generator-ts/src/TSClient/NullTypes.ts
@@ -1,0 +1,25 @@
+export const nullTypes = `
+export const NullTypes = {
+  DbNull: runtime.objectEnumValues.classes.DbNull as (new (secret: never) => typeof runtime.objectEnumValues.instances.DbNull),
+  JsonNull: runtime.objectEnumValues.classes.JsonNull as (new (secret: never) => typeof runtime.objectEnumValues.instances.JsonNull),
+  AnyNull: runtime.objectEnumValues.classes.AnyNull as (new (secret: never) => typeof runtime.objectEnumValues.instances.AnyNull),
+}
+/**
+ * Helper for filtering JSON entries that have \`null\` on the database (empty on the db)
+ *
+ * @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-on-a-json-field
+ */
+export const DbNull = runtime.objectEnumValues.instances.DbNull
+/**
+ * Helper for filtering JSON entries that have JSON \`null\` values (not empty on the db)
+ *
+ * @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-on-a-json-field
+ */
+export const JsonNull = runtime.objectEnumValues.instances.JsonNull
+/**
+ * Helper for filtering JSON entries that are \`Prisma.DbNull\` or \`Prisma.JsonNull\`
+ *
+ * @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-on-a-json-field
+ */
+export const AnyNull = runtime.objectEnumValues.instances.AnyNull
+`

--- a/packages/client-generator-ts/src/TSClient/common.ts
+++ b/packages/client-generator-ts/src/TSClient/common.ts
@@ -1,3 +1,4 @@
+import { nullTypes } from './NullTypes'
 import type { TSClientOptions } from './TSClient'
 
 export const commonCodeTS = ({ clientVersion, engineVersion, generator }: TSClientOptions) => {
@@ -87,32 +88,7 @@ export type InputJsonObject = runtime.InputJsonObject
 export type InputJsonArray = runtime.InputJsonArray
 export type InputJsonValue = runtime.InputJsonValue
 
-export const NullTypes = {
-  DbNull: runtime.objectEnumValues.classes.DbNull as (new (secret: never) => typeof runtime.objectEnumValues.instances.DbNull),
-  JsonNull: runtime.objectEnumValues.classes.JsonNull as (new (secret: never) => typeof runtime.objectEnumValues.instances.JsonNull),
-  AnyNull: runtime.objectEnumValues.classes.AnyNull as (new (secret: never) => typeof runtime.objectEnumValues.instances.AnyNull),
-}
-
-/**
- * Helper for filtering JSON entries that have \`null\` on the database (empty on the db)
- *
- * @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-on-a-json-field
- */
-export const DbNull = runtime.objectEnumValues.instances.DbNull
-
-/**
- * Helper for filtering JSON entries that have JSON \`null\` values (not empty on the db)
- *
- * @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-on-a-json-field
- */
-export const JsonNull = runtime.objectEnumValues.instances.JsonNull
-
-/**
- * Helper for filtering JSON entries that are \`Prisma.DbNull\` or \`Prisma.JsonNull\`
- *
- * @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-on-a-json-field
- */
-export const AnyNull = runtime.objectEnumValues.instances.AnyNull
+${nullTypes}
 
 type SelectAndInclude = {
   select: any

--- a/packages/client-generator-ts/src/TSClient/file-generators/PrismaNamespaceBrowserFile.ts
+++ b/packages/client-generator-ts/src/TSClient/file-generators/PrismaNamespaceBrowserFile.ts
@@ -2,6 +2,7 @@ import * as ts from '@prisma/ts-builders'
 
 import { Enum } from '../Enum'
 import { GenerateContext } from '../GenerateContext'
+import { nullTypes } from '../NullTypes'
 
 const jsDocHeader = `/*
  * WARNING: This is an internal file that is subject to change!
@@ -20,9 +21,14 @@ export function createPrismaNamespaceBrowserFile(context: GenerateContext): stri
 
   return `${jsDocHeader}
 ${ts.stringify(ts.moduleImport(`${context.runtimeBase}/index-browser`).asNamespace('runtime'))}
+
 export type * from '${context.importFileName(`../models`)}'
 export type * from '${context.importFileName(`./prismaNamespace`)}'
+
 export const Decimal = runtime.Decimal
+
+${nullTypes}
+
 ${new Enum(
   {
     name: 'ModelName',
@@ -30,9 +36,10 @@ ${new Enum(
   },
   true,
 ).toTS()}
-/**
+/*
  * Enums
  */
+
 ${prismaEnums?.join('\n\n')}
 `
 }


### PR DESCRIPTION
This PR adds the JSON null types to the `browser.ts` entry point of the new generated client using the `prisma-client` generator. 
This was previously causing issues if the users schema contains a model with an optional JSON field:

```prisma
model User {
  id        Int      @id @default(autoincrement())
  field     Json?
}
```

Fixes: https://github.com/prisma/prisma/issues/28097

Note that this change is not perfect though as the singleton instances (`JSONNull`, `DBNull`, `AnyNull`) are different between the imports from `./generated/client` and `./generated/browser`. The underlying instances come from two different exports of the `@prisma/client` package. Hence the types are also distinct although they are named the same!

So something like this will still cause a type check error in user land for now:

```typescript
// PrismaClient imported from `client` entrypoint
import { PrismaClient } from './generated/client'
// Prisma utils incl JSONNull imported from `browser` entrypoint
import { Prisma } from './generated/browser'

const prisma = new PrismaClient({...})

const user = await prisma.user.create({
  data: { field: Prisma.JsonNull },
})
```

Resulting in this a bit cryptic TS error:
```
Type 'JsonNull' is not assignable to type 'NullableJsonNullValueInput | InputJsonValue | undefined'.
  Type 'JsonNull' is not assignable to type 'InputJsonObject'.
    Index signature for type 'string' is missing in type 'JsonNull'.ts(2322)
```

We intend to fix this with an additional change that centralizes those shared utility types in a single export of the `@prisma/client` package so all paths lead to the same underlying instances.