### PR TITLE
refactor: don't use schema datasource in Studio

### DIFF
--- a/packages/cli/src/Studio.ts
+++ b/packages/cli/src/Studio.ts
@@ -1,17 +1,7 @@
 import type { PrismaConfigInternal } from '@prisma/config'
-import Debug from '@prisma/debug'
+import { Debug } from '@prisma/debug'
 import { enginesVersion } from '@prisma/engines'
-import {
-  arg,
-  Command,
-  format,
-  getEffectiveUrl,
-  HelpError,
-  isError,
-  loadSchemaContext,
-  mergeSchemas,
-  resolveUrl,
-} from '@prisma/internals'
+import { arg, Command, format, HelpError, isError, loadSchemaContext, mergeSchemas } from '@prisma/internals'
 import { StudioServer } from '@prisma/studio-server'
 import getPort, { portNumbers } from 'get-port'
 import { bold, dim, red } from 'kleur/colors'
@@ -118,7 +108,9 @@ ${bold('Examples')}
 
     const adapter = await config.studio?.adapter()
 
-    if (!schemaContext.primaryDatasource) throw new Error('No datasource found in schema')
+    if (config.engine !== 'classic') {
+      throw new Error('Using driver adapters in Studio is not yet supported')
+    }
 
     process.env.PRISMA_DISABLE_WARNINGS = 'true' // disable client warnings
     const studio = new StudioServer({
@@ -132,7 +124,7 @@ ${bold('Examples')}
         resolve: {
           '@prisma/client': path.resolve(__dirname, '../prisma-client/index.js'),
         },
-        directUrl: resolveUrl(getEffectiveUrl(schemaContext.primaryDatasource)),
+        directUrl: config.datasource.url,
       },
       versions: {
         prisma: packageJson.version,

--- a/packages/internals/src/cli/checkUnsupportedDataProxy.ts
+++ b/packages/internals/src/cli/checkUnsupportedDataProxy.ts
@@ -1,7 +1,7 @@
+import { PrismaConfigInternal } from '@prisma/config'
 import { green } from 'kleur/colors'
 
-import { getEffectiveUrl, link, SchemaContext } from '..'
-import { resolveUrl } from '../engine-commands/getConfig'
+import { link } from '..'
 
 /**
  * Get the message to display when a command is forbidden with a data proxy flag
@@ -21,26 +21,10 @@ More information about this limitation: ${link('https://pris.ly/d/accelerate-lim
  * @param urls list of urls to check
  * @param schemaContexts list of schema contexts to check
  */
-export function checkUnsupportedDataProxy({
-  cmd,
-  schemaContext = undefined,
-  urls = [],
-}: {
-  cmd: string
-  schemaContext?: SchemaContext
-  urls?: (string | undefined)[]
-}) {
-  for (const url of urls) {
-    if (url && url.includes('prisma://')) {
+export function checkUnsupportedDataProxy({ cmd, config }: { cmd: string; config?: PrismaConfigInternal }) {
+  if (config?.engine === 'classic') {
+    if (config.datasource.url.startsWith('prisma://')) {
       throw new Error(forbiddenCmdWithDataProxyFlagMessage(cmd))
     }
-  }
-
-  if (!schemaContext?.primaryDatasource) return
-
-  const url = resolveUrl(getEffectiveUrl(schemaContext.primaryDatasource))
-
-  if (url?.startsWith('prisma://')) {
-    throw new Error(forbiddenCmdWithDataProxyFlagMessage(cmd))
   }
 }

--- a/packages/migrate/src/commands/DbDrop.ts
+++ b/packages/migrate/src/commands/DbDrop.ts
@@ -87,7 +87,7 @@ ${bold('Examples')}
       schemaEngineConfig: config,
     })
 
-    checkUnsupportedDataProxy({ cmd: 'db drop', schemaContext })
+    checkUnsupportedDataProxy({ cmd: 'db drop', config })
 
     const datasourceInfo = parseDatasourceInfo(schemaContext.primaryDatasource)
     printDatasource({ datasourceInfo })

--- a/packages/migrate/src/commands/DbExecute.ts
+++ b/packages/migrate/src/commands/DbExecute.ts
@@ -139,7 +139,7 @@ See \`${green(getCommandWithExecutor('prisma db execute -h'))}\``,
       )
     }
 
-    checkUnsupportedDataProxy({ cmd, urls: [config.datasource.url] })
+    checkUnsupportedDataProxy({ cmd, config })
 
     const datasourceType: EngineArgs.DbExecuteDatasourceType = {
       tag: 'url',

--- a/packages/migrate/src/commands/DbPull.ts
+++ b/packages/migrate/src/commands/DbPull.ts
@@ -126,10 +126,7 @@ Set composite types introspection depth to 2 levels
 
     const cmd = 'db pull'
 
-    checkUnsupportedDataProxy({
-      cmd,
-      schemaContext: schemaContext ?? undefined,
-    })
+    checkUnsupportedDataProxy({ cmd, config })
 
     const adapter = config.engine === 'js' ? await config.adapter() : undefined
 

--- a/packages/migrate/src/commands/DbPush.ts
+++ b/packages/migrate/src/commands/DbPush.ts
@@ -86,7 +86,7 @@ ${bold('Examples')}
 
     const { migrationsDirPath } = inferDirectoryConfig(schemaContext, config)
 
-    checkUnsupportedDataProxy({ cmd: 'db push', schemaContext })
+    checkUnsupportedDataProxy({ cmd: 'db push', config })
 
     const datasourceInfo = parseDatasourceInfo(schemaContext.primaryDatasource)
     const adapter = config.engine === 'js' ? await config.adapter() : undefined

--- a/packages/migrate/src/commands/MigrateDeploy.ts
+++ b/packages/migrate/src/commands/MigrateDeploy.ts
@@ -76,7 +76,7 @@ ${bold('Examples')}
     })
     const { migrationsDirPath } = inferDirectoryConfig(schemaContext, config)
 
