### PR TITLE
chore: fix jest inline snapshot update

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "p-reduce": "3.0.0",
     "p-retry": "4.6.2",
     "prettier": "3.6.2",
+    "prettier2": "npm:prettier@2.8.8",
     "regenerator-runtime": "0.14.1",
     "resolve": "1.22.10",
     "safe-buffer": "5.2.1",

--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
   preset: '../../helpers/test/presets/withSnapshotSerializer.js',
   testPathIgnorePatterns: ['\\.vitest.ts$'],
   setupFilesAfterEnv: ['./jest.setup.js'],
+  prettierPath: '../../node_modules/prettier2',
 }

--- a/packages/client-engine-runtime/jest.config.js
+++ b/packages/client-engine-runtime/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   preset: '../../helpers/test/presets/default.js',
+  prettierPath: '../../node_modules/prettier2',
 }

--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -31,4 +31,5 @@ module.exports = {
   testTimeout: 90_000,
   setupFiles: ['./helpers/jestSetup.js'],
   openHandlesTimeout: 10_000,
+  prettierPath: '../../node_modules/prettier2',
 }

--- a/packages/client/tests/functional/jest.config.js
+++ b/packages/client/tests/functional/jest.config.js
@@ -18,6 +18,7 @@ module.exports = () => {
     setupFilesAfterEnv: ['./_utils/setupFilesAfterEnv.ts'],
     testTimeout,
     collectCoverage: process.env.CI ? true : false,
+    prettierPath: '../../../../node_modules/prettier2',
   }
 
   if (process.env['JEST_JUNIT_DISABLE'] !== 'true') {

--- a/packages/debug/jest.config.js
+++ b/packages/debug/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   preset: '../../helpers/test/presets/default.js',
+  prettierPath: '../../node_modules/prettier2',
 }

--- a/packages/engines/jest.config.js
+++ b/packages/engines/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   preset: '../../helpers/test/presets/default.js',
+  prettierPath: '../../node_modules/prettier2',
 }

--- a/packages/fetch-engine/jest.config.js
+++ b/packages/fetch-engine/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   preset: '../../helpers/test/presets/default.js',
+  prettierPath: '../../node_modules/prettier2',
 }

--- a/packages/get-platform/jest.config.js
+++ b/packages/get-platform/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   preset: '../../helpers/test/presets/default.js',
   snapshotSerializers: ['./src/test-utils/jestSnapshotSerializer'],
+  prettierPath: '../../node_modules/prettier2',
 }

--- a/packages/integration-tests/jest.config.js
+++ b/packages/integration-tests/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   preset: '../../helpers/test/presets/withSnapshotSerializer.js',
+  prettierPath: '../../node_modules/prettier2',
 }

--- a/packages/internals/jest.config.js
+++ b/packages/internals/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   preset: '../../helpers/test/presets/default.js',
+  prettierPath: '../../node_modules/prettier2',
 }

--- a/packages/migrate/jest.config.js
+++ b/packages/migrate/jest.config.js
@@ -13,4 +13,5 @@ module.exports = {
   modulePathIgnorePatterns: ['<rootDir>/src/__tests__/fixtures/'],
   // to allow large-ish tests in `postgresql-views`
   testTimeout: 10_000,
+  prettierPath: '../../node_modules/prettier2',
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       prettier:
         specifier: 3.6.2
         version: 3.6.2
+      prettier2:
+        specifier: npm:prettier@2.8.8
+        version: prettier@2.8.8
       regenerator-runtime:
         specifier: 0.14.1
         version: 0.14.1
@@ -6717,6 +6720,11 @@ packages:
   prettier-linter-helpers@1.0.0:
     resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
     engines: {node: '>=6.0.0'}
+
+  prettier@2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
 
   prettier@3.5.3:
     resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
@@ -13485,6 +13493,8 @@ snapshots:
   prettier-linter-helpers@1.0.0:
     dependencies:
       fast-diff: 1.3.0
+
+  prettier@2.8.8: {}
 
   prettier@3.5.3: {}
 


### PR DESCRIPTION
Until we can upgrade to Jest 30, we need to make updating inline snapshots in Jest 29 work. It requires a custom Prettier installation because it doesn't support Prettier 3.