### PR TITLE
chore: bump minimum Node version to 20.19

### DIFF
--- a/.github/workflows/auto-close-github-discussions.yml
+++ b/.github/workflows/auto-close-github-discussions.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '20.19.0'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install & build
         uses: ./.github/actions/setup
         with:
-          node-version: 20
+          node-version: '20.19.0'
           skip-tsc: false
 
       - name: Run benchmarks

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install & build
         uses: ./.github/actions/setup
         with:
-          node-version: 18
+          node-version: 20
           skip-tsc: true
           skip-build: true
 

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install & build
         uses: ./.github/actions/setup
         with:
-          node-version: 20
+          node-version: '20.19.0'
           skip-tsc: true
           skip-build: true
 

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Install & build
         uses: ./.github/actions/setup
         with:
-          node-version: 20
+          node-version: '20.19.0'
           skip-tsc: false
 
       - name: Publish all packages to npm

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Install & build
         uses: ./.github/actions/setup
         with:
-          node-version: 18
+          node-version: 20
           skip-tsc: false
 
       - name: Publish all packages to npm

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -55,7 +55,7 @@ jobs:
 
       - uses: ./.github/actions/setup
         with:
-          node-version: 18
+          node-version: '20.19.0'
           skip-tsc: false
 
       - name: Publish all packages to npm

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Install & build
         uses: ./.github/actions/setup
         with:
-          node-version: 20
+          node-version: '20.19.0'
           engine-hash: ${{ inputs.engineHash }}
           skip-tsc: false
 

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -112,7 +112,7 @@ jobs:
       matrix:
         shard: ['1/5', '2/5', '3/5', '4/5', '5/5']
         queryEngine: ${{ fromJson(inputs.queryEngine) }}
-        node: [20, 22, 24]
+        node: ['20.19.0', '22.12.0', '24.0.0']
         previewFeatures: ['', 'relationJoins']
     env:
       NODE_OPTIONS: '--max-old-space-size=8096'
@@ -184,7 +184,7 @@ jobs:
       fail-fast: false
       matrix:
         shard: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
-        node: [20, 22, 24]
+        node: ['20.19.0', '22.12.0', '24.0.0']
     steps:
       - uses: actions/checkout@v4
 
@@ -257,7 +257,7 @@ jobs:
             'js_pg_cockroachdb',
           ]
         shard: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
-        node: [20]
+        node: ['20.19.0']
         previewFeatures: ['', 'relationJoins']
     steps:
       - uses: actions/checkout@v4
@@ -314,7 +314,7 @@ jobs:
         provider: ['postgresql'] # TODO: test on all providers once it becomes stable
         clientRuntime: ['node'] # TODO: test on wasm
         shard: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
-        node: [20] # TODO: test on all node versions once it becomes stable
+        node: ['20.19.0'] # TODO: test on all node versions once it becomes stable
     steps:
       - uses: actions/checkout@v4
 
@@ -379,7 +379,7 @@ jobs:
             'js_pg_cockroachdb',
           ]
         shard: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
-        node: [20]
+        node: ['20.19.0']
     steps:
       - uses: actions/checkout@v4
 
@@ -434,7 +434,7 @@ jobs:
       matrix:
         provider: ['postgresql', 'mysql']
         shard: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
-        node: [20]
+        node: ['20.19.0']
     steps:
       - uses: actions/checkout@v4
 
@@ -489,7 +489,7 @@ jobs:
       fail-fast: false
       matrix:
         queryEngine: ['library'] # TODO: binary engine is leaking at the moment
-        node: [20, 22, 24]
+        node: ['20.19.0', '22.12.0', '24.0.0']
     steps:
       - uses: actions/checkout@v4
 
@@ -586,7 +586,7 @@ jobs:
         # The Node.js version here is only used for the GitHub Actions job
         # The version used by the tests is actually defined in
         # ./packages/client/tests/e2e/_utils/standard.dockerfile
-        node: [20]
+        node: ['20.19.0']
     steps:
       - uses: actions/checkout@v4
 
@@ -627,7 +627,7 @@ jobs:
       matrix:
         relationMode: ['', 'foreignKeys', 'prisma']
         os: [ubuntu-latest]
-        node: [20]
+        node: ['20.19.0']
     env:
       NODE_OPTIONS: '--max-old-space-size=8096'
       JEST_JUNIT_SUITE_NAME: 'client/functional'
@@ -701,7 +701,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20]
+        node: ['20.19.0']
     steps:
       - uses: actions/checkout@v4
 
@@ -729,7 +729,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 24]
+        node: ['20.19.0', '22.12.0', '24.0.0']
     steps:
       - uses: actions/checkout@v4
 
@@ -774,7 +774,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20]
+        node: ['20.19.0']
     steps:
       - uses: actions/checkout@v4
 
@@ -801,7 +801,7 @@ jobs:
       fail-fast: false
       matrix:
         queryEngine: ${{ fromJson(inputs.queryEngine) }}
-        node: [20]
+        node: ['20.19.0']
     steps:
       - uses: actions/checkout@v4
 
@@ -846,7 +846,7 @@ jobs:
       matrix:
         queryEngine: ${{ fromJson(inputs.queryEngine) }}
         os: [ubuntu-latest]
-        node: [20, 22, 24]
+        node: ['20.19.0', '22.12.0', '24.0.0']
     steps:
       - uses: actions/checkout@v4
 
@@ -891,7 +891,7 @@ jobs:
       matrix:
         queryEngine: ${{ fromJson(inputs.queryEngine) }}
         os: [ubuntu-latest]
-        node: [20, 22, 24]
+        node: ['20.19.0', '22.12.0', '24.0.0']
         # driverAdapter: ['', 'libsql'] # TODO: once we have all tests pass with driver adapters actually enable them on CI and add further adapters
         driverAdapter: ['']
     steps:
@@ -940,7 +940,7 @@ jobs:
       matrix:
         queryEngine: ${{ fromJson(inputs.queryEngine) }}
         os: [ubuntu-latest]
-        node: [20, 22, 24]
+        node: ['20.19.0', '22.12.0', '24.0.0']
     steps:
       - uses: actions/checkout@v4
 
@@ -984,7 +984,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [20, 22, 24]
+        node: ['20.19.0', '22.12.0', '24.0.0']
         include:
           - os: windows-latest
             version: 18
@@ -1015,7 +1015,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [20, 22, 24]
+        node: ['20.19.0', '22.12.0', '24.0.0']
     steps:
       - uses: actions/checkout@v4
 
@@ -1082,7 +1082,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [20, 24]
+        node: ['20.19.0', '24.0.0']
     steps:
       - uses: actions/checkout@v4
 
@@ -1129,7 +1129,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [24]
+        node: ['24.0.0']
     steps:
       - uses: actions/checkout@v4
 
@@ -1188,7 +1188,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-14, windows-latest]
-        node: [20]
+        node: ['20.19.0']
         queryEngine: ${{ fromJson(inputs.queryEngine) }}
         shard: ['1/2', '2/2']
     if: |
@@ -1258,7 +1258,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-14, windows-latest]
-        node: [20]
+        node: ['20.19.0']
         queryEngine: ${{ fromJson(inputs.queryEngine) }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -112,7 +112,7 @@ jobs:
       matrix:
         shard: ['1/5', '2/5', '3/5', '4/5', '5/5']
         queryEngine: ${{ fromJson(inputs.queryEngine) }}
-        node: ['20.19.0', '22.12.0', '24.0.0']
+        node: ['20.19.0', '22.12.0', '24.0.1']
         previewFeatures: ['', 'relationJoins']
     env:
       NODE_OPTIONS: '--max-old-space-size=8096'
@@ -184,7 +184,7 @@ jobs:
       fail-fast: false
       matrix:
         shard: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
-        node: ['20.19.0', '22.12.0', '24.0.0']
+        node: ['20.19.0', '22.12.0', '24.0.1']
     steps:
       - uses: actions/checkout@v4
 
@@ -489,7 +489,7 @@ jobs:
       fail-fast: false
       matrix:
         queryEngine: ['library'] # TODO: binary engine is leaking at the moment
-        node: ['20.19.0', '22.12.0', '24.0.0']
+        node: ['20.19.0', '22.12.0', '24.0.1']
     steps:
       - uses: actions/checkout@v4
 
@@ -729,7 +729,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['20.19.0', '22.12.0', '24.0.0']
+        node: ['20.19.0', '22.12.0', '24.0.1']
     steps:
       - uses: actions/checkout@v4
 
@@ -846,7 +846,7 @@ jobs:
       matrix:
         queryEngine: ${{ fromJson(inputs.queryEngine) }}
         os: [ubuntu-latest]
-        node: ['20.19.0', '22.12.0', '24.0.0']
+        node: ['20.19.0', '22.12.0', '24.0.1']
     steps:
       - uses: actions/checkout@v4
 
@@ -891,7 +891,7 @@ jobs:
       matrix:
         queryEngine: ${{ fromJson(inputs.queryEngine) }}
         os: [ubuntu-latest]
-        node: ['20.19.0', '22.12.0', '24.0.0']
+        node: ['20.19.0', '22.12.0', '24.0.1']
         # driverAdapter: ['', 'libsql'] # TODO: once we have all tests pass with driver adapters actually enable them on CI and add further adapters
         driverAdapter: ['']
     steps:
@@ -940,7 +940,7 @@ jobs:
       matrix:
         queryEngine: ${{ fromJson(inputs.queryEngine) }}
         os: [ubuntu-latest]
-        node: ['20.19.0', '22.12.0', '24.0.0']
+        node: ['20.19.0', '22.12.0', '24.0.1']
     steps:
       - uses: actions/checkout@v4
 
@@ -984,7 +984,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: ['20.19.0', '22.12.0', '24.0.0']
+        node: ['20.19.0', '22.12.0', '24.0.1']
         include:
           - os: windows-latest
             version: 18
@@ -1015,7 +1015,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: ['20.19.0', '22.12.0', '24.0.0']
+        node: ['20.19.0', '22.12.0', '24.0.1']
     steps:
       - uses: actions/checkout@v4
 
@@ -1082,7 +1082,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: ['20.19.0', '24.0.0']
+        node: ['20.19.0', '24.0.1']
     steps:
       - uses: actions/checkout@v4
 
@@ -1129,7 +1129,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: ['24.0.0']
+        node: ['24.0.1']
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -112,7 +112,7 @@ jobs:
       matrix:
         shard: ['1/5', '2/5', '3/5', '4/5', '5/5']
         queryEngine: ${{ fromJson(inputs.queryEngine) }}
-        node: ['20.19.0', '22.12.0', '24.0.1']
+        node: ['20.19.0', '22.12.0', '24']
         previewFeatures: ['', 'relationJoins']
     env:
       NODE_OPTIONS: '--max-old-space-size=8096'
@@ -184,7 +184,7 @@ jobs:
       fail-fast: false
       matrix:
         shard: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
-        node: ['20.19.0', '22.12.0', '24.0.1']
+        node: ['20.19.0', '22.12.0', '24']
     steps:
       - uses: actions/checkout@v4
 
@@ -489,7 +489,7 @@ jobs:
       fail-fast: false
       matrix:
         queryEngine: ['library'] # TODO: binary engine is leaking at the moment
-        node: ['20.19.0', '22.12.0', '24.0.1']
+        node: ['20.19.0', '22.12.0', '24']
     steps:
       - uses: actions/checkout@v4
 
@@ -729,7 +729,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['20.19.0', '22.12.0', '24.0.1']
+        node: ['20.19.0', '22.12.0', '24']
     steps:
       - uses: actions/checkout@v4
 
@@ -846,7 +846,7 @@ jobs:
       matrix:
         queryEngine: ${{ fromJson(inputs.queryEngine) }}
         os: [ubuntu-latest]
-        node: ['20.19.0', '22.12.0', '24.0.1']
+        node: ['20.19.0', '22.12.0', '24']
     steps:
       - uses: actions/checkout@v4
 
@@ -891,7 +891,7 @@ jobs:
       matrix:
         queryEngine: ${{ fromJson(inputs.queryEngine) }}
         os: [ubuntu-latest]
-        node: ['20.19.0', '22.12.0', '24.0.1']
+        node: ['20.19.0', '22.12.0', '24']
         # driverAdapter: ['', 'libsql'] # TODO: once we have all tests pass with driver adapters actually enable them on CI and add further adapters
         driverAdapter: ['']
     steps:
@@ -940,7 +940,7 @@ jobs:
       matrix:
         queryEngine: ${{ fromJson(inputs.queryEngine) }}
         os: [ubuntu-latest]
-        node: ['20.19.0', '22.12.0', '24.0.1']
+        node: ['20.19.0', '22.12.0', '24']
     steps:
       - uses: actions/checkout@v4
 
@@ -984,7 +984,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: ['20.19.0', '22.12.0', '24.0.1']
+        node: ['20.19.0', '22.12.0', '24']
         include:
           - os: windows-latest
             version: 18
@@ -1015,7 +1015,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: ['20.19.0', '22.12.0', '24.0.1']
+        node: ['20.19.0', '22.12.0', '24']
     steps:
       - uses: actions/checkout@v4
 
@@ -1082,7 +1082,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: ['20.19.0', '24.0.1']
+        node: ['20.19.0', '24']
     steps:
       - uses: actions/checkout@v4
 
@@ -1129,7 +1129,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: ['24.0.1']
+        node: ['24']
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -112,7 +112,7 @@ jobs:
       matrix:
         shard: ['1/5', '2/5', '3/5', '4/5', '5/5']
         queryEngine: ${{ fromJson(inputs.queryEngine) }}
-        node: [18, 20, 22, 24]
+        node: [20, 22, 24]
         previewFeatures: ['', 'relationJoins']
     env:
       NODE_OPTIONS: '--max-old-space-size=8096'
@@ -184,7 +184,7 @@ jobs:
       fail-fast: false
       matrix:
         shard: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
-        node: [18, 20, 22, 24]
+        node: [20, 22, 24]
     steps:
       - uses: actions/checkout@v4
 
@@ -314,7 +314,7 @@ jobs:
         provider: ['postgresql'] # TODO: test on all providers once it becomes stable
         clientRuntime: ['node'] # TODO: test on wasm
         shard: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
-        node: [18] # TODO: test on all node versions once it becomes stable
+        node: [20] # TODO: test on all node versions once it becomes stable
     steps:
       - uses: actions/checkout@v4
 
@@ -489,7 +489,7 @@ jobs:
       fail-fast: false
       matrix:
         queryEngine: ['library'] # TODO: binary engine is leaking at the moment
-        node: [18, 20, 22, 24]
+        node: [20, 22, 24]
     steps:
       - uses: actions/checkout@v4
 
@@ -627,7 +627,7 @@ jobs:
       matrix:
         relationMode: ['', 'foreignKeys', 'prisma']
         os: [ubuntu-latest]
-        node: [18]
+        node: [20]
     env:
       NODE_OPTIONS: '--max-old-space-size=8096'
       JEST_JUNIT_SUITE_NAME: 'client/functional'
@@ -701,7 +701,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18]
+        node: [20]
     steps:
       - uses: actions/checkout@v4
 
