### PR TITLE
chore: remove unused query engine related logic

### DIFF
--- a/.github/workflows/build-engine-branch.yml
+++ b/.github/workflows/build-engine-branch.yml
@@ -67,13 +67,7 @@ jobs:
           path: |
             target/release/schema-engine
             target/release/schema-engine.exe
-            target/release/query-engine
-            target/release/query-engine.exe
-            target/release/libquery_engine.so
-            target/release/libquery_engine.dylib
-            target/release/query_engine.dll
             target/prisma-schema-wasm
-            query-engine/query-engine-wasm/pkg
             query-compiler/query-compiler-wasm/pkg
             schema-engine/schema-engine-wasm/pkg
           key: ${{ runner.os }}-engine-${{ steps.engine-hash.outputs.engineHash }}-${{ github.event.number }}
@@ -97,10 +91,7 @@ jobs:
         if: steps.artifacts-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          cargo build --release \
-            -p query-engine \
-            -p query-engine-node-api \
-            -p schema-engine-cli
+          cargo build --release -p schema-engine-cli
 
       - uses: cargo-bins/cargo-binstall@main
 
@@ -153,12 +144,6 @@ jobs:
         shell: bash
         run: |
           make PROFILE=release build-schema-wasm
-
-      - name: Build query-engine-wasm
-        if: steps.artifacts-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          make WASM_BUILD_PROFILE=release build-qe-wasm
 
       - name: Build query-compiler-wasm
         if: steps.artifacts-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/update-engines-version.yml
+++ b/.github/workflows/update-engines-version.yml
@@ -49,12 +49,6 @@ jobs:
           echo 'Checking that @prisma/prisma-schema-wasm has the published version @${{ github.event.inputs.version }}'
           pnpm --package=@prisma/ensure-npm-release dlx enr update -p @prisma/prisma-schema-wasm -u ${{ github.event.inputs.version }}
 
-      # Note: @prisma/query-engine-wasm might take a few minutes before it's available too
-      - name: Check if version of @prisma/query-engine-wasm is available on npm
-        run: |
-          echo 'Checking that @prisma/query-engine-wasm has the published version @${{ github.event.inputs.version }}'
-          pnpm --package=@prisma/ensure-npm-release dlx enr update -p @prisma/query-engine-wasm -u ${{ github.event.inputs.version }}
-
       # Note: @prisma/query-compiler-wasm might take a few minutes before it's available too
       - name: Check if version of @prisma/query-compiler-wasm is available on npm
         run: |
@@ -84,15 +78,6 @@ jobs:
           command: |
             echo 'Updating @prisma/prisma-schema-wasm to ${{ github.event.inputs.version }} using pnpm'
             pnpm update -r @prisma/prisma-schema-wasm@${{ github.event.inputs.version }}
-
-      - name: Update the dependencies (@prisma/query-engine-wasm)
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 7
-          max_attempts: 3
-          command: |
-            echo 'Updating @prisma/query-engine-wasm to ${{ github.event.inputs.version }} using pnpm'
-            pnpm update -r @prisma/query-engine-wasm@${{ github.event.inputs.version }}
 
       - name: Update the dependencies (@prisma/query-compiler-wasm)
         uses: nick-fields/retry@v3
@@ -147,7 +132,6 @@ jobs:
             |---------|---------|
             |`@prisma/engines-version`| https://npmjs.com/package/@prisma/engines-version/v/${{ github.event.inputs.version }}|
             |`@prisma/prisma-schema-wasm`| https://npmjs.com/package/@prisma/prisma-schema-wasm/v/${{ github.event.inputs.version }}|
-            |`@prisma/query-engine-wasm`| https://npmjs.com/package/@prisma/query-engine-wasm/v/${{ github.event.inputs.version }}|
             |`@prisma/query-compiler-wasm`| https://npmjs.com/package/@prisma/query-compiler-wasm/v/${{ github.event.inputs.version }}|
             |`@prisma/schema-engine-wasm`| https://npmjs.com/package/@prisma/schema-engine-wasm/v/${{ github.event.inputs.version }}|
             ## Engines commit
