### PR TITLE
fix: support multiple Prisma instances with different providers

### DIFF
--- a/packages/client/tests/e2e/issues/28221-multiple-provider-clients/.gitignore
+++ b/packages/client/tests/e2e/issues/28221-multiple-provider-clients/.gitignore
@@ -1,0 +1,1 @@
+pnpm-lock.yaml

--- a/packages/client/tests/e2e/issues/28221-multiple-provider-clients/_steps.cts
+++ b/packages/client/tests/e2e/issues/28221-multiple-provider-clients/_steps.cts
@@ -1,0 +1,20 @@
+import { $ } from 'zx'
+
+import { executeSteps } from '../../_utils/executeSteps'
+
+void executeSteps({
+  setup: async () => {
+    await $`pnpm install`
+    for (const provider of ['mysql', 'postgres']) {
+      await $`pnpm exec prisma generate --schema=./prisma/${provider}/schema.prisma`
+      await $`pnpm exec prisma db push --force-reset --skip-generate --schema=./prisma/${provider}/schema.prisma`
+    }
+  },
+  test: async () => {
+    await $`tsx src/index.ts`
+  },
+  finish: async () => {
+    await $`echo "done"`
+  },
+  // keep: true, // keep docker open to debug it
+})

--- a/packages/client/tests/e2e/issues/28221-multiple-provider-clients/docker-compose.yaml
+++ b/packages/client/tests/e2e/issues/28221-multiple-provider-clients/docker-compose.yaml
@@ -1,0 +1,38 @@
+services:
+  test-e2e:
+    environment:
+      - POSTGRES_URL=postgres://prisma:prisma@postgres:5432/tests
+      - MYSQL_URL=mysql://root:root@mysql:3306/tests
+    depends_on:
+      postgres:
+        condition: service_healthy
+      mysql:
+        condition: service_healthy
+
+  postgres:
+    image: postgres:16
+    environment:
+      - POSTGRES_DB=tests
+      - POSTGRES_USER=prisma
+      - POSTGRES_PASSWORD=prisma
+    healthcheck:
+      test: ['CMD', 'pg_isready', '-U', 'prisma', '-d', 'tests']
+      interval: 5s
+      timeout: 2s
+      retries: 20
+
+  mysql:
+    image: mysql:9.0
+    command: --lower_case_table_names=1
+    restart: unless-stopped
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_DATABASE=tests
+      - MYSQL_PASSWORD=prisma
+    ports:
+      - '3306:3306'
+    healthcheck:
+      test: ['CMD', 'mysqladmin', 'ping', '-h127.0.0.1', '-P3306']
+      interval: 5s
+      timeout: 2s
+      retries: 20

--- a/packages/client/tests/e2e/issues/28221-multiple-provider-clients/docker-compose.yaml
+++ b/packages/client/tests/e2e/issues/28221-multiple-provider-clients/docker-compose.yaml
@@ -29,8 +29,6 @@ services:
       - MYSQL_ROOT_PASSWORD=root
       - MYSQL_DATABASE=tests
       - MYSQL_PASSWORD=prisma
-    ports:
-      - '3306:3306'
     healthcheck:
       test: ['CMD', 'mysqladmin', 'ping', '-h127.0.0.1', '-P3306']
       interval: 5s

--- a/packages/client/tests/e2e/issues/28221-multiple-provider-clients/package.json
+++ b/packages/client/tests/e2e/issues/28221-multiple-provider-clients/package.json
@@ -1,0 +1,16 @@
+{
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js",
+  "scripts": {},
+  "type": "module",
+  "dependencies": {
+    "@prisma/adapter-pg": "/tmp/prisma-adapter-pg-0.0.0.tgz",
+    "@prisma/adapter-mariadb": "/tmp/prisma-adapter-mariadb-0.0.0.tgz",
+    "@prisma/client": "/tmp/prisma-client-0.0.0.tgz"
+  },
+  "devDependencies": {
+    "@types/node": "18.19.76",
+    "prisma": "/tmp/prisma-0.0.0.tgz"
+  }
+}

--- a/packages/client/tests/e2e/issues/28221-multiple-provider-clients/prisma/mysql/schema.prisma
+++ b/packages/client/tests/e2e/issues/28221-multiple-provider-clients/prisma/mysql/schema.prisma
@@ -1,0 +1,16 @@
+generator client {
+  provider     = "prisma-client"
+  output       = "../../generated/mysql-client"
+  engineType   = "client"
+}
+
+datasource db {
+  provider = "mysql"
+  url      = env("MYSQL_URL")
+}
+
+model User {
+  id    Int    @id @default(autoincrement())
+  email String @unique
+  name  String
+}

--- a/packages/client/tests/e2e/issues/28221-multiple-provider-clients/prisma/postgres/schema.prisma
+++ b/packages/client/tests/e2e/issues/28221-multiple-provider-clients/prisma/postgres/schema.prisma
@@ -1,0 +1,16 @@
+generator client {
+  provider     = "prisma-client"
+  output       = "../../generated/postgres-client"
+  engineType   = "client"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("POSTGRES_URL")
+}
+
+model User {
+  id    Int    @id @default(autoincrement())
+  email String @unique
+  name  String
+}

--- a/packages/client/tests/e2e/issues/28221-multiple-provider-clients/src/database.ts
+++ b/packages/client/tests/e2e/issues/28221-multiple-provider-clients/src/database.ts
@@ -1,0 +1,24 @@
+import { PrismaMariaDb } from '@prisma/adapter-mariadb'
+import { PrismaPg } from '@prisma/adapter-pg'
+
+import { PrismaClient as MySQLClient } from '../generated/mysql-client/client'
+import { PrismaClient as PostgresClient } from '../generated/postgres-client/client'
+
+// PostgreSQL client
+const postgresClient = new PostgresClient({
+  adapter: new PrismaPg({ connectionString: process.env.POSTGRES_URL! }, { schema: 'public' }),
+})
+
+// MySQL client
+const mysqlUrl = new URL(process.env.MYSQL_URL!)
+const mysqlClient = new MySQLClient({
+  adapter: new PrismaMariaDb({
+    host: mysqlUrl.hostname,
+    user: mysqlUrl.username,
+    password: mysqlUrl.password,
+    database: mysqlUrl.pathname.slice(1),
+    port: Number(mysqlUrl.port),
+  }),
+})
+
+export { mysqlClient, postgresClient }

--- a/packages/client/tests/e2e/issues/28221-multiple-provider-clients/src/index.ts
+++ b/packages/client/tests/e2e/issues/28221-multiple-provider-clients/src/index.ts
@@ -1,0 +1,15 @@
+import { mysqlClient, postgresClient } from './database'
+
+async function main() {
+  // First query to PostgreSQL - works fine
+  const postgresData = await postgresClient.user.findFirst()
+  console.log('PostgreSQL query succeeded:', postgresData)
+
+  // Second query to MySQL - fails with error
+  const mysqlData = await mysqlClient.user.findFirst()
+  console.log('MySQL query succeeded:', mysqlData)
+
+  process.exit(0)
+}
+
+void main()


### PR DESCRIPTION
The bug happens because of our cache, which currently ignores the provider in use

[TML-1503](https://linear.app/prisma-company/issue/TML-1503/fix-usage-of-multiple-prisma-clients-with-different-providers)

Fixes https://github.com/prisma/prisma/issues/28221