@@ -729,7 +729,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20, 22, 24]
+        node: [20, 22, 24]
     steps:
       - uses: actions/checkout@v4
 
@@ -774,7 +774,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18]
+        node: [20]
     steps:
       - uses: actions/checkout@v4
 
@@ -801,7 +801,7 @@ jobs:
       fail-fast: false
       matrix:
         queryEngine: ${{ fromJson(inputs.queryEngine) }}
-        node: [18]
+        node: [20]
     steps:
       - uses: actions/checkout@v4
 
@@ -846,7 +846,7 @@ jobs:
       matrix:
         queryEngine: ${{ fromJson(inputs.queryEngine) }}
         os: [ubuntu-latest]
-        node: [18, 20, 22, 24]
+        node: [20, 22, 24]
     steps:
       - uses: actions/checkout@v4
 
@@ -891,7 +891,7 @@ jobs:
       matrix:
         queryEngine: ${{ fromJson(inputs.queryEngine) }}
         os: [ubuntu-latest]
-        node: [18, 20, 22, 24]
+        node: [20, 22, 24]
         # driverAdapter: ['', 'libsql'] # TODO: once we have all tests pass with driver adapters actually enable them on CI and add further adapters
         driverAdapter: ['']
     steps:
@@ -940,7 +940,7 @@ jobs:
       matrix:
         queryEngine: ${{ fromJson(inputs.queryEngine) }}
         os: [ubuntu-latest]
-        node: [18, 20, 22, 24]
+        node: [20, 22, 24]
     steps:
       - uses: actions/checkout@v4
 
@@ -984,7 +984,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [18, 20, 22, 24]
+        node: [20, 22, 24]
         include:
           - os: windows-latest
             version: 18
@@ -1015,7 +1015,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [18, 20, 22, 24]
+        node: [20, 22, 24]
     steps:
       - uses: actions/checkout@v4
 
@@ -1082,7 +1082,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [18, 24]
+        node: [20, 24]
     steps:
       - uses: actions/checkout@v4
 
@@ -1188,7 +1188,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-14, windows-latest]
-        node: [18]
+        node: [20]
         queryEngine: ${{ fromJson(inputs.queryEngine) }}
         shard: ['1/2', '2/2']
     if: |