@@ -195,7 +179,6 @@ jobs:
             |---------|---------|
             |`@prisma/engines-version`| https://npmjs.com/package/@prisma/engines-version/v/${{ github.event.inputs.version }}|
             |`@prisma/prisma-schema-wasm`| https://npmjs.com/package/@prisma/prisma-schema-wasm/v/${{ github.event.inputs.version }}|
-            |`@prisma/query-engine-wasm`| https://npmjs.com/package/@prisma/query-engine-wasm/v/${{ github.event.inputs.version }}|
             |`@prisma/query-compiler-wasm`| https://npmjs.com/package/@prisma/query-compiler-wasm/v/${{ github.event.inputs.version }}|
             |`@prisma/schema-engine-wasm`| https://npmjs.com/package/@prisma/schema-engine-wasm/v/${{ github.event.inputs.version }}|
             ## Engines commit
@@ -239,7 +222,6 @@ jobs:
             |---------|---------|
             |`@prisma/engines-version`| https://npmjs.com/package/@prisma/engines-version/v/${{ github.event.inputs.version }}|
             |`@prisma/prisma-schema-wasm`| https://npmjs.com/package/@prisma/prisma-schema-wasm/v/${{ github.event.inputs.version }}|
-            |`@prisma/query-engine-wasm`| https://npmjs.com/package/@prisma/query-engine-wasm/v/${{ github.event.inputs.version }}|
             |`@prisma/query-compiler-wasm`| https://npmjs.com/package/@prisma/query-compiler-wasm/v/${{ github.event.inputs.version }}|
             |`@prisma/schema-engine-wasm`| https://npmjs.com/package/@prisma/schema-engine-wasm/v/${{ github.event.inputs.version }}|
             ## Engines commit

--- a/.gitignore
+++ b/.gitignore
@@ -10,12 +10,8 @@ pnpm-debug.log
 .turbo
 
 /target
-query-engine*
 migration-engine*
 schema-engine*
-libquery_engine*
-libquery-engine*
-query_engine-windows.dll.node
 
 *tmp.db
 dist/

--- a/TESTING.md
+++ b/TESTING.md
@@ -472,8 +472,6 @@ Once the integration version is published on npm:
 ## How to trigger artificial panics for our engines
 
 Sometimes it may be useful to trigger a panic in the Rust binaries or libraries used by Prisma under the hood.
-Most of the Rust artifacts are shipped as binaries, whereas `query-engine` is shipped both as a library (by default) and as a binary (on demand).
-To change the default Rust artifacts' type used under the hood, you can set the `PRISMA_CLI_QUERY_ENGINE_TYPE` environment variable to either `library` or `binary`.
 
 ### Setup
 
@@ -488,10 +486,10 @@ To change the default Rust artifacts' type used under the hood, you can set the 
 
 - run `FORCE_PANIC_PRISMA_SCHEMA=1 npx prisma format`
 
-### Trigger panic in Query Engine - Get DMMF
+### Trigger panic in Get DMMF
 
-- run `FORCE_PANIC_QUERY_ENGINE_GET_DMMF=1 npx prisma validate`
+- run `FORCE_PANIC_GET_DMMF=1 npx prisma validate`
 
-### Trigger panic in Query Engine - Get Config
+### Trigger panic in Get Config
 
-- run `FORCE_PANIC_QUERY_ENGINE_GET_CONFIG=1 npx prisma validate`
+- run `FORCE_PANIC_GET_CONFIG=1 npx prisma validate`

