### PR TITLE
feat: make CLI help output consistent by separating flags from options

### DIFF
--- a/packages/cli/src/Format.ts
+++ b/packages/cli/src/Format.ts
@@ -36,6 +36,10 @@ ${bold('Options')}
     --config   Custom path to your Prisma config file
     --schema   Custom path to your Prisma schema
 
+${bold('Flags')}
+
+  --check   Check if the schema is formatted without modifying it
+
 ${bold('Examples')}
 
 With an existing Prisma schema

--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -61,14 +61,18 @@ ${bold('Usage')}
   ${dim('$')} prisma generate [options]
 
 ${bold('Options')}
-          -h, --help   Display this help message
-            --config   Custom path to your Prisma config file
-            --schema   Custom path to your Prisma schema
-               --sql   Generate typed sql module
-             --watch   Watch the Prisma schema and rerun after a change
-         --generator   Generator to use (may be provided multiple times)
-         --no-engine   Generate a client for use with Accelerate only
-          --no-hints   Hides the hint messages but still outputs errors and warnings
+
+    -h, --help   Display this help message
+      --config   Custom path to your Prisma config file
+      --schema   Custom path to your Prisma schema
+   --generator   Generator to use (may be provided multiple times)
+
+${bold('Flags')}
+
+           --sql   Generate typed sql module
+         --watch   Watch the Prisma schema and rerun after a change
+     --no-engine   Generate a client for use with Accelerate only
+      --no-hints   Hides the hint messages but still outputs errors and warnings
    --allow-no-models   Allow generating a client without models (default)
     --require-models   Do not allow generating a client without models
 

--- a/packages/migrate/src/commands/DbDrop.ts
+++ b/packages/migrate/src/commands/DbDrop.ts
@@ -41,10 +41,14 @@ ${bold('Usage')}
 
 ${bold('Options')}
 
-   -h, --help   Display this help message
-     --config   Custom path to your Prisma config file
-     --schema   Custom path to your Prisma schema
-  -f, --force   Skip the confirmation prompt
+  -h, --help   Display this help message
+    --config   Custom path to your Prisma config file
+    --schema   Custom path to your Prisma schema
+
+${bold('Flags')}
+
+  -f, --force           Skip the confirmation prompt
+  --preview-feature     Opt-in to the preview feature
 
 ${bold('Examples')}
 

--- a/packages/migrate/src/commands/DbPull.ts
+++ b/packages/migrate/src/commands/DbPull.ts
@@ -54,22 +54,23 @@ Pull the state from the database to the Prisma schema using introspection
 
 ${bold('Usage')}
 
-  ${dim('$')} prisma db pull [flags/options]
-
-${bold('Flags')}
-
-              -h, --help   Display this help message
-                 --force   Ignore current Prisma schema file
-                 --print   Print the introspected Prisma schema to stdout
+  ${dim('$')} prisma db pull [options]
 
 ${bold('Options')}
 
-                --config   Custom path to your Prisma config file
-                --schema   Custom path to your Prisma schema
-  --composite-type-depth   Specify the depth for introspecting composite types (e.g. Embedded Documents in MongoDB)
-                           Number, default is -1 for infinite depth, 0 = off
-               --schemas   Specify the database schemas to introspect. This overrides the schemas defined in the datasource block of your Prisma schema.
-              --local-d1   Generate a Prisma schema from a local Cloudflare D1 database
+                -h, --help   Display this help message
+                  --config   Custom path to your Prisma config file
+                  --schema   Custom path to your Prisma schema
+    --composite-type-depth   Specify the depth for introspecting composite types (e.g. Embedded Documents in MongoDB)
+                             Number, default is -1 for infinite depth, 0 = off
+                 --schemas   Specify the database schemas to introspect. This overrides the schemas defined in the datasource block of your Prisma schema.
+
+${bold('Flags')}
+
+  --force      Ignore current Prisma schema file
+  --print      Print the introspected Prisma schema to stdout
+  --local-d1   Generate a Prisma schema from a local Cloudflare D1 database
+
 ${bold('Examples')}
 
 With an existing Prisma schema

--- a/packages/migrate/src/commands/DbPush.ts
+++ b/packages/migrate/src/commands/DbPush.ts
@@ -38,9 +38,12 @@ ${bold('Usage')}
 
 ${bold('Options')}
 