@@ -1258,7 +1258,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-14, windows-latest]
-        node: [18]
+        node: [20]
         queryEngine: ${{ fromJson(inputs.queryEngine) }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/update-engines-version.yml
+++ b/.github/workflows/update-engines-version.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           cache: 'pnpm'
-          node-version: '20'
+          node-version: '20.19.0'
 
       # This step uses `@prisma/ensure-npm-release` (abbv. `enr`) https://github.com/prisma/ensure-npm-release
       - name: Check if version of @prisma/engines-version is available on npm

--- a/.github/workflows/update-engines-version.yml
+++ b/.github/workflows/update-engines-version.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           cache: 'pnpm'
-          node-version: '18'
+          node-version: '20'
 
       # This step uses `@prisma/ensure-npm-release` (abbv. `enr`) https://github.com/prisma/ensure-npm-release
       - name: Check if version of @prisma/engines-version is available on npm

--- a/.github/workflows/update-studio-version.yml
+++ b/.github/workflows/update-studio-version.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           cache: 'pnpm'
-          node-version: '20'
+          node-version: '20.19.0'
 
       # This step uses `@prisma/ensure-npm-release` (abbv. `enr`) https://github.com/prisma/ensure-npm-release
       - name: Check if version is available on npm

--- a/.github/workflows/update-studio-version.yml
+++ b/.github/workflows/update-studio-version.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           cache: 'pnpm'
-          node-version: '18'
+          node-version: '20'
 
       # This step uses `@prisma/ensure-npm-release` (abbv. `enr`) https://github.com/prisma/ensure-npm-release
       - name: Check if version is available on npm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ To help maintainers triage efficiently:
 
 ## General Prerequisites
 
-1. Install Node.js `>=18.18` minimum, [latest LTS is recommended](https://nodejs.org/en/about/releases/)
+1. Install Node.js `>=20.19` minimum, [latest LTS is recommended](https://nodejs.org/en/about/releases/)
    - Recommended: use [`nvm`](https://github.com/nvm-sh/nvm) for managing Node.js versions
 
 1. Install [`pnpm`](https://pnpm.io/) (for installing npm dependencies, using pnpm workspaces)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "triggerEmptyDevReleaseByIncrementingThisNumber": 0,
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20.19",
+    "node": "^20.19 || ^22.12 || ^24.0",
     "pnpm": ">=10.15 <11"
   },
   "packageManager": "pnpm@10.15.1",
@@ -47,7 +47,7 @@
     "@types/fs-extra": "11.0.4",
     "@types/graphviz": "0.0.39",
     "@types/jest": "29.5.14",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/resolve": "1.20.6",
     "@typescript-eslint/eslint-plugin": "7.15.0",
     "@typescript-eslint/parser": "7.15.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "triggerEmptyDevReleaseByIncrementingThisNumber": 0,
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=18.18",
+    "node": ">=20.19",
     "pnpm": ">=10.15 <11"
   },
   "packageManager": "pnpm@10.15.1",
@@ -47,7 +47,7 @@
     "@types/fs-extra": "11.0.4",
     "@types/graphviz": "0.0.39",
     "@types/jest": "29.5.14",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/resolve": "1.20.6",
     "@typescript-eslint/eslint-plugin": "7.15.0",
     "@typescript-eslint/parser": "7.15.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,7 +39,7 @@
   "bugs": "https://github.com/prisma/prisma/issues",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=18.18"
+    "node": ">=20.19"
   },
   "prisma": {
     "prismaCommit": "placeholder-for-commit-hash-replaced-during-publishing-in-publish-ts"
@@ -126,7 +126,7 @@
     "@swc/jest": "0.2.37",
     "@types/fs-extra": "11.0.4",
     "@types/jest": "29.5.14",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "async-listen": "3.1.0",
     "checkpoint-client": "1.1.33",
     "chokidar": "4.0.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,7 +39,7 @@
   "bugs": "https://github.com/prisma/prisma/issues",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20.19"
+    "node": "^20.19 || ^22.12 || ^24.0"
   },
   "prisma": {
     "prismaCommit": "placeholder-for-commit-hash-replaced-during-publishing-in-publish-ts"
@@ -126,7 +126,7 @@
     "@swc/jest": "0.2.37",
     "@types/fs-extra": "11.0.4",
     "@types/jest": "29.5.14",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "async-listen": "3.1.0",
     "checkpoint-client": "1.1.33",
     "chokidar": "4.0.3",

--- a/packages/cli/scripts/preinstall.ts
+++ b/packages/cli/scripts/preinstall.ts
@@ -24,7 +24,7 @@ export function printMessageAndExitIfUnsupportedNodeVersion(nodeVersion: MajorMi
   const [nodeMajorVersion, nodeMinorVersion] = extractSemanticVersionParts(nodeVersion)
 
   // Minimum Node.js version supported by Prisma
-  const MIN_NODE_VERSION = '18.18'
+  const MIN_NODE_VERSION = '20.19'
   const [MIN_NODE_MAJOR_VERSION, MIN_NODE_MINOR_VERSION] = extractSemanticVersionParts(MIN_NODE_VERSION)
 
   if (

--- a/packages/cli/scripts/preinstall.ts
+++ b/packages/cli/scripts/preinstall.ts
@@ -23,17 +23,24 @@ function extractSemanticVersionParts(version: MajorMinor | MajorMinorPatch) {
 export function printMessageAndExitIfUnsupportedNodeVersion(nodeVersion: MajorMinorPatch) {
   const [nodeMajorVersion, nodeMinorVersion] = extractSemanticVersionParts(nodeVersion)
 
-  // Minimum Node.js version supported by Prisma
-  const MIN_NODE_VERSION = '20.19'
-  const [MIN_NODE_MAJOR_VERSION, MIN_NODE_MINOR_VERSION] = extractSemanticVersionParts(MIN_NODE_VERSION)
+  // Minimum Node.js versions supported by Prisma
+  const MIN_NODE_VERSION_MATRIX: Record<string, string> = {
+    '20': '19',
+    '22': '12',
+    '24': '0',
+  }
 
   if (
-    nodeMajorVersion < MIN_NODE_MAJOR_VERSION ||
-    (nodeMajorVersion === MIN_NODE_MAJOR_VERSION && nodeMinorVersion < MIN_NODE_MINOR_VERSION)
+    !(nodeMajorVersion in MIN_NODE_VERSION_MATRIX) ||
+    nodeMinorVersion < parseInt(MIN_NODE_VERSION_MATRIX[nodeMajorVersion], 10)
   ) {
+    const supportedVersions = Object.entries(MIN_NODE_VERSION_MATRIX)
+      .map(([major, minor]) => `${major}.${minor}`)
+      .join(', ')
+
     console.error(
       drawBox({
-        str: `Prisma only supports Node.js >= ${MIN_NODE_VERSION}.\nPlease upgrade your Node.js version.`,
+        str: `Prisma only supports Node.js versions ${supportedVersions}.\nPlease upgrade your Node.js version.`,
         height: 2,
         width: 48,
         horizontalPadding: 4,

--- a/packages/cli/scripts/preinstall.ts
+++ b/packages/cli/scripts/preinstall.ts
@@ -24,16 +24,13 @@ export function printMessageAndExitIfUnsupportedNodeVersion(nodeVersion: MajorMi
   const [nodeMajorVersion, nodeMinorVersion] = extractSemanticVersionParts(nodeVersion)
 
   // Minimum Node.js versions supported by Prisma
-  const MIN_NODE_VERSION_MATRIX: Record<string, string> = {
-    '20': '19',
-    '22': '12',
-    '24': '0',
+  const MIN_NODE_VERSION_MATRIX: Record<string, number> = {
+    '20': 19,
+    '22': 12,
+    '24': 0,
   }
 
-  if (
-    !(nodeMajorVersion in MIN_NODE_VERSION_MATRIX) ||
-    nodeMinorVersion < parseInt(MIN_NODE_VERSION_MATRIX[nodeMajorVersion], 10)
-  ) {
+  if (!(nodeMajorVersion in MIN_NODE_VERSION_MATRIX) || nodeMinorVersion < MIN_NODE_VERSION_MATRIX[nodeMajorVersion]) {
     const supportedVersions = Object.entries(MIN_NODE_VERSION_MATRIX)
       .map(([major, minor]) => `${major}.${minor}`)
       .join(', ')

--- a/packages/cli/src/__tests__/preinstall.test.ts
+++ b/packages/cli/src/__tests__/preinstall.test.ts
@@ -23,7 +23,7 @@ it.each(['16.18.0', '18.20.8', '20.18.3', '22.11.0'] as const)(
   },
 )
 
-it.each(['20.19.5', '22.12.0', '22.20.0', '24.0.0', '24.10.0'] as const)(
+it.each(['20.19.5', '22.12.0', '22.20.0', '24.0.1', '24.10.0'] as const)(
   'should do nothing when Node.js version is supported - %s',
   (version) => {
     printMessageAndExitIfUnsupportedNodeVersion(version)

--- a/packages/cli/src/__tests__/preinstall.test.ts
+++ b/packages/cli/src/__tests__/preinstall.test.ts
@@ -4,52 +4,36 @@ import { printMessageAndExitIfUnsupportedNodeVersion } from '../../scripts/prein
 
 const ctx = jestContext.new().add(jestConsoleContext()).assemble()
 
-it('should exit 1 and print a message when Node.js minor version is lower than minimum - 18.0', () => {
-  const mockExit = jest.spyOn(process, 'exit').mockImplementation()
+it.each(['16.18.0', '18.20.8', '20.18.3', '22.11.0'] as const)(
+  'should exit 1 and print a message when Node.js major version is lower than minimum - %s',
+  (version) => {
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation()
 
-  printMessageAndExitIfUnsupportedNodeVersion('18.0.0')
+    printMessageAndExitIfUnsupportedNodeVersion(version)
 
-  expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`
-    "┌──────────────────────────────────────────────┐
-    │    Prisma only supports Node.js >= 20.19.    │
-    │    Please upgrade your Node.js version.      │
-    └──────────────────────────────────────────────┘"
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    "┌─────────────────────────────────────────────────────────────────┐
+    │    Prisma only supports Node.js versions 20.19, 22.12, 24.0.    │
+    │    Please upgrade your Node.js version.                         │
+    └─────────────────────────────────────────────────────────────────┘"
   `)
 
-  expect(mockExit).toHaveBeenCalledWith(1)
-  mockExit.mockRestore()
-})
+    expect(mockExit).toHaveBeenCalledWith(1)
+    mockExit.mockRestore()
+  },
+)
 
-it('should exit 1 and print a message when Node.js major version is lower than minimum - 16.18', () => {
-  const mockExit = jest.spyOn(process, 'exit').mockImplementation()
+it.each(['20.19.5', '22.12.0', '22.20.0', '24.0.0', '24.10.0'] as const)(
+  'should do nothing when Node.js version is supported - %s',
+  (version) => {
+    printMessageAndExitIfUnsupportedNodeVersion(version)
 
-  printMessageAndExitIfUnsupportedNodeVersion('16.18.0')
-
-  expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`
-    "┌──────────────────────────────────────────────┐
-    │    Prisma only supports Node.js >= 20.19.    │
-    │    Please upgrade your Node.js version.      │
-    └──────────────────────────────────────────────┘"
-  `)
-
-  expect(mockExit).toHaveBeenCalledWith(1)
-  mockExit.mockRestore()
-})
-
-it('should do nothing when Node.js version is supported - 20.19', () => {
-  printMessageAndExitIfUnsupportedNodeVersion('20.19.0')
-
-  expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-})
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+  },
+)
 
 it('should do nothing when Node.js version is supported - current', () => {
   printMessageAndExitIfUnsupportedNodeVersion(process.versions.node as `${number}.${number}.${number}`)
-
-  expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-})
-
-it('should do nothing when Node.js version is supported - 22.12', () => {
-  printMessageAndExitIfUnsupportedNodeVersion('22.12.0')
 
   expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
 })

--- a/packages/cli/src/__tests__/preinstall.test.ts
+++ b/packages/cli/src/__tests__/preinstall.test.ts
@@ -11,7 +11,7 @@ it('should exit 1 and print a message when Node.js minor version is lower than m
 
   expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`
     "┌──────────────────────────────────────────────┐
-    │    Prisma only supports Node.js >= 18.18.    │
+    │    Prisma only supports Node.js >= 20.19.    │
     │    Please upgrade your Node.js version.      │
     └──────────────────────────────────────────────┘"
   `)
@@ -27,7 +27,7 @@ it('should exit 1 and print a message when Node.js major version is lower than m
 
   expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`
     "┌──────────────────────────────────────────────┐
-    │    Prisma only supports Node.js >= 18.18.    │
+    │    Prisma only supports Node.js >= 20.19.    │
     │    Please upgrade your Node.js version.      │
     └──────────────────────────────────────────────┘"
   `)
@@ -36,8 +36,8 @@ it('should exit 1 and print a message when Node.js major version is lower than m
   mockExit.mockRestore()
 })
 
-it('should do nothing when Node.js version is supported - 18.18', () => {
-  printMessageAndExitIfUnsupportedNodeVersion('18.18.0')
+it('should do nothing when Node.js version is supported - 20.19', () => {
+  printMessageAndExitIfUnsupportedNodeVersion('20.19.0')
 
   expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
 })
@@ -48,8 +48,8 @@ it('should do nothing when Node.js version is supported - current', () => {
   expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
 })
 
-it('should do nothing when Node.js version is supported - 20.0', () => {
-  printMessageAndExitIfUnsupportedNodeVersion('20.0.0')
+it('should do nothing when Node.js version is supported - 22.12', () => {
+  printMessageAndExitIfUnsupportedNodeVersion('22.12.0')
 
   expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
 })

--- a/packages/client-engine-runtime/package.json
+++ b/packages/client-engine-runtime/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.14",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "jest": "29.7.0",
     "jest-junit": "16.0.0"
   },

--- a/packages/client-engine-runtime/package.json
+++ b/packages/client-engine-runtime/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.14",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "jest": "29.7.0",
     "jest-junit": "16.0.0"
   },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -164,7 +164,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20.19"
+    "node": "^20.19 || ^22.12 || ^24.0"
   },
   "homepage": "https://www.prisma.io",
   "repository": {
@@ -271,7 +271,7 @@
     "@types/jest": "29.5.14",
     "@types/js-levenshtein": "1.1.3",
     "@types/mssql": "9.1.8",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/pg": "8.11.11",
     "arg": "5.0.2",
     "benchmark": "2.1.4",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -164,7 +164,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=18.18"
+    "node": ">=20.19"
   },
   "homepage": "https://www.prisma.io",
   "repository": {
@@ -271,7 +271,7 @@
     "@types/jest": "29.5.14",
     "@types/js-levenshtein": "1.1.3",
     "@types/mssql": "9.1.8",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/pg": "8.11.11",
     "arg": "5.0.2",
     "benchmark": "2.1.4",

--- a/packages/client/src/runtime/core/engines/library/DefaultLibraryLoader.ts
+++ b/packages/client/src/runtime/core/engines/library/DefaultLibraryLoader.ts
@@ -49,11 +49,9 @@ export function load(libraryPath: string): Library {
     // system OpenSSL on Linux but the dynamic linker resolves the symbols from
     // the Node.js binary instead.
     //
-    // @ts-expect-error TODO: typings don't define dlopen -- needs to be fixed upstream
     flags = os.constants.dlopen.RTLD_LAZY | os.constants.dlopen.RTLD_DEEPBIND
   }
 
-  // @ts-expect-error TODO: typings don't define dlopen -- needs to be fixed upstream
   process.dlopen(libraryModule, fullLibraryPath, flags)
 
   cache[libraryPath] = libraryModule.exports

--- a/packages/client/tests/e2e/_utils/standard.dockerfile
+++ b/packages/client/tests/e2e/_utils/standard.dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:20
 
 RUN npm -v
 

--- a/packages/client/tests/e2e/accelerate-types/package.json
+++ b/packages/client/tests/e2e/accelerate-types/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "expect-type": "0.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.4.5"

--- a/packages/client/tests/e2e/accelerate-types/package.json
+++ b/packages/client/tests/e2e/accelerate-types/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "expect-type": "0.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.4.5"

--- a/packages/client/tests/e2e/adapter-d1-itx-error/package.json
+++ b/packages/client/tests/e2e/adapter-d1-itx-error/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/adapter-d1-itx-error/package.json
+++ b/packages/client/tests/e2e/adapter-d1-itx-error/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/browser-bundle/package.json
+++ b/packages/client/tests/e2e/browser-bundle/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "vitest": "3.2.4"
   }

--- a/packages/client/tests/e2e/browser-bundle/package.json
+++ b/packages/client/tests/e2e/browser-bundle/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "vitest": "3.2.4"
   }

--- a/packages/client/tests/e2e/browser-enum/package.json
+++ b/packages/client/tests/e2e/browser-enum/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/browser-enum/package.json
+++ b/packages/client/tests/e2e/browser-enum/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/browser-unsupported-errors/package.json
+++ b/packages/client/tests/e2e/browser-unsupported-errors/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/browser-unsupported-errors/package.json
+++ b/packages/client/tests/e2e/browser-unsupported-errors/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/bundler-detection-error/package.json
+++ b/packages/client/tests/e2e/bundler-detection-error/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/bundler-detection-error/package.json
+++ b/packages/client/tests/e2e/bundler-detection-error/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/client-entrypoint/package.json
+++ b/packages/client/tests/e2e/client-entrypoint/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/client-entrypoint/package.json
+++ b/packages/client/tests/e2e/client-entrypoint/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/connection-limit-reached/package.json
+++ b/packages/client/tests/e2e/connection-limit-reached/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/connection-limit-reached/package.json
+++ b/packages/client/tests/e2e/connection-limit-reached/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/default-version/package.json
+++ b/packages/client/tests/e2e/default-version/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "typescript": "5.4.5"
   },
   "pnpm": {

--- a/packages/client/tests/e2e/default-version/package.json
+++ b/packages/client/tests/e2e/default-version/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50",
+    "@types/node": "20.19.0",
     "typescript": "5.4.5"
   },
   "pnpm": {

--- a/packages/client/tests/e2e/driver-adapters-accelerate/package.json
+++ b/packages/client/tests/e2e/driver-adapters-accelerate/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/driver-adapters-accelerate/package.json
+++ b/packages/client/tests/e2e/driver-adapters-accelerate/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/driver-adapters-custom-db-schema/adapter-neon/package.json
+++ b/packages/client/tests/e2e/driver-adapters-custom-db-schema/adapter-neon/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "pnpm": {

--- a/packages/client/tests/e2e/driver-adapters-custom-db-schema/adapter-neon/package.json
+++ b/packages/client/tests/e2e/driver-adapters-custom-db-schema/adapter-neon/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "pnpm": {

--- a/packages/client/tests/e2e/driver-adapters-custom-db-schema/adapter-pg/package.json
+++ b/packages/client/tests/e2e/driver-adapters-custom-db-schema/adapter-pg/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/pg": "^8.11.6",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }

--- a/packages/client/tests/e2e/driver-adapters-custom-db-schema/adapter-pg/package.json
+++ b/packages/client/tests/e2e/driver-adapters-custom-db-schema/adapter-pg/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/pg": "^8.11.6",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }

--- a/packages/client/tests/e2e/engine-not-found-error/binary-targets-incorrectly-pinned/package.json
+++ b/packages/client/tests/e2e/engine-not-found-error/binary-targets-incorrectly-pinned/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/engine-not-found-error/binary-targets-incorrectly-pinned/package.json
+++ b/packages/client/tests/e2e/engine-not-found-error/binary-targets-incorrectly-pinned/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/engine-not-found-error/bundler-tampered-with-engine-copy/package.json
+++ b/packages/client/tests/e2e/engine-not-found-error/bundler-tampered-with-engine-copy/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/engine-not-found-error/bundler-tampered-with-engine-copy/package.json
+++ b/packages/client/tests/e2e/engine-not-found-error/bundler-tampered-with-engine-copy/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/engine-not-found-error/native-generated-different-platform/package.json
+++ b/packages/client/tests/e2e/engine-not-found-error/native-generated-different-platform/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/engine-not-found-error/native-generated-different-platform/package.json
+++ b/packages/client/tests/e2e/engine-not-found-error/native-generated-different-platform/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/engine-not-found-error/tooling-tampered-with-engine-copy/package.json
+++ b/packages/client/tests/e2e/engine-not-found-error/tooling-tampered-with-engine-copy/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/engine-not-found-error/tooling-tampered-with-engine-copy/package.json
+++ b/packages/client/tests/e2e/engine-not-found-error/tooling-tampered-with-engine-copy/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/enum-import-in-edge/package.json
+++ b/packages/client/tests/e2e/enum-import-in-edge/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/enum-import-in-edge/package.json
+++ b/packages/client/tests/e2e/enum-import-in-edge/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/enum-import-unused/package.json
+++ b/packages/client/tests/e2e/enum-import-unused/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.6.3"
   }

--- a/packages/client/tests/e2e/enum-import-unused/package.json
+++ b/packages/client/tests/e2e/enum-import-unused/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.6.3"
   }

--- a/packages/client/tests/e2e/env-var-security/package.json
+++ b/packages/client/tests/e2e/env-var-security/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.6.3"
   }

--- a/packages/client/tests/e2e/env-var-security/package.json
+++ b/packages/client/tests/e2e/env-var-security/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.6.3"
   }

--- a/packages/client/tests/e2e/example/package.json
+++ b/packages/client/tests/e2e/example/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/example/package.json
+++ b/packages/client/tests/e2e/example/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/external-tables/package.json
+++ b/packages/client/tests/e2e/external-tables/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@prisma/config": "/tmp/prisma-config-0.0.0.tgz",
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.7.3"
   }

--- a/packages/client/tests/e2e/external-tables/package.json
+++ b/packages/client/tests/e2e/external-tables/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@prisma/config": "/tmp/prisma-config-0.0.0.tgz",
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.7.3"
   }

--- a/packages/client/tests/e2e/generator-config-types/package.json
+++ b/packages/client/tests/e2e/generator-config-types/package.json
@@ -7,7 +7,7 @@
     "@prisma/generator-helper": "/tmp/prisma-generator-helper-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "expect-type": "0.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }

--- a/packages/client/tests/e2e/generator-config-types/package.json
+++ b/packages/client/tests/e2e/generator-config-types/package.json
@@ -7,7 +7,7 @@
     "@prisma/generator-helper": "/tmp/prisma-generator-helper-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "expect-type": "0.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }

--- a/packages/client/tests/e2e/invalid-package-version/package.json
+++ b/packages/client/tests/e2e/invalid-package-version/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/invalid-package-version/package.json
+++ b/packages/client/tests/e2e/invalid-package-version/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/issues/16418-slow-compilation-big-schema/package.json
+++ b/packages/client/tests/e2e/issues/16418-slow-compilation-big-schema/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "vitest": "3.2.4"
   }

--- a/packages/client/tests/e2e/issues/16418-slow-compilation-big-schema/package.json
+++ b/packages/client/tests/e2e/issues/16418-slow-compilation-big-schema/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "vitest": "3.2.4"
   }

--- a/packages/client/tests/e2e/issues/16600-tsc-crash-extensions/package.json
+++ b/packages/client/tests/e2e/issues/16600-tsc-crash-extensions/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/issues/16600-tsc-crash-extensions/package.json
+++ b/packages/client/tests/e2e/issues/16600-tsc-crash-extensions/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/issues/17303-interactive-transaction-errors/package.json
+++ b/packages/client/tests/e2e/issues/17303-interactive-transaction-errors/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "expect-type": "0.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.4.5"

--- a/packages/client/tests/e2e/issues/17303-interactive-transaction-errors/package.json
+++ b/packages/client/tests/e2e/issues/17303-interactive-transaction-errors/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "expect-type": "0.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.4.5"

--- a/packages/client/tests/e2e/issues/19866-ts-composite-declaration/package.json
+++ b/packages/client/tests/e2e/issues/19866-ts-composite-declaration/package.json
@@ -8,7 +8,7 @@
     "typescript": "5.4.5"
   },
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/issues/19866-ts-composite-declaration/package.json
+++ b/packages/client/tests/e2e/issues/19866-ts-composite-declaration/package.json
@@ -8,7 +8,7 @@
     "typescript": "5.4.5"
   },
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/issues/19999-tsc-extensions-oom/package.json
+++ b/packages/client/tests/e2e/issues/19999-tsc-extensions-oom/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.4.5"
   }

--- a/packages/client/tests/e2e/issues/19999-tsc-extensions-oom/package.json
+++ b/packages/client/tests/e2e/issues/19999-tsc-extensions-oom/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.4.5"
   }

--- a/packages/client/tests/e2e/issues/24634-env-loading/package.json
+++ b/packages/client/tests/e2e/issues/24634-env-loading/package.json
@@ -8,7 +8,7 @@
     "typescript": "5.4.5"
   },
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/issues/24634-env-loading/package.json
+++ b/packages/client/tests/e2e/issues/24634-env-loading/package.json
@@ -8,7 +8,7 @@
     "typescript": "5.4.5"
   },
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/issues/27128-generate-watch/package.json
+++ b/packages/client/tests/e2e/issues/27128-generate-watch/package.json
@@ -7,6 +7,6 @@
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "22.15.23"
+    "@types/node": "20.19.0"
   }
 }

