### PR TITLE
fix(client): fix `invalid-sqlite-isolation-level` test

### DIFF
--- a/packages/client/tests/functional/invalid-sqlite-isolation-level/tests.ts
+++ b/packages/client/tests/functional/invalid-sqlite-isolation-level/tests.ts
@@ -1,6 +1,6 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type $ from './generated/prisma/client'
+import type * as $ from './generated/prisma/client'
 
 declare let prisma: $.PrismaClient
 

--- a/packages/client/tests/functional/invalid-sqlite-isolation-level/tests.ts
+++ b/packages/client/tests/functional/invalid-sqlite-isolation-level/tests.ts
@@ -32,8 +32,5 @@ testMatrix.setupTestSuite(
         The isolation level check is specific to SQLite.
       `,
     },
-    skip(when, { generatorType }) {
-      when(generatorType === 'prisma-client-ts', '@ts-expect-error is not used with prisma-client-ts. This is a bug')
-    },
   },
 )


### PR DESCRIPTION
This PR:
- closes [TML-1561](https://linear.app/prisma-company/issue/TML-1561/fix-invalid-sqlite-isolation-level-functional-test)
- fixes `invalid-sqlite-isolation-level` in functional tests
