### PR TITLE
chore: rename adapter exports to use acronyms as words

### DIFF
--- a/packages/adapter-better-sqlite3/src/better-sqlite3.ts
+++ b/packages/adapter-better-sqlite3/src/better-sqlite3.ts
@@ -45,7 +45,7 @@ class BetterSQLite3Queryable<ClientT extends StdClient> implements SqlQueryable 
 
   constructor(
     protected readonly client: ClientT,
-    protected readonly adapterOptions?: PrismaBetterSQLite3Options,
+    protected readonly adapterOptions?: PrismaBetterSqlite3Options,
   ) {}
 
   /**
@@ -142,7 +142,7 @@ class BetterSQLite3Transaction extends BetterSQLite3Queryable<StdClient> impleme
   constructor(
     client: StdClient,
     readonly options: TransactionOptions,
-    adapterOptions: PrismaBetterSQLite3Options | undefined,
+    adapterOptions: PrismaBetterSqlite3Options | undefined,
     unlockParent: () => void,
   ) {
     super(client, adapterOptions)
@@ -162,10 +162,10 @@ class BetterSQLite3Transaction extends BetterSQLite3Queryable<StdClient> impleme
   }
 }
 
-export class PrismaBetterSQLite3Adapter extends BetterSQLite3Queryable<StdClient> implements SqlDriverAdapter {
+export class PrismaBetterSqlite3Adapter extends BetterSQLite3Queryable<StdClient> implements SqlDriverAdapter {
   #mutex = new Mutex()
 
-  constructor(client: StdClient, adapterOptions?: PrismaBetterSQLite3Options) {
+  constructor(client: StdClient, adapterOptions?: PrismaBetterSqlite3Options) {
     super(client, adapterOptions)
   }
 
@@ -214,31 +214,31 @@ type BetterSQLite3InputParams = BetterSQLite3Options & {
   url: ':memory:' | (string & {})
 }
 
-export type PrismaBetterSQLite3Options = {
+export type PrismaBetterSqlite3Options = {
   shadowDatabaseUrl?: string
   timestampFormat?: 'iso8601' | 'unixepoch-ms'
 }
 
-export class PrismaBetterSQLite3AdapterFactory implements SqlMigrationAwareDriverAdapterFactory {
+export class PrismaBetterSqlite3AdapterFactory implements SqlMigrationAwareDriverAdapterFactory {
   readonly provider = 'sqlite'
   readonly adapterName = packageName
 
   readonly #config: BetterSQLite3InputParams
-  readonly #options?: PrismaBetterSQLite3Options
+  readonly #options?: PrismaBetterSqlite3Options
 
-  constructor(config: BetterSQLite3InputParams, options?: PrismaBetterSQLite3Options) {
+  constructor(config: BetterSQLite3InputParams, options?: PrismaBetterSqlite3Options) {
     this.#config = config
     this.#options = options
   }
 
   connect(): Promise<SqlDriverAdapter> {
-    return Promise.resolve(new PrismaBetterSQLite3Adapter(createBetterSQLite3Client(this.#config), this.#options))
+    return Promise.resolve(new PrismaBetterSqlite3Adapter(createBetterSQLite3Client(this.#config), this.#options))
   }
 
   connectToShadowDb(): Promise<SqlDriverAdapter> {
     const url = this.#options?.shadowDatabaseUrl ?? ':memory:'
     return Promise.resolve(
-      new PrismaBetterSQLite3Adapter(createBetterSQLite3Client({ ...this.#config, url }), this.#options),
+      new PrismaBetterSqlite3Adapter(createBetterSQLite3Client({ ...this.#config, url }), this.#options),
     )
   }
 }

--- a/packages/adapter-better-sqlite3/src/conversion.ts
+++ b/packages/adapter-better-sqlite3/src/conversion.ts
@@ -1,6 +1,6 @@
 import { ArgType, ColumnType, ColumnTypeEnum, Debug, ResultValue } from '@prisma/driver-adapter-utils'
 
-import { PrismaBetterSQLite3Options } from './better-sqlite3'
+import { PrismaBetterSqlite3Options } from './better-sqlite3'
 
 const debug = Debug('prisma:driver-adapter:better-sqlite3:conversion')
 
@@ -192,7 +192,7 @@ export function mapRow(row: Row, columnTypes: ColumnType[]): ResultValue[] {
 export function mapArg<A>(
   arg: A | Date,
   argType: ArgType,
-  options?: PrismaBetterSQLite3Options,
+  options?: PrismaBetterSqlite3Options,
 ): null | number | BigInt | Uint8Array | string | A {
   if (arg === null) {
     return null

--- a/packages/adapter-better-sqlite3/src/index.ts
+++ b/packages/adapter-better-sqlite3/src/index.ts
@@ -1,1 +1,1 @@
-export { PrismaBetterSQLite3AdapterFactory as PrismaBetterSQLite3 } from './better-sqlite3'
+export { PrismaBetterSqlite3AdapterFactory as PrismaBetterSqlite3 } from './better-sqlite3'

--- a/packages/adapter-d1/src/d1.test.ts
+++ b/packages/adapter-d1/src/d1.test.ts
@@ -6,9 +6,9 @@ import {
 } from '@prisma/driver-adapter-utils'
 import { afterEach, describe, expect, expectTypeOf, test, vi } from 'vitest'
 
-import { PrismaD1HTTP } from '.'
+import { PrismaD1Http } from '.'
 import { PrismaD1 } from './d1'
-import { PrismaD1HTTPAdapterFactory } from './d1-http'
+import { PrismaD1HttpAdapterFactory } from './d1-http'
 import { PrismaD1WorkerAdapterFactory } from './d1-worker'
 
 describe('D1 adapter instance creation', () => {
@@ -18,9 +18,9 @@ describe('D1 adapter instance creation', () => {
 
   test('create a migration-aware adapter with cloudflare env variables', async () => {
     const adapter = mockAdapter('sqlite')
-    const connect = vi.spyOn(PrismaD1HTTPAdapterFactory.prototype, 'connect').mockResolvedValue(adapter)
+    const connect = vi.spyOn(PrismaD1HttpAdapterFactory.prototype, 'connect').mockResolvedValue(adapter)
     const connectToShadowDb = vi
-      .spyOn(PrismaD1HTTPAdapterFactory.prototype, 'connectToShadowDb')
+      .spyOn(PrismaD1HttpAdapterFactory.prototype, 'connectToShadowDb')
       .mockResolvedValue(adapter)
 
     const factory = new PrismaD1({
@@ -36,14 +36,14 @@ describe('D1 adapter instance creation', () => {
     expect(connectToShadowDb).toHaveBeenCalled()
   })
 
-  test('create a migration-aware adapter using PrismaD1HTTP with cloudflare env variables', async () => {
+  test('create a migration-aware adapter using PrismaD1Http with cloudflare env variables', async () => {
     const adapter = mockAdapter('sqlite')
-    const connect = vi.spyOn(PrismaD1HTTPAdapterFactory.prototype, 'connect').mockResolvedValue(adapter)
+    const connect = vi.spyOn(PrismaD1HttpAdapterFactory.prototype, 'connect').mockResolvedValue(adapter)
     const connectToShadowDb = vi
-      .spyOn(PrismaD1HTTPAdapterFactory.prototype, 'connectToShadowDb')
+      .spyOn(PrismaD1HttpAdapterFactory.prototype, 'connectToShadowDb')
       .mockResolvedValue(adapter)
 
-    const factory = new PrismaD1HTTP({
+    const factory = new PrismaD1Http({
       CLOUDFLARE_ACCOUNT_ID: 'test',
       CLOUDFLARE_D1_TOKEN: 'test',
       CLOUDFLARE_DATABASE_ID: 'test',

--- a/packages/adapter-d1/src/d1.ts
+++ b/packages/adapter-d1/src/d1.ts
@@ -2,14 +2,14 @@ import { D1Database } from '@cloudflare/workers-types'
 import { SqlDriverAdapter, SqlDriverAdapterFactory } from '@prisma/driver-adapter-utils'
 
 import { name as packageName } from '../package.json'
-import { D1HTTPParams, isD1HTTPParams, PrismaD1HTTPAdapterFactory } from './d1-http'
+import { D1HttpParams, isD1HttpParams, PrismaD1HttpAdapterFactory } from './d1-http'
 import { PrismaD1WorkerAdapterFactory } from './d1-worker'
 
 // This is a wrapper type that can conform to either `SqlDriverAdapterFactory` or
 // `SqlMigrationAwareDriverAdapterFactory`, depending on the type of the argument passed to the
-// constructor. If the argument is of type `D1HTTPParams`, it will leverage
-// `PrismaD1HTTPAdapterFactory`. Otherwise, it will use `PrismaD1WorkerAdapterFactory`.
-export class PrismaD1<Args extends D1Database | D1HTTPParams = D1Database> implements PrismaD1Interface<Args> {
+// constructor. If the argument is of type `D1HttpParams`, it will leverage
+// `PrismaD1HttpAdapterFactory`. Otherwise, it will use `PrismaD1WorkerAdapterFactory`.
+export class PrismaD1<Args extends D1Database | D1HttpParams = D1Database> implements PrismaD1Interface<Args> {
   readonly provider = 'sqlite'
   readonly adapterName = packageName
 
@@ -17,9 +17,9 @@ export class PrismaD1<Args extends D1Database | D1HTTPParams = D1Database> imple
   connectToShadowDb!: PrismaD1Interface<Args>['connectToShadowDb']
 
   constructor(params: Args) {
-    if (isD1HTTPParams(params)) {
-      const factory = new PrismaD1HTTPAdapterFactory(params)
-      const self = this as PrismaD1Interface<D1HTTPParams>
+    if (isD1HttpParams(params)) {
+      const factory = new PrismaD1HttpAdapterFactory(params)
+      const self = this as PrismaD1Interface<D1HttpParams>
       self.connect = factory.connect.bind(factory)
       self.connectToShadowDb = factory.connectToShadowDb.bind(factory)
     } else {
@@ -31,5 +31,5 @@ export class PrismaD1<Args extends D1Database | D1HTTPParams = D1Database> imple
 }
 
 type PrismaD1Interface<Params> = SqlDriverAdapterFactory & {
-  connectToShadowDb: Params extends D1HTTPParams ? () => Promise<SqlDriverAdapter> : undefined
+  connectToShadowDb: Params extends D1HttpParams ? () => Promise<SqlDriverAdapter> : undefined
 }

--- a/packages/adapter-d1/src/index.ts
+++ b/packages/adapter-d1/src/index.ts
@@ -1,3 +1,3 @@
 export { PrismaD1 } from './d1'
 // exported for backwards compatibility
-export { PrismaD1HTTPAdapterFactory as PrismaD1HTTP } from './d1-http'
+export { PrismaD1HttpAdapterFactory as PrismaD1Http } from './d1-http'

--- a/packages/adapter-libsql/README.md
+++ b/packages/adapter-libsql/README.md
@@ -18,17 +18,17 @@ Update your Prisma Client instance to use the libSQL database Client:
 ```ts
 // Import needed packages
 import { PrismaClient } from '@prisma/client'
-import { PrismaLibSQL } from '@prisma/adapter-libsql'
+import { PrismaLibSql } from '@prisma/adapter-libsql'
 // You can alternatively use the web version of the client if you're running in
 // a constrained environment where the standard libsql client doesn't work:
-// import { PrismaLibSQL } from '@prisma/adapter-libsql/web'
+// import { PrismaLibSql } from '@prisma/adapter-libsql/web'
 
 // Setup
 const connectionString = `${process.env.TURSO_DATABASE_URL}`
 const authToken = `${process.env.TURSO_AUTH_TOKEN}`
 
 // Init prisma client
-const adapter = new PrismaLibSQL({
+const adapter = new PrismaLibSql({
   url: connectionString,
   authToken,
 })

--- a/packages/adapter-libsql/src/conversion.ts
+++ b/packages/adapter-libsql/src/conversion.ts
@@ -1,7 +1,7 @@
 import { InValue, Row, Value } from '@libsql/client'
 import { ArgType, ColumnType, ColumnTypeEnum, Debug, ResultValue } from '@prisma/driver-adapter-utils'
 
-import { PrismaLibSQLOptions } from './libsql'
+import { PrismaLibSqlOptions } from './libsql'
 
 const debug = Debug('prisma:driver-adapter:libsql:conversion')
 
@@ -173,7 +173,7 @@ export function mapRow(row: Row, columnTypes: ColumnType[]): ResultValue[] {
   return result
 }
 
-export function mapArg(arg: unknown, argType: ArgType, options?: PrismaLibSQLOptions): InValue {
+export function mapArg(arg: unknown, argType: ArgType, options?: PrismaLibSqlOptions): InValue {
   if (arg === null) {
     return null
   }

--- a/packages/adapter-libsql/src/index-node.ts
+++ b/packages/adapter-libsql/src/index-node.ts
@@ -1,1 +1,1 @@
-export { PrismaLibSQLAdapterFactory as PrismaLibSQL } from './libsql-node'
+export { PrismaLibSqlAdapterFactory as PrismaLibSql } from './libsql-node'

--- a/packages/adapter-libsql/src/index-web.ts
+++ b/packages/adapter-libsql/src/index-web.ts
@@ -1,1 +1,1 @@
-export { PrismaLibSQLWebAdapterFactory as PrismaLibSQL } from './libsql-web'
+export { PrismaLibSqlWebAdapterFactory as PrismaLibSql } from './libsql-web'

--- a/packages/adapter-libsql/src/libsql-node.ts
+++ b/packages/adapter-libsql/src/libsql-node.ts
@@ -1,8 +1,8 @@
 import { type Client, type Config, createClient } from '@libsql/client'
 
-import { PrismaLibSQLAdapterFactoryBase } from './libsql'
+import { PrismaLibSqlAdapterFactoryBase } from './libsql'
 
-export class PrismaLibSQLAdapterFactory extends PrismaLibSQLAdapterFactoryBase {
+export class PrismaLibSqlAdapterFactory extends PrismaLibSqlAdapterFactoryBase {
   createClient(config: Config): Client {
     return createClient(config)
   }

--- a/packages/adapter-libsql/src/libsql-web.ts
+++ b/packages/adapter-libsql/src/libsql-web.ts
@@ -1,8 +1,8 @@
 import { type Client, type Config, createClient } from '@libsql/client/web'
 
-import { PrismaLibSQLAdapterFactoryBase } from './libsql'
+import { PrismaLibSqlAdapterFactoryBase } from './libsql'
 
-export class PrismaLibSQLWebAdapterFactory extends PrismaLibSQLAdapterFactoryBase {
+export class PrismaLibSqlWebAdapterFactory extends PrismaLibSqlAdapterFactoryBase {
   createClient(config: Config): Client {
     return createClient(config)
   }

--- a/packages/adapter-libsql/src/libsql.test.ts
+++ b/packages/adapter-libsql/src/libsql.test.ts
@@ -2,15 +2,15 @@ import type { Client } from '@libsql/client'
 import { ColumnTypeEnum, IsolationLevel, SqlMigrationAwareDriverAdapterFactory } from '@prisma/driver-adapter-utils'
 import { describe, expect, test, vi } from 'vitest'
 
-import { PrismaLibSQLAdapterFactoryBase } from './libsql'
-import { PrismaLibSQLAdapterFactory } from './libsql-node'
+import { PrismaLibSqlAdapterFactoryBase } from './libsql'
+import { PrismaLibSqlAdapterFactory } from './libsql-node'
 
 describe.each([
   (factory: SqlMigrationAwareDriverAdapterFactory) => factory.connect(),
   (factory: SqlMigrationAwareDriverAdapterFactory) => factory.connectToShadowDb(),
 ])('behavior of the adapter with "%s"', (connect) => {
   test('executes and parses simple queries', async () => {
-    const factory = new PrismaLibSQLAdapterFactory({ url: ':memory:' })
+    const factory = new PrismaLibSqlAdapterFactory({ url: ':memory:' })
     const conn = await connect(factory)
 
     await expect(
@@ -30,7 +30,7 @@ describe.each([
   })
 
   test('executes and parses simple statements', async () => {
-    const factory = new PrismaLibSQLAdapterFactory({ url: ':memory:' })
+    const factory = new PrismaLibSqlAdapterFactory({ url: ':memory:' })
     const conn = await connect(factory)
 
     await expect(
@@ -62,7 +62,7 @@ describe.each([
   })
 
   test('executes simple scripts', async () => {
-    const factory = new PrismaLibSQLAdapterFactory({ url: ':memory:' })
+    const factory = new PrismaLibSqlAdapterFactory({ url: ':memory:' })
     const conn = await connect(factory)
 
     await expect(
@@ -81,7 +81,7 @@ describe.each([
   })
 
   test('query errors get converted to DriverAdapterError', async () => {
-    const factory = new PrismaLibSQLAdapterFactory({ url: ':memory:' })
+    const factory = new PrismaLibSqlAdapterFactory({ url: ':memory:' })
     const conn = await connect(factory)
 
     await expect(
@@ -97,7 +97,7 @@ describe.each([
   })
 
   test('execute errors get converted to DriverAdapterError', async () => {
-    const factory = new PrismaLibSQLAdapterFactory({ url: ':memory:' })
+    const factory = new PrismaLibSqlAdapterFactory({ url: ':memory:' })
     const conn = await connect(factory)
 
     await expect(
@@ -113,7 +113,7 @@ describe.each([
   })
 
   test('script errors get converted to DriverAdapterError', async () => {
-    const factory = new PrismaLibSQLAdapterFactory({ url: ':memory:' })
+    const factory = new PrismaLibSqlAdapterFactory({ url: ':memory:' })
     const conn = await connect(factory)
 
     await expect(
@@ -125,7 +125,7 @@ describe.each([
   })
 
   test('executes a SERIALIZABLE transaction', async () => {
-    const factory = new PrismaLibSQLAdapterFactory({ url: ':memory:' })
+    const factory = new PrismaLibSqlAdapterFactory({ url: ':memory:' })
     const conn = await connect(factory)
 
     await conn.executeScript(`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`)
@@ -144,7 +144,7 @@ describe.each([
   })
 
   test('rolls back a SERIALIZABLE transaction', async () => {
-    const factory = new PrismaLibSQLAdapterFactory({ url: ':memory:' })
+    const factory = new PrismaLibSqlAdapterFactory({ url: ':memory:' })
     const conn = await connect(factory)
 
     await conn.executeScript(`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`)
@@ -163,7 +163,7 @@ describe.each([
   })
 
   test('rejects any other isolation level', async () => {
-    const factory = new PrismaLibSQLAdapterFactory({ url: ':memory:' })
+    const factory = new PrismaLibSqlAdapterFactory({ url: ':memory:' })
     const conn = await connect(factory)
 
     for (const level of [
@@ -185,14 +185,14 @@ describe.each([
   (factory: SqlMigrationAwareDriverAdapterFactory) => factory.connectToShadowDb(),
 ])('usage of the underlying connection with "%s"', (connect) => {
   test('dispose closes the underlying connection', async () => {
-    const factory = new PrismaLibSQLAdapterFactoryMock({ url: ':memory:' })
+    const factory = new PrismaLibSqlAdapterFactoryMock({ url: ':memory:' })
     const conn = await connect(factory)
     await expect(conn.dispose()).resolves.toBeUndefined()
     expect(factory.connection.close).toHaveBeenCalledTimes(1)
   })
 
   test('commit commits the underlying transaction', async () => {
-    const factory = new PrismaLibSQLAdapterFactoryMock({ url: ':memory:' })
+    const factory = new PrismaLibSqlAdapterFactoryMock({ url: ':memory:' })
     const conn = await connect(factory)
     const tx = await conn.startTransaction('SERIALIZABLE')
     expect(tx.options.usePhantomQuery).toBe(true)
@@ -201,7 +201,7 @@ describe.each([
   })
 
   test('rollback rolls back the underlying transaction', async () => {
-    const factory = new PrismaLibSQLAdapterFactoryMock({ url: ':memory:' })
+    const factory = new PrismaLibSqlAdapterFactoryMock({ url: ':memory:' })
     const conn = await connect(factory)
     const tx = await conn.startTransaction('SERIALIZABLE')
     expect(tx.options.usePhantomQuery).toBe(true)
@@ -210,7 +210,7 @@ describe.each([
   })
 })
 
-class PrismaLibSQLAdapterFactoryMock extends PrismaLibSQLAdapterFactoryBase {
+class PrismaLibSqlAdapterFactoryMock extends PrismaLibSqlAdapterFactoryBase {
   connection = {
     execute: vi.fn(),
     batch: vi.fn(),

--- a/packages/adapter-libsql/src/libsql.ts
+++ b/packages/adapter-libsql/src/libsql.ts
@@ -36,7 +36,7 @@ class LibSqlQueryable<ClientT extends StdClient | TransactionClient> implements 
 
   constructor(
     protected readonly client: ClientT,
-    protected readonly adapterOptions?: PrismaLibSQLOptions,
+    protected readonly adapterOptions?: PrismaLibSqlOptions,
   ) {}
 
   /**
@@ -101,7 +101,7 @@ class LibSqlTransaction extends LibSqlQueryable<TransactionClient> implements Tr
   constructor(
     client: TransactionClient,
     readonly options: TransactionOptions,
-    adapterOptions: PrismaLibSQLOptions | undefined,
+    adapterOptions: PrismaLibSqlOptions | undefined,
     unlockParent: () => void,
   ) {
     super(client, adapterOptions)
@@ -131,8 +131,8 @@ class LibSqlTransaction extends LibSqlQueryable<TransactionClient> implements Tr
   }
 }
 
-export class PrismaLibSQLAdapter extends LibSqlQueryable<StdClient> implements SqlDriverAdapter {
-  constructor(client: StdClient, adapterOptions?: PrismaLibSQLOptions) {
+export class PrismaLibSqlAdapter extends LibSqlQueryable<StdClient> implements SqlDriverAdapter {
+  constructor(client: StdClient, adapterOptions?: PrismaLibSqlOptions) {
     super(client, adapterOptions)
   }
 
@@ -181,30 +181,30 @@ export class PrismaLibSQLAdapter extends LibSqlQueryable<StdClient> implements S
   }
 }
 
-export type PrismaLibSQLOptions = {
+export type PrismaLibSqlOptions = {
   timestampFormat?: 'iso8601' | 'unixepoch-ms'
 }
 
-export abstract class PrismaLibSQLAdapterFactoryBase implements SqlMigrationAwareDriverAdapterFactory {
+export abstract class PrismaLibSqlAdapterFactoryBase implements SqlMigrationAwareDriverAdapterFactory {
   readonly provider = 'sqlite'
   readonly adapterName = packageName
 
   readonly #config: LibSqlConfig
-  readonly #options?: PrismaLibSQLOptions
+  readonly #options?: PrismaLibSqlOptions
 
-  constructor(config: LibSqlConfig, options?: PrismaLibSQLOptions) {
+  constructor(config: LibSqlConfig, options?: PrismaLibSqlOptions) {
     this.#config = config
     this.#options = options
   }
 
   connect(): Promise<SqlDriverAdapter> {
-    return Promise.resolve(new PrismaLibSQLAdapter(this.createClient(this.#config), this.#options))
+    return Promise.resolve(new PrismaLibSqlAdapter(this.createClient(this.#config), this.#options))
   }
 
   connectToShadowDb(): Promise<SqlDriverAdapter> {
     // TODO: the user should be able to provide a custom URL for the shadow database
     return Promise.resolve(
-      new PrismaLibSQLAdapter(this.createClient({ ...this.#config, url: ':memory:' }), this.#options),
+      new PrismaLibSqlAdapter(this.createClient({ ...this.#config, url: ':memory:' }), this.#options),
     )
   }
 

--- a/packages/adapter-neon/src/index.ts
+++ b/packages/adapter-neon/src/index.ts
@@ -1,1 +1,1 @@
-export { PrismaNeonAdapterFactory as PrismaNeon, PrismaNeonHTTPAdapterFactory as PrismaNeonHTTP } from './neon'
+export { PrismaNeonAdapterFactory as PrismaNeon, PrismaNeonHttpAdapterFactory as PrismaNeonHttp } from './neon'

--- a/packages/adapter-neon/src/neon.ts
+++ b/packages/adapter-neon/src/neon.ts
@@ -247,7 +247,7 @@ export class PrismaNeonAdapterFactory implements SqlDriverAdapterFactory {
   }
 }
 
-export class PrismaNeonHTTPAdapter extends NeonQueryable implements SqlDriverAdapter {
+export class PrismaNeonHttpAdapter extends NeonQueryable implements SqlDriverAdapter {
   private client: (sql: string, params: any[], opts: Record<string, any>) => neon.NeonQueryPromise<any, any>
 
   constructor(client: neon.NeonQueryFunction<any, any>) {
@@ -292,7 +292,7 @@ export class PrismaNeonHTTPAdapter extends NeonQueryable implements SqlDriverAda
   async dispose(): Promise<void> {}
 }
 
-export class PrismaNeonHTTPAdapterFactory implements SqlDriverAdapterFactory {
+export class PrismaNeonHttpAdapterFactory implements SqlDriverAdapterFactory {
   readonly provider = 'postgres'
   readonly adapterName = packageName
 
@@ -302,6 +302,6 @@ export class PrismaNeonHTTPAdapterFactory implements SqlDriverAdapterFactory {
   ) {}
 
   async connect(): Promise<SqlDriverAdapter> {
-    return new PrismaNeonHTTPAdapter(neon.neon(this.connectionString, this.options))
+    return new PrismaNeonHttpAdapter(neon.neon(this.connectionString, this.options))
   }
 }

--- a/packages/bundle-size/da-workers-libsql-web/index.js
+++ b/packages/bundle-size/da-workers-libsql-web/index.js
@@ -1,10 +1,10 @@
-import { PrismaLibSQL } from '@prisma/adapter-libsql/web'
+import { PrismaLibSql } from '@prisma/adapter-libsql/web'
 
 import { PrismaClient } from './client/wasm'
 
 export default {
   async fetch(request, env) {
-    const adapter = new PrismaLibSQL({
+    const adapter = new PrismaLibSql({
       url: env.DRIVER_ADAPTERS_TURSO_CF_BASIC_DATABASE_URL,
       authToken: env.DRIVER_ADAPTERS_TURSO_CF_BASIC_TOKEN,
     })
@@ -13,7 +13,6 @@ export default {
     const users = await prisma.user.findMany()
     const result = JSON.stringify(users)
 
-    // eslint-disable-next-line no-undef
     return new Response(result)
   },
 }

--- a/packages/bundle-size/da-workers-libsql/index.js
+++ b/packages/bundle-size/da-workers-libsql/index.js
@@ -1,10 +1,10 @@
-import { PrismaLibSQL } from '@prisma/adapter-libsql'
+import { PrismaLibSql } from '@prisma/adapter-libsql'
 
 import { PrismaClient } from './client/wasm'
 
 export default {
   async fetch(request, env) {
-    const adapter = new PrismaLibSQL({
+    const adapter = new PrismaLibSql({
       url: env.DRIVER_ADAPTERS_TURSO_CF_BASIC_DATABASE_URL,
       authToken: env.DRIVER_ADAPTERS_TURSO_CF_BASIC_TOKEN,
     })
@@ -13,7 +13,6 @@ export default {
     const users = await prisma.user.findMany()
     const result = JSON.stringify(users)
 
-    // eslint-disable-next-line no-undef
     return new Response(result)
   },
 }

--- a/packages/cli/src/__tests__/fixtures/studio-test-project-driver-adapter/prisma.config.ts
+++ b/packages/cli/src/__tests__/fixtures/studio-test-project-driver-adapter/prisma.config.ts
@@ -17,9 +17,9 @@ export default defineConfig({
   schema: path.join(__dirname, 'schema-c.prisma'),
   studio: {
     adapter: async () => {
-      const { PrismaLibSQL } = await import('@prisma/adapter-libsql')
+      const { PrismaLibSql } = await import('@prisma/adapter-libsql')
 
-      return new PrismaLibSQL({
+      return new PrismaLibSql({
         url: env.DOTENV_PRISMA_STUDIO_LIBSQL_DATABASE_URL,
       })
     },

--- a/packages/client/tests/e2e/prisma-client-imports-postgres/src/default.ts
+++ b/packages/client/tests/e2e/prisma-client-imports-postgres/src/default.ts
@@ -1,6 +1,5 @@
-/* eslint-disable import/no-duplicates */
 import { neonConfig } from '@neondatabase/serverless'