--- a/packages/client/tests/e2e/issues/27128-generate-watch/package.json
+++ b/packages/client/tests/e2e/issues/27128-generate-watch/package.json
@@ -7,6 +7,6 @@
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "20.19.0"
+    "@types/node": "~20.19.0"
   }
 }

--- a/packages/client/tests/e2e/issues/orm-1310-generator-js-qc-no-engine/package.json
+++ b/packages/client/tests/e2e/issues/orm-1310-generator-js-qc-no-engine/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/issues/orm-1310-generator-js-qc-no-engine/package.json
+++ b/packages/client/tests/e2e/issues/orm-1310-generator-js-qc-no-engine/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/mongodb-notablescan/package.json
+++ b/packages/client/tests/e2e/mongodb-notablescan/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/mongodb-notablescan/package.json
+++ b/packages/client/tests/e2e/mongodb-notablescan/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/multi-schema-with-external/package.json
+++ b/packages/client/tests/e2e/multi-schema-with-external/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@prisma/config": "/tmp/prisma-config-0.0.0.tgz",
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.7.3"
   }

--- a/packages/client/tests/e2e/multi-schema-with-external/package.json
+++ b/packages/client/tests/e2e/multi-schema-with-external/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@prisma/config": "/tmp/prisma-config-0.0.0.tgz",
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.7.3"
   }

--- a/packages/client/tests/e2e/nextjs-schema-not-found/10_monorepo-serverComponents-customOutput-noReExport/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/10_monorepo-serverComponents-customOutput-noReExport/packages/service/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/react": "18.3.3",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/10_monorepo-serverComponents-customOutput-noReExport/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/10_monorepo-serverComponents-customOutput-noReExport/packages/service/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/react": "18.3.3",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/11_monorepo-noServerComponents-noCustomOutput-reExportIndirect/packages/db/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/11_monorepo-noServerComponents-noCustomOutput-reExportIndirect/packages/db/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/11_monorepo-noServerComponents-noCustomOutput-reExportIndirect/packages/db/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/11_monorepo-noServerComponents-noCustomOutput-reExportIndirect/packages/db/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/11_monorepo-noServerComponents-noCustomOutput-reExportIndirect/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/11_monorepo-noServerComponents-noCustomOutput-reExportIndirect/packages/service/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/react": "18.3.3",
     "webpack": "5.91.0"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/11_monorepo-noServerComponents-noCustomOutput-reExportIndirect/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/11_monorepo-noServerComponents-noCustomOutput-reExportIndirect/packages/service/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/react": "18.3.3",
     "webpack": "5.91.0"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/12_monorepo-serverComponents-noCustomOutput-reExportIndirect/packages/db/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/12_monorepo-serverComponents-noCustomOutput-reExportIndirect/packages/db/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/12_monorepo-serverComponents-noCustomOutput-reExportIndirect/packages/db/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/12_monorepo-serverComponents-noCustomOutput-reExportIndirect/packages/db/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/12_monorepo-serverComponents-noCustomOutput-reExportIndirect/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/12_monorepo-serverComponents-noCustomOutput-reExportIndirect/packages/service/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/react": "18.3.3"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/12_monorepo-serverComponents-noCustomOutput-reExportIndirect/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/12_monorepo-serverComponents-noCustomOutput-reExportIndirect/packages/service/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/react": "18.3.3"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/13_monorepo-noServerComponents-customOutput-reExportDirect/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/13_monorepo-noServerComponents-customOutput-reExportDirect/packages/service/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/react": "18.3.3"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/13_monorepo-noServerComponents-customOutput-reExportDirect/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/13_monorepo-noServerComponents-customOutput-reExportDirect/packages/service/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/react": "18.3.3"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/14_monorepo-serverComponents-customOutput-reExportDirect/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/14_monorepo-serverComponents-customOutput-reExportDirect/packages/service/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/react": "18.3.3"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/14_monorepo-serverComponents-customOutput-reExportDirect/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/14_monorepo-serverComponents-customOutput-reExportDirect/packages/service/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/react": "18.3.3"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/15_monorepo-noServerComponents-customOutput-reExportIndirect/packages/db/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/15_monorepo-noServerComponents-customOutput-reExportIndirect/packages/db/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/15_monorepo-noServerComponents-customOutput-reExportIndirect/packages/db/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/15_monorepo-noServerComponents-customOutput-reExportIndirect/packages/db/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/15_monorepo-noServerComponents-customOutput-reExportIndirect/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/15_monorepo-noServerComponents-customOutput-reExportIndirect/packages/service/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/react": "18.3.3",
     "webpack": "5.91.0"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/15_monorepo-noServerComponents-customOutput-reExportIndirect/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/15_monorepo-noServerComponents-customOutput-reExportIndirect/packages/service/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/react": "18.3.3",
     "webpack": "5.91.0"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/16_monorepo-serverComponents-customOutput-reExportIndirect/packages/db/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/16_monorepo-serverComponents-customOutput-reExportIndirect/packages/db/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/16_monorepo-serverComponents-customOutput-reExportIndirect/packages/db/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/16_monorepo-serverComponents-customOutput-reExportIndirect/packages/db/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/16_monorepo-serverComponents-customOutput-reExportIndirect/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/16_monorepo-serverComponents-customOutput-reExportIndirect/packages/service/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/react": "18.3.3"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/16_monorepo-serverComponents-customOutput-reExportIndirect/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/16_monorepo-serverComponents-customOutput-reExportIndirect/packages/service/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/react": "18.3.3"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/17_monorepo-noServerComponents-customOutput-reExportIndirect-ts/packages/db/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/17_monorepo-noServerComponents-customOutput-reExportIndirect-ts/packages/db/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/17_monorepo-noServerComponents-customOutput-reExportIndirect-ts/packages/db/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/17_monorepo-noServerComponents-customOutput-reExportIndirect-ts/packages/db/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/17_monorepo-noServerComponents-customOutput-reExportIndirect-ts/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/17_monorepo-noServerComponents-customOutput-reExportIndirect-ts/packages/service/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/react": "18.3.3",
     "webpack": "5.91.0"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/17_monorepo-noServerComponents-customOutput-reExportIndirect-ts/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/17_monorepo-noServerComponents-customOutput-reExportIndirect-ts/packages/service/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/react": "18.3.3",
     "webpack": "5.91.0"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/packages/db/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/packages/db/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/packages/db/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/packages/db/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/packages/service/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/react": "18.3.3"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/packages/service/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/react": "18.3.3"
   },
   "dependencies": {

--- a/packages/client/tests/e2e/nextjs-schema-not-found/19_monorepo-noServerComponents-newGenerator-reExportIndirect-ts/packages/db/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/19_monorepo-noServerComponents-newGenerator-reExportIndirect-ts/packages/db/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.8.3"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/19_monorepo-noServerComponents-newGenerator-reExportIndirect-ts/packages/db/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/19_monorepo-noServerComponents-newGenerator-reExportIndirect-ts/packages/db/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.8.3"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/19_monorepo-noServerComponents-newGenerator-reExportIndirect-ts/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/19_monorepo-noServerComponents-newGenerator-reExportIndirect-ts/packages/service/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/react": "19.1.0",
     "webpack": "5.99.5",
     "typescript": "5.8.3",

--- a/packages/client/tests/e2e/nextjs-schema-not-found/19_monorepo-noServerComponents-newGenerator-reExportIndirect-ts/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/19_monorepo-noServerComponents-newGenerator-reExportIndirect-ts/packages/service/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/react": "19.1.0",
     "webpack": "5.99.5",
     "typescript": "5.8.3",

--- a/packages/client/tests/e2e/nextjs-schema-not-found/20_monorepo-serverComponents-newGenerator-reExportIndirect-ts/packages/db/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/20_monorepo-serverComponents-newGenerator-reExportIndirect-ts/packages/db/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.8.3"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/20_monorepo-serverComponents-newGenerator-reExportIndirect-ts/packages/db/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/20_monorepo-serverComponents-newGenerator-reExportIndirect-ts/packages/db/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.8.3"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/20_monorepo-serverComponents-newGenerator-reExportIndirect-ts/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/20_monorepo-serverComponents-newGenerator-reExportIndirect-ts/packages/service/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/react": "19.1.0",
     "webpack": "5.99.5",
     "typescript": "5.8.3",

--- a/packages/client/tests/e2e/nextjs-schema-not-found/20_monorepo-serverComponents-newGenerator-reExportIndirect-ts/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/20_monorepo-serverComponents-newGenerator-reExportIndirect-ts/packages/service/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "devDependencies": {
     "@prisma/nextjs-monorepo-workaround-plugin": "/tmp/prisma-nextjs-monorepo-workaround-plugin-0.0.0.tgz",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/react": "19.1.0",
     "webpack": "5.99.5",
     "typescript": "5.8.3",

--- a/packages/client/tests/e2e/nextjs-schema-not-found/3_simplerepo-noServerComponents-noCustomOutput-noReExport/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/3_simplerepo-noServerComponents-noCustomOutput-noReExport/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/react": "18.3.3",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/3_simplerepo-noServerComponents-noCustomOutput-noReExport/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/3_simplerepo-noServerComponents-noCustomOutput-noReExport/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/react": "18.3.3",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/4_simplerepo-serverComponents-noCustomOutput-noReExport/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/4_simplerepo-serverComponents-noCustomOutput-noReExport/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/react": "18.3.3",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/4_simplerepo-serverComponents-noCustomOutput-noReExport/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/4_simplerepo-serverComponents-noCustomOutput-noReExport/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/react": "18.3.3",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/5_simplerepo-noServerComponents-customOutput-noReExport/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/5_simplerepo-noServerComponents-customOutput-noReExport/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/react": "18.3.3",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/5_simplerepo-noServerComponents-customOutput-noReExport/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/5_simplerepo-noServerComponents-customOutput-noReExport/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/react": "18.3.3",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/6_simplerepo-serverComponents-customOutput-noReExport/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/6_simplerepo-serverComponents-customOutput-noReExport/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/react": "18.3.3",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/6_simplerepo-serverComponents-customOutput-noReExport/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/6_simplerepo-serverComponents-customOutput-noReExport/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/react": "18.3.3",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/7_monorepo-noServerComponents-noCustomOutput-noReExport/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/7_monorepo-noServerComponents-noCustomOutput-noReExport/packages/service/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/react": "18.3.3",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/7_monorepo-noServerComponents-noCustomOutput-noReExport/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/7_monorepo-noServerComponents-noCustomOutput-noReExport/packages/service/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/react": "18.3.3",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/8_monorepo-serverComponents-noCustomOutput-noReExport/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/8_monorepo-serverComponents-noCustomOutput-noReExport/packages/service/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/react": "18.3.3",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/8_monorepo-serverComponents-noCustomOutput-noReExport/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/8_monorepo-serverComponents-noCustomOutput-noReExport/packages/service/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/react": "18.3.3",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/9_monorepo-noServerComponents-customOutput-noReExport/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/9_monorepo-noServerComponents-customOutput-noReExport/packages/service/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/react": "18.3.3",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/nextjs-schema-not-found/9_monorepo-noServerComponents-customOutput-noReExport/packages/service/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/9_monorepo-noServerComponents-customOutput-noReExport/packages/service/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/react": "18.3.3",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/noengine-file-deletion/package.json
+++ b/packages/client/tests/e2e/noengine-file-deletion/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/noengine-file-deletion/package.json
+++ b/packages/client/tests/e2e/noengine-file-deletion/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/output-location-warning/package.json
+++ b/packages/client/tests/e2e/output-location-warning/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "jest": "29.7.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }

--- a/packages/client/tests/e2e/output-location-warning/package.json
+++ b/packages/client/tests/e2e/output-location-warning/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "jest": "29.7.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }

--- a/packages/client/tests/e2e/pg-global-type-parsers/package.json
+++ b/packages/client/tests/e2e/pg-global-type-parsers/package.json
@@ -10,6 +10,6 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.50"
+    "@types/node": "20.19.0"
   }
 }

--- a/packages/client/tests/e2e/pg-global-type-parsers/package.json
+++ b/packages/client/tests/e2e/pg-global-type-parsers/package.json
@@ -10,6 +10,6 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0"
+    "@types/node": "~20.19.0"
   }
 }

