### PR TITLE
test: test for relation join crash

### DIFF
--- a/packages/client/tests/functional/issues/28213-relation-join-batch-crash/_matrix.ts
+++ b/packages/client/tests/functional/issues/28213-relation-join-batch-crash/_matrix.ts
@@ -1,0 +1,4 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+import { allProviders } from '../../_utils/providers'
+
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/issues/28213-relation-join-batch-crash/_matrix.ts
+++ b/packages/client/tests/functional/issues/28213-relation-join-batch-crash/_matrix.ts
@@ -1,4 +1,6 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
-import { allProviders } from '../../_utils/providers'
+import { Providers } from '../../_utils/providers'
 
-export default defineMatrix(() => [allProviders])
+export default defineMatrix(() => [
+  [{ provider: Providers.POSTGRESQL }, { provider: Providers.COCKROACHDB }, { provider: Providers.MYSQL }],
+])

--- a/packages/client/tests/functional/issues/28213-relation-join-batch-crash/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/28213-relation-join-batch-crash/prisma/_schema.ts
@@ -1,0 +1,19 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+
+  datasource db {
+    provider = "${provider}"
+    url      = env("DATABASE_URI_${provider}")
+  }
+
+  model User {
+    id    ${idForProvider(provider)}
+  }
+  `
+})

--- a/packages/client/tests/functional/issues/28213-relation-join-batch-crash/tests.ts
+++ b/packages/client/tests/functional/issues/28213-relation-join-batch-crash/tests.ts
@@ -19,5 +19,9 @@ testMatrix.setupTestSuite(
     skip: (skip, conf) => {
       skip(!conf.previewFeatures?.includes('relationJoins'), 'this test is only for relation joins')
     },
+    optOut: {
+      from: ['mongodb', 'sqlite', 'sqlserver'],
+      reason: 'this test is only for relationJoins capable databases',
+    },
   },
 )

--- a/packages/client/tests/functional/issues/28213-relation-join-batch-crash/tests.ts
+++ b/packages/client/tests/functional/issues/28213-relation-join-batch-crash/tests.ts
@@ -1,0 +1,23 @@
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(
+  () => {
+    test('should not crash when submitting a batch with relationLoadStrategy join', async () => {
+      await expect(
+        Promise.all([
+          prisma.user.findUnique({ where: { id: '1' }, relationLoadStrategy: 'join' }),
+          prisma.user.findUnique({ where: { id: '2' }, relationLoadStrategy: 'join' }),
+        ]),
+      ).resolves.toEqual([null, null])
+    })
+  },
+  {
+    skip: (skip, conf) => {
+      skip(!conf.previewFeatures?.includes('relationJoins'), 'this test is only for relation joins')
+    },
+  },
+)


### PR DESCRIPTION
Adds a test for fix added in https://github.com/prisma/prisma-engines/pull/5630

[TML-1489](https://linear.app/prisma-company/issue/TML-1489/fix-crashing-relationjoins-batches)

/engine-branch fix/fix-relation-join-batch-crash