### PR TITLE
fix(cli): support `prisma-client` in telemetry

### DIFF
--- a/packages/cli/src/__tests__/checkpoint.test.ts
+++ b/packages/cli/src/__tests__/checkpoint.test.ts
@@ -105,11 +105,13 @@ it('should read data from Prisma schema', async () => {
   await expect(tryToReadDataFromSchema('./schema.prisma')).resolves.toMatchInlineSnapshot(`
     {
       "schemaGeneratorsProviders": [
+        "prisma-client",
         "prisma-client-js",
         "something",
       ],
       "schemaPreviewFeatures": [
         "extendedIndexes",
+        "fullTextSearch",
       ],
       "schemaProvider": "sqlite",
     }

--- a/packages/cli/src/__tests__/fixtures/checkpoint-read-schema/schema.prisma
+++ b/packages/cli/src/__tests__/fixtures/checkpoint-read-schema/schema.prisma
@@ -1,18 +1,24 @@
 datasource my_db {
-    provider = "sqlite"
-    url      = env("SQLITE_URL")
+  provider = "sqlite"
+  url      = env("SQLITE_URL")
 }
 
 generator client {
-    provider        = "prisma-client-js"
-    previewFeatures = ["extendedIndexes"]
+  provider        = "prisma-client"
+  previewFeatures = ["extendedIndexes"]
+}
+
+generator classicClient {
+  provider        = "prisma-client-js"
+  previewFeatures = ["fullTextSearch"]
+  output          = "./generated/prisma"
 }
 
 generator something {
-    provider = "something"
+  provider = "something"
 }
 
 model Blog {
-    id        Int @id
-    viewCount Int
+  id        Int @id
+  viewCount Int
 }

--- a/packages/cli/src/utils/checkpoint.ts
+++ b/packages/cli/src/utils/checkpoint.ts
@@ -1,4 +1,4 @@
-import Debug from '@prisma/debug'
+import { Debug } from '@prisma/debug'
 import {
   arg,
   getCLIPathHash,
@@ -133,16 +133,16 @@ export async function tryToReadDataFromSchema(schemaPath?: string, schemaPathFro
       .filter((generator) => generator && generator.provider)
       .map((generator) => parseEnvValue(generator.provider))
 
-    // restrict the search to previewFeatures of `provider = 'prisma-client-js'`
-    // (this was not scoped to `prisma-client-js` before Prisma 3.0)
-    // TODO: we should normalize how `previewFeatures` are extracted, since we currently support
-    // multiple generators (`prisma-client-js`, `prisma-client`), and each generator can occur
-    // more than once.
-    const prismaClientJSGenerator = schemaContext.generators.find(
-      (generator) => parseEnvValue(generator.provider) === 'prisma-client-js',
-    )
-    if (prismaClientJSGenerator && prismaClientJSGenerator.previewFeatures.length > 0) {
-      schemaPreviewFeatures = prismaClientJSGenerator.previewFeatures
+    const clientGeneratorProviders = ['prisma-client', 'prisma-client-js']
+    const previewFeatures = schemaContext.generators
+      .filter((generator) => {
+        const provider = generator?.provider ? parseEnvValue(generator.provider) : undefined
+        return provider !== undefined && clientGeneratorProviders.includes(provider)
+      })
+      .flatMap((generator) => generator.previewFeatures ?? [])
+
+    if (previewFeatures.length > 0) {
+      schemaPreviewFeatures = Array.from(new Set(previewFeatures))
     }
   } catch (e) {
     debug(


### PR DESCRIPTION
Support extracting and merging preview features from both generators.

Closes: https://linear.app/prisma-company/issue/TML-1547/fix-broken-telemetry-with-prisma-client-generator
