### PR TITLE
feat(migrate): [breaking] no automatic `prisma generate` on `migrate`/`db` commands

### DIFF
--- a/packages/cli/src/DebugInfo.ts
+++ b/packages/cli/src/DebugInfo.ts
@@ -123,7 +123,6 @@ ${formatEnvValue('PRISMA_SHOW_ALL_TRACES')}
 
 For Prisma Migrate
 ${formatEnvValue('PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK')}
-${formatEnvValue('PRISMA_MIGRATE_SKIP_GENERATE')}
 ${formatEnvValue('PRISMA_MIGRATE_SKIP_SEED')}
 
 For Prisma Studio

--- a/packages/cli/src/__tests__/commands/DebugInfo.test.ts
+++ b/packages/cli/src/__tests__/commands/DebugInfo.test.ts
@@ -62,7 +62,6 @@ const envVars = {
   PRISMA_GENERATE_IN_POSTINSTALL: 'true',
   PRISMA_SHOW_ALL_TRACES: 'true',
   PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK: 'true',
-  PRISMA_MIGRATE_SKIP_GENERATE: 'true',
   PRISMA_MIGRATE_SKIP_SEED: 'true',
   BROWSER: 'something',
 }
@@ -146,7 +145,6 @@ describe('debug', () => {
 
       For Prisma Migrate
       - PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK:
-      - PRISMA_MIGRATE_SKIP_GENERATE:
       - PRISMA_MIGRATE_SKIP_SEED:
 
       For Prisma Studio
@@ -227,7 +225,6 @@ describe('debug', () => {
 
       For Prisma Migrate
       - PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK: \`\`
-      - PRISMA_MIGRATE_SKIP_GENERATE: \`\`
       - PRISMA_MIGRATE_SKIP_SEED: \`\`
 
       For Prisma Studio
@@ -305,7 +302,6 @@ describe('debug', () => {
 
       For Prisma Migrate
       - PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK: \`true\`
-      - PRISMA_MIGRATE_SKIP_GENERATE: \`true\`
       - PRISMA_MIGRATE_SKIP_SEED: \`true\`
 
       For Prisma Studio

--- a/packages/client/src/__tests__/integration/__helpers__/migrateDb.ts
+++ b/packages/client/src/__tests__/integration/__helpers__/migrateDb.ts
@@ -3,7 +3,7 @@ import { DbPush } from '@prisma/migrate'
 
 /**
  * Creates/Resets the database and apply necessary SQL to be in sync with the provided Prisma schema
- * Run `db push --force-reset --skip-generate` using the provided schema and configured datasource
+ * Run `db push --force-reset` using the provided schema and configured datasource
  */
 export async function migrateDb({ schemaPath }: { schemaPath: string }) {
   const consoleInfoMock = jest.spyOn(console, 'info').mockImplementation()
@@ -22,6 +22,6 @@ export async function migrateDb({ schemaPath }: { schemaPath: string }) {
     },
   }
 
-  await DbPush.new().parse(['--force-reset', '--skip-generate'], runtimeConfig)
+  await DbPush.new().parse(['--force-reset'], runtimeConfig)
   consoleInfoMock.mockRestore()
 }

--- a/packages/client/tests/e2e/bundler-detection-error/_steps.ts
+++ b/packages/client/tests/e2e/bundler-detection-error/_steps.ts
@@ -6,7 +6,7 @@ void executeSteps({
   setup: async () => {
     await $`pnpm install`
     await $`pnpm prisma generate`
-    await $`pnpm exec prisma db push --force-reset --skip-generate`
+    await $`pnpm exec prisma db push --force-reset`
   },
   test: async () => {
     await $`pnpm exec esbuild src/index.ts --bundle --outdir=dist --platform=node`

--- a/packages/client/tests/e2e/client-entrypoint/_steps.ts
+++ b/packages/client/tests/e2e/client-entrypoint/_steps.ts
@@ -6,7 +6,7 @@ void executeSteps({
   setup: async () => {
     await $`pnpm install`
     await $`pnpm prisma generate`
-    await $`pnpm exec prisma db push --force-reset --skip-generate`
+    await $`pnpm exec prisma db push --force-reset`
   },
   test: async () => {
     await $`pnpm exec prisma -v`

--- a/packages/client/tests/e2e/connection-limit-reached/_steps.ts
+++ b/packages/client/tests/e2e/connection-limit-reached/_steps.ts
@@ -6,7 +6,7 @@ void executeSteps({
   setup: async () => {
     await $`pnpm install`
     await $`pnpm prisma generate`
-    await $`pnpm prisma db push --force-reset --skip-generate`
+    await $`pnpm prisma db push --force-reset`
   },
   test: async () => {
     await $`pnpm jest`

--- a/packages/client/tests/e2e/driver-adapters-custom-db-schema/adapter-neon/_steps.ts
+++ b/packages/client/tests/e2e/driver-adapters-custom-db-schema/adapter-neon/_steps.ts
@@ -6,7 +6,7 @@ void executeSteps({
   setup: async () => {
     await $`pnpm install`
     await $`pnpm prisma generate`
-    await $`pnpm prisma db push --force-reset --accept-data-loss --skip-generate`
+    await $`pnpm prisma db push --force-reset --accept-data-loss`
   },
   test: async () => {
     await $`pnpm exec jest`

--- a/packages/client/tests/e2e/driver-adapters-custom-db-schema/adapter-pg/_steps.ts
+++ b/packages/client/tests/e2e/driver-adapters-custom-db-schema/adapter-pg/_steps.ts
@@ -6,7 +6,7 @@ void executeSteps({
   setup: async () => {
     await $`pnpm install`
     await $`pnpm prisma generate`
-    await $`pnpm prisma db push --force-reset --accept-data-loss --skip-generate`
+    await $`pnpm prisma db push --force-reset --accept-data-loss`
   },
   test: async () => {
     await $`pnpm exec jest`

--- a/packages/client/tests/e2e/example/_steps.ts
+++ b/packages/client/tests/e2e/example/_steps.ts
@@ -6,7 +6,7 @@ void executeSteps({
   setup: async () => {
     await $`pnpm install`
     await $`pnpm prisma generate`
-    await $`pnpm exec prisma db push --force-reset --skip-generate`
+    await $`pnpm exec prisma db push --force-reset`
   },
   test: async () => {
     await $`pnpm exec prisma -v`

--- a/packages/client/tests/e2e/issues/16600-tsc-crash-extensions/_steps.ts
+++ b/packages/client/tests/e2e/issues/16600-tsc-crash-extensions/_steps.ts
@@ -6,7 +6,7 @@ void executeSteps({
   setup: async () => {
     await $`pnpm install`
     await $`pnpm prisma generate`
-    await $`pnpm exec prisma db push --force-reset --skip-generate`
+    await $`pnpm exec prisma db push --force-reset`
   },
   test: async () => {
     await $`ts-node src/index.ts`

--- a/packages/client/tests/e2e/issues/19999-tsc-extensions-oom/_steps.ts
+++ b/packages/client/tests/e2e/issues/19999-tsc-extensions-oom/_steps.ts
@@ -6,7 +6,7 @@ void executeSteps({
   setup: async () => {
     await $`pnpm install`
     await $`pnpm prisma generate`
-    await $`pnpm exec prisma db push --force-reset --skip-generate`
+    await $`pnpm exec prisma db push --force-reset`
   },
   test: async () => {
     await $`ts-node src/index.ts`

--- a/packages/client/tests/e2e/issues/28221-multiple-provider-clients/_steps.cts
+++ b/packages/client/tests/e2e/issues/28221-multiple-provider-clients/_steps.cts
@@ -7,7 +7,7 @@ void executeSteps({
     await $`pnpm install`
     for (const provider of ['mysql', 'postgres']) {
       await $`pnpm exec prisma generate --config=./prisma/${provider}/prisma.config.ts`
-      await $`pnpm exec prisma db push --force-reset --skip-generate --config=./prisma/${provider}/prisma.config.ts`
+      await $`pnpm exec prisma db push --force-reset --config=./prisma/${provider}/prisma.config.ts`
     }
   },
   test: async () => {

--- a/packages/client/tests/e2e/mongodb-notablescan/_steps.ts
+++ b/packages/client/tests/e2e/mongodb-notablescan/_steps.ts
@@ -7,7 +7,7 @@ void executeSteps({
     await $`pnpm install`
     await $`pnpm prisma version`
     await $`pnpm prisma generate`
-    await $`pnpm prisma db push --force-reset --skip-generate`
+    await $`pnpm prisma db push --force-reset`
   },
   test: async () => {
     // Skipped until MongoDB support is added to Prisma 7

--- a/packages/client/tests/e2e/nextjs-schema-not-found/10_monorepo-serverComponents-customOutput-noReExport/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/10_monorepo-serverComponents-customOutput-noReExport/_steps.ts
@@ -6,6 +6,7 @@ import { testServerComponents } from '../_shared/test'
 void executeSteps({
   setup: async () => {
     await $`pnpm install`
+    await $`pnpm prisma generate`
     cd('packages/service')
     await $`pnpm exec prisma db push --force-reset`
   },

--- a/packages/client/tests/e2e/prisma-client-generator/enums-tsoa/_steps.cts
+++ b/packages/client/tests/e2e/prisma-client-generator/enums-tsoa/_steps.cts
@@ -6,7 +6,7 @@ void executeSteps({
   setup: async () => {
     await $`pnpm install`
     await $`pnpm prisma generate`
-    await $`pnpm prisma db push --force-reset --skip-generate`
+    await $`pnpm prisma db push --force-reset`
   },
   test: async () => {
     await $`pnpm tsoa routes`

--- a/packages/client/tests/e2e/prisma-client-generator/node-tsup-esm/_steps.cts
+++ b/packages/client/tests/e2e/prisma-client-generator/node-tsup-esm/_steps.cts
@@ -6,7 +6,7 @@ void executeSteps({
   setup: async () => {
     await $`pnpm install`
     await $`pnpm prisma generate`
-    await $`pnpm prisma db push --force-reset --skip-generate`
+    await $`pnpm prisma db push --force-reset`
     await $`pnpm tsup src/test.ts --format esm`
   },
   test: async () => {

--- a/packages/client/tests/e2e/prisma-client-generator/node-tsx-cjs/_steps.ts
+++ b/packages/client/tests/e2e/prisma-client-generator/node-tsx-cjs/_steps.ts
@@ -5,7 +5,7 @@ import { executeSteps } from '../../_utils/executeSteps'
 void executeSteps({
   setup: async () => {
     await $`pnpm install`
-    await $`pnpm prisma db push --force-reset --skip-generate`
+    await $`pnpm prisma db push --force-reset`
     await $`pnpm prisma generate`
   },
   test: async () => {

--- a/packages/client/tests/e2e/prisma-client-generator/node-tsx-esm-mts/_steps.ts
+++ b/packages/client/tests/e2e/prisma-client-generator/node-tsx-esm-mts/_steps.ts
@@ -5,7 +5,7 @@ import { executeSteps } from '../../_utils/executeSteps'
 void executeSteps({
   setup: async () => {
     await $`pnpm install`
-    await $`pnpm prisma db push --force-reset --skip-generate`
+    await $`pnpm prisma db push --force-reset`
     await $`pnpm prisma generate`
   },
   test: async () => {

--- a/packages/client/tests/e2e/prisma-client-generator/node-tsx-esm/_steps.cts
+++ b/packages/client/tests/e2e/prisma-client-generator/node-tsx-esm/_steps.cts
@@ -5,7 +5,7 @@ import { executeSteps } from '../../_utils/executeSteps'
 void executeSteps({
   setup: async () => {
     await $`pnpm install`
-    await $`pnpm prisma db push --force-reset --skip-generate`
+    await $`pnpm prisma db push --force-reset`
     await $`pnpm prisma generate`
   },
   test: async () => {

--- a/packages/client/tests/e2e/publish-extensions/_steps.ts
+++ b/packages/client/tests/e2e/publish-extensions/_steps.ts
@@ -13,7 +13,7 @@ void executeSteps({
     cd('..')
     await $`pnpm install`
     await $`pnpm prisma generate`
-    await $`pnpm exec prisma db push --force-reset --skip-generate`
+    await $`pnpm exec prisma db push --force-reset`
   },
   test: async () => {
     await $`pnpm exec tsc --noEmit`

--- a/packages/client/tests/e2e/schema-folder-sqlite/_steps.ts
+++ b/packages/client/tests/e2e/schema-folder-sqlite/_steps.ts
@@ -5,6 +5,7 @@ import { executeSteps } from '../_utils/executeSteps'
 void executeSteps({
   setup: async () => {
     await $`pnpm install`
+    await $`pnpm prisma generate`
     await $`pnpm prisma db push --force-reset`
   },
   test: async () => {

--- a/packages/client/tests/e2e/schema-not-found-sst-electron/_steps.ts
+++ b/packages/client/tests/e2e/schema-not-found-sst-electron/_steps.ts
@@ -5,6 +5,7 @@ import { executeSteps } from '../_utils/executeSteps'
 void executeSteps({
   setup: async () => {
     await $`pnpm install`
+    await $`pnpm prisma generate`
     await $`pnpm exec prisma db push --force-reset`
   },
   test: async () => {

--- a/packages/client/tests/e2e/typed-sql-query-compiler-adapter-libsql/_steps.ts
+++ b/packages/client/tests/e2e/typed-sql-query-compiler-adapter-libsql/_steps.ts
@@ -5,7 +5,7 @@ import { executeSteps } from '../_utils/executeSteps'
 void executeSteps({
   setup: async () => {
     await $`pnpm install`
-    await $`pnpm exec prisma db push --force-reset --skip-generate`
+    await $`pnpm exec prisma db push --force-reset`
     await $`pnpm prisma generate --sql`
   },
   test: async () => {

--- a/packages/client/tests/e2e/typed-sql/_steps.ts
+++ b/packages/client/tests/e2e/typed-sql/_steps.ts
@@ -5,7 +5,7 @@ import { executeSteps } from '../_utils/executeSteps'
 void executeSteps({
   setup: async () => {
     await $`pnpm install`
-    await $`pnpm exec prisma db push --force-reset --skip-generate`
+    await $`pnpm exec prisma db push --force-reset`
     await $`pnpm prisma generate --sql`
   },
   test: async () => {

--- a/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteEnv.ts
@@ -160,7 +160,7 @@ export async function setupTestSuiteDatabase({
     if (suiteConfig.matrixOptions.driverAdapter === AdapterProviders.JS_D1) {
       await setupTestSuiteDatabaseD1({ schemaPath, cfWorkerBindings: cfWorkerBindings!, alterStatementCallback })
     } else {
-      const dbPushParams = ['--skip-generate']
+      const dbPushParams = [] as string[]
 
       // we reuse and clean the db when it is explicitly required
       if (process.env.TEST_REUSE_DATABASE === 'true') {

--- a/packages/client/tests/memory/_utils/database.ts
+++ b/packages/client/tests/memory/_utils/database.ts
@@ -12,7 +12,7 @@ export async function setupMemoryTestDatabase(testDir: MemoryTestDir) {
   const config = await getMemoryTestConfig(testDir)
 
   return withNoOutput(async () => {
-    await DbPush.new().parse(['--force-reset', '--skip-generate'], config)
+    await DbPush.new().parse(['--force-reset'], config)
   })
 }
 

--- a/packages/migrate/src/Migrate.ts
+++ b/packages/migrate/src/Migrate.ts
@@ -1,15 +1,5 @@
-import { defaultRegistry } from '@prisma/client-generator-registry'
 import { SchemaEngineConfigInternal } from '@prisma/config'
-import { enginesVersion } from '@prisma/engines-version'
-import {
-  getGenerators,
-  getGeneratorSuccessMessage,
-  MigrateTypes,
-  SchemaContext,
-  toSchemasContainer,
-} from '@prisma/internals'
-import { dim } from 'kleur/colors'
-import logUpdate from 'log-update'
+import { MigrateTypes, SchemaContext, toSchemasContainer } from '@prisma/internals'
 
 import { Extension } from './extensions'
 import type { SchemaEngine } from './SchemaEngine'
@@ -228,38 +218,5 @@ export class Migrate {
       warnings,
       unexecutable,
     }
-  }
-
-  public async tryToRunGenerate(): Promise<void> {
-    if (!this.schemaContext) throw new Error('this.schemaContext is undefined')
-
-    const message: string[] = []
-
-    process.stdout.write('\n') // empty line
-    logUpdate(`Running generate... ${dim('(Use --skip-generate to skip the generators)')}`)
-
-    const generators = await getGenerators({
-      schemaContext: this.schemaContext,
-      printDownloadProgress: true,
-      version: enginesVersion,
-      registry: defaultRegistry.toInternal(),
-    })
-
-    for (const generator of generators) {
-      logUpdate(`Running generate... - ${generator.getPrettyName()}`)
-
-      const before = Math.round(performance.now())
-      try {
-        await generator.generate()
-        const after = Math.round(performance.now())
-        message.push(getGeneratorSuccessMessage(generator, after - before))
-        generator.stop()
-      } catch (e: any) {
-        message.push(`${e.message}`)
-        generator.stop()
-      }
-    }
-
-    logUpdate(message.join('\n'))
   }
 }

--- a/packages/migrate/src/__tests__/Baseline.test.ts
+++ b/packages/migrate/src/__tests__/Baseline.test.ts
@@ -18,8 +18,6 @@ describe('Baselining', () => {
   beforeEach(() => {
     // Disable prompts
     process.env.GITHUB_ACTIONS = '1'
-    // Disable generate
-    process.env.PRISMA_MIGRATE_SKIP_GENERATE = '1'
   })
 
   describeMatrix({ providers: { sqlite: true }, driverAdapters: allDriverAdapters }, 'SQLite', () => {

--- a/packages/migrate/src/__tests__/DbPush.test.ts
+++ b/packages/migrate/src/__tests__/DbPush.test.ts
@@ -9,10 +9,6 @@ import { createDefaultTestContext } from './__helpers__/context'
 
 const ctx = createDefaultTestContext()
 
-beforeEach(() => {
-  process.env.PRISMA_MIGRATE_SKIP_GENERATE = '1'
-})
-
 describe('push', () => {
   // A test that requires docker (e.g, because it relies on extensions being installed)
   const inDockerIt = process.env.TEST_NO_DOCKER ? it.skip : it

--- a/packages/migrate/src/__tests__/MigrateDev.test.ts
+++ b/packages/migrate/src/__tests__/MigrateDev.test.ts
@@ -31,8 +31,6 @@ beforeEach(() => {
   clearPromptInjection('before')
   // Disable prompts
   process.env.GITHUB_ACTIONS = '1'
-  // Disable generate
-  process.env.PRISMA_MIGRATE_SKIP_GENERATE = '1'
 })
 
 afterEach(() => {

--- a/packages/migrate/src/__tests__/MigrateReset.test.ts
+++ b/packages/migrate/src/__tests__/MigrateReset.test.ts
@@ -5,10 +5,6 @@ import { createDefaultTestContext } from './__helpers__/context'
 
 const ctx = createDefaultTestContext()
 
-beforeEach(() => {
-  process.env.PRISMA_MIGRATE_SKIP_GENERATE = '1'
-})
-
 describe('common', () => {
   it('wrong flag', async () => {
     const commandInstance = MigrateReset.new()

--- a/packages/migrate/src/commands/DbPush.ts
+++ b/packages/migrate/src/commands/DbPush.ts
@@ -42,7 +42,6 @@ ${bold('Options')}
              --schema   Custom path to your Prisma schema
    --accept-data-loss   Ignore data loss warnings
         --force-reset   Force a reset of the database before push
-      --skip-generate   Skip triggering generators (e.g. Prisma Client)
 
 ${bold('Examples')}
 
@@ -64,7 +63,6 @@ ${bold('Examples')}
         '-h': '--help',
         '--accept-data-loss': Boolean,
         '--force-reset': Boolean,
-        '--skip-generate': Boolean,
         '--schema': String,
         '--config': String,
         '--telemetry-information': String,
@@ -243,11 +241,6 @@ ${bold(red('All data will be lost.'))}
           provider === 'mongodb' ? migrationSuccessMongoMessage : migrationSuccessStdMessage
         } ${migrationTimeMessage}\n`,
       )
-    }
-
-    // Run if not skipped
-    if (!process.env.PRISMA_MIGRATE_SKIP_GENERATE && !args['--skip-generate']) {
-      await migrate.tryToRunGenerate()
     }
 
     return ``

--- a/packages/migrate/src/commands/MigrateDev.ts
+++ b/packages/migrate/src/commands/MigrateDev.ts
@@ -55,7 +55,6 @@ ${bold('Options')}
        -n, --name   Name the migration
     --create-only   Create a new migration but do not apply it
                     The migration will be empty if there are no changes in Prisma schema
-  --skip-generate   Skip triggering generators (e.g. Prisma Client)
       --skip-seed   Skip triggering seed
 
 ${bold('Examples')}
@@ -81,7 +80,6 @@ ${bold('Examples')}
       '--create-only': Boolean,
       '--schema': String,
       '--config': String,
-      '--skip-generate': Boolean,
       '--skip-seed': Boolean,
       '--telemetry-information': String,
     })