--- a/packages/client/tests/e2e/pg-self-signed-cert-error/package.json
+++ b/packages/client/tests/e2e/pg-self-signed-cert-error/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/pg-self-signed-cert-error/package.json
+++ b/packages/client/tests/e2e/pg-self-signed-cert-error/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/platform-caching-error/package.json
+++ b/packages/client/tests/e2e/platform-caching-error/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/platform-caching-error/package.json
+++ b/packages/client/tests/e2e/platform-caching-error/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/prisma-client-generator/enums-tsoa/package.json
+++ b/packages/client/tests/e2e/prisma-client-generator/enums-tsoa/package.json
@@ -8,7 +8,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "tsup": "8.4.0"
   }

--- a/packages/client/tests/e2e/prisma-client-generator/enums-tsoa/package.json
+++ b/packages/client/tests/e2e/prisma-client-generator/enums-tsoa/package.json
@@ -8,7 +8,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "tsup": "8.4.0"
   }

--- a/packages/client/tests/e2e/prisma-client-generator/node-tsup-esm/package.json
+++ b/packages/client/tests/e2e/prisma-client-generator/node-tsup-esm/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "tsup": "8.4.0"
   }

--- a/packages/client/tests/e2e/prisma-client-generator/node-tsup-esm/package.json
+++ b/packages/client/tests/e2e/prisma-client-generator/node-tsup-esm/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "tsup": "8.4.0"
   }

--- a/packages/client/tests/e2e/prisma-client-generator/node-tsx-cjs/package.json
+++ b/packages/client/tests/e2e/prisma-client-generator/node-tsx-cjs/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/prisma-client-generator/node-tsx-cjs/package.json
+++ b/packages/client/tests/e2e/prisma-client-generator/node-tsx-cjs/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/prisma-client-generator/node-tsx-esm-mts/package.json
+++ b/packages/client/tests/e2e/prisma-client-generator/node-tsx-esm-mts/package.json
@@ -6,7 +6,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/prisma-client-generator/node-tsx-esm-mts/package.json
+++ b/packages/client/tests/e2e/prisma-client-generator/node-tsx-esm-mts/package.json
@@ -6,7 +6,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/prisma-client-generator/node-tsx-esm/package.json
+++ b/packages/client/tests/e2e/prisma-client-generator/node-tsx-esm/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/prisma-client-generator/node-tsx-esm/package.json
+++ b/packages/client/tests/e2e/prisma-client-generator/node-tsx-esm/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/prisma-client-imports-mysql/package.json
+++ b/packages/client/tests/e2e/prisma-client-imports-mysql/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "jest": "29.7.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.4.5"

--- a/packages/client/tests/e2e/prisma-client-imports-mysql/package.json
+++ b/packages/client/tests/e2e/prisma-client-imports-mysql/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "jest": "29.7.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.4.5"

--- a/packages/client/tests/e2e/prisma-client-imports-postgres/package.json
+++ b/packages/client/tests/e2e/prisma-client-imports-postgres/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/pg": "8.11.6",
     "@types/ws": "8.5.10",
     "jest": "29.7.0",

--- a/packages/client/tests/e2e/prisma-client-imports-postgres/package.json
+++ b/packages/client/tests/e2e/prisma-client-imports-postgres/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/pg": "8.11.6",
     "@types/ws": "8.5.10",
     "jest": "29.7.0",

--- a/packages/client/tests/e2e/prisma-client-imports-sqlite/package.json
+++ b/packages/client/tests/e2e/prisma-client-imports-sqlite/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "jest": "29.7.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.4.5"

--- a/packages/client/tests/e2e/prisma-client-imports-sqlite/package.json
+++ b/packages/client/tests/e2e/prisma-client-imports-sqlite/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "jest": "29.7.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.4.5"

--- a/packages/client/tests/e2e/prisma-config/package.json
+++ b/packages/client/tests/e2e/prisma-config/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@prisma/config": "/tmp/prisma-config-0.0.0.tgz",
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.7.3"
   }

--- a/packages/client/tests/e2e/prisma-config/package.json
+++ b/packages/client/tests/e2e/prisma-config/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@prisma/config": "/tmp/prisma-config-0.0.0.tgz",
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.7.3"
   }

--- a/packages/client/tests/e2e/publish-extensions/package.json
+++ b/packages/client/tests/e2e/publish-extensions/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/publish-extensions/package.json
+++ b/packages/client/tests/e2e/publish-extensions/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/require-in-the-middle/package.json
+++ b/packages/client/tests/e2e/require-in-the-middle/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/require-in-the-middle/package.json
+++ b/packages/client/tests/e2e/require-in-the-middle/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/runtimes/data-proxy-custom-output/package.json
+++ b/packages/client/tests/e2e/runtimes/data-proxy-custom-output/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "expect-type": "0.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }

--- a/packages/client/tests/e2e/runtimes/data-proxy-custom-output/package.json
+++ b/packages/client/tests/e2e/runtimes/data-proxy-custom-output/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "expect-type": "0.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }

--- a/packages/client/tests/e2e/schema-folder-sqlite/package.json
+++ b/packages/client/tests/e2e/schema-folder-sqlite/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/schema-folder-sqlite/package.json
+++ b/packages/client/tests/e2e/schema-folder-sqlite/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/schema-not-found-sst-electron/package.json
+++ b/packages/client/tests/e2e/schema-not-found-sst-electron/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/schema-not-found-sst-electron/package.json
+++ b/packages/client/tests/e2e/schema-not-found-sst-electron/package.json
@@ -7,7 +7,7 @@
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
   },
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/structured-output/prisma-config/package.json
+++ b/packages/client/tests/e2e/structured-output/prisma-config/package.json
@@ -8,7 +8,7 @@
     "zx": "^7"
   },
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "vitest": "3.2.4"
   },

--- a/packages/client/tests/e2e/structured-output/prisma-config/package.json
+++ b/packages/client/tests/e2e/structured-output/prisma-config/package.json
@@ -8,7 +8,7 @@
     "zx": "^7"
   },
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "vitest": "3.2.4"
   },

--- a/packages/client/tests/e2e/ts-version/5.4/package.json
+++ b/packages/client/tests/e2e/ts-version/5.4/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.4.5"
   }

--- a/packages/client/tests/e2e/ts-version/5.4/package.json
+++ b/packages/client/tests/e2e/ts-version/5.4/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.4.5"
   }

--- a/packages/client/tests/e2e/ts-version/5.5/package.json
+++ b/packages/client/tests/e2e/ts-version/5.5/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.5.4"
   }

--- a/packages/client/tests/e2e/ts-version/5.5/package.json
+++ b/packages/client/tests/e2e/ts-version/5.5/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.5.4"
   }

--- a/packages/client/tests/e2e/ts-version/5.6/package.json
+++ b/packages/client/tests/e2e/ts-version/5.6/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.6.3"
   }

--- a/packages/client/tests/e2e/ts-version/5.6/package.json
+++ b/packages/client/tests/e2e/ts-version/5.6/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.6.3"
   }

--- a/packages/client/tests/e2e/ts-version/5.7/package.json
+++ b/packages/client/tests/e2e/ts-version/5.7/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.7.3"
   }

--- a/packages/client/tests/e2e/ts-version/5.7/package.json
+++ b/packages/client/tests/e2e/ts-version/5.7/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.7.3"
   }

--- a/packages/client/tests/e2e/ts-version/5.8/package.json
+++ b/packages/client/tests/e2e/ts-version/5.8/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.8.3"
   }

--- a/packages/client/tests/e2e/ts-version/5.8/package.json
+++ b/packages/client/tests/e2e/ts-version/5.8/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.8.3"
   }

--- a/packages/client/tests/e2e/ts-version/5.9/package.json
+++ b/packages/client/tests/e2e/ts-version/5.9/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.9.3"
   }

--- a/packages/client/tests/e2e/ts-version/5.9/package.json
+++ b/packages/client/tests/e2e/ts-version/5.9/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "5.9.3"
   }

--- a/packages/client/tests/e2e/ts-version/beta/package.json
+++ b/packages/client/tests/e2e/ts-version/beta/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "beta"
   }

--- a/packages/client/tests/e2e/ts-version/beta/package.json
+++ b/packages/client/tests/e2e/ts-version/beta/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "beta"
   }

--- a/packages/client/tests/e2e/ts-version/latest/package.json
+++ b/packages/client/tests/e2e/ts-version/latest/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "latest"
   }

--- a/packages/client/tests/e2e/ts-version/latest/package.json
+++ b/packages/client/tests/e2e/ts-version/latest/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "latest"
   }

--- a/packages/client/tests/e2e/ts-version/next/package.json
+++ b/packages/client/tests/e2e/ts-version/next/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "next"
   }

--- a/packages/client/tests/e2e/ts-version/next/package.json
+++ b/packages/client/tests/e2e/ts-version/next/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "typescript": "next"
   }

--- a/packages/client/tests/e2e/typed-sql-query-compiler-adapter-libsql/package.json
+++ b/packages/client/tests/e2e/typed-sql-query-compiler-adapter-libsql/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/typed-sql-query-compiler-adapter-libsql/package.json
+++ b/packages/client/tests/e2e/typed-sql-query-compiler-adapter-libsql/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/typed-sql/package.json
+++ b/packages/client/tests/e2e/typed-sql/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/typed-sql/package.json
+++ b/packages/client/tests/e2e/typed-sql/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/unsupported-browser-error/package.json
+++ b/packages/client/tests/e2e/unsupported-browser-error/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "wrangler": "3.114.14"
   }

--- a/packages/client/tests/e2e/unsupported-browser-error/package.json
+++ b/packages/client/tests/e2e/unsupported-browser-error/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "wrangler": "3.114.14"
   }

--- a/packages/client/tests/e2e/unsupported-edge-error/package.json
+++ b/packages/client/tests/e2e/unsupported-edge-error/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "wrangler": "3.114.14"
   }

--- a/packages/client/tests/e2e/unsupported-edge-error/package.json
+++ b/packages/client/tests/e2e/unsupported-edge-error/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.12",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "/tmp/prisma-0.0.0.tgz",
     "wrangler": "3.114.14"
   }

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -28,7 +28,7 @@
   "bugs": "https://github.com/prisma/prisma/issues",
   "devDependencies": {
     "@types/jest": "29.5.14",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "jest": "29.7.0",
     "jest-junit": "16.0.0",
     "kleur": "4.1.5",

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -28,7 +28,7 @@
   "bugs": "https://github.com/prisma/prisma/issues",
   "devDependencies": {
     "@types/jest": "29.5.14",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "jest": "29.7.0",
     "jest-junit": "16.0.0",
     "kleur": "4.1.5",

--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -15,7 +15,7 @@
     "@swc/core": "1.11.5",
     "@swc/jest": "0.2.37",
     "@types/jest": "29.5.14",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "execa": "5.1.1",
     "typescript": "5.4.5",
     "vitest": "3.2.4"

--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -15,7 +15,7 @@
     "@swc/core": "1.11.5",
     "@swc/jest": "0.2.37",
     "@types/jest": "29.5.14",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "execa": "5.1.1",
     "typescript": "5.4.5",
     "vitest": "3.2.4"

--- a/packages/fetch-engine/package.json
+++ b/packages/fetch-engine/package.json
@@ -15,7 +15,7 @@
   "bugs": "https://github.com/prisma/prisma/issues",
   "enginesOverride": {},
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/progress": "2.0.7",
     "del": "6.1.1",
     "execa": "8.0.1",

--- a/packages/fetch-engine/package.json
+++ b/packages/fetch-engine/package.json
@@ -15,7 +15,7 @@
   "bugs": "https://github.com/prisma/prisma/issues",
   "enginesOverride": {},
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/progress": "2.0.7",
     "del": "6.1.1",
     "execa": "8.0.1",

--- a/packages/generator-helper/package.json
+++ b/packages/generator-helper/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@swc-node/register": "1.10.9",
     "@types/cross-spawn": "6.0.6",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "typescript": "5.4.5",
     "cross-spawn": "7.0.6",
     "kleur": "4.1.5"

--- a/packages/generator-helper/package.json
+++ b/packages/generator-helper/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@swc-node/register": "1.10.9",
     "@types/cross-spawn": "6.0.6",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "typescript": "5.4.5",
     "cross-spawn": "7.0.6",
     "kleur": "4.1.5"

--- a/packages/get-platform/package.json
+++ b/packages/get-platform/package.json
@@ -18,7 +18,7 @@
     "@swc/core": "1.11.5",
     "@swc/jest": "0.2.37",
     "@types/jest": "29.5.14",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "benchmark": "2.1.4",
     "escape-string-regexp": "5.0.0",
     "execa": "8.0.1",

--- a/packages/get-platform/package.json
+++ b/packages/get-platform/package.json
@@ -18,7 +18,7 @@
     "@swc/core": "1.11.5",
     "@swc/jest": "0.2.37",
     "@types/jest": "29.5.14",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "benchmark": "2.1.4",
     "escape-string-regexp": "5.0.0",
     "execa": "8.0.1",

--- a/packages/get-platform/src/test-utils/vitestContext.ts
+++ b/packages/get-platform/src/test-utils/vitestContext.ts
@@ -253,7 +253,7 @@ export const vitestProcessExitContext =
       ctx.mocked['process.exit'] = vi.spyOn(process, 'exit').mockImplementation((number) => {
         throw new Error('process.exit: ' + number)
       })
-      ctx.recordedExitCode = () => ctx.mocked['process.exit'].mock.calls[0]?.[0] ?? 0
+      ctx.recordedExitCode = () => Number(ctx.mocked['process.exit'].mock.calls[0]?.[0] ?? 0)
     })
 
     afterEach(() => {

--- a/packages/instrumentation/package.json
+++ b/packages/instrumentation/package.json
@@ -27,7 +27,7 @@
   "bugs": "https://github.com/prisma/prisma/issues",
   "devDependencies": {
     "@prisma/internals": "workspace:*",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@opentelemetry/api": "1.9.0",
     "typescript": "5.4.5"
   },

--- a/packages/instrumentation/package.json
+++ b/packages/instrumentation/package.json
@@ -27,7 +27,7 @@
   "bugs": "https://github.com/prisma/prisma/issues",
   "devDependencies": {
     "@prisma/internals": "workspace:*",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@opentelemetry/api": "1.9.0",
     "typescript": "5.4.5"
   },

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -20,7 +20,7 @@
     "@swc/jest": "0.2.37",
     "@types/jest": "29.5.14",
     "@types/mssql": "9.1.8",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/pg": "8.11.11",
     "@types/sqlite3": "3.1.11",
     "decimal.js": "10.5.0",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -20,7 +20,7 @@
     "@swc/jest": "0.2.37",
     "@types/jest": "29.5.14",
     "@types/mssql": "9.1.8",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/pg": "8.11.11",
     "@types/sqlite3": "3.1.11",
     "decimal.js": "10.5.0",

--- a/packages/internals/package.json
+++ b/packages/internals/package.json
@@ -33,7 +33,7 @@
     "@swc/jest": "0.2.37",
     "@types/babel__helper-validator-identifier": "7.15.2",
     "@types/jest": "29.5.14",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/resolve": "1.20.6",
     "archiver": "6.0.2",
     "checkpoint-client": "1.1.33",

--- a/packages/internals/package.json
+++ b/packages/internals/package.json
@@ -33,7 +33,7 @@
     "@swc/jest": "0.2.37",
     "@types/babel__helper-validator-identifier": "7.15.2",
     "@types/jest": "29.5.14",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/resolve": "1.20.6",
     "archiver": "6.0.2",
     "checkpoint-client": "1.1.33",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -22,7 +22,7 @@
     "@swc/core": "1.11.5",
     "@swc/jest": "0.2.37",
     "@types/jest": "29.5.14",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/pg": "8.11.11",
     "@types/prompts": "2.4.9",
     "@types/sqlite3": "3.1.11",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -22,7 +22,7 @@
     "@swc/core": "1.11.5",
     "@swc/jest": "0.2.37",
     "@types/jest": "29.5.14",
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/pg": "8.11.11",
     "@types/prompts": "2.4.9",
     "@types/sqlite3": "3.1.11",

--- a/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-custom-ts-node/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-custom-ts-node/package.json
@@ -6,6 +6,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "20.19.0"
+    "@types/node": "~20.19.0"
   }
 }

