### PR TITLE
feat(adapter-mssql): support multiSubnetFailover flag in connection string

### DIFF
--- a/packages/adapter-mssql/src/connection-string.test.ts
+++ b/packages/adapter-mssql/src/connection-string.test.ts
@@ -100,16 +100,12 @@ describe('parseConnectionString', () => {
     })
   })
 
-  it('should parse multiSubnetFailover parameter correctly', () => {
-    const testCases = [
-      { input: 'sqlserver://localhost;database=testdb;multiSubnetFailover=true', expected: true },
-      { input: 'sqlserver://localhost;database=testdb;multiSubnetFailover=false', expected: false },
-    ]
-
-    testCases.forEach(({ input, expected }) => {
-      const config = parseConnectionString(input)
-      expect(config.options?.multiSubnetFailover).toBe(expected)
-    })
+  it.each([
+    { input: 'sqlserver://localhost;database=testdb;multiSubnetFailover=true', expected: true },
+    { input: 'sqlserver://localhost;database=testdb;multiSubnetFailover=false', expected: false },
+  ])('should parse multiSubnetFailover parameter correctly for %o', ({ input, expected }) => {
+    const config = parseConnectionString(input)
+    expect(config.options?.multiSubnetFailover).toBe(expected)
   })
 
   describe('connection pool parameters', () => {

--- a/packages/adapter-mssql/src/connection-string.test.ts
+++ b/packages/adapter-mssql/src/connection-string.test.ts
@@ -100,6 +100,18 @@ describe('parseConnectionString', () => {
     })
   })
 
+  it('should parse multiSubnetFailover parameter correctly', () => {
+    const testCases = [
+      { input: 'sqlserver://localhost;database=testdb;multiSubnetFailover=true', expected: true },
+      { input: 'sqlserver://localhost;database=testdb;multiSubnetFailover=false', expected: false },
+    ]
+
+    testCases.forEach(({ input, expected }) => {
+      const config = parseConnectionString(input)
+      expect(config.options?.multiSubnetFailover).toBe(expected)
+    })
+  })
+
   describe('connection pool parameters', () => {
     it('should parse connectionLimit parameter correctly', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;connectionLimit=10'

--- a/packages/adapter-mssql/src/connection-string.ts
+++ b/packages/adapter-mssql/src/connection-string.ts
@@ -118,6 +118,12 @@ export function parseConnectionString(connectionString: string): sql.config {
     config.options.trustServerCertificate = trustServerCertificate.toLowerCase() === 'true'
   }
 
+  const multiSubnetFailover = firstKey(parameters, 'multiSubnetFailover')
+  if (multiSubnetFailover !== null) {
+    config.options = config.options || {}
+    config.options.multiSubnetFailover = multiSubnetFailover.toLowerCase() === 'true'
+  }
+
   const connectionLimit = firstKey(parameters, 'connectionLimit')
   if (connectionLimit !== null) {
     config.pool = config.pool || {}
@@ -293,6 +299,7 @@ const handledParameters = [
   'initial catalog',
   'isolationLevel',
   'loginTimeout',
+  'multiSubnetFailover',
   'password',
   'poolTimeout',
   'pwd',


### PR DESCRIPTION
MultiSubnetFailover is a SQL Server connection property that enables faster failovers for Always On Availability Groups and Failover Cluster Instances, whether across single or multiple subnets. When enabled, clients connecting to a SQL Server listener will attempt to connect to all its IP addresses simultaneously, choosing the first one that responds, which significantly reduces reconnection time after a failover event. 

The Tedious package [supports it as an option](https://github.com/tediousjs/tedious/blob/ebb023ed90969a7ec0e4b036533ad52739d921f7/src/connection.ts#L756), however to use it from a connection string it needs to be extracted.

Ref https://github.com/prisma/prisma/issues/9187