### PR TITLE
feat(qpe): expose package version as an export

### DIFF
--- a/packages/query-plan-executor/src/index.ts
+++ b/packages/query-plan-executor/src/index.ts
@@ -1,3 +1,4 @@
+export { version } from '../package.json'
 export { parseDuration } from './formats/duration'
 export { parseInteger } from './formats/numeric'
 export { parseSize } from './formats/size'


### PR DESCRIPTION
Export the package version as a named export from
`@prisma/query-plan-executor`. This is necessary for the `Prisma-Engine-Hash` header validation to work in `prisma dev`.

Part of https://linear.app/prisma-company/issue/TML-1317/add-qc-support-in-local-ppg-with-accelerate-api