-           -h, --help   Display this help message
-             --config   Custom path to your Prisma config file
-             --schema   Custom path to your Prisma schema
+  -h, --help   Display this help message
+    --config   Custom path to your Prisma config file
+    --schema   Custom path to your Prisma schema
+
+${bold('Flags')}
+
    --accept-data-loss   Ignore data loss warnings
         --force-reset   Force a reset of the database before push
       --skip-generate   Skip triggering generators (e.g. Prisma Client)

--- a/packages/migrate/src/commands/MigrateDev.ts
+++ b/packages/migrate/src/commands/MigrateDev.ts
@@ -50,10 +50,13 @@ ${bold('Usage')}
 
 ${bold('Options')}
 
-       -h, --help   Display this help message
-         --config   Custom path to your Prisma config file
-         --schema   Custom path to your Prisma schema
-       -n, --name   Name the migration
+  -h, --help   Display this help message
+    --config   Custom path to your Prisma config file
+    --schema   Custom path to your Prisma schema
+  -n, --name   Name the migration
+
+${bold('Flags')}
+
     --create-only   Create a new migration but do not apply it
                     The migration will be empty if there are no changes in Prisma schema
   --skip-generate   Skip triggering generators (e.g. Prisma Client)

--- a/packages/migrate/src/commands/MigrateReset.ts
+++ b/packages/migrate/src/commands/MigrateReset.ts
@@ -37,9 +37,12 @@ ${bold('Usage')}
 
 ${bold('Options')}
 
-       -h, --help   Display this help message
-         --config   Custom path to your Prisma config file
-         --schema   Custom path to your Prisma schema
+  -h, --help   Display this help message
+    --config   Custom path to your Prisma config file
+    --schema   Custom path to your Prisma schema
+
+${bold('Flags')}
+
   --skip-generate   Skip triggering generators (e.g. Prisma Client)
       --skip-seed   Skip triggering seed
       -f, --force   Skip the confirmation prompt


### PR DESCRIPTION
## Summary

This PR standardizes the CLI help output across all Prisma commands by separating Boolean flags into their own "Flags" section, following the pattern established in `MigrateDiff.ts`. Previously, some commands mixed options and flags together under a single "Options" section, making it harder for users to distinguish between parameters that require values and those that don't.

## Problem

The CLI help output was inconsistent across commands. For example:

**Before (`prisma migrate dev --help`):**
```
Options

       -h, --help   Display this help message
         --config   Custom path to your Prisma config file
         --schema   Custom path to your Prisma schema
       -n, --name   Name the migration
    --create-only   Create a new migration but do not apply it
  --skip-generate   Skip triggering generators (e.g. Prisma Client)
      --skip-seed   Skip triggering seed
```

While `migrate diff` already had the correct format with separate sections, other commands mixed everything together.

## Solution

Updated 7 command files to consistently separate Boolean flags into their own section:

**After (`prisma migrate dev --help`):**
```
Options

  -h, --help   Display this help message
    --config   Custom path to your Prisma config file
    --schema   Custom path to your Prisma schema
  -n, --name   Name the migration

Flags

    --create-only   Create a new migration but do not apply it
  --skip-generate   Skip triggering generators (e.g. Prisma Client)
      --skip-seed   Skip triggering seed
```

## Changes

### Commands Updated

- **`prisma migrate dev`** - Separated `--create-only`, `--skip-generate`, `--skip-seed`
- **`prisma db push`** - Separated `--accept-data-loss`, `--force-reset`, `--skip-generate`
- **`prisma db pull`** - Separated `--force`, `--print`, `--local-d1` (also reorganized for consistency)
- **`prisma migrate reset`** - Separated `--skip-generate`, `--skip-seed`, `--force`
- **`prisma db drop`** - Separated `--force`, `--preview-feature`
- **`prisma generate`** - Separated `--sql`, `--watch`, `--no-engine`, `--no-hints`, `--allow-no-models`, `--require-models`
- **`prisma format`** - Separated `--check`

### Files Modified

- `packages/migrate/src/commands/MigrateDev.ts`
- `packages/migrate/src/commands/DbPush.ts`
- `packages/migrate/src/commands/DbPull.ts`
- `packages/migrate/src/commands/MigrateReset.ts`
- `packages/migrate/src/commands/DbDrop.ts`
- `packages/cli/src/Generate.ts`
- `packages/cli/src/Format.ts`