@@ -300,12 +298,6 @@ ${bold('Examples')}
 
 ${green('Your database is now in sync with your schema.')}\n`,
       )
-    }
-
-    // Run if not skipped
-    if (!process.env.PRISMA_MIGRATE_SKIP_GENERATE && !args['--skip-generate']) {
-      await migrate.tryToRunGenerate()
-      process.stdout.write('\n') // empty line
     }
 
     // If database was created we want to run the seed if not skipped

--- a/packages/migrate/src/commands/MigrateReset.ts
+++ b/packages/migrate/src/commands/MigrateReset.ts
@@ -39,7 +39,6 @@ ${bold('Options')}
        -h, --help   Display this help message
          --config   Custom path to your Prisma config file
          --schema   Custom path to your Prisma schema
-  --skip-generate   Skip triggering generators (e.g. Prisma Client)
       --skip-seed   Skip triggering seed
       -f, --force   Skip the confirmation prompt
 
@@ -61,7 +60,6 @@ ${bold('Examples')}
       '-h': '--help',
       '--force': Boolean,
       '-f': '--force',
-      '--skip-generate': Boolean,
       '--skip-seed': Boolean,
       '--schema': String,
       '--config': String,
@@ -157,11 +155,6 @@ The following migration(s) have been applied:\n\n${printFilesFromMigrationIds('m
           'migration.sql': '',
         })}\n`,
       )
-    }
-
-    // Run if not skipped
-    if (!process.env.PRISMA_MIGRATE_SKIP_GENERATE && !args['--skip-generate']) {
-      await migrate.tryToRunGenerate()
     }
 
     // Run if not skipped


### PR DESCRIPTION
This PR:
- closes [TML-1513](https://linear.app/prisma-company/issue/TML-1513/remove-automatic-prisma-client-generation-from-other-commands)
- removes automatic generation of Prisma Client in:
  - `prisma db push`
  - `prisma migrate dev`
  - `prisma migrate reset`
- removes support for the following env vars:
  - `PRISMA_MIGRATE_SKIP_GENERATE `