### PR TITLE
chore: mark type benchmark tests package private

### DIFF
--- a/packages/type-benchmark-tests/package.json
+++ b/packages/type-benchmark-tests/package.json
@@ -1,6 +1,7 @@
 {
   "type": "module",
   "name": "@prisma/type-benchmark-tests",
+  "private": true,
   "version": "0.0.0",
   "description": "This package is intended for Prisma's internal use and only performs type benchmark tests.",
   "repository": {


### PR DESCRIPTION
We shouldn't be publishing the `type-benchmark-tests` to npm