## Benefits

1. **Clear distinction** - Users can immediately see which parameters require values (Options) and which are boolean toggles (Flags)
2. **Improved readability** - Command interfaces are easier to scan and understand at a glance
3. **Consistent experience** - All Prisma CLI commands now follow the same help output pattern
4. **Better UX** - Users can quickly find the flag they need without parsing through mixed parameter types

## Testing

- ✅ Project builds successfully
- ✅ Existing tests pass
- ✅ Manually verified help output for all modified commands
- ✅ No functional changes - only documentation improvements

This is a documentation-only change with no impact on command functionality.

> [!WARNING]
>
> <details>
> <summary>Firewall rules blocked me from connecting to one or more addresses (expand for details)</summary>
>
> #### I tried to connect to the following addresses, but was blocked by firewall rules:
>
> - `checkpoint.prisma.io`
>   - Triggering command: `/usr/local/bin/node /home/REDACTED/work/prisma/prisma/packages/cli/build/child {&#34;product&#34;:&#34;prisma&#34;,&#34;version&#34;:&#34;0.0.0&#34;,&#34;cli_install_type&#34;:&#34;local&#34;,&#34;information&#34;:&#34;&#34;,&#34;local_timestamp&#34;:&#34;2025-10-21T06:06:16Z&#34;,&#34;project_hash&#34;:&#34;25b568fd&#34;,&#34;cli_path&#34;:&#34;/home/REDACTED/work/prisma/prisma/packages/cli/build/index.js&#34;,&#34;cli_path_hash&#34;:&#34;4c97c773&#34;,&#34;endpoint&#34;:&#34;REDACTED&#34;,&#34;disable&#34;:false,&#34;arch&#34;:&#34;x64&#34;,&#34;os&#34;:&#34;linux&#34;,&#34;node_version&#34;:&#34;v20.19.5&#34;,&#34;ci&#34;:true,&#34;ci_name&#34;:&#34;GitHub Actions&#34;,&#34;command&#34;:&#34;generate&#34;,&#34;schema_providers&#34;:[&#34;postgresql&#34;],&#34;schema_preview_features&#34;:[],&#34;schema_generators_providers&#34;:[&#34;prisma-client-js&#34;],&#34;cache_file&#34;:&#34;/home/REDACTED/.cache/checkpoint-nodejs/prisma-4c97c773&#34;,&#34;cache_duration&#34;:43200000,&#34;remind_duration&#34;:172800000,&#34;force&#34;:false,&#34;timeout&#34;:5000,&#34;unref&#34;:true,&#34;child_path&#34;:&#34;/home/REDACTED/work/prisma/prisma/packages/cli/build/child&#34;,&#34;client_event_id&#34;:&#34;&#34;,&#34;previous_client_event_id&#34;:&#34;&#34;,&#34;check_if_update_available&#34;:true}` (dns block)
>   - Triggering command: `/usr/local/bin/node /home/REDACTED/work/prisma/prisma/packages/cli/build/child {&#34;product&#34;:&#34;prisma&#34;,&#34;version&#34;:&#34;0.0.0&#34;,&#34;cli_install_type&#34;:&#34;local&#34;,&#34;information&#34;:&#34;&#34;,&#34;local_timestamp&#34;:&#34;2025-10-21T06:06:19Z&#34;,&#34;project_hash&#34;:&#34;6f43b2ff&#34;,&#34;cli_path&#34;:&#34;/home/REDACTED/work/prisma/prisma/packages/cli/build/index.js&#34;,&#34;cli_path_hash&#34;:&#34;4c97c773&#34;,&#34;endpoint&#34;:&#34;REDACTED&#34;,&#34;disable&#34;:false,&#34;arch&#34;:&#34;x64&#34;,&#34;os&#34;:&#34;linux&#34;,&#34;node_version&#34;:&#34;v20.19.5&#34;,&#34;ci&#34;:true,&#34;ci_name&#34;:&#34;GitHub Actions&#34;,&#34;command&#34;:&#34;generate&#34;,&#34;schema_providers&#34;:[&#34;postgresql&#34;],&#34;schema_preview_features&#34;:[],&#34;schema_generators_providers&#34;:[&#34;prisma-client-js&#34;],&#34;cache_file&#34;:&#34;/home/REDACTED/.cache/checkpoint-nodejs/prisma-4c97c773&#34;,&#34;cache_duration&#34;:43200000,&#34;remind_duration&#34;:172800000,&#34;force&#34;:false,&#34;timeout&#34;:5000,&#34;unref&#34;:true,&#34;child_path&#34;:&#34;/home/REDACTED/work/prisma/prisma/packages/cli/build/child&#34;,&#34;client_event_id&#34;:&#34;&#34;,&#34;previous_client_event_id&#34;:&#34;&#34;,&#34;check_if_update_available&#34;:true}` (dns block)
>   - Triggering command: `/usr/local/bin/node /home/REDACTED/work/prisma/prisma/packages/cli/build/child {&#34;product&#34;:&#34;prisma&#34;,&#34;version&#34;:&#34;0.0.0&#34;,&#34;cli_install_type&#34;:&#34;local&#34;,&#34;information&#34;:&#34;&#34;,&#34;local_timestamp&#34;:&#34;2025-10-21T06:06:20Z&#34;,&#34;project_hash&#34;:&#34;3fc7fe0b&#34;,&#34;cli_path&#34;:&#34;/home/REDACTED/work/prisma/prisma/packages/cli/build/index.js&#34;,&#34;cli_path_hash&#34;:&#34;4c97c773&#34;,&#34;endpoint&#34;:&#34;REDACTED&#34;,&#34;disable&#34;:false,&#34;arch&#34;:&#34;x64&#34;,&#34;os&#34;:&#34;linux&#34;,&#34;node_version&#34;:&#34;v20.19.5&#34;,&#34;ci&#34;:true,&#34;ci_name&#34;:&#34;GitHub Actions&#34;,&#34;command&#34;:&#34;generate&#34;,&#34;schema_providers&#34;:[&#34;postgresql&#34;],&#34;schema_preview_features&#34;:[],&#34;schema_generators_providers&#34;:[&#34;prisma-client-js&#34;],&#34;cache_file&#34;:&#34;/home/REDACTED/.cache/checkpoint-nodejs/prisma-4c97c773&#34;,&#34;cache_duration&#34;:43200000,&#34;remind_duration&#34;:172800000,&#34;force&#34;:false,&#34;timeout&#34;:5000,&#34;unref&#34;:true,&#34;child_path&#34;:&#34;/home/REDACTED/work/prisma/prisma/packages/cli/build/child&#34;,&#34;client_event_id&#34;:&#34;&#34;,&#34;previous_client_event_id&#34;:&#34;&#34;,&#34;check_if_update_available&#34;:true}` (dns block)
>
> If you need me to access, download, or install something from one of these locations, you can either:
>
> - Configure [Actions setup steps](https://gh.io/copilot/actions-setup-steps) to set up my environment, which run before the firewall is enabled
> - Add the appropriate URLs or hosts to the custom allowlist in this repository's [Copilot coding agent settings](https://github.com/jpaveg/prisma/settings/copilot/coding_agent) (admins only)
>
> </details>

<!-- START COPILOT CODING AGENT SUFFIX -->



<details>

<summary>Original prompt</summary>

> The prisma CLI help option output is inconsistent. Currently, in a file like packages/migrate/src/commands/MigrateDiff.ts, we have the following arg structure:
> ```ts
>  const args = arg(
>       argv,
>       {
>         '--help': Boolean,
>         '-h': '--help',
>         '--output': String,
>         '-o': '--output',
>         // From
>         '--from-empty': Boolean,
>         '--from-schema-datasource': String,
>         '--from-schema-datamodel': String,
>         '--from-url': String,
>         '--from-migrations': String,
>         '--from-local-d1': Boolean,
>         // To
>         '--to-empty': Boolean,
>         '--to-schema-datasource': String,
>         '--to-schema-datamodel': String,
>         '--to-url': String,
>         '--to-migrations': String,
>         '--to-local-d1': Boolean,
>         // Others
>         '--shadow-database-url': String,
>         '--script': Boolean,
>         '--exit-code': Boolean,
>         '--telemetry-information': String,
>         '--config': String,
>       },
>       false,
>     )
> ```
> 
> and the CLI output differentiates between options and flags:
> ```ts
> const helpOptions = format(
>   `${bold('Usage')}
> 
>   ${dim('$')} prisma migrate diff [options]
> 
> ${bold('Options')}
> 
>   -h, --help               Display this help message
>   --config                 Custom path to your Prisma config file
>   -o, --output             Writes to a file instead of stdout
> 
> ${italic('From and To inputs (1 `--from-...` and 1 `--to-...` must be provided):')}
>   --from-url               A datasource URL
>   --to-url
> 
>   --from-empty             Flag to assume from or to is an empty datamodel
>   --to-empty
> 
>   --from-schema-datamodel  Path to a Prisma schema file, uses the ${italic('datamodel')} for the diff
>   --to-schema-datamodel
> 
>   --from-schema-datasource Path to a Prisma schema file, uses the ${italic('datasource url')} for the diff
>   --to-schema-datasource
> 
>   --from-migrations        Path to the Prisma Migrate migrations directory
>   --to-migrations
> 
>   --from-local-d1          Automatically locate the local Cloudflare D1 database
>   --to-local-d1
> 
> ${italic('Shadow database (only required if using --from-migrations or --to-migrations):')}
>   --shadow-database-url    URL for the shadow database
> 
> ${bold('Flags')}
> 
>   --script                 Render a SQL script to stdout instead of the default human readable summary (not supported on MongoDB)
>   --exit-code              Change the exit code behavior to signal if the diff is empty or not (Empty: 0, Error: 1, Not empty: 2). Default behavior is Success: 0, Error: 1.`,
> )
> ```
> 
> however, in other files, like packages/migrate/src/commands/MigrateDev.ts, we have the following arg structure:
> ```ts
>     const args = arg(argv, {
>       '--help': Boolean,
>       '-h': '--help',
>       '--name': String,
>       '-n': '--name',
>       // '--force': Boolean,
>       // '-f': '--force',
>       '--create-only': Boolean,
>       '--schema': String,
>       '--config': String,
>       '--skip-generate': Boolean,
>       '--skip-seed': Boolean,
>       '--telemetry-information': String,
>     })
> ```
> and the CLI output does not make this distinction:
> ```ts
> private static help = format(`
> ${
>   process.platform === 'win32' ? '' : '🏋️  '
> }Create a migration from changes in Prisma schema, apply it to the database, trigger generators (e.g. Prisma Client)
>  
> ${bold('Usage')}
> 
>   ${dim('$')} prisma migrate dev [options]
> 
> ${bold('Options')}
> 
>        -h, --help   Display this help message
>          --config   Custom path to your Prisma config file
>          --schema   Custom path to your Prisma schema
>        -n, --name   Name the migration
>     --create-only   Create a new migration but do not apply it
>                     The migration will be empty if there are no changes in Prisma schema
>   --skip-generate   Skip triggering generators (e.g. Prisma Client)
>       --skip-seed   Skip triggering seed
> 
> ${bold('Examples')}
> 
>   Create a migration from changes in Prisma schema, apply it to the database, trigger generators (e.g. Prisma Client)
>   ${dim('$')} prisma migrate dev
> 
>   Specify a schema
>   ${dim('$')} prisma migrate dev --schema=./schema.prisma
> 
>   Create a migration without applying it
>   ${dim('$')} prisma migrate dev --create-only
>   `)
> ```
> 
> 
> I think this would be a good first contribution to the project. Let's ensure that all CLI commands that offer flag options have help outputs that follow the same layout as the MigrateDiff.ts file, with Flags having their own section in the help output.


</details>



<!-- START COPILOT CODING AGENT TIPS -->
---

✨ Let Copilot coding agent [set things up for you](https://github.com/jpaveg/prisma/issues/new?title=✨+Set+up+Copilot+instructions&body=Configure%20instructions%20for%20this%20repository%20as%20documented%20in%20%5BBest%20practices%20for%20Copilot%20coding%20agent%20in%20your%20repository%5D%28https://gh.io/copilot-coding-agent-tips%29%2E%0A%0A%3COnboard%20this%20repo%3E&assignees=copilot) — coding agent works faster and does higher quality work when set up for your repo.
