### PR TITLE
feat(client-generator-ts)!: Add support for generating optional TypeScript properties from nullable schema fields

### DIFF
--- a/packages/client-generator-ts/src/TSClient/Output.test.ts
+++ b/packages/client-generator-ts/src/TSClient/Output.test.ts
@@ -1,0 +1,38 @@
+import * as DMMF from '@prisma/dmmf'
+import * as ts from '@prisma/ts-builders'
+import { beforeEach, describe, expect, test } from 'vitest'
+
+import { DMMFHelper } from '../dmmf'
+import { buildModelOutputProperty } from './Output'
+
+describe('buildModelOutputProperty', () => {
+  let dmmf: DMMFHelper
+
+  beforeEach(() => {
+    dmmf = { isComposite: () => false } as DMMFHelper
+  })
+
+  test('should add optional modifier to non-required fields', () => {
+    const field: DMMF.Field = {
+      name: 'age',
+      kind: 'scalar',
+      isList: false,
+      isRequired: false,
+      isUnique: false,
+      isId: false,
+      isReadOnly: false,
+      type: 'String',
+      hasDefaultValue: false,
+      relationName: undefined,
+      relationFromFields: undefined,
+      relationToFields: undefined,
+      relationOnDelete: undefined,
+      documentation: undefined,
+    }
+
+    const property = buildModelOutputProperty(field, dmmf)
+
+    expect(property.isOptional).toBe(true)
+    expect(ts.stringify(property.type)).toEqual('string | null')
+  })
+})

--- a/packages/client-generator-ts/src/TSClient/Output.test.ts
+++ b/packages/client-generator-ts/src/TSClient/Output.test.ts
@@ -5,11 +5,48 @@ import { beforeEach, describe, expect, test } from 'vitest'
 import { DMMFHelper } from '../dmmf'
 import { buildModelOutputProperty } from './Output'
 
+function dmmf(inputObjectTypes: DMMF.InputType[] = [], models: DMMF.Model[] = []) {
+  return new DMMFHelper({
+    schema: {
+      inputObjectTypes: {
+        prisma: inputObjectTypes,
+      },
+      outputObjectTypes: {
+        prisma: [
+          { name: 'Query', fields: [] },
+          { name: 'Mutation', fields: [] },
+        ],
+        model: [],
+      },
+      enumTypes: {
+        prisma: [],
+      },
+      fieldRefTypes: {
+        prisma: [],
+      },
+    },
+    datamodel: {
+      models: models,
+      types: [],
+      enums: [],
+      indexes: [],
+    },
+
+    mappings: {
+      modelOperations: [],
+      otherOperations: {
+        read: [],
+        write: [],
+      },
+    },
+  })
+}
+
 describe('buildModelOutputProperty', () => {
-  let dmmf: DMMFHelper
+  let dmmfHelper: DMMFHelper
 
   beforeEach(() => {
-    dmmf = { isComposite: () => false } as DMMFHelper
+    dmmfHelper = dmmf()
   })
 
   test('should add optional modifier to non-required fields', () => {
@@ -30,7 +67,7 @@ describe('buildModelOutputProperty', () => {
       documentation: undefined,
     }
 
-    const property = buildModelOutputProperty(field, dmmf)
+    const property = buildModelOutputProperty(field, dmmfHelper)
 
     expect(property.isOptional).toBe(true)
     expect(ts.stringify(property.type)).toEqual('string | null')

--- a/packages/client-generator-ts/src/TSClient/Output.ts
+++ b/packages/client-generator-ts/src/TSClient/Output.ts
@@ -36,6 +36,9 @@ export function buildModelOutputProperty(field: DMMF.Field, dmmf: DMMFHelper) {
   if (field.documentation) {
     property.setDocComment(ts.docComment(field.documentation))
   }
+  if (!field.isRequired) {
+    property.optional()
+  }
   return property
 }
 


### PR DESCRIPTION
**Description**
-  Make nullable fields in schema generate optional properties in TypeScript types

closes #27914 