### PR TITLE
fix(tests): don't replace the process.env object

### DIFF
--- a/packages/cli/src/__tests__/artificial-panic.test.ts
+++ b/packages/cli/src/__tests__/artificial-panic.test.ts
@@ -9,6 +9,22 @@ import { Validate } from '../Validate'
 
 const ctx = jestContext.new().assemble()
 
+function restoreEnvSnapshot(snapshot: NodeJS.ProcessEnv) {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in snapshot)) {
+      delete process.env[key]
+    }
+  }
+
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
 /**
  * Note: under the hood, these artificial-panic tests uses the Wasm'd `getConfig` and `getDMMF` definitions
  */
@@ -19,7 +35,7 @@ describe('artificial-panic introspection', () => {
 
   afterEach(() => {
     // reset env vars to backup state
-    process.env = { ...OLD_ENV }
+    restoreEnvSnapshot(OLD_ENV)
   })
 
   it('schema-engine', async () => {
@@ -49,7 +65,7 @@ describe('artificial-panic formatter', () => {
   const OLD_ENV = { ...process.env }
 
   afterEach(() => {
-    process.env = { ...OLD_ENV }
+    restoreEnvSnapshot(OLD_ENV)
   })
 
   it('formatter', async () => {
@@ -75,7 +91,7 @@ describe('artificial-panic get-config', () => {
   const OLD_ENV = { ...process.env }
 
   afterEach(() => {
-    process.env = { ...OLD_ENV }
+    restoreEnvSnapshot(OLD_ENV)
   })
 
   it('get-config', async () => {
@@ -101,7 +117,7 @@ describe('artificial-panic validate', () => {
   const OLD_ENV = { ...process.env }
 
   afterEach(() => {
-    process.env = { ...OLD_ENV }
+    restoreEnvSnapshot(OLD_ENV)
   })
 
   it('validate', async () => {
@@ -145,7 +161,7 @@ describe('artificial-panic getDMMF', () => {
   const OLD_ENV = { ...process.env }
 
   afterEach(() => {
-    process.env = { ...OLD_ENV }
+    restoreEnvSnapshot(OLD_ENV)
   })
 
   it('getDMMF', async () => {

--- a/packages/cli/src/__tests__/commands/CLI.test.ts
+++ b/packages/cli/src/__tests__/commands/CLI.test.ts
@@ -55,19 +55,31 @@ describe('CLI', () => {
   })
 
   describe('ensureNeededBinariesExist', () => {
-    const originalEnv = process.env
-    process.env = { ...originalEnv }
+    const originalEnv = { ...process.env }
+    const resetEnv = () => {
+      for (const key of Object.keys(process.env)) {
+        if (!(key in originalEnv)) {
+          delete process.env[key]
+        }
+      }
+
+      for (const [key, value] of Object.entries(originalEnv)) {
+        if (value === undefined) {
+          delete process.env[key]
+        } else {
+          process.env[key] = value
+        }
+      }
+    }
 
     beforeAll(() => {
-      process.env = {
-        ...originalEnv,
-        PRISMA_CLI_QUERY_ENGINE_TYPE: undefined,
-        PRISMA_CLIENT_ENGINE_TYPE: undefined,
-      }
+      resetEnv()
+      delete process.env.PRISMA_CLI_QUERY_ENGINE_TYPE
+      delete process.env.PRISMA_CLIENT_ENGINE_TYPE
     })
 
     afterAll(() => {
-      process.env = { ...originalEnv }
+      resetEnv()
     })
 
     describe('with `config.migrate.engine === "js"`, should not download schema-engine', () => {

--- a/packages/cli/src/__tests__/commands/Format.test.ts
+++ b/packages/cli/src/__tests__/commands/Format.test.ts
@@ -12,12 +12,28 @@ const ctx = jestContext.new().add(jestConsoleContext()).assemble()
 
 const originalEnv = { ...process.env }
 
+function restoreEnv() {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) {
+      delete process.env[key]
+    }
+  }
+
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
 describe('format', () => {
   beforeEach(() => {
-    process.env = { ...originalEnv }
+    restoreEnv()
   })
   afterAll(() => {
-    process.env = { ...originalEnv }
+    restoreEnv()
   })
 
   describe('multi-schema-files', () => {

--- a/packages/cli/src/__tests__/commands/Generate.test.ts
+++ b/packages/cli/src/__tests__/commands/Generate.test.ts
@@ -9,6 +9,22 @@ import { promotions, renderPromotion } from '../../utils/handlePromotions'
 
 const ctx = jestContext.new().add(jestConsoleContext()).assemble()
 
+function restoreEnvSnapshot(snapshot: NodeJS.ProcessEnv) {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in snapshot)) {
+      delete process.env[key]
+    }
+  }
+
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
 describe('using cli', () => {
   // Replace any possible entry in `promotions`'s texts with a fixed string to make the snapshot stable
   function sanitiseStdout(stdout: string): string {
@@ -623,7 +639,7 @@ describe('in postinstall', () => {
   })
 
   afterEach(() => {
-    process.env = { ...oldEnv }
+    restoreEnvSnapshot(oldEnv)
   })
 
   it('should not throw errors if prisma schema not found', async () => {

--- a/packages/cli/src/__tests__/commands/Studio.test.ts
+++ b/packages/cli/src/__tests__/commands/Studio.test.ts
@@ -11,6 +11,22 @@ import { Studio } from '../../Studio'
 
 const originalEnv = { ...process.env }
 
+function restoreEnv() {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) {
+      delete process.env[key]
+    }
+  }
+
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
 const ctx = jestContext.new().add(jestConsoleContext()).assemble()
 
 const STUDIO_TEST_PORT = 5678
@@ -37,8 +53,7 @@ describeIf(!process.env.PRISMA_QUERY_ENGINE_LIBRARY && !process.env.PRISMA_QUERY
   'studio with alternative urls and prisma://',
   () => {
     afterEach(() => {
-      // Back to original env vars
-      process.env = { ...originalEnv }
+      restoreEnv()
     })
 
     test('queries work if url is prisma:// and directUrl is set', async () => {

--- a/packages/cli/src/__tests__/commands/Validate.test.ts
+++ b/packages/cli/src/__tests__/commands/Validate.test.ts
@@ -10,12 +10,28 @@ const ctx = jestContext.new().add(jestConsoleContext()).assemble()
 
 const originalEnv = { ...process.env }
 
+function restoreEnv() {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) {
+      delete process.env[key]
+    }
+  }
+
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
 describe('validate', () => {
   beforeEach(() => {
-    process.env = { ...originalEnv }
+    restoreEnv()
   })
   afterAll(() => {
-    process.env = { ...originalEnv }
+    restoreEnv()
   })
 
   describe('multi-schema-files', () => {

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -46,19 +46,31 @@ describe('version', () => {
     })
 
     describe('bypassing query engine env vars', () => {
-      const originalEnv = process.env
-      process.env = { ...originalEnv }
+      const originalEnv = { ...process.env }
+      const resetEnv = () => {
+        for (const key of Object.keys(process.env)) {
+          if (!(key in originalEnv)) {
+            delete process.env[key]
+          }
+        }
+
+        for (const [key, value] of Object.entries(originalEnv)) {
+          if (value === undefined) {
+            delete process.env[key]
+          } else {
+            process.env[key] = value
+          }
+        }
+      }
 
       beforeAll(() => {
-        process.env = {
-          ...originalEnv,
-          PRISMA_CLI_QUERY_ENGINE_TYPE: undefined,
-          PRISMA_CLIENT_ENGINE_TYPE: undefined,
-        }
+        resetEnv()
+        delete process.env.PRISMA_CLI_QUERY_ENGINE_TYPE
+        delete process.env.PRISMA_CLIENT_ENGINE_TYPE
       })
 
       afterAll(() => {
-        process.env = { ...originalEnv }
+        resetEnv()
       })
 
       test('does not download query-engine when engine type is client', async () => {

--- a/packages/cli/src/__tests__/nps.test.ts
+++ b/packages/cli/src/__tests__/nps.test.ts
@@ -14,13 +14,31 @@ const longTimeUserCommandState: CommandState = { firstCommandTimestamp: '2019-01
 
 describe('nps survey', () => {
   const originalEnv = { ...process.env }
+  const restoreEnv = () => {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key]
+      }
+    }
+
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  }
 
   let mockRead: jest.SpyInstance
   let mockWrite: jest.SpyInstance
   let mockExists: jest.SpyInstance
 
   beforeEach(() => {
-    process.env = {}
+    restoreEnv()
+    for (const key of Object.keys(process.env)) {
+      delete process.env[key]
+    }
   })
 
   afterEach(() => {
@@ -30,7 +48,7 @@ describe('nps survey', () => {
   })
 
   afterAll(() => {
-    process.env = originalEnv
+    restoreEnv()
   })
 
   it('should exit immediately if running in CI', async () => {

--- a/packages/client-generator-js/src/utils/buildNFTAnnotations.test.ts
+++ b/packages/client-generator-js/src/utils/buildNFTAnnotations.test.ts
@@ -113,11 +113,26 @@ describe('dataproxy', () => {
 
 describe('special cases for Netlify', () => {
   const originalEnv = { ...process.env }
+  const restoreEnv = () => {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key]
+      }
+    }
+
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  }
   beforeEach(() => {
-    process.env = { ...originalEnv }
+    restoreEnv()
   })
   afterAll(() => {
-    process.env = { ...originalEnv }
+    restoreEnv()
   })
 
   /**

--- a/packages/client-generator-ts/src/utils/buildNFTAnnotations.test.ts
+++ b/packages/client-generator-ts/src/utils/buildNFTAnnotations.test.ts
@@ -101,11 +101,26 @@ describe('dataproxy', () => {
 
 describe('special cases for Netlify', () => {
   const originalEnv = { ...process.env }
+  const restoreEnv = () => {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key]
+      }
+    }
+
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  }
   beforeEach(() => {
-    process.env = { ...originalEnv }
+    restoreEnv()
   })
   afterAll(() => {
-    process.env = { ...originalEnv }
+    restoreEnv()
   })
 
   /**

--- a/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
@@ -71,7 +71,22 @@ function setupTestSuiteMatrix(
   ) => void,
   options?: MatrixOptions,
 ) {
-  const originalEnv = process.env
+  const originalEnv = { ...process.env }
+  const restoreEnv = () => {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key]
+      }
+    }
+
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  }
   const suiteMeta = getTestSuiteMeta()
   const cliMeta = getTestSuiteCliMeta()
   const suiteConfigs = getTestSuiteConfigs(suiteMeta)
@@ -252,7 +267,7 @@ function setupTestSuiteMatrix(
           process.env[datasourceInfo.directEnvVarName] = datasourceInfo.databaseUrl
           await dropTestSuiteDatabase({ suiteMeta, suiteConfig, errors: [], cfWorkerBindings })
         }
-        process.env = originalEnv
+        restoreEnv()
         delete globalThis['datasourceInfo']
         delete globalThis['loaded']
         delete globalThis['prisma']

--- a/packages/client/tests/functional/accelerate-bad-url-errors/tests.ts
+++ b/packages/client/tests/functional/accelerate-bad-url-errors/tests.ts
@@ -8,9 +8,24 @@ declare const newPrismaClient: NewPrismaClient<PrismaClient, typeof PrismaClient
 testMatrix.setupTestSuite(
   (suiteConfig, suiteMeta, clientMeta) => {
     const OLD_ENV = { ...process.env }
+    const restoreEnv = () => {
+      for (const key of Object.keys(process.env)) {
+        if (!(key in OLD_ENV)) {
+          delete process.env[key]
+        }
+      }
+
+      for (const [key, value] of Object.entries(OLD_ENV)) {
+        if (value === undefined) {
+          delete process.env[key]
+        } else {
+          process.env[key] = value
+        }
+      }
+    }
 
     afterEach(() => {
-      process.env = OLD_ENV
+      restoreEnv()
     })
 
     testIf(clientMeta.dataProxy)('url starts with invalid://', async () => {

--- a/packages/client/tests/functional/engine-selection-logic/tests.ts
+++ b/packages/client/tests/functional/engine-selection-logic/tests.ts
@@ -7,14 +7,29 @@ declare const newPrismaClient: NewPrismaClient<PrismaClient, typeof PrismaClient
 
 testMatrix.setupTestSuite(
   ({ provider, driverAdapter }, suiteMeta, clientMeta) => {
-    const OLD_ENV = process.env
+    const OLD_ENV = { ...process.env }
+    const restoreEnv = () => {
+      for (const key of Object.keys(process.env)) {
+        if (!(key in OLD_ENV)) {
+          delete process.env[key]
+        }
+      }
+
+      for (const [key, value] of Object.entries(OLD_ENV)) {
+        if (value === undefined) {
+          delete process.env[key]
+        } else {
+          process.env[key] = value
+        }
+      }
+    }
 
     beforeEach(() => {
-      process.env = { ...OLD_ENV }
+      restoreEnv()
     })
 
     afterAll(() => {
-      process.env = OLD_ENV
+      restoreEnv()
     })
 
     describe('via env var', () => {

--- a/packages/client/tests/functional/invalid-env-value/tests.ts
+++ b/packages/client/tests/functional/invalid-env-value/tests.ts
@@ -9,15 +9,30 @@ declare const newPrismaClient: NewPrismaClient<PrismaClient, typeof PrismaClient
 
 testMatrix.setupTestSuite(
   ({ provider }, _suiteMeta, clientMeta) => {
-    const OLD_ENV = process.env
+    const OLD_ENV = { ...process.env }
+    const restoreEnv = () => {
+      for (const key of Object.keys(process.env)) {
+        if (!(key in OLD_ENV)) {
+          delete process.env[key]
+        }
+      }
+
+      for (const [key, value] of Object.entries(OLD_ENV)) {
+        if (value === undefined) {
+          delete process.env[key]
+        } else {
+          process.env[key] = value
+        }
+      }
+    }
 
     beforeEach(() => {
-      process.env = { ...OLD_ENV }
+      restoreEnv()
       process.env[`DATABASE_URI_${provider}`] = 'http://some-invalid-url'
     })
 
     afterEach(() => {
-      process.env = OLD_ENV
+      restoreEnv()
     })
 
     test('PrismaClientInitializationError for invalid env', async () => {

--- a/packages/internals/src/__tests__/engine-commands/validate.test.ts
+++ b/packages/internals/src/__tests__/engine-commands/validate.test.ts
@@ -10,6 +10,22 @@ import { fixturesPath } from '../__utils__/fixtures'
 
 jest.setTimeout(10_000)
 
+function restoreEnvSnapshot(snapshot: NodeJS.ProcessEnv) {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in snapshot)) {
+      delete process.env[key]
+    }
+  }
+
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
 if (process.env.CI) {
   // 10s is not always enough for the "big schema" test on macOS CI.
   jest.setTimeout(60_000)
@@ -21,16 +37,18 @@ describe('validate', () => {
   describe.skip('colors', () => {
     // backup env vars
     const OLD_ENV = { ...process.env }
-    const { NO_COLOR: _, ...OLD_ENV_WITHOUT_NO_COLOR } = OLD_ENV
 
     beforeEach(() => {
       // jest.resetModules()
-      process.env = { ...OLD_ENV_WITHOUT_NO_COLOR, FORCE_COLOR: '0', CI: '1' }
+      restoreEnvSnapshot(OLD_ENV)
+      delete process.env.NO_COLOR
+      process.env.FORCE_COLOR = '0'
+      process.env.CI = '1'
     })
 
     afterEach(() => {
       // reset env vars to backup state
-      process.env = { ...OLD_ENV }
+      restoreEnvSnapshot(OLD_ENV)
     })
 
     test('failures should have colors by default', () => {

--- a/packages/internals/src/utils/__tests__/isCi.test.ts
+++ b/packages/internals/src/utils/__tests__/isCi.test.ts
@@ -3,13 +3,29 @@ import { isCi } from '../isCi'
 const originalEnv = { ...process.env }
 const originalStdinisTTY = process.stdin.isTTY
 
+function restoreEnv() {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) {
+      delete process.env[key]
+    }
+  }
+
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
 describe('isCi', () => {
   beforeEach(() => {
-    process.env = originalEnv
+    restoreEnv()
     process.stdin.isTTY = originalStdinisTTY
   })
   afterAll(() => {
-    process.env = originalEnv
+    restoreEnv()
     process.stdin.isTTY = originalStdinisTTY
   })
 

--- a/packages/internals/src/utils/__tests__/isInteractive.test.ts
+++ b/packages/internals/src/utils/__tests__/isInteractive.test.ts
@@ -2,12 +2,28 @@ import { isInteractive } from '../isInteractive'
 
 const originalEnv = { ...process.env }
 
+function restoreEnv() {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) {
+      delete process.env[key]
+    }
+  }
+
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
 describe('isInteractive', () => {
   beforeEach(() => {
-    process.env = { ...originalEnv }
+    restoreEnv()
   })
   afterAll(() => {
-    process.env = { ...originalEnv }
+    restoreEnv()
   })
 
   describe('in non TTY environment', () => {

--- a/packages/migrate/src/__tests__/setup.ts
+++ b/packages/migrate/src/__tests__/setup.ts
@@ -1,14 +1,30 @@
-const originalEnv = process.env
+const originalEnv = { ...process.env }
 const originalCwd = process.cwd()
+
+function restoreEnv() {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) {
+      delete process.env[key]
+    }
+  }
+
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
 
 beforeEach(() => {
   process.chdir(originalCwd)
-  process.env = { ...originalEnv }
+  restoreEnv()
   // To avoid the loading spinner prints in local cli output snapshot tests
   process.env.CI = 'true'
 })
 
 afterEach(() => {
   process.chdir(originalCwd)
-  process.env = { ...originalEnv }
+  restoreEnv()
 })


### PR DESCRIPTION
`process.env` is a proxy that makes environment variables set through it available to Node.js process via `setenv`. Replacing it with a plain object breaks this. This caused some issues in another PR I'm working on.

Part of https://linear.app/prisma-company/issue/TML-1499/refactor-prismaprisma-schema-engine-cli-tests-to-introduce