--- a/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-custom-ts-node/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-custom-ts-node/package.json
@@ -6,6 +6,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.19.76"
+    "@types/node": "20.19.0"
   }
 }

--- a/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-js-extra-args/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-js-extra-args/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.19.76"
+    "@types/node": "20.19.0"
   },
   "prisma": {
     "seed": "node prisma/seed.js --my-custom-arg-from-config-1 my-value --my-custom-arg-from-config-2=my-value -y"

--- a/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-js-extra-args/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-js-extra-args/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "20.19.0"
+    "@types/node": "~20.19.0"
   },
   "prisma": {
     "seed": "node prisma/seed.js --my-custom-arg-from-config-1 my-value --my-custom-arg-from-config-2=my-value -y"

--- a/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-js/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-js/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.19.76"
+    "@types/node": "20.19.0"
   },
   "prisma": {
     "seed": "node prisma/seed.js"

--- a/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-js/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-js/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "20.19.0"
+    "@types/node": "~20.19.0"
   },
   "prisma": {
     "seed": "node prisma/seed.js"

--- a/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-legacy-custom-ts-node/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-legacy-custom-ts-node/package.json
@@ -6,6 +6,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "20.19.0"
+    "@types/node": "~20.19.0"
   }
 }

--- a/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-legacy-custom-ts-node/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-legacy-custom-ts-node/package.json
@@ -6,6 +6,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.19.76"
+    "@types/node": "20.19.0"
   }
 }

--- a/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-legacy/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-legacy/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "20.19.0"
+    "@types/node": "~20.19.0"
   }
 }

--- a/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-legacy/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-legacy/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.19.76"
+    "@types/node": "20.19.0"
   }
 }

--- a/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-sh/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-sh/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "20.19.0"
+    "@types/node": "~20.19.0"
   },
   "prisma": {
     "seed": "./prisma/seed.sh"

--- a/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-sh/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-sh/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.19.76"
+    "@types/node": "20.19.0"
   },
   "prisma": {
     "seed": "./prisma/seed.sh"

--- a/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-ts-esm/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-ts-esm/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "type": "module",
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "ts-node": "10.9.2",
     "typescript": "5.4.5"
   },

--- a/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-ts-esm/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-ts-esm/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "type": "module",
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "ts-node": "10.9.2",
     "typescript": "5.4.5"
   },

--- a/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-ts/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-ts/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.19.76"
+    "@types/node": "20.19.0"
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"

--- a/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-ts/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite-ts/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "20.19.0"
+    "@types/node": "~20.19.0"
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"

--- a/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "20.19.0"
+    "@types/node": "~20.19.0"
   }
 }

--- a/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-package-json/seed-sqlite/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.19.76"
+    "@types/node": "20.19.0"
   }
 }

--- a/packages/migrate/src/__tests__/fixtures/seed-from-prisma-config/seed-sqlite-js-extra-args/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-prisma-config/seed-sqlite-js-extra-args/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "20.19.0"
+    "@types/node": "~20.19.0"
   }
 }

--- a/packages/migrate/src/__tests__/fixtures/seed-from-prisma-config/seed-sqlite-js-extra-args/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-prisma-config/seed-sqlite-js-extra-args/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.19.76"
+    "@types/node": "20.19.0"
   }
 }

--- a/packages/migrate/src/__tests__/fixtures/seed-from-prisma-config/seed-sqlite-js/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-prisma-config/seed-sqlite-js/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "20.19.0"
+    "@types/node": "~20.19.0"
   }
 }

--- a/packages/migrate/src/__tests__/fixtures/seed-from-prisma-config/seed-sqlite-js/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-prisma-config/seed-sqlite-js/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.19.76"
+    "@types/node": "20.19.0"
   }
 }

--- a/packages/migrate/src/__tests__/fixtures/seed-from-prisma-config/seed-sqlite-sh/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-prisma-config/seed-sqlite-sh/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "20.19.0"
+    "@types/node": "~20.19.0"
   }
 }

--- a/packages/migrate/src/__tests__/fixtures/seed-from-prisma-config/seed-sqlite-sh/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-prisma-config/seed-sqlite-sh/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.19.76"
+    "@types/node": "20.19.0"
   }
 }

--- a/packages/migrate/src/__tests__/fixtures/seed-from-prisma-config/seed-sqlite-skips-deprecated-package-json/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-prisma-config/seed-sqlite-skips-deprecated-package-json/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "20.19.0"
+    "@types/node": "~20.19.0"
   },
   "prisma": {
     "seed": "node prisma/seed-deprecated.js"

--- a/packages/migrate/src/__tests__/fixtures/seed-from-prisma-config/seed-sqlite-skips-deprecated-package-json/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-prisma-config/seed-sqlite-skips-deprecated-package-json/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.19.76"
+    "@types/node": "20.19.0"
   },
   "prisma": {
     "seed": "node prisma/seed-deprecated.js"

--- a/packages/migrate/src/__tests__/fixtures/seed-from-prisma-config/seed-sqlite-ts-esm/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-prisma-config/seed-sqlite-ts-esm/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "type": "module",
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "ts-node": "10.9.2",
     "typescript": "5.4.5"
   }

--- a/packages/migrate/src/__tests__/fixtures/seed-from-prisma-config/seed-sqlite-ts-esm/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-prisma-config/seed-sqlite-ts-esm/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "type": "module",
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "ts-node": "10.9.2",
     "typescript": "5.4.5"
   }

--- a/packages/migrate/src/__tests__/fixtures/seed-from-prisma-config/seed-sqlite-ts/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-prisma-config/seed-sqlite-ts/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "20.19.0"
+    "@types/node": "~20.19.0"
   }
 }

--- a/packages/migrate/src/__tests__/fixtures/seed-from-prisma-config/seed-sqlite-ts/package.json
+++ b/packages/migrate/src/__tests__/fixtures/seed-from-prisma-config/seed-sqlite-ts/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "18.19.76"
+    "@types/node": "20.19.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 9.30.0
       '@microsoft/api-extractor':
         specifier: 7.52.11
-        version: 7.52.11(@types/node@18.19.76)
+        version: 7.52.11(@types/node@20.19.0)
       '@octokit/graphql':
         specifier: 8.2.1
         version: 8.2.1
@@ -51,8 +51,8 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 18.19.76
-        version: 18.19.76
+        specifier: 20.19.0
+        version: 20.19.0
       '@types/resolve':
         specifier: 1.20.6
         version: 1.20.6
@@ -67,7 +67,7 @@ importers:
         version: 7.15.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.4.5)
       '@vitest/coverage-v8':
         specifier: 3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.0)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0))
       arg:
         specifier: 5.0.2
         version: 5.0.2
@@ -103,7 +103,7 @@ importers:
         version: 4.6.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.4.5)
       eslint-plugin-jest:
         specifier: 28.11.0
-        version: 28.11.0(@typescript-eslint/eslint-plugin@7.15.0(@typescript-eslint/parser@7.15.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.4.5))(eslint@9.22.0(jiti@2.4.2))(typescript@5.4.5))(eslint@9.22.0(jiti@2.4.2))(jest@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 28.11.0(@typescript-eslint/eslint-plugin@7.15.0(@typescript-eslint/parser@7.15.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.4.5))(eslint@9.22.0(jiti@2.4.2))(typescript@5.4.5))(eslint@9.22.0(jiti@2.4.2))(jest@29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5)))(typescript@5.4.5)
       eslint-plugin-local-rules:
         specifier: 3.0.2
         version: 3.0.2
@@ -184,7 +184,7 @@ importers:
         version: 1.3.0
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5)
+        version: 10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5)
       ts-toolbelt:
         specifier: 9.6.0
         version: 9.6.0
@@ -199,7 +199,7 @@ importers:
         version: 5.4.5
       vitest:
         specifier: 3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.0)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
       wrangler:
         specifier: 3.114.14
         version: 3.114.14(@cloudflare/workers-types@4.20250903.0)
@@ -396,7 +396,7 @@ importers:
     devDependencies:
       '@inquirer/prompts':
         specifier: 7.3.3
-        version: 7.3.3(@types/node@18.19.76)
+        version: 7.3.3(@types/node@20.19.0)
       '@libsql/client':
         specifier: 0.8.1
         version: 0.8.1
@@ -455,8 +455,8 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 18.19.76
-        version: 18.19.76
+        specifier: 20.19.0
+        version: 20.19.0
       async-listen:
         specifier: 3.1.0
         version: 3.1.0
@@ -480,7 +480,7 @@ importers:
         version: 7.1.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5))
+        version: 29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5))
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -540,7 +540,7 @@ importers:
         version: 1.19.0(hono@4.9.4)
       '@inquirer/prompts':
         specifier: 7.3.3
-        version: 7.3.3(@types/node@18.19.76)
+        version: 7.3.3(@types/node@20.19.0)
       '@jest/create-cache-key-function':
         specifier: 29.7.0
         version: 29.7.0
@@ -698,8 +698,8 @@ importers:
         specifier: 9.1.8
         version: 9.1.8
       '@types/node':
-        specifier: 18.19.76
-        version: 18.19.76
+        specifier: 20.19.0
+        version: 20.19.0
       '@types/pg':
         specifier: 8.11.11
         version: 8.11.11
@@ -735,10 +735,10 @@ importers:
         version: 4.0.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5))
+        version: 29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5))
       jest-extended:
         specifier: 4.0.2
-        version: 4.0.2(jest@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5)))
+        version: 4.0.2(jest@29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5)))
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -870,11 +870,11 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 18.19.76
-        version: 18.19.76
+        specifier: 20.19.0
+        version: 20.19.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.8.2))
+        version: 29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.8.2))
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -1067,11 +1067,11 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 18.19.76
-        version: 18.19.76
+        specifier: 20.19.0
+        version: 20.19.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5))
+        version: 29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5))
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -1119,8 +1119,8 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 18.19.76
-        version: 18.19.76
+        specifier: 20.19.0
+        version: 20.19.0
       execa:
         specifier: 5.1.1
         version: 5.1.1
@@ -1129,7 +1129,7 @@ importers:
         version: 5.4.5
       vitest:
         specifier: 3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.0)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
 
   packages/fetch-engine:
     dependencies:
@@ -1144,8 +1144,8 @@ importers:
         version: link:../get-platform
     devDependencies:
       '@types/node':
-        specifier: 18.19.76
-        version: 18.19.76
+        specifier: 20.19.0
+        version: 20.19.0
       '@types/progress':
         specifier: 2.0.7
         version: 2.0.7
@@ -1229,8 +1229,8 @@ importers:
         specifier: 6.0.6
         version: 6.0.6
       '@types/node':
-        specifier: 18.19.76
-        version: 18.19.76
+        specifier: 20.19.0
+        version: 20.19.0
       cross-spawn:
         specifier: 7.0.6
         version: 7.0.6
@@ -1260,8 +1260,8 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 18.19.76
-        version: 18.19.76
+        specifier: 20.19.0
+        version: 20.19.0
       benchmark:
         specifier: 2.1.4
         version: 2.1.4
@@ -1276,7 +1276,7 @@ importers:
         version: 5.1.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5))
