### PR TITLE
feat(cli): remove deprecated `introspect` cmd

### DIFF
--- a/packages/cli/src/CLI.ts
+++ b/packages/cli/src/CLI.ts
@@ -3,8 +3,8 @@ import { Debug } from '@prisma/debug'
 import { ensureNeededBinariesExist } from '@prisma/engines'
 import type { BinaryPaths, DownloadOptions } from '@prisma/fetch-engine'
 import type { Command, Commands } from '@prisma/internals'
-import { arg, drawBox, format, HelpError, isError, link, logger, unknownCommand } from '@prisma/internals'
-import { bold, dim, green, red, underline } from 'kleur/colors'
+import { arg, drawBox, format, HelpError, isError, link, unknownCommand } from '@prisma/internals'
+import { bold, dim, green, red } from 'kleur/colors'
 import { match } from 'ts-pattern'
 
 import { runCheckpointClientCheck } from './utils/checkpoint'
@@ -101,16 +101,6 @@ export class CLI implements Command {
     // Throw if "lift"
     if (cmdName === 'lift') {
       throw new Error(`${red('prisma lift')} has been renamed to ${green('prisma migrate')}`)
-    }
-    // warn if "introspect"
-    else if (cmdName === 'introspect') {
-      logger.warn('')
-      logger.warn(
-        `${bold(
-          `The ${underline('prisma introspect')} command is deprecated. Please use ${green('prisma db pull')} instead.`,
-        )}`,
-      )
-      logger.warn('')
     }
 
     const cmd = this.cmds[cmdName]

--- a/packages/cli/src/__tests__/commands/CLI.test.ts
+++ b/packages/cli/src/__tests__/commands/CLI.test.ts
@@ -1,6 +1,5 @@
 import { defaultTestConfig, defineConfig } from '@prisma/config'
 import { jestConsoleContext, jestContext } from '@prisma/get-platform'
-import { DbPull } from '@prisma/migrate'
 
 import { CLI } from '../../CLI'
 import { Validate } from '../../Validate'
@@ -25,10 +24,6 @@ function createCLI(download = jest.fn()) {
       //   // drop: DbDrop.new(),
       //   seed: DbSeed.new(),
       // }),
-      /**
-       * @deprecated since version 2.30.0, use `db pull` instead (renamed)
-       */
-      introspect: DbPull.new(),
       // dev: Dev.new(),
       // studio: Studio.new(),
       // generate: Generate.new(),
@@ -37,7 +32,7 @@ function createCLI(download = jest.fn()) {
       // format: Format.new(),
       // telemetry: Telemetry.new(),
     },
-    ['version', 'init', 'migrate', 'db', 'introspect', 'dev', 'studio', 'generate', 'validate', 'format', 'telemetry'],
+    ['version', 'init', 'migrate', 'db', 'dev', 'studio', 'generate', 'validate', 'format', 'telemetry'],
     download,
   )
 }
@@ -192,22 +187,5 @@ describe('CLI', () => {
 
   it('unknown command', async () => {
     await expect(cliInstance.parse(['doesnotexist'], defaultTestConfig())).resolves.toThrow()
-  })
-
-  it('introspect should include deprecation warning', async () => {
-    const result = cliInstance.parse(['introspect'], defaultTestConfig())
-
-    await expect(result).rejects.toMatchInlineSnapshot(`
-      "Could not find a schema.prisma file that is required for this command.
-      You can either provide it with --schema, set it as \`prisma.schema\` in your package.json or put it into the default location ./prisma/schema.prisma https://pris.ly/d/prisma-schema-location"
-    `)
-    expect(ctx.mocked['console.log'].mock.calls).toHaveLength(0)
-    expect(ctx.mocked['console.info'].mock.calls).toHaveLength(0)
-    expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
-      "prisma:warn 
-      prisma:warn The prisma introspect command is deprecated. Please use prisma db pull instead.
-      prisma:warn "
-    `)
-    expect(ctx.mocked['console.error'].mock.calls).toHaveLength(0)
   })
 })

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -139,10 +139,6 @@ async function main(): Promise<number> {
         // drop: DbDrop.new(),
         seed: DbSeed.new(),
       }),
-      /**
-       * @deprecated since version 2.30.0, use `db pull` instead (renamed)
-       */
-      introspect: DbPull.new(),
       studio: Studio.new(),
       generate: Generate.new(),
       version: Version.new(),
@@ -158,7 +154,7 @@ async function main(): Promise<number> {
       // TODO: add login subcommand to --help after it works.
       login: new SubCommand('@prisma/cli-login'),
     },
-    ['version', 'init', 'migrate', 'db', 'introspect', 'studio', 'generate', 'validate', 'format', 'telemetry'],
+    ['version', 'init', 'migrate', 'db', 'studio', 'generate', 'validate', 'format', 'telemetry'],
     download,
   )
 

--- a/packages/internals/src/sendPanic.ts
+++ b/packages/internals/src/sendPanic.ts
@@ -86,9 +86,7 @@ export async function sendPanic({
 
 function getCommand(): string {
   // don't send url
-  if (process.argv[2] === 'introspect') {
-    return 'introspect'
-  } else if (process.argv[2] === 'db' && process.argv[3] === 'pull') {
+  if (process.argv[2] === 'db' && process.argv[3] === 'pull') {
     return 'db pull'
   }
   return process.argv.slice(2).join(' ')


### PR DESCRIPTION
This PR:
- closes [TML-1502](https://linear.app/prisma-company/issue/TML-1502/remove-deprecated-prisma-introspect-command)
- removes support for `prisma introspect`, an alias for `prisma db pull` that was deprecated in Prisma 2.30.0.