-import { PrismaNeon, PrismaNeonHTTP } from '@prisma/adapter-neon'
+import { PrismaNeon, PrismaNeonHttp } from '@prisma/adapter-neon'
 import { PrismaPg } from '@prisma/adapter-pg'
 import { PrismaClient } from '@prisma/client'
 // @ts-ignore no types available
@@ -39,7 +38,7 @@ export const neonPrismaClient = new PrismaClient({
 void neonPrismaClient.user.findMany()
 
 export const neonHttpPrismaClient = new PrismaClient({
-  adapter: new PrismaNeonHTTP('postgresql://user:password@example.com/dbname', {
+  adapter: new PrismaNeonHttp('postgresql://user:password@example.com/dbname', {
     arrayMode: false,
     fullResults: true,
   }),

--- a/packages/client/tests/e2e/prisma-client-imports-postgres/src/dep.ts
+++ b/packages/client/tests/e2e/prisma-client-imports-postgres/src/dep.ts
@@ -1,5 +1,5 @@
 import { neonConfig } from '@neondatabase/serverless'
-import { PrismaNeon, PrismaNeonHTTP } from '@prisma/adapter-neon'
+import { PrismaNeon, PrismaNeonHttp } from '@prisma/adapter-neon'
 import { PrismaPg } from '@prisma/adapter-pg'
 import { withAccelerate } from '@prisma/extension-accelerate'
 import { readReplicas } from '@prisma/extension-read-replicas'
@@ -31,7 +31,7 @@ export const neonPrismaClient = new PrismaClient({
 void neonPrismaClient.user.findMany()
 
 export const neonHttpPrismaClient = new PrismaClient({
-  adapter: new PrismaNeonHTTP('postgresql://user:password@example.com/dbname', {
+  adapter: new PrismaNeonHttp('postgresql://user:password@example.com/dbname', {
     arrayMode: false,
     fullResults: true,
   }),

--- a/packages/client/tests/e2e/prisma-client-imports-postgres/src/no-dep.ts
+++ b/packages/client/tests/e2e/prisma-client-imports-postgres/src/no-dep.ts
@@ -1,6 +1,6 @@
 import { neonConfig } from '@neondatabase/serverless'
-// import { PrismaLibSQL } from '@prisma/adapter-libsql'
-import { PrismaNeon, PrismaNeonHTTP } from '@prisma/adapter-neon'
+// import { PrismaLibSql } from '@prisma/adapter-libsql'
+import { PrismaNeon, PrismaNeonHttp } from '@prisma/adapter-neon'
 import { PrismaPg } from '@prisma/adapter-pg'
 import { withAccelerate } from '@prisma/extension-accelerate'
 import { readReplicas } from '@prisma/extension-read-replicas'
@@ -32,7 +32,7 @@ export const neonPrismaClient = new PrismaClient({
 void neonPrismaClient.user.findMany()
 
 export const neonHttpPrismaClient = new PrismaClient({
-  adapter: new PrismaNeonHTTP('postgresql://user:password@example.com/dbname', {
+  adapter: new PrismaNeonHttp('postgresql://user:password@example.com/dbname', {
     arrayMode: false,
     fullResults: true,
   }),

--- a/packages/client/tests/e2e/prisma-client-imports-sqlite/src/esm-only-pkgs/default.ts
+++ b/packages/client/tests/e2e/prisma-client-imports-sqlite/src/esm-only-pkgs/default.ts
@@ -1,8 +1,8 @@
-import { PrismaLibSQL } from '@prisma/adapter-libsql'
+import { PrismaLibSql } from '@prisma/adapter-libsql'
 import { PrismaClient } from '@prisma/client'
 
 export const libsqlPrismaClient = new PrismaClient({
-  adapter: new PrismaLibSQL({
+  adapter: new PrismaLibSql({
     url: 'libsql://test-prisma.turso.io',
     authToken: '',
   }),

--- a/packages/client/tests/e2e/prisma-client-imports-sqlite/src/esm-only-pkgs/dep.ts
+++ b/packages/client/tests/e2e/prisma-client-imports-sqlite/src/esm-only-pkgs/dep.ts
@@ -1,8 +1,8 @@
-import { PrismaLibSQL } from '@prisma/adapter-libsql'
+import { PrismaLibSql } from '@prisma/adapter-libsql'
 import { PrismaClient } from 'db'
 
 export const libsqlPrismaClient = new PrismaClient({
-  adapter: new PrismaLibSQL({
+  adapter: new PrismaLibSql({
     url: 'libsql://test-prisma.turso.io',
     authToken: '',
   }),

--- a/packages/client/tests/e2e/prisma-client-imports-sqlite/src/esm-only-pkgs/no-dep.ts
+++ b/packages/client/tests/e2e/prisma-client-imports-sqlite/src/esm-only-pkgs/no-dep.ts
@@ -1,9 +1,9 @@
-import { PrismaLibSQL } from '@prisma/adapter-libsql'
+import { PrismaLibSql } from '@prisma/adapter-libsql'
 
 import { PrismaClient } from '../../custom'
 
 export const libsqlPrismaClient = new PrismaClient({
-  adapter: new PrismaLibSQL({
+  adapter: new PrismaLibSql({
     url: 'libsql://test-prisma.turso.io',
     authToken: '',
   }),

--- a/packages/client/tests/e2e/typed-sql-query-compiler-adapter-libsql/src/index.ts
+++ b/packages/client/tests/e2e/typed-sql-query-compiler-adapter-libsql/src/index.ts
@@ -1,10 +1,10 @@
-import { PrismaLibSQL } from '@prisma/adapter-libsql'
+import { PrismaLibSql } from '@prisma/adapter-libsql'
 
 import { PrismaClient } from './generated/prisma/client'
 import { conversionByVariant, filterTrackingEvents, getTrackingEvents } from './generated/prisma/sql'
 
 async function main() {
-  const adapter = new PrismaLibSQL({
+  const adapter = new PrismaLibSql({
     url: 'file:./prisma/dev.db',
   })
   const prisma = new PrismaClient({ adapter })

--- a/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
@@ -226,10 +226,10 @@ export function setupTestSuiteClientDriverAdapter({
   }
 
   if (driverAdapter === AdapterProviders.JS_LIBSQL) {
-    const { PrismaLibSQL } = require('@prisma/adapter-libsql') as typeof import('@prisma/adapter-libsql')
+    const { PrismaLibSql } = require('@prisma/adapter-libsql') as typeof import('@prisma/adapter-libsql')
 
     return {
-      adapter: new PrismaLibSQL({
+      adapter: new PrismaLibSql({
         url: datasourceInfo.databaseUrl,
         intMode: 'bigint',
       }),
@@ -244,11 +244,11 @@ export function setupTestSuiteClientDriverAdapter({
   }
 
   if (driverAdapter === AdapterProviders.JS_BETTER_SQLITE3) {
-    const { PrismaBetterSQLite3 } =
+    const { PrismaBetterSqlite3 } =
       require('@prisma/adapter-better-sqlite3') as typeof import('@prisma/adapter-better-sqlite3')
 
     return {
-      adapter: new PrismaBetterSQLite3({
+      adapter: new PrismaBetterSqlite3({
         // Workaround to avoid the Prisma validation error:
         // ```
         // Error validating datasource `db`: the URL must start with the protocol `file:`

--- a/packages/client/tests/functional/unixepoch-ms-datetime/tests.ts
+++ b/packages/client/tests/functional/unixepoch-ms-datetime/tests.ts
@@ -1,5 +1,5 @@
-import { PrismaBetterSQLite3 } from '@prisma/adapter-better-sqlite3'
-import { PrismaLibSQL } from '@prisma/adapter-libsql'
+import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
+import { PrismaLibSql } from '@prisma/adapter-libsql'
 import { randomUUID } from 'crypto'
 
 import { AdapterProviders } from '../_utils/providers'
@@ -123,7 +123,7 @@ testMatrix.setupTestSuite(
 )
 
 function createClient(info: DatasourceInfo, driverAdapter?: `${AdapterProviders}`) {
-  const constructor = driverAdapter === AdapterProviders.JS_BETTER_SQLITE3 ? PrismaBetterSQLite3 : PrismaLibSQL
+  const constructor = driverAdapter === AdapterProviders.JS_BETTER_SQLITE3 ? PrismaBetterSqlite3 : PrismaLibSql
 
   return newPrismaClient({
     // @ts-test-if: driverAdapter !== undefined

--- a/packages/migrate/src/__tests__/__helpers__/driverAdapters.ts
+++ b/packages/migrate/src/__tests__/__helpers__/driverAdapters.ts
@@ -1,4 +1,4 @@
-import { PrismaLibSQL } from '@prisma/adapter-libsql'
+import { PrismaLibSql } from '@prisma/adapter-libsql'
 import {
   OfficialDriverAdapterName,
   Provider,
@@ -22,7 +22,7 @@ const driverAdapters: Record<string, DriverAdapterTestConfig> = {
     adapter: (ctx: BaseContext) => () => {
       const url = 'file:' + path.join(ctx.tmpDir, 'dev.db')
       return Promise.resolve(
-        new PrismaLibSQL({
+        new PrismaLibSql({
           url,
         }),
       )

--- a/sandbox/driver-adapters/src/neon.http.ts
+++ b/sandbox/driver-adapters/src/neon.http.ts
@@ -1,10 +1,10 @@
-import { PrismaNeonHTTP } from '@prisma/adapter-neon'
+import { PrismaNeonHttp } from '@prisma/adapter-neon'
 import { smokeTest } from './test'
 
 async function main() {
   const connectionString = `${process.env.JS_NEON_DATABASE_URL as string}`
 
-  const adapter = new PrismaNeonHTTP(connectionString, {
+  const adapter = new PrismaNeonHttp(connectionString, {
     arrayMode: false,
     fullResults: true,
   })


### PR DESCRIPTION
[TML-1466](https://linear.app/prisma-company/issue/TML-1466/rename-public-exports-from-prismaadapter-packages)

Renames all exports to follow the acronyms-as-words convention.