### PR TITLE
chore: demonstration of `effect/Schema` bug in TypeScript 5.4 -> 5.6

### DIFF
--- a/packages/client/tests/e2e/ts-version/5.4/prisma.config.ts
+++ b/packages/client/tests/e2e/ts-version/5.4/prisma.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'prisma/config'
+
+export default defineConfig({
+  schema: './prisma/schema.prisma',
+  engine: 'classic',
+  datasource: {
+    url: 'file:./db',
+  },
+})

--- a/packages/client/tests/e2e/ts-version/5.5/prisma.config.ts
+++ b/packages/client/tests/e2e/ts-version/5.5/prisma.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'prisma/config'
+
+export default defineConfig({
+  schema: './prisma/schema.prisma',
+  engine: 'classic',
+  datasource: {
+    url: 'file:./db',
+  },
+})

--- a/packages/client/tests/e2e/ts-version/5.6/prisma.config.ts
+++ b/packages/client/tests/e2e/ts-version/5.6/prisma.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'prisma/config'
+
+export default defineConfig({
+  schema: './prisma/schema.prisma',
+  engine: 'classic',
+  datasource: {
+    url: 'file:./db',
+  },
+})

--- a/packages/client/tests/e2e/ts-version/5.7/prisma.config.ts
+++ b/packages/client/tests/e2e/ts-version/5.7/prisma.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'prisma/config'
+
+export default defineConfig({
+  schema: './prisma/schema.prisma',
+  engine: 'classic',
+  datasource: {
+    url: 'file:./db',
+  },
+})

--- a/packages/client/tests/e2e/ts-version/beta/prisma.config.ts
+++ b/packages/client/tests/e2e/ts-version/beta/prisma.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'prisma/config'
+
+export default defineConfig({
+  schema: './prisma/schema.prisma',
+  engine: 'classic',
+  datasource: {
+    url: 'file:./db',
+  },
+})

--- a/packages/client/tests/e2e/ts-version/latest/prisma.config.ts
+++ b/packages/client/tests/e2e/ts-version/latest/prisma.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'prisma/config'
+
+export default defineConfig({
+  schema: './prisma/schema.prisma',
+  engine: 'classic',
+  datasource: {
+    url: 'file:./db',
+  },
+})

--- a/packages/client/tests/e2e/ts-version/next/prisma.config.ts
+++ b/packages/client/tests/e2e/ts-version/next/prisma.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'prisma/config'
+
+export default defineConfig({
+  schema: './prisma/schema.prisma',
+  engine: 'classic',
+  datasource: {
+    url: 'file:./db',
+  },
+})


### PR DESCRIPTION
Using `effect@3.18.4`, this is what I see in lines **3277:3282** of `node_modules/effect/dist/Schema.d.ts`:

```typescript
/**
 * @category Duration filters
 * @since 3.10.0
 */
export declare const betweenDuration: <S extends Schema.Any>(minimum: duration_.DurationInput, maximum: duration_.DurationInput, annotations?: Annotations.Filter<Schema.Type<S>>) => <A extends duration_.Duration>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>) => filter<S>;
declare const Uint8ArrayFromSelf_base: declare<Uint8Array<ArrayBufferLike>, Uint8Array<ArrayBufferLike>, readonly [], never>;
```

The last line has a type error:

```
Type 'Uint8Array' is not generic.ts(2315)
```

