### PR TITLE
fix(qpe): add prisma-transaction-id header in tx start response

### DIFF
--- a/packages/query-plan-executor/src/server/server.ts
+++ b/packages/query-plan-executor/src/server/server.ts
@@ -86,6 +86,7 @@ function createHonoServer(app: App, options: Options) {
     })
     .post('/transaction/start', zValidator('json', TransactionStartRequestBody), async (c) => {
       const result = await app.startTransaction(c.req.valid('json'), c.get('resourceLimits'))
+      c.header('Prisma-Transaction-Id', result.id)
       return c.json(result satisfies TransactionStartResponseBody)
     })
     .post('/transaction/:txId/query', zValidator('json', QueryRequestBody), async (c) => {


### PR DESCRIPTION
Closes: https://linear.app/prisma-company/issue/TML-1514/add-prisma-transaction-id-header-to-transactionstart-response-in-qpe