+        version: 29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5))
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -1297,7 +1297,7 @@ importers:
         version: 5.4.5
       vitest:
         specifier: 3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.0)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
 
   packages/instrumentation:
     dependencies:
@@ -1312,8 +1312,8 @@ importers:
         specifier: workspace:*
         version: link:../internals
       '@types/node':
-        specifier: 18.19.76
-        version: 18.19.76
+        specifier: 20.19.0
+        version: 20.19.0
       typescript:
         specifier: 5.4.5
         version: 5.4.5
@@ -1345,8 +1345,8 @@ importers:
         specifier: 9.1.8
         version: 9.1.8
       '@types/node':
-        specifier: 18.19.76
-        version: 18.19.76
+        specifier: 20.19.0
+        version: 20.19.0
       '@types/pg':
         specifier: 8.11.11
         version: 8.11.11
@@ -1361,7 +1361,7 @@ importers:
         version: 5.1.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5))
+        version: 29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5))
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -1454,8 +1454,8 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 18.19.76
-        version: 18.19.76
+        specifier: 20.19.0
+        version: 20.19.0
       '@types/resolve':
         specifier: 1.20.6
         version: 1.20.6
@@ -1512,7 +1512,7 @@ importers:
         version: 3.1.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5))
+        version: 29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5))
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -1617,8 +1617,8 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 18.19.76
-        version: 18.19.76
+        specifier: 20.19.0
+        version: 20.19.0
       '@types/pg':
         specifier: 8.11.11
         version: 8.11.11
@@ -1645,7 +1645,7 @@ importers:
         version: 4.0.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5))
+        version: 29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5))
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -3632,6 +3632,9 @@ packages:
 
   '@types/node@18.19.76':
     resolution: {integrity: sha512-yvR7Q9LdPz2vGpmpJX5LolrgRdWvB67MJKDPSgIIzpFbaf9a1j/f5DnLp5VDyHGMR0QZHlTr1afsD87QCXFHKw==}
+
+  '@types/node@20.19.0':
+    resolution: {integrity: sha512-hfrc+1tud1xcdVTABC2JiomZJEklMcXYNTVtZLAeqTVWD+qL5jkHKT+1lOtqDdGxt+mB53DTtiz673vfjU8D1Q==}
 
   '@types/node@24.3.0':
     resolution: {integrity: sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==}
@@ -7638,6 +7641,9 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici-types@7.10.0:
     resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
 
@@ -8786,27 +8792,27 @@ snapshots:
   '@img/sharp-win32-x64@0.33.5':
     optional: true
 
-  '@inquirer/checkbox@4.1.3(@types/node@18.19.76)':
+  '@inquirer/checkbox@4.1.3(@types/node@20.19.0)':
     dependencies:
-      '@inquirer/core': 10.1.8(@types/node@18.19.76)
+      '@inquirer/core': 10.1.8(@types/node@20.19.0)
       '@inquirer/figures': 1.0.11
-      '@inquirer/type': 3.0.5(@types/node@18.19.76)
+      '@inquirer/type': 3.0.5(@types/node@20.19.0)
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
 
-  '@inquirer/confirm@5.1.7(@types/node@18.19.76)':
+  '@inquirer/confirm@5.1.7(@types/node@20.19.0)':
     dependencies:
-      '@inquirer/core': 10.1.8(@types/node@18.19.76)
-      '@inquirer/type': 3.0.5(@types/node@18.19.76)
+      '@inquirer/core': 10.1.8(@types/node@20.19.0)
+      '@inquirer/type': 3.0.5(@types/node@20.19.0)
     optionalDependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
 
-  '@inquirer/core@10.1.8(@types/node@18.19.76)':
+  '@inquirer/core@10.1.8(@types/node@20.19.0)':
     dependencies:
       '@inquirer/figures': 1.0.11
-      '@inquirer/type': 3.0.5(@types/node@18.19.76)
+      '@inquirer/type': 3.0.5(@types/node@20.19.0)
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
       mute-stream: 2.0.0
@@ -8814,93 +8820,93 @@ snapshots:
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
 
-  '@inquirer/editor@4.2.8(@types/node@18.19.76)':
+  '@inquirer/editor@4.2.8(@types/node@20.19.0)':
     dependencies:
-      '@inquirer/core': 10.1.8(@types/node@18.19.76)
-      '@inquirer/type': 3.0.5(@types/node@18.19.76)
+      '@inquirer/core': 10.1.8(@types/node@20.19.0)
+      '@inquirer/type': 3.0.5(@types/node@20.19.0)
       external-editor: 3.1.0
     optionalDependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
 
-  '@inquirer/expand@4.0.10(@types/node@18.19.76)':
+  '@inquirer/expand@4.0.10(@types/node@20.19.0)':
     dependencies:
-      '@inquirer/core': 10.1.8(@types/node@18.19.76)
-      '@inquirer/type': 3.0.5(@types/node@18.19.76)
+      '@inquirer/core': 10.1.8(@types/node@20.19.0)
+      '@inquirer/type': 3.0.5(@types/node@20.19.0)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
 
   '@inquirer/figures@1.0.11': {}
 
-  '@inquirer/input@4.1.7(@types/node@18.19.76)':
+  '@inquirer/input@4.1.7(@types/node@20.19.0)':
     dependencies:
-      '@inquirer/core': 10.1.8(@types/node@18.19.76)
-      '@inquirer/type': 3.0.5(@types/node@18.19.76)
+      '@inquirer/core': 10.1.8(@types/node@20.19.0)
+      '@inquirer/type': 3.0.5(@types/node@20.19.0)
     optionalDependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
 
-  '@inquirer/number@3.0.10(@types/node@18.19.76)':
+  '@inquirer/number@3.0.10(@types/node@20.19.0)':
     dependencies:
-      '@inquirer/core': 10.1.8(@types/node@18.19.76)
-      '@inquirer/type': 3.0.5(@types/node@18.19.76)
+      '@inquirer/core': 10.1.8(@types/node@20.19.0)
+      '@inquirer/type': 3.0.5(@types/node@20.19.0)
     optionalDependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
 
-  '@inquirer/password@4.0.10(@types/node@18.19.76)':
+  '@inquirer/password@4.0.10(@types/node@20.19.0)':
     dependencies:
-      '@inquirer/core': 10.1.8(@types/node@18.19.76)
-      '@inquirer/type': 3.0.5(@types/node@18.19.76)
+      '@inquirer/core': 10.1.8(@types/node@20.19.0)
+      '@inquirer/type': 3.0.5(@types/node@20.19.0)
       ansi-escapes: 4.3.2
     optionalDependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
 
-  '@inquirer/prompts@7.3.3(@types/node@18.19.76)':
+  '@inquirer/prompts@7.3.3(@types/node@20.19.0)':
     dependencies:
-      '@inquirer/checkbox': 4.1.3(@types/node@18.19.76)
-      '@inquirer/confirm': 5.1.7(@types/node@18.19.76)
-      '@inquirer/editor': 4.2.8(@types/node@18.19.76)
-      '@inquirer/expand': 4.0.10(@types/node@18.19.76)
-      '@inquirer/input': 4.1.7(@types/node@18.19.76)
-      '@inquirer/number': 3.0.10(@types/node@18.19.76)
-      '@inquirer/password': 4.0.10(@types/node@18.19.76)
-      '@inquirer/rawlist': 4.0.10(@types/node@18.19.76)
-      '@inquirer/search': 3.0.10(@types/node@18.19.76)
-      '@inquirer/select': 4.0.10(@types/node@18.19.76)
+      '@inquirer/checkbox': 4.1.3(@types/node@20.19.0)
+      '@inquirer/confirm': 5.1.7(@types/node@20.19.0)
+      '@inquirer/editor': 4.2.8(@types/node@20.19.0)
+      '@inquirer/expand': 4.0.10(@types/node@20.19.0)
+      '@inquirer/input': 4.1.7(@types/node@20.19.0)
+      '@inquirer/number': 3.0.10(@types/node@20.19.0)
+      '@inquirer/password': 4.0.10(@types/node@20.19.0)
+      '@inquirer/rawlist': 4.0.10(@types/node@20.19.0)
+      '@inquirer/search': 3.0.10(@types/node@20.19.0)
+      '@inquirer/select': 4.0.10(@types/node@20.19.0)
     optionalDependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
 
-  '@inquirer/rawlist@4.0.10(@types/node@18.19.76)':
+  '@inquirer/rawlist@4.0.10(@types/node@20.19.0)':
     dependencies:
-      '@inquirer/core': 10.1.8(@types/node@18.19.76)
-      '@inquirer/type': 3.0.5(@types/node@18.19.76)
+      '@inquirer/core': 10.1.8(@types/node@20.19.0)
+      '@inquirer/type': 3.0.5(@types/node@20.19.0)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
 
-  '@inquirer/search@3.0.10(@types/node@18.19.76)':
+  '@inquirer/search@3.0.10(@types/node@20.19.0)':
     dependencies:
-      '@inquirer/core': 10.1.8(@types/node@18.19.76)
+      '@inquirer/core': 10.1.8(@types/node@20.19.0)
       '@inquirer/figures': 1.0.11
-      '@inquirer/type': 3.0.5(@types/node@18.19.76)
+      '@inquirer/type': 3.0.5(@types/node@20.19.0)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
 
-  '@inquirer/select@4.0.10(@types/node@18.19.76)':
+  '@inquirer/select@4.0.10(@types/node@20.19.0)':
     dependencies:
-      '@inquirer/core': 10.1.8(@types/node@18.19.76)
+      '@inquirer/core': 10.1.8(@types/node@20.19.0)
       '@inquirer/figures': 1.0.11
-      '@inquirer/type': 3.0.5(@types/node@18.19.76)
+      '@inquirer/type': 3.0.5(@types/node@20.19.0)
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
 
-  '@inquirer/type@3.0.5(@types/node@18.19.76)':
+  '@inquirer/type@3.0.5(@types/node@20.19.0)':
     optionalDependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -8930,27 +8936,27 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5))
+      jest-config: 29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -8971,21 +8977,21 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.8.2))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.8.2))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.8.2))
+      jest-config: 29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.8.2))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -9014,7 +9020,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -9032,7 +9038,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.0.2
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -9054,7 +9060,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.30
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -9124,7 +9130,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
       '@types/yargs': 17.0.13
       chalk: 4.1.2
 
@@ -9249,23 +9255,23 @@ snapshots:
   '@libsql/win32-x64-msvc@0.3.10':
     optional: true
 
-  '@microsoft/api-extractor-model@7.30.7(@types/node@18.19.76)':
+  '@microsoft/api-extractor-model@7.30.7(@types/node@20.19.0)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.14.0(@types/node@18.19.76)
+      '@rushstack/node-core-library': 5.14.0(@types/node@20.19.0)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.52.11(@types/node@18.19.76)':
+  '@microsoft/api-extractor@7.52.11(@types/node@20.19.0)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.30.7(@types/node@18.19.76)
+      '@microsoft/api-extractor-model': 7.30.7(@types/node@20.19.0)
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.14.0(@types/node@18.19.76)
+      '@rushstack/node-core-library': 5.14.0(@types/node@20.19.0)
       '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.15.4(@types/node@18.19.76)
-      '@rushstack/ts-command-line': 5.0.2(@types/node@18.19.76)
+      '@rushstack/terminal': 0.15.4(@types/node@20.19.0)
+      '@rushstack/ts-command-line': 5.0.2(@types/node@20.19.0)
       lodash: 4.17.21
       minimatch: 10.0.3
       resolve: 1.22.10
@@ -9622,7 +9628,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.36.0':
     optional: true
 
-  '@rushstack/node-core-library@5.14.0(@types/node@18.19.76)':
+  '@rushstack/node-core-library@5.14.0(@types/node@20.19.0)':
     dependencies:
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
@@ -9633,23 +9639,23 @@ snapshots:
       resolve: 1.22.10
       semver: 7.5.4
     optionalDependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
 
   '@rushstack/rig-package@0.5.3':
     dependencies:
       resolve: 1.22.10
       strip-json-comments: 3.1.1
 
-  '@rushstack/terminal@0.15.4(@types/node@18.19.76)':
+  '@rushstack/terminal@0.15.4(@types/node@20.19.0)':
     dependencies:
-      '@rushstack/node-core-library': 5.14.0(@types/node@18.19.76)
+      '@rushstack/node-core-library': 5.14.0(@types/node@20.19.0)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
 
-  '@rushstack/ts-command-line@5.0.2(@types/node@18.19.76)':
+  '@rushstack/ts-command-line@5.0.2(@types/node@20.19.0)':
     dependencies:
-      '@rushstack/terminal': 0.15.4(@types/node@18.19.76)
+      '@rushstack/terminal': 0.15.4(@types/node@20.19.0)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -9684,7 +9690,7 @@ snapshots:
   '@slack/webhook@7.0.5':
     dependencies:
       '@slack/types': 2.14.0
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
       axios: 1.8.4
     transitivePeerDependencies:
       - debug
@@ -9850,7 +9856,7 @@ snapshots:
 
   '@types/cross-spawn@6.0.6':
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
 
   '@types/debug@4.1.12':
     dependencies:
@@ -9877,17 +9883,17 @@ snapshots:
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
 
   '@types/geojson@7946.0.16': {}
 
   '@types/graceful-fs@4.1.5':
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
 
   '@types/graphviz@0.0.39':
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
 
   '@types/istanbul-lib-coverage@2.0.4': {}
 
@@ -9910,7 +9916,7 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
 
   '@types/minimist@1.2.2': {}
 
@@ -9928,6 +9934,10 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
+  '@types/node@20.19.0':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@24.3.0':
     dependencies:
       undici-types: 7.10.0
