### PR TITLE
refactor: use config in `parseDatasourceInfo`

### DIFF
--- a/packages/internals/src/engine-commands/getConfig.ts
+++ b/packages/internals/src/engine-commands/getConfig.ts
@@ -1,5 +1,5 @@
 import Debug from '@prisma/debug'
-import type { DataSource, EnvValue, GeneratorConfig } from '@prisma/generator'
+import type { DataSource, GeneratorConfig } from '@prisma/generator'
 import { getBinaryTargetForCurrentPlatform } from '@prisma/get-platform'
 import * as E from 'fp-ts/Either'
 import { pipe } from 'fp-ts/lib/function'
@@ -63,18 +63,6 @@ ${detailsHeader} ${message}`
     super(addVersionDetailsToErrorMessage(errorMessageWithContext))
     this.name = 'GetConfigError'
   }
-}
-
-export function getEffectiveUrl(ds: DataSource): EnvValue {
-  return ds.url
-}
-
-export function resolveUrl(envValue: EnvValue | undefined) {
-  const urlFromValue = envValue?.value
-  const urlEnvVarName = envValue?.fromEnvVar
-  const urlEnvVarValue = urlEnvVarName ? process.env[urlEnvVarName] : undefined
-
-  return urlFromValue ?? urlEnvVarValue
 }
 
 /**

--- a/packages/internals/src/engine-commands/index.ts
+++ b/packages/internals/src/engine-commands/index.ts
@@ -1,6 +1,6 @@
 export { formatSchema } from './formatSchema'
 export type { ConfigMetaFormat } from './getConfig'
-export { getConfig, getEffectiveUrl } from './getConfig'
+export { getConfig } from './getConfig'
 export type { GetDMMFOptions } from './getDmmf'
 export { getDMMF } from './getDmmf'
 export { getEnginesInfo, resolveEngine } from './getEnginesInfo'

--- a/packages/internals/src/index.ts
+++ b/packages/internals/src/index.ts
@@ -31,7 +31,6 @@ export type {
 export { arg, format, isError } from './cli/utils'
 export { credentialsToUri, protocolToConnectorType, uriToCredentials } from './convertCredentials'
 export * from './engine-commands'
-export { resolveUrl } from './engine-commands/getConfig'
 export { relativizePathInPSLError } from './engine-commands/relativizePathInPSLError'
 export { Generator } from './Generator'
 export {

--- a/packages/migrate/src/__tests__/fixtures/provider-switch-postgresql-to-sqlite/prisma.config.ts
+++ b/packages/migrate/src/__tests__/fixtures/provider-switch-postgresql-to-sqlite/prisma.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from '@prisma/config'
+
+export default defineConfig({
+  engine: 'classic',
+  datasource: {
+    url: 'file:./dev.db',
+  },
+})

--- a/packages/migrate/src/commands/DbDrop.ts
+++ b/packages/migrate/src/commands/DbDrop.ts
@@ -89,7 +89,7 @@ ${bold('Examples')}
 
     checkUnsupportedDataProxy({ cmd: 'db drop', config })
 
-    const datasourceInfo = parseDatasourceInfo(schemaContext.primaryDatasource)
+    const datasourceInfo = parseDatasourceInfo(schemaContext.primaryDatasource, config)
     printDatasource({ datasourceInfo })
 
     process.stdout.write('\n') // empty line

--- a/packages/migrate/src/commands/DbPull.ts
+++ b/packages/migrate/src/commands/DbPull.ts
@@ -134,7 +134,7 @@ Set composite types introspection depth to 2 levels
     if (schemaContext && !args['--print']) {
       printSchemaLoadedMessage(schemaContext.loadedFromPathForLogMessages)
 
-      printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext?.primaryDatasource), adapter })
+      printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext?.primaryDatasource, config), adapter })
     }
 
     if (!schemaContext) {

--- a/packages/migrate/src/commands/DbPush.ts
+++ b/packages/migrate/src/commands/DbPush.ts
@@ -89,7 +89,7 @@ ${bold('Examples')}
 
     checkUnsupportedDataProxy({ cmd: 'db push', config })
 
-    const datasourceInfo = parseDatasourceInfo(schemaContext.primaryDatasource)
+    const datasourceInfo = parseDatasourceInfo(schemaContext.primaryDatasource, config)
     const adapter = config.engine === 'js' ? await config.adapter() : undefined
     printDatasource({ datasourceInfo, adapter })
     const schemaFilter: MigrateTypes.SchemaFilter = {

--- a/packages/migrate/src/commands/MigrateDeploy.ts
+++ b/packages/migrate/src/commands/MigrateDeploy.ts
@@ -80,7 +80,7 @@ ${bold('Examples')}
     checkUnsupportedDataProxy({ cmd: 'migrate deploy', config })
 
     const adapter = config.engine === 'js' ? await config.adapter() : undefined
-    printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext.primaryDatasource), adapter })
+    printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext.primaryDatasource, config), adapter })
 
     const schemaFilter: MigrateTypes.SchemaFilter = {
       externalTables: config.tables?.external ?? [],

--- a/packages/migrate/src/commands/MigrateDev.ts
+++ b/packages/migrate/src/commands/MigrateDev.ts
@@ -102,7 +102,7 @@ ${bold('Examples')}
 
     checkUnsupportedDataProxy({ cmd: 'migrate dev', config })
 
-    const datasourceInfo = parseDatasourceInfo(schemaContext.primaryDatasource)
+    const datasourceInfo = parseDatasourceInfo(schemaContext.primaryDatasource, config)
     const adapter = config.engine === 'js' ? await config.adapter() : undefined
 
     printDatasource({ datasourceInfo, adapter })

--- a/packages/migrate/src/commands/MigrateReset.ts
+++ b/packages/migrate/src/commands/MigrateReset.ts
@@ -81,7 +81,7 @@ ${bold('Examples')}
       schemaEngineConfig: config,
     })
     const { migrationsDirPath } = inferDirectoryConfig(schemaContext, config)
-    const datasourceInfo = parseDatasourceInfo(schemaContext.primaryDatasource)
+    const datasourceInfo = parseDatasourceInfo(schemaContext.primaryDatasource, config)
     const adapter = config.engine === 'js' ? await config.adapter() : undefined
 
     printDatasource({ datasourceInfo, adapter })

--- a/packages/migrate/src/commands/MigrateResolve.ts
+++ b/packages/migrate/src/commands/MigrateResolve.ts
@@ -89,7 +89,7 @@ ${bold('Examples')}
 
     checkUnsupportedDataProxy({ cmd: 'migrate resolve', config })
 
-    printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext.primaryDatasource), adapter })
+    printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext.primaryDatasource, config), adapter })
 
     // if both are not defined
     if (!args['--applied'] && !args['--rolled-back']) {

--- a/packages/migrate/src/commands/MigrateStatus.ts
+++ b/packages/migrate/src/commands/MigrateStatus.ts
@@ -80,7 +80,7 @@ Check the status of your database migrations
 
     checkUnsupportedDataProxy({ cmd: 'migrate status', config })
 
-    printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext.primaryDatasource), adapter })
+    printDatasource({ datasourceInfo: parseDatasourceInfo(schemaContext.primaryDatasource, config), adapter })
 
     const schemaFilter: MigrateTypes.SchemaFilter = {
       externalTables: config.tables?.external ?? [],

--- a/packages/migrate/src/utils/ensureDatabaseExists.ts
+++ b/packages/migrate/src/utils/ensureDatabaseExists.ts
@@ -3,13 +3,7 @@ import path from 'node:path'
 import { PrismaConfigInternal } from '@prisma/config'
 import { DataSource } from '@prisma/generator'
 import type { DatabaseCredentials } from '@prisma/internals'
-import {
-  canConnectToDatabase,
-  createDatabase,
-  getEffectiveUrl,
-  PRISMA_POSTGRES_PROVIDER,
-  uriToCredentials,
-} from '@prisma/internals'
+import { canConnectToDatabase, createDatabase, PRISMA_POSTGRES_PROVIDER, uriToCredentials } from '@prisma/internals'
 import { bold } from 'kleur/colors'
 
 import { ConnectorType } from './printDatasources'
@@ -38,14 +32,20 @@ export type DatasourceInfo = {
   configDir?: string
 }
 
-export function parseDatasourceInfo(datasource: DataSource | undefined): DatasourceInfo {
+export function parseDatasourceInfo(datasource: DataSource | undefined, config: PrismaConfigInternal): DatasourceInfo {
+  let url: string | undefined
+
+  if (config.engine === 'classic') {
+    url = config.datasource.url
+  }
+
   if (!datasource) {
     return {
       name: undefined,
       prettyProvider: undefined,
       dbName: undefined,
       dbLocation: undefined,
-      url: undefined,
+      url,
       schema: undefined,
       schemas: undefined,
       configDir: undefined,
@@ -53,7 +53,6 @@ export function parseDatasourceInfo(datasource: DataSource | undefined): Datasou
   }
 
   const prettyProvider = prettifyProvider(datasource.provider)
-  const url = getEffectiveUrl(datasource).value
 
   // url parsing for sql server is not implemented
   if (!url || datasource.provider === 'sqlserver') {


### PR DESCRIPTION
Use datasource URL from config instead of from schema in `parseDatasourceInfo` function.

Ref: https://linear.app/prisma-company/issue/TML-1545/remove-url-datasource-attribute-from-psl
