### PR TITLE
fix: do not apply default timeouts to internal transactions

### DIFF
--- a/packages/client-engine-runtime/src/interpreter/query-interpreter.ts
+++ b/packages/client-engine-runtime/src/interpreter/query-interpreter.ts
@@ -245,7 +245,7 @@ export class QueryInterpreter {
         }
 
         const transactionManager = this.#transactionManager.manager
-        const transactionInfo = await transactionManager.startTransaction()
+        const transactionInfo = await transactionManager.startInternalTransaction()
         const transaction = await transactionManager.getTransaction(transactionInfo, 'query')
         try {
           const value = await this.interpretNode(node.args, transaction, scope, generators)


### PR DESCRIPTION
[TML-1474](https://linear.app/prisma-company/issue/TML-1474/interactive-transaction-timeouts-are-applied-to-internally-started)