@@ -9942,7 +9952,7 @@ snapshots:
 
   '@types/pg@8.11.6':
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
       pg-protocol: 1.6.1
       pg-types: 4.0.2
 
@@ -9950,16 +9960,16 @@ snapshots:
 
   '@types/progress@2.0.7':
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
 
   '@types/prompts@2.4.9':
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
       kleur: 3.0.3
 
   '@types/readable-stream@4.0.14':
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
       safe-buffer: 5.1.2
 
   '@types/resolve@1.20.6': {}
@@ -9970,7 +9980,7 @@ snapshots:
 
   '@types/sqlite3@3.1.11':
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
 
   '@types/stack-utils@2.0.1': {}
 
@@ -9982,7 +9992,7 @@ snapshots:
 
   '@types/ws@8.5.6':
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
 
   '@types/yargs-parser@21.0.0': {}
 
@@ -10126,7 +10136,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.0)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -10141,7 +10151,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.0)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10153,13 +10163,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.2.2(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0))':
+  '@vitest/mocker@3.2.4(vite@6.2.2(@types/node@20.19.0)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.2.2(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.2.2(@types/node@20.19.0)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
 
   '@vitest/mocker@3.2.4(vite@6.2.2(@types/node@24.3.0)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
@@ -10918,13 +10928,13 @@ snapshots:
       crc-32: 1.2.2
       readable-stream: 3.6.2
 
-  create-jest@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5)):
+  create-jest@29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5))
+      jest-config: 29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -10933,13 +10943,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.8.2)):
+  create-jest@29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.8.2)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.8.2))
+      jest-config: 29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.8.2))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -11275,13 +11285,13 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-jest@28.11.0(@typescript-eslint/eslint-plugin@7.15.0(@typescript-eslint/parser@7.15.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.4.5))(eslint@9.22.0(jiti@2.4.2))(typescript@5.4.5))(eslint@9.22.0(jiti@2.4.2))(jest@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5)))(typescript@5.4.5):
+  eslint-plugin-jest@28.11.0(@typescript-eslint/eslint-plugin@7.15.0(@typescript-eslint/parser@7.15.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.4.5))(eslint@9.22.0(jiti@2.4.2))(typescript@5.4.5))(eslint@9.22.0(jiti@2.4.2))(jest@29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5)))(typescript@5.4.5):
     dependencies:
       '@typescript-eslint/utils': 7.15.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.4.5)
       eslint: 9.22.0(jiti@2.4.2)
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 7.15.0(@typescript-eslint/parser@7.15.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.4.5))(eslint@9.22.0(jiti@2.4.2))(typescript@5.4.5)
-      jest: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5))
+      jest: 29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -12158,7 +12168,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.1
@@ -12178,16 +12188,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5)):
+  jest-cli@29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5))
+      create-jest: 29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5))
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5))
+      jest-config: 29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.6.0
@@ -12197,16 +12207,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.8.2)):
+  jest-cli@29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.8.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.8.2))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.8.2))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.8.2))
+      create-jest: 29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.8.2))
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.8.2))
+      jest-config: 29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.8.2))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.6.0
@@ -12216,7 +12226,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5)):
+  jest-config@29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5)):
     dependencies:
       '@babel/core': 7.21.8
       '@jest/test-sequencer': 29.7.0
@@ -12241,13 +12251,13 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 18.19.76
-      ts-node: 10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5)
+      '@types/node': 20.19.0
+      ts-node: 10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.8.2)):
+  jest-config@29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.8.2)):
     dependencies:
       '@babel/core': 7.21.8
       '@jest/test-sequencer': 29.7.0
@@ -12272,8 +12282,8 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 18.19.76
-      ts-node: 10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.8.2)
+      '@types/node': 20.19.0
+      ts-node: 10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.8.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -12302,16 +12312,16 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  jest-extended@4.0.2(jest@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5))):
+  jest-extended@4.0.2(jest@29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5))):
     dependencies:
       jest-diff: 29.7.0
       jest-get-type: 29.6.3
     optionalDependencies:
-      jest: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5))
+      jest: 29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5))
 
   jest-get-type@29.6.3: {}
 
@@ -12319,7 +12329,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.5
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -12365,7 +12375,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.2(jest-resolve@29.7.0):
@@ -12400,7 +12410,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -12428,7 +12438,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.1
@@ -12478,7 +12488,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -12497,7 +12507,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -12506,35 +12516,35 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5)):
+  jest@29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5))
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5))
+      jest-cli: 29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.8.2)):
+  jest@29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.8.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.8.2))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.8.2))
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.8.2))
+      jest-cli: 29.7.0(@types/node@20.19.0)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.8.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -14217,7 +14227,7 @@ snapshots:
       '@azure/identity': 4.3.0
       '@azure/keyvault-keys': 4.6.0
       '@js-joda/core': 5.6.3
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
       bl: 6.0.12
       iconv-lite: 0.6.3
       js-md4: 0.3.2
@@ -14355,14 +14365,14 @@ snapshots:
     dependencies:
       typescript: 5.4.5
 
-  ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.4.5):
+  ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.4.5):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
       acorn: 8.14.1
       acorn-walk: 8.3.2
       arg: 4.1.3
@@ -14375,14 +14385,14 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.11.5
 
-  ts-node@10.9.2(@swc/core@1.11.5)(@types/node@18.19.76)(typescript@5.8.2):
+  ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.0)(typescript@5.8.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
       acorn: 8.14.1
       acorn-walk: 8.3.2
       arg: 4.1.3
@@ -14495,6 +14505,8 @@ snapshots:
 
   undici-types@5.26.5: {}
 
+  undici-types@6.21.0: {}
+
   undici-types@7.10.0: {}
 
   undici@5.28.5:
@@ -14580,13 +14592,13 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.4.1
 
-  vite-node@3.2.4(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0):
+  vite-node@3.2.4(@types/node@20.19.0)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.2.2(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.2.2(@types/node@20.19.0)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -14622,13 +14634,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.2.2(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0):
+  vite@6.2.2(@types/node@20.19.0)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.5
       postcss: 8.5.3
       rollup: 4.36.0
     optionalDependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
       fsevents: 2.3.3
       jiti: 2.4.2
       terser: 5.27.0
@@ -14648,11 +14660,11 @@ snapshots:
       tsx: 4.19.3
       yaml: 2.7.0
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.0)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.2.2(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0))
+      '@vitest/mocker': 3.2.4(vite@6.2.2(@types/node@20.19.0)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -14670,12 +14682,12 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.2.2(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
-      vite-node: 3.2.4(@types/node@18.19.76)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.2.2(@types/node@20.19.0)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite-node: 3.2.4(@types/node@20.19.0)(jiti@2.4.2)(terser@5.27.0)(tsx@4.19.3)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
-      '@types/node': 18.19.76
+      '@types/node': 20.19.0
     transitivePeerDependencies:
       - jiti
       - less

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,7 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 20.19.0
+        specifier: ~20.19.0
         version: 20.19.0
       '@types/resolve':
         specifier: 1.20.6
@@ -455,7 +455,7 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 20.19.0
+        specifier: ~20.19.0
         version: 20.19.0
       async-listen:
         specifier: 3.1.0
@@ -698,7 +698,7 @@ importers:
         specifier: 9.1.8
         version: 9.1.8
       '@types/node':
-        specifier: 20.19.0
+        specifier: ~20.19.0
         version: 20.19.0
       '@types/pg':
         specifier: 8.11.11
@@ -870,7 +870,7 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 20.19.0
+        specifier: ~20.19.0
         version: 20.19.0
       jest:
         specifier: 29.7.0
@@ -1067,7 +1067,7 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 20.19.0
+        specifier: ~20.19.0
         version: 20.19.0
       jest:
         specifier: 29.7.0
@@ -1119,7 +1119,7 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 20.19.0
+        specifier: ~20.19.0
         version: 20.19.0
       execa:
         specifier: 5.1.1
@@ -1144,7 +1144,7 @@ importers:
         version: link:../get-platform
     devDependencies:
       '@types/node':
-        specifier: 20.19.0
+        specifier: ~20.19.0
         version: 20.19.0
       '@types/progress':
         specifier: 2.0.7
@@ -1229,7 +1229,7 @@ importers:
         specifier: 6.0.6
         version: 6.0.6
       '@types/node':
-        specifier: 20.19.0
+        specifier: ~20.19.0
         version: 20.19.0
       cross-spawn:
         specifier: 7.0.6
@@ -1260,7 +1260,7 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 20.19.0
+        specifier: ~20.19.0
         version: 20.19.0
       benchmark:
         specifier: 2.1.4
@@ -1312,7 +1312,7 @@ importers:
         specifier: workspace:*
         version: link:../internals
       '@types/node':
-        specifier: 20.19.0
+        specifier: ~20.19.0
         version: 20.19.0
       typescript:
         specifier: 5.4.5
@@ -1345,7 +1345,7 @@ importers:
         specifier: 9.1.8
         version: 9.1.8
       '@types/node':
-        specifier: 20.19.0
+        specifier: ~20.19.0
         version: 20.19.0
       '@types/pg':
         specifier: 8.11.11
@@ -1454,7 +1454,7 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 20.19.0
+        specifier: ~20.19.0
         version: 20.19.0
       '@types/resolve':
         specifier: 1.20.6
@@ -1617,7 +1617,7 @@ importers:
         specifier: 29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 20.19.0
+        specifier: ~20.19.0
         version: 20.19.0
       '@types/pg':
         specifier: 8.11.11

--- a/sandbox/basic-sqlite/package.json
+++ b/sandbox/basic-sqlite/package.json
@@ -18,7 +18,7 @@
     "@prisma/config": "../../packages/config"
   },
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "prisma": "../../packages/cli",
     "ts-node": "10.9.2",
     "typescript": "5.2.2"

--- a/sandbox/basic-sqlite/package.json
+++ b/sandbox/basic-sqlite/package.json
@@ -18,7 +18,7 @@
     "@prisma/config": "../../packages/config"
   },
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "../../packages/cli",
     "ts-node": "10.9.2",
     "typescript": "5.2.2"

--- a/sandbox/driver-adapters/README.md
+++ b/sandbox/driver-adapters/README.md
@@ -4,8 +4,8 @@ This is a playground for testing the Prisma Client with Driver Adapters (aka Nod
 
 ## How to setup
 
-We assume Node.js `v18.18`+ is installed. If not, run `nvm use` in the current directory.
-This is very important to double-check if you have multiple versions installed, as PlanetScale requires either Node.js `v18.18`+ or a custom `fetch` function.
+We assume Node.js `v20.19`+ is installed. If not, run `nvm use` in the current directory.
+This is very important to double-check if you have multiple versions installed, as PlanetScale requires either Node.js `v20.19`+ or a custom `fetch` function.
 
 - Create a `.envrc` starting from `.envrc.example`, and fill in the missing values following the given template
 - Install Node.js dependencies via

--- a/sandbox/driver-adapters/package.json
+++ b/sandbox/driver-adapters/package.json
@@ -32,7 +32,7 @@
     "undici": "5.27.2"
   },
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/pg": "../../packages/adapter-pg/node_modules/@types/pg",
     "prisma": "../../packages/cli",
     "tsx": "4.1.2",

--- a/sandbox/driver-adapters/package.json
+++ b/sandbox/driver-adapters/package.json
@@ -32,7 +32,7 @@
     "undici": "5.27.2"
   },
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/pg": "../../packages/adapter-pg/node_modules/@types/pg",
     "prisma": "../../packages/cli",
     "tsx": "4.1.2",

--- a/sandbox/query-compiler/package.json
+++ b/sandbox/query-compiler/package.json
@@ -20,7 +20,7 @@
     "pg": "../../packages/adapter-pg/node_modules/pg"
   },
   "devDependencies": {
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "@types/pg": "../../packages/adapter-pg/node_modules/@types/pg",
     "prisma": "../../packages/cli",
     "ts-node": "*",

--- a/sandbox/query-compiler/package.json
+++ b/sandbox/query-compiler/package.json
@@ -20,7 +20,7 @@
     "pg": "../../packages/adapter-pg/node_modules/pg"
   },
   "devDependencies": {
-    "@types/node": "18.19.76",
+    "@types/node": "20.19.0",
     "@types/pg": "../../packages/adapter-pg/node_modules/@types/pg",
     "prisma": "../../packages/cli",
     "ts-node": "*",

--- a/sandbox/tracing/package.json
+++ b/sandbox/tracing/package.json
@@ -25,7 +25,7 @@
     "@opentelemetry/resources": "1.26.0",
     "@opentelemetry/sdk-trace-base": "1.26.0",
     "@opentelemetry/semantic-conventions": "1.27.0",
-    "@types/node": "22.5.3",
+    "@types/node": "20.19.0",
     "prisma": "../../packages/cli",
     "ts-node": "10.9.2",
     "typescript": "5.5.4"

--- a/sandbox/tracing/package.json
+++ b/sandbox/tracing/package.json
@@ -25,7 +25,7 @@
     "@opentelemetry/resources": "1.26.0",
     "@opentelemetry/sdk-trace-base": "1.26.0",
     "@opentelemetry/semantic-conventions": "1.27.0",
-    "@types/node": "20.19.0",
+    "@types/node": "~20.19.0",
     "prisma": "../../packages/cli",
     "ts-node": "10.9.2",
     "typescript": "5.5.4"


### PR DESCRIPTION
[TML-1337](https://linear.app/prisma-company/issue/TML-1337/prisma-7-update-minimum-nodejs-versions)

Updates Node constraints to be:
- `^20.19 || ^22.12 || ^24.0` - for the engines in package.json (should allow using a newer minor versions)
- `~20.19.0` - for the typings (we should NOT rely on minor added types)
- `['20.19.0', '22.12.0', '24.0.1']` - for CI (we want to test our behavior on our lowest supported versions)