### PR TITLE
fix: fix hanging transactions #17303

### DIFF
--- a/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
+++ b/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
@@ -243,10 +243,7 @@ export class TransactionManager {
             const query = COMMIT_QUERY()
             await this.#withQuerySpanAndEvent(query, tx.transaction, () => tx.transaction!.executeRaw(query)).then(
               () => tx.transaction!.commit(),
-              async (err) => {
-                await tx.transaction!.rollback()
-                throw err
-              },
+              (err) => tx.transaction!.rollback().catch(() => Promise.reject(err)),
             )
           }
         } else if (tx.transaction) {

--- a/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
+++ b/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
@@ -243,7 +243,10 @@ export class TransactionManager {
             const query = COMMIT_QUERY()
             await this.#withQuerySpanAndEvent(query, tx.transaction, () => tx.transaction!.executeRaw(query)).then(
               () => tx.transaction!.commit(),
-              (err) => tx.transaction!.rollback().finally(() => Promise.reject(err)),
+              async (err) => {
+                await tx.transaction!.rollback()
+                throw err
+              },
             )
           }
         } else if (tx.transaction) {

--- a/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
+++ b/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
@@ -241,8 +241,11 @@ export class TransactionManager {
             await this.#withQuerySpanAndEvent(PHANTOM_COMMIT_QUERY(), tx.transaction, () => tx.transaction!.commit())
           } else {
             const query = COMMIT_QUERY()
-            await this.#withQuerySpanAndEvent(query, tx.transaction, () => tx.transaction!.executeRaw(query))
-            await tx.transaction.commit()
+            try {
+              await this.#withQuerySpanAndEvent(query, tx.transaction, () => tx.transaction!.executeRaw(query))
+            } finally {
+              await tx.transaction.commit()
+            }
           }
         } else if (tx.transaction) {
           if (tx.transaction.options.usePhantomQuery) {
@@ -251,8 +254,11 @@ export class TransactionManager {
             )
           } else {
             const query = ROLLBACK_QUERY()
-            await this.#withQuerySpanAndEvent(query, tx.transaction, () => tx.transaction!.executeRaw(query))
-            await tx.transaction.rollback()
+            try {
+              await this.#withQuerySpanAndEvent(query, tx.transaction, () => tx.transaction!.executeRaw(query))
+            } finally {
+              await tx.transaction.rollback()
+            }
           }
         }
       } finally {

--- a/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
+++ b/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
@@ -243,7 +243,10 @@ export class TransactionManager {
             const query = COMMIT_QUERY()
             await this.#withQuerySpanAndEvent(query, tx.transaction, () => tx.transaction!.executeRaw(query)).then(
               () => tx.transaction!.commit(),
-              (err) => tx.transaction!.rollback().catch(() => Promise.reject(err)),
+              (err) => {
+                const fail = () => Promise.reject(err)
+                return tx.transaction!.rollback().then(fail, fail)
+              },
             )
           }
         } else if (tx.transaction) {

--- a/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
+++ b/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
@@ -254,11 +254,10 @@ export class TransactionManager {
             )
           } else {
             const query = ROLLBACK_QUERY()
-            try {
-              await this.#withQuerySpanAndEvent(query, tx.transaction, () => tx.transaction!.executeRaw(query))
-            } finally {
-              await tx.transaction.rollback()
-            }
+            await this.#withQuerySpanAndEvent(query, tx.transaction, () => tx.transaction!.executeRaw(query)).then(
+              () => tx.transaction!.commit(),
+              (err) => tx.transaction!.rollback().finally(() => Promise.reject(err)),
+            )
           }
         }
       } finally {

--- a/packages/client/tests/e2e/issues/17303-interactive-transaction-errors/_steps.ts
+++ b/packages/client/tests/e2e/issues/17303-interactive-transaction-errors/_steps.ts
@@ -8,7 +8,7 @@ void executeSteps({
     await $`pnpm prisma migrate dev`
   },
   test: async () => {
-    // await $`pnpm run start`
+    await $`pnpm run start`
   },
   finish: async () => {
     await $`echo "done"`

--- a/packages/client/tests/e2e/issues/17303-interactive-transaction-errors/_steps.ts
+++ b/packages/client/tests/e2e/issues/17303-interactive-transaction-errors/_steps.ts
@@ -5,6 +5,7 @@ import { executeSteps } from '../../_utils/executeSteps'
 void executeSteps({
   setup: async () => {
     await $`pnpm install`
+    await $`pnpm prisma generate`
     await $`pnpm prisma migrate dev`
   },
   test: async () => {

--- a/packages/client/tests/e2e/issues/17303-interactive-transaction-errors/tests/index.ts
+++ b/packages/client/tests/e2e/issues/17303-interactive-transaction-errors/tests/index.ts
@@ -11,5 +11,5 @@ test('should not create a Foo record because the database trigger always throws 
     prisma.$transaction(async (transactionClient: PrismaClient) => {
       await transactionClient.foo.create({})
     }),
-  ).rejects.toThrow('Error in connector: Error querying the database: ERROR: Foo cannot be created!')
+  ).rejects.toThrow('Foo cannot be created!')
 })


### PR DESCRIPTION
[TML-1562](https://linear.app/prisma-company/issue/TML-1562/investigate-and-fix-issues17303-interactive-transaction-errors-e2e)

Simply adds a `finally` block to make sure we always dispose of the transactions