-    checkUnsupportedDataProxy({ cmd: 'migrate deploy', schemaContext })
+    checkUnsupportedDataProxy({ cmd: 'migrate deploy', config })
 
     const adapter = config.engine === 'js' ? await config.adapter() : undefined
     printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext.primaryDatasource), adapter })

--- a/packages/migrate/src/commands/MigrateDev.ts
+++ b/packages/migrate/src/commands/MigrateDev.ts
@@ -99,7 +99,7 @@ ${bold('Examples')}
     })
     const { migrationsDirPath } = inferDirectoryConfig(schemaContext, config)
 
-    checkUnsupportedDataProxy({ cmd: 'migrate dev', schemaContext })
+    checkUnsupportedDataProxy({ cmd: 'migrate dev', config })
 
     const datasourceInfo = parseDatasourceInfo(schemaContext.primaryDatasource)
     const adapter = config.engine === 'js' ? await config.adapter() : undefined

--- a/packages/migrate/src/commands/MigrateReset.ts
+++ b/packages/migrate/src/commands/MigrateReset.ts
@@ -85,7 +85,7 @@ ${bold('Examples')}
 
     printDatasource({ datasourceInfo, adapter })
 
-    checkUnsupportedDataProxy({ cmd: 'migrate reset', schemaContext })
+    checkUnsupportedDataProxy({ cmd: 'migrate reset', config })
 
     // `ensureDatabaseExists` is not compatible with WebAssembly.
     // TODO: check why the output and error handling here is different than in `MigrateDeploy`.

--- a/packages/migrate/src/commands/MigrateResolve.ts
+++ b/packages/migrate/src/commands/MigrateResolve.ts
@@ -87,7 +87,7 @@ ${bold('Examples')}
     const { migrationsDirPath } = inferDirectoryConfig(schemaContext, config)
     const adapter = config.engine === 'js' ? await config.adapter() : undefined
 
-    checkUnsupportedDataProxy({ cmd: 'migrate resolve', schemaContext })
+    checkUnsupportedDataProxy({ cmd: 'migrate resolve', config })
 
     printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext.primaryDatasource), adapter })
 

--- a/packages/migrate/src/commands/MigrateStatus.ts
+++ b/packages/migrate/src/commands/MigrateStatus.ts
@@ -78,7 +78,7 @@ Check the status of your database migrations
     const { migrationsDirPath } = inferDirectoryConfig(schemaContext, config)
     const adapter = config.engine === 'js' ? await config.adapter() : undefined
 
-    checkUnsupportedDataProxy({ cmd: 'migrate status', schemaContext })
+    checkUnsupportedDataProxy({ cmd: 'migrate status', config })
 
     printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext.primaryDatasource), adapter })
 


### PR DESCRIPTION
Load datasource URL from config file in Studio.

Ref: https://linear.app/prisma-company/issue/TML-1545/remove-url-datasource-attribute-from-psl
