### PR TITLE
feat(config): `env` utility improvements 

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,1 +1,1 @@
-export { defineConfig, type PrismaConfig, type PrismaConfigInternal } from '@prisma/config'
+export { defineConfig, env, type PrismaConfig, type PrismaConfigInternal } from '@prisma/config'

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -5,10 +5,10 @@ export class PrismaConfigEnvError extends Error {
   }
 }
 
-export function env<Env extends Record<string, string>>(name: keyof Env): string {
-  const value = (process.env as Env)[name]
+export function env<Env extends Record<string, string | undefined>>(name: keyof Env & string): string {
+  const value = process.env[name]
   if (!value) {
-    throw new PrismaConfigEnvError(name as string)
+    throw new PrismaConfigEnvError(name)
   }
   return value
 }

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -5,10 +5,10 @@ export class PrismaConfigEnvError extends Error {
   }
 }
 
-export function env(name: string): string {
-  const value = process.env[name]
+export function env<Env extends Record<string, string>>(name: keyof Env): string {
+  const value = (process.env as Env)[name]
   if (!value) {
-    throw new PrismaConfigEnvError(name)
+    throw new PrismaConfigEnvError(name as string)
   }
   return value
 }


### PR DESCRIPTION
This PR:
- Closes [TML-1531](https://linear.app/prisma-company/issue/TML-1531/env-dx-expose-to-prismaconfig-add-type-safety)
- Exposes `env` to `prisma/config`:
  ```diff
  // ./prisma.config.ts
  - import { env } from '@prisma/config'
  + import { env } from 'prisma/config'
  ```
- Introduces type-safe env variable support for `env`:
  ```typescript
  import { defineConfig, env } from 'prisma/config'
  import 'dotenv/config'
  
  type Env = {
    DATABASE_URL: string
    SHADOW_DATABASE_URL: string
  }
  
  export default defineConfig({
    engine: 'classic',
    datasource: {
      url: env<Env>('DATABASE_URL'),
    },
  })
  ```

  https://github.com/user-attachments/assets/53827492-7189-4f7d-843b-84309c3ad441

