### PR TITLE
feat(config): add `env` helper

### DIFF
--- a/packages/config/src/__tests__/env.test.ts
+++ b/packages/config/src/__tests__/env.test.ts
@@ -1,0 +1,40 @@
+import { afterAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { env, PrismaConfigEnvError } from '../env'
+
+const VAR_NAME = 'PRISMA_CONFIG_ENV_TEST'
+const originalValue = process.env[VAR_NAME]
+
+describe('env', () => {
+  beforeEach(() => {
+    delete process.env[VAR_NAME]
+  })
+
+  afterAll(() => {
+    if (originalValue === undefined) {
+      delete process.env[VAR_NAME]
+    } else {
+      process.env[VAR_NAME] = originalValue
+    }
+  })
+
+  test('returns the value when the environment variable is defined', () => {
+    process.env[VAR_NAME] = 'postgresql://example'
+    expect(env(VAR_NAME)).toBe('postgresql://example')
+  })
+
+  test('throws when the environment variable is missing', () => {
+    expect(() => env(VAR_NAME)).toThrowError(PrismaConfigEnvError)
+    expect(() => env(VAR_NAME)).toThrowErrorMatchingInlineSnapshot(
+      `[PrismaConfigEnvError: Missing required environment variable: PRISMA_CONFIG_ENV_TEST]`,
+    )
+  })
+
+  test('throws when the environment variable is an empty string', () => {
+    process.env[VAR_NAME] = ''
+    expect(() => env(VAR_NAME)).toThrowError(PrismaConfigEnvError)
+    expect(() => env(VAR_NAME)).toThrowErrorMatchingInlineSnapshot(
+      `[PrismaConfigEnvError: Missing required environment variable: PRISMA_CONFIG_ENV_TEST]`,
+    )
+  })
+})

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -1,0 +1,14 @@
+export class PrismaConfigEnvError extends Error {
+  constructor(name: string) {
+    super(`Missing required environment variable: ${name}`)
+    this.name = 'PrismaConfigEnvError'
+  }
+}
+
+export function env(name: string): string {
+  const value = process.env[name]
+  if (!value) {
+    throw new PrismaConfigEnvError(name)
+  }
+  return value
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,5 +1,6 @@
 export { defaultTestConfig } from './defaultTestConfig'
 export { defineConfig } from './defineConfig'
+export { env, PrismaConfigEnvError } from './env'
 export type { ConfigDiagnostic, ConfigFromFile, InjectFormatters, LoadConfigFromFileError } from './loadConfigFromFile'
 export { loadConfigFromFile } from './loadConfigFromFile'
 export { loadConfigFromPackageJson } from './loadConfigFromPackageJson'


### PR DESCRIPTION
Add a helper that safely checks if an environment variable is defined and is not empty, and returns its value if so, otherwise throws an error.

This allows users to avoid having boilerplate code related to environment variables in their config files or using unsafe assertions like `process.env.DATABASE_URL!`.

Usage:

```ts
import { defineConfig, env } from '@prisma/config'

export default defineConfig({
  engine: 'classic',
  datasource: {
    url: env('DATABASE_URL'),
  },
})
```

Closes: https://linear.app/prisma-company/issue/TML-1508/env-helper-in-prismaconfig