--- a/packages/cli/src/__tests__/artificial-panic.test.ts
+++ b/packages/cli/src/__tests__/artificial-panic.test.ts
@@ -97,7 +97,7 @@ describe('artificial-panic get-config', () => {
   it('get-config', async () => {
     ctx.fixture('artificial-panic')
     expect.assertions(3)
-    process.env.FORCE_PANIC_QUERY_ENGINE_GET_CONFIG = '1'
+    process.env.FORCE_PANIC_GET_CONFIG = '1'
 
     const command = new Validate()
     try {
@@ -123,7 +123,7 @@ describe('artificial-panic validate', () => {
   it('validate', async () => {
     ctx.fixture('artificial-panic')
     expect.assertions(3)
-    process.env.FORCE_PANIC_QUERY_ENGINE_GET_DMMF = '1'
+    process.env.FORCE_PANIC_GET_DMMF = '1'
 
     const command = new Validate()
     try {
@@ -141,7 +141,7 @@ describe('artificial-panic validate', () => {
   it('format', async () => {
     ctx.fixture('artificial-panic')
     expect.assertions(3)
-    process.env.FORCE_PANIC_QUERY_ENGINE_GET_DMMF = '1'
+    process.env.FORCE_PANIC_GET_DMMF = '1'
 
     const command = new Format()
     try {
@@ -167,7 +167,7 @@ describe('artificial-panic getDMMF', () => {
   it('getDMMF', async () => {
     ctx.fixture('artificial-panic')
     expect.assertions(3)
-    process.env.FORCE_PANIC_QUERY_ENGINE_GET_DMMF = '1'
+    process.env.FORCE_PANIC_GET_DMMF = '1'
 
     try {
       await getDMMF({

--- a/packages/cli/src/__tests__/commands/CLI.test.ts
+++ b/packages/cli/src/__tests__/commands/CLI.test.ts
@@ -50,7 +50,7 @@ describe('CLI', () => {
   })
 
   describe('ensureNeededBinariesExist', () => {
-    describe('with `config.migrate.engine === "js"`, should not download schema-engine', () => {
+    it('should not download schema engine with `engine: "js"`', async () => {
       // prisma.config.ts
       const config = defineConfig({
         experimental: {
@@ -63,31 +63,27 @@ describe('CLI', () => {
         },
       })
 
-      it('should not download query-engine when engineType = "client"', async () => {
-        ctx.fixture('ensure-needed-binaries-exist')
+      ctx.fixture('ensure-needed-binaries-exist')
 
-        await cliInstance.parse(['validate', '--schema', './using-query-compiler.prisma'], config)
-        expect(download).toHaveBeenCalledWith(
-          expect.objectContaining({
-            binaries: {},
-          }),
-        )
-      })
+      await cliInstance.parse(['validate', '--schema', './using-query-compiler.prisma'], config)
+      expect(download).toHaveBeenCalledWith(
+        expect.objectContaining({
+          binaries: {},
+        }),
+      )
     })
 
-    describe('without config.migrate.adapter, should download schema-engine', () => {
-      it('should not download query-engine when engineType = "client"', async () => {
-        ctx.fixture('ensure-needed-binaries-exist')
+    it('should download schema engine without `engine: "js"`', async () => {
+      ctx.fixture('ensure-needed-binaries-exist')
 
-        await cliInstance.parse(['validate', '--schema', './using-query-compiler.prisma'], defaultTestConfig())
-        expect(download).toHaveBeenCalledWith(
-          expect.objectContaining({
-            binaries: {
-              'schema-engine': expect.any(String),
-            },
-          }),
-        )
-      })
+      await cliInstance.parse(['validate', '--schema', './using-query-compiler.prisma'], defaultTestConfig())
+      expect(download).toHaveBeenCalledWith(
+        expect.objectContaining({
+          binaries: {
+            'schema-engine': expect.any(String),
+          },
+        }),
+      )
     })
   })
 

--- a/packages/cli/src/__tests__/commands/Validate.test.ts
+++ b/packages/cli/src/__tests__/commands/Validate.test.ts
@@ -2,7 +2,6 @@
 
 import { defaultTestConfig } from '@prisma/config'
 import { jestConsoleContext, jestContext } from '@prisma/get-platform'
-import { serializeQueryEngineName } from '@prisma/internals'
 
 import { Validate } from '../../Validate'
 
@@ -309,7 +308,7 @@ describe('validate', () => {
       try {
         await Validate.new().parse(['--schema', './prisma/postgres.prisma'], defaultTestConfig())
       } catch (e) {
-        expect(serializeQueryEngineName(e.message)).toMatchInlineSnapshot(`
+        expect(e.message).toMatchInlineSnapshot(`
           "Prisma schema validation - (validate wasm)
           Error code: P1012
           error: Error validating: Invalid referential action: \`NoAction\`. Allowed values: (\`Cascade\`, \`Restrict\`, \`SetNull\`). \`NoAction\` is not implemented for Postgres when using \`relationMode = "prisma"\`, you could try using \`Restrict\` instead. Learn more at https://pris.ly/d/relation-mode
@@ -339,7 +338,7 @@ describe('validate', () => {
       try {
         await Validate.new().parse(['--schema', './prisma/postgres.prisma'], defaultTestConfig())
       } catch (e) {
-        expect(serializeQueryEngineName(e.message)).toMatchInlineSnapshot(`
+        expect(e.message).toMatchInlineSnapshot(`
           "Prisma schema validation - (validate wasm)
           Error code: P1012
           error: Error validating: Invalid referential action: \`NoAction\`. Allowed values: (\`Cascade\`, \`Restrict\`, \`SetNull\`). \`NoAction\` is not implemented for Postgres when using \`relationMode = "prisma"\`, you could try using \`Restrict\` instead. Learn more at https://pris.ly/d/relation-mode

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -39,11 +39,11 @@ describe('version', () => {
 
 function cleanSnapshot(str: string, versionOverride?: string): string {
   // sanitize engine path
-  // Query Engine (Node-API) : libquery-engine e996df5d66a2314d1da15d31047f9777fc2fbdd9 (at ../../home/runner/work/prisma/prisma/node_modules/.pnpm/@prisma+engines@3.11.0-41.e996df5d66a2314d1da15d31047f9777fc2fbdd9/node_modules/@prisma/engines/libquery_engine-TEST_PLATFORM.LIBRARY_TYPE.node)
-  // +                                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  // Query Engine (Node-API) : libquery-engine 5a2e5869b69a983e279380ec68596b71beae9eff (at ../../cli/src/__tests__/commands/version-test-engines/libquery_engine-TEST_PLATFORM.LIBRARY_TYPE.node, resolved by PRISMA_QUERY_ENGINE_LIBRARY)
-  // =>                                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  // Query Engine (Node-API) : libquery-engine e996df5d66a2314d1da15d31047f9777fc2fbdd9 (at sanitized_path/libquery_engine-TEST_PLATFORM.LIBRARY_TYPE.node)
+  // Schema Engine : schema-engine e996df5d66a2314d1da15d31047f9777fc2fbdd9 (at ../../home/runner/work/prisma/prisma/node_modules/.pnpm/@prisma+engines@3.11.0-41.e996df5d66a2314d1da15d31047f9777fc2fbdd9/node_modules/@prisma/engines/schema-engine-TEST_PLATFORM)
+  // +
+  // Schema Engine : schema-engine 5a2e5869b69a983e279380ec68596b71beae9eff (at ../../cli/src/__tests__/commands/version-test-engines/schema-engine-TEST_PLATFORM, resolved by PRISMA_SCHEMA_ENGINE_BINARY)
+  // =>
+  // Schema Engine : schema-engine e996df5d66a2314d1da15d31047f9777fc2fbdd9 (at sanitized_path/schema-engine-TEST_PLATFORM)
   //                                                                                    ^^^^^^^^^^^^^^^^^^^
   str = str.replace(/\(at (.*engines)(\/|\\)/g, '(at sanitized_path/')
 

--- a/packages/cli/src/__tests__/incomplete-schemas.test.ts
+++ b/packages/cli/src/__tests__/incomplete-schemas.test.ts
@@ -4,7 +4,6 @@ import { stripVTControlCharacters } from 'node:util'
 
 import { defaultTestConfig, loadConfigFromFile } from '@prisma/config'
 import { jestContext } from '@prisma/get-platform'
-import { serializeQueryEngineName } from '@prisma/internals'
 import { DbExecute, DbPull, DbPush, MigrateDev, MigrateReset } from '@prisma/migrate'
 import fs from 'fs'
 
@@ -67,7 +66,7 @@ describe('[wasm] incomplete-schemas', () => {
       try {
         await Format.new().parse([], await loadFixtureConfig())
       } catch (e) {
-        expect(serializeQueryEngineName(stripVTControlCharacters(e.message))).toMatchInlineSnapshot(
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(
           `"Failed to load Prisma config: ConfigLoadError"`,
         )
       }
@@ -221,7 +220,7 @@ describe('[wasm] incomplete-schemas', () => {
       try {
         await Format.new().parse([], await loadFixtureConfig())
       } catch (e) {
-        expect(serializeQueryEngineName(stripVTControlCharacters(e.message))).toMatchInlineSnapshot(
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(
           `"Failed to load Prisma config: ConfigLoadError"`,
         )
       }
@@ -250,7 +249,7 @@ describe('[wasm] incomplete-schemas', () => {
       try {
         await Format.new().parse([], await loadFixtureConfig())
       } catch (e) {
-        expect(serializeQueryEngineName(stripVTControlCharacters(e.message))).toMatchInlineSnapshot(
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(
           `"Failed to load Prisma config: ConfigLoadError"`,
         )
       }
@@ -279,7 +278,7 @@ describe('[wasm] incomplete-schemas', () => {
       try {
         await Format.new().parse([], await loadFixtureConfig())
       } catch (e) {
-        expect(serializeQueryEngineName(stripVTControlCharacters(e.message))).toMatchInlineSnapshot(
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(
           `"Failed to load Prisma config: ConfigLoadError"`,
         )
       }
@@ -362,7 +361,7 @@ describe('[normalized library/binary] incomplete-schemas', () => {
       try {
         await DbPush.new().parse([], await loadFixtureConfig())
       } catch (e) {
-        expect(serializeQueryEngineName(stripVTControlCharacters(e.message))).toMatchInlineSnapshot(
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(
           `"Failed to load Prisma config: ConfigLoadError"`,
         )
       }
@@ -373,7 +372,7 @@ describe('[normalized library/binary] incomplete-schemas', () => {
       try {
         await DbPull.new().parse([], await loadFixtureConfig())
       } catch (e) {
-        expect(serializeQueryEngineName(stripVTControlCharacters(e.message))).toMatchInlineSnapshot(
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(
           `"Failed to load Prisma config: ConfigLoadError"`,
         )
       }
@@ -387,7 +386,7 @@ describe('[normalized library/binary] incomplete-schemas', () => {
         const config = await loadFixtureConfig()
         await DbExecute.new().parse(['--file=./script.sql'], config)
       } catch (e) {
-        expect(serializeQueryEngineName(stripVTControlCharacters(e.message))).toMatchInlineSnapshot(
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(
           `"Failed to load Prisma config: ConfigLoadError"`,
         )
       }
@@ -398,7 +397,7 @@ describe('[normalized library/binary] incomplete-schemas', () => {
       try {
         await MigrateReset.new().parse([], await loadFixtureConfig())
       } catch (e) {
-        expect(serializeQueryEngineName(stripVTControlCharacters(e.message))).toMatchInlineSnapshot(
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(
           `"Failed to load Prisma config: ConfigLoadError"`,
         )
       }
@@ -409,7 +408,7 @@ describe('[normalized library/binary] incomplete-schemas', () => {
       try {
         await MigrateDev.new().parse([], await loadFixtureConfig())
       } catch (e) {
-        expect(serializeQueryEngineName(stripVTControlCharacters(e.message))).toMatchInlineSnapshot(
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(
           `"Failed to load Prisma config: ConfigLoadError"`,
         )
       }

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -271,28 +271,20 @@ function handleIndividualError(error: Error): void {
  */
 
 // macOS
-path.join(__dirname, '../../engines/query-engine-darwin')
 path.join(__dirname, '../../engines/schema-engine-darwin')
 // Windows
-path.join(__dirname, '../../engines/query-engine-windows.exe')
 path.join(__dirname, '../../engines/schema-engine-windows.exe')
 
 // Debian openssl-1.0.x
-path.join(__dirname, '../../engines/query-engine-debian-openssl-1.0.x')
 path.join(__dirname, '../../engines/schema-engine-debian-openssl-1.0.x')
 // Debian openssl-1.1.x
-path.join(__dirname, '../../engines/query-engine-debian-openssl-1.1.x')
 path.join(__dirname, '../../engines/schema-engine-debian-openssl-1.1.x')
 // Debian openssl-3.0.x
-path.join(__dirname, '../../engines/query-engine-debian-openssl-3.0.x')
 path.join(__dirname, '../../engines/schema-engine-debian-openssl-3.0.x')
 
 // Red Hat Enterprise Linux openssl-1.0.x
-path.join(__dirname, '../../engines/query-engine-rhel-openssl-1.0.x')
 path.join(__dirname, '../../engines/schema-engine-rhel-openssl-1.0.x')
 // Red Hat Enterprise Linux openssl-1.1.x
-path.join(__dirname, '../../engines/query-engine-rhel-openssl-1.1.x')
 path.join(__dirname, '../../engines/schema-engine-rhel-openssl-1.1.x')
 // Red Hat Enterprise Linux openssl-3.0.x
-path.join(__dirname, '../../engines/query-engine-rhel-openssl-3.0.x')
 path.join(__dirname, '../../engines/schema-engine-rhel-openssl-3.0.x')

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -210,7 +210,6 @@
     "@prisma/internals": "workspace:*",
     "@prisma/migrate": "workspace:*",
     "@prisma/query-compiler-wasm": "6.19.0-33.next-fca7ed8aa5fe6347594ad793adb59b37f021379a",
-    "@prisma/query-engine-wasm": "6.19.0-33.next-fca7ed8aa5fe6347594ad793adb59b37f021379a",
     "@prisma/query-plan-executor": "workspace:*",
     "@prisma/ts-builders": "workspace:*",
     "@snaplet/copycat": "6.0.0",

--- a/packages/client/src/utils/getTestClient.ts
+++ b/packages/client/src/utils/getTestClient.ts
@@ -65,7 +65,7 @@ type GenerateTestClientOptions = {
 }
 
 /**
- * Actually generates a test client with its own query-engine into ./@prisma/client
+ * Actually generates a test client into ./@prisma/client
  */
 export async function generateTestClient({ projectDir }: GenerateTestClientOptions = {}): Promise<any> {
   if (!projectDir) {

--- a/packages/get-platform/src/test-utils/jestSnapshotSerializer.js
+++ b/packages/get-platform/src/test-utils/jestSnapshotSerializer.js
@@ -54,16 +54,6 @@ function removePlatforms(str) {
   return str.replace(binaryTargetRegex, 'TEST_PLATFORM')
 }
 
-// When updating snapshots this is sensitive to OS
-// macOS will update extension to .dylib.node, but CI uses .so.node for example
-// Note that on Windows the file name doesn't start with "lib".
-function normalizeNodeApiLibFilePath(str) {
-  return str.replace(
-    /((lib)?query_engine-TEST_PLATFORM\.)(.*)(\.node)/g,
-    'libquery_engine-TEST_PLATFORM.LIBRARY_TYPE.node',
-  )
-}
-
 function normalizeBinaryFilePath(str) {
   // write a regex expression that matches strings ending with ".exe" followed by any number of space characters with an empty string:
   return str.replace(/\.exe(\s+)?(\W.*)/g, '$1$2').replace(/\.exe$/g, '')
@@ -144,7 +134,6 @@ module.exports = {
       // From Client package
       normalizeGitHubLinks,
       removePlatforms,
-      normalizeNodeApiLibFilePath,
       normalizeBinaryFilePath,
       normalizeTsClientStackTrace,
       trimErrorPaths,

--- a/packages/internals/package.json
+++ b/packages/internals/package.json
@@ -22,7 +22,6 @@
   "files": [
     "README.md",
     "dist",
-    "!**/libquery_engine*",
     "!dist/get-generators/engines/*",
     "scripts"
   ],

--- a/packages/internals/src/engine-commands/getConfig.ts
+++ b/packages/internals/src/engine-commands/getConfig.ts
@@ -87,7 +87,7 @@ export async function getConfig(options: GetConfigOptions): Promise<ConfigMetaFo
   const configEither = pipe(
     E.tryCatch(
       () => {
-        if (process.env.FORCE_PANIC_QUERY_ENGINE_GET_CONFIG) {
+        if (process.env.FORCE_PANIC_GET_CONFIG) {
           debug('Triggering a Rust panic...')
           prismaSchemaWasm.debug_panic()
         }

--- a/packages/internals/src/engine-commands/getDmmf.ts
+++ b/packages/internals/src/engine-commands/getDmmf.ts
@@ -59,7 +59,7 @@ export async function getDMMF(options: GetDMMFOptions): Promise<DMMF.Document> {
   const dmmfPipeline = pipe(
     E.tryCatch(
       () => {
-        if (process.env.FORCE_PANIC_QUERY_ENGINE_GET_DMMF) {
+        if (process.env.FORCE_PANIC_GET_DMMF) {
           debug('Triggering a Rust panic...')
           prismaSchemaWasm.debug_panic()
         }

--- a/packages/internals/src/engine-commands/validate.ts
+++ b/packages/internals/src/engine-commands/validate.ts
@@ -53,9 +53,9 @@ export function validate(options: ValidateOptions): void {
         /**
          * Note: `validate` was introduced as a substitute of `getDMMF` to validate schemas the
          * same way `getDMMF` did, but without the expensive DMMF document computation, so we
-         * keep using `FORCE_PANIC_QUERY_ENGINE_GET_DMMF` to avoid breaking changes in env vars.
+         * keep using `FORCE_PANIC_GET_DMMF` to avoid breaking changes in env vars.
          */
-        if (process.env.FORCE_PANIC_QUERY_ENGINE_GET_DMMF) {
+        if (process.env.FORCE_PANIC_GET_DMMF) {
           debug('Triggering a Rust panic...')
           prismaSchemaWasm.debug_panic()
         }

--- a/packages/internals/src/index.ts
+++ b/packages/internals/src/index.ts
@@ -96,7 +96,6 @@ export {
 } from './utils/prismaPostgres'
 export { extractSchemaContent, type SchemaFileInput } from './utils/schemaFileInput'
 export { type MultipleSchemas } from './utils/schemaFileInput'
-export { serializeQueryEngineName } from './utils/serializeQueryEngineName'
 export { setClassName } from './utils/setClassName'
 export { toSchemasContainer, toSchemasWithConfigDir } from './utils/toSchemasContainer'
 export { vercelPkgPathRegex } from './utils/vercelPkgPathRegex'

--- a/packages/internals/src/utils/serializeQueryEngineName.ts
+++ b/packages/internals/src/utils/serializeQueryEngineName.ts
@@ -1,7 +1,0 @@
-/**
- * Normalize the snapshot messages related to the interaction with Query Engine.
- */
-export function serializeQueryEngineName(message: string) {
-  const normalizedName = 'query-engine-NORMALIZED'
-  return message.replace(/query-engine-node-api library/g, normalizedName)
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -676,9 +676,6 @@ importers:
       '@prisma/query-compiler-wasm':
         specifier: 6.19.0-33.next-fca7ed8aa5fe6347594ad793adb59b37f021379a
         version: 6.19.0-33.next-fca7ed8aa5fe6347594ad793adb59b37f021379a
-      '@prisma/query-engine-wasm':
-        specifier: 6.19.0-33.next-fca7ed8aa5fe6347594ad793adb59b37f021379a
-        version: 6.19.0-33.next-fca7ed8aa5fe6347594ad793adb59b37f021379a
       '@prisma/query-plan-executor':
         specifier: workspace:*
         version: link:../query-plan-executor
@@ -3407,9 +3404,6 @@ packages:
 
   '@prisma/query-compiler-wasm@6.19.0-33.next-fca7ed8aa5fe6347594ad793adb59b37f021379a':
     resolution: {integrity: sha512-eNIznigPtvyKdpzUs9QNvvP6K4TsyHy9shbWVKo3D60+zp6zaS4xIe4v8Q65hrFh6Y+u1FcXGKEWoJEVQ3wjxw==}
-
-  '@prisma/query-engine-wasm@6.19.0-33.next-fca7ed8aa5fe6347594ad793adb59b37f021379a':
-    resolution: {integrity: sha512-AVwdJOnzMquXkkbmuKOpmeeNsrorcejRxmfkromee68wEvfr+ss20yxWbzncUtis7XJ+81Lg94TLUUm7NvaN3Q==}
 
   '@prisma/schema-engine-wasm@6.19.0-21.next-3ab778d6c5a8df0d39fd88ffd67461d3395af732':
     resolution: {integrity: sha512-8ssPNAbY51M8pxnbHQUgfKnP/NL+F4MLcwCVd9Ui7L7hIrwL4+HGG9DOWkNGg4NbcM0hfBAAa23mSqt3AovOAw==}
@@ -9839,8 +9833,6 @@ snapshots:
   '@prisma/prisma-schema-wasm@6.19.0-33.next-fca7ed8aa5fe6347594ad793adb59b37f021379a': {}
 
   '@prisma/query-compiler-wasm@6.19.0-33.next-fca7ed8aa5fe6347594ad793adb59b37f021379a': {}
-
-  '@prisma/query-engine-wasm@6.19.0-33.next-fca7ed8aa5fe6347594ad793adb59b37f021379a': {}
 
   '@prisma/schema-engine-wasm@6.19.0-21.next-3ab778d6c5a8df0d39fd88ffd67461d3395af732': {}
 

--- a/scripts/bump-engines.ts
+++ b/scripts/bump-engines.ts
@@ -23,7 +23,6 @@ async function main() {
 
   await run(path.join(__dirname, '..'), `pnpm update -r @prisma/engines-version@${version}`)
   await run(path.join(__dirname, '..'), `pnpm update -r @prisma/prisma-schema-wasm@${version}`)
-  await run(path.join(__dirname, '..'), `pnpm update -r @prisma/query-engine-wasm@${version}`)
   await run(path.join(__dirname, '..'), `pnpm update -r @prisma/query-compiler-wasm@${version}`)
   await run(path.join(__dirname, '..'), `pnpm update -r @prisma/schema-engine-wasm@${version}`)
 


### PR DESCRIPTION
Remove unused query engine dependencies, QE update logic, and QE-related test logic.

Ref: https://linear.app/prisma-company/issue/TML-1554/remove-query-engine-from-prisma-engines
Ref: https://github.com/prisma/prisma-engines/pull/5685