Note that `Uint8Array`, since [TypeScript 5.7](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-7.html#support-for---target-es2024-and---lib-es2024), requires a type parameter.

There's also a possibly related issue [here](https://github.com/Effect-TS/effect/issues/5326).

---

How to reproduce:
- `pnpm i && pnpm build`
- `cd packages/client`
- `pnpm run test:e2e ts-version/5.4` → observe an error. Replace `5.4` with `5.5` and `5.6` to observe the same failures on different versions of TypeScript.
  ```sh
  $ pnpm exec tsc --noEmit
  node_modules/.pnpm/effect@3.18.4/node_modules/effect/dist/dts/Schema.d.ts(3282,48): error TS2315: Type 'Uint8Array' is not generic.
  node_modules/.pnpm/effect@3.18.4/node_modules/effect/dist/dts/Schema.d.ts(3282,77): error TS2315: Type 'Uint8Array' is not generic.
  node_modules/.pnpm/effect@3.18.4/node_modules/effect/dist/dts/Utils.d.ts(19,26): error TS2314: Generic type 'IterableIterator<T>' requires 1 type argument(s).
  node_modules/.pnpm/effect@3.18.4/node_modules/effect/dist/dts/Utils.d.ts(63,26): error TS2314: Generic type 'IterableIterator<T>' requires 1 type argument(s).
  node_modules/.pnpm/effect@3.18.4/node_modules/effect/dist/dts/Utils.d.ts(69,53): error TS2314: Generic type 'IterableIterator<T>' requires 1 type argument(s).
  node_modules/.pnpm/effect@3.18.4/node_modules/effect/dist/dts/Utils.d.ts(88,26): error TS2314: Generic type 'IterableIterator<T>' requires 1 type argument(s).
  $ echo "done"
  done
  /usr/local/lib/node_modules/zx/build/core.js:146
              let output = new ProcessOutput(code, signal, stdout, stderr, combined, message);
                           ^
  
  
  ProcessOutput [Error]: 
      at Object.test (/test/ts-version/5.4/_steps.ts:11:11)
      exit code: 2 (Misuse of shell builtins)
      at ChildProcess.<anonymous> (/usr/local/lib/node_modules/zx/build/core.js:146:26)
      at ChildProcess.emit (node:events:517:28)
      at maybeClose (node:internal/child_process:1098:16)
      at ChildProcess._handle.onexit (node:internal/child_process:303:5)
      at Process.callbackTrampoline (node:internal/async_hooks:128:17) {
    _code: 2,
    _signal: null,
    _stdout: "node_modules/.pnpm/effect@3.18.4/node_modules/effect/dist/dts/Schema.d.ts(3282,48): error TS2315: Type 'Uint8Array' is not generic.\n" +
      "node_modules/.pnpm/effect@3.18.4/node_modules/effect/dist/dts/Schema.d.ts(3282,77): error TS2315: Type 'Uint8Array' is not generic.\n" +
      "node_modules/.pnpm/effect@3.18.4/node_modules/effect/dist/dts/Utils.d.ts(19,26): error TS2314: Generic type 'IterableIterator<T>' requires 1 type argument(s).\n" +
      "node_modules/.pnpm/effect@3.18.4/node_modules/effect/dist/dts/Utils.d.ts(63,26): error TS2314: Generic type 'IterableIterator<T>' requires 1 type argument(s).\n" +
      "node_modules/.pnpm/effect@3.18.4/node_modules/effect/dist/dts/Utils.d.ts(69,53): error TS2314: Generic type 'IterableIterator<T>' requires 1 type argument(s).\n" +
      "node_modules/.pnpm/effect@3.18.4/node_modules/effect/dist/dts/Utils.d.ts(88,26): error TS2314: Generic type 'IterableIterator<T>' requires 1 type argument(s).\n",
    _stderr: '',
    _combined: "node_modules/.pnpm/effect@3.18.4/node_modules/effect/dist/dts/Schema.d.ts(3282,48): error TS2315: Type 'Uint8Array' is not generic.\n" +
      "node_modules/.pnpm/effect@3.18.4/node_modules/effect/dist/dts/Schema.d.ts(3282,77): error TS2315: Type 'Uint8Array' is not generic.\n" +
      "node_modules/.pnpm/effect@3.18.4/node_modules/effect/dist/dts/Utils.d.ts(19,26): error TS2314: Generic type 'IterableIterator<T>' requires 1 type argument(s).\n" +
      "node_modules/.pnpm/effect@3.18.4/node_modules/effect/dist/dts/Utils.d.ts(63,26): error TS2314: Generic type 'IterableIterator<T>' requires 1 type argument(s).\n" +
      "node_modules/.pnpm/effect@3.18.4/node_modules/effect/dist/dts/Utils.d.ts(69,53): error TS2314: Generic type 'IterableIterator<T>' requires 1 type argument(s).\n" +
      "node_modules/.pnpm/effect@3.18.4/node_modules/effect/dist/dts/Utils.d.ts(88,26): error TS2314: Generic type 'IterableIterator<T>' requires 1 type argument(s).\n"
  }
  ```


- `pnpm run test:e2e ts-version/5.7` → observe a success.