### PR TITLE
feat(client-generator-js): rename `/wasm` to `/edge`

### DIFF
--- a/packages/bundle-size/da-workers-d1/index.js
+++ b/packages/bundle-size/da-workers-d1/index.js
@@ -1,6 +1,6 @@
 import { PrismaD1 } from '@prisma/adapter-d1'
 
-import { PrismaClient } from './client/wasm'
+import { PrismaClient } from './client/edge'
 
 export default {
   async fetch(request, env) {
@@ -10,7 +10,6 @@ export default {
     const users = await prisma.user.findMany()
     const result = JSON.stringify(users)
 
-    // eslint-disable-next-line no-undef
     return new Response(result)
   },
 }

--- a/packages/bundle-size/da-workers-libsql-web/index.js
+++ b/packages/bundle-size/da-workers-libsql-web/index.js
@@ -1,6 +1,6 @@
 import { PrismaLibSql } from '@prisma/adapter-libsql/web'
 
-import { PrismaClient } from './client/wasm'
+import { PrismaClient } from './client/edge'
 
 export default {
   async fetch(request, env) {

--- a/packages/bundle-size/da-workers-libsql/index.js
+++ b/packages/bundle-size/da-workers-libsql/index.js
@@ -1,6 +1,6 @@
 import { PrismaLibSql } from '@prisma/adapter-libsql'
 
-import { PrismaClient } from './client/wasm'
+import { PrismaClient } from './client/edge'
 
 export default {
   async fetch(request, env) {

--- a/packages/bundle-size/da-workers-mariadb/index.js
+++ b/packages/bundle-size/da-workers-mariadb/index.js
@@ -1,6 +1,6 @@
 import { PrismaMariaDb } from '@prisma/adapter-mariadb'
 
-import { PrismaClient } from './client/wasm'
+import { PrismaClient } from './client/edge'
 
 export default {
   async fetch(request, env) {
@@ -12,7 +12,6 @@ export default {
     const users = await prisma.user.findMany()
     const result = JSON.stringify(users)
 
-    // eslint-disable-next-line no-undef
     return new Response(result)
   },
 }

--- a/packages/bundle-size/da-workers-mssql/index.js
+++ b/packages/bundle-size/da-workers-mssql/index.js
@@ -1,6 +1,6 @@
 import { PrismaMssql } from '@prisma/adapter-mssql'
 
-import { PrismaClient } from './client/wasm'
+import { PrismaClient } from './client/edge'
 
 export default {
   async fetch(request, env) {
@@ -12,7 +12,6 @@ export default {
     const users = await prisma.user.findMany()
     const result = JSON.stringify(users)
 
-    // eslint-disable-next-line no-undef
     return new Response(result)
   },
 }

--- a/packages/bundle-size/da-workers-neon/index.js
+++ b/packages/bundle-size/da-workers-neon/index.js
@@ -1,6 +1,6 @@
 import { PrismaNeon } from '@prisma/adapter-neon'
 
-import { PrismaClient } from './client/wasm'
+import { PrismaClient } from './client/edge'
 
 export default {
   async fetch(request, env) {
@@ -10,7 +10,6 @@ export default {
     const users = await prisma.user.findMany()
     const result = JSON.stringify(users)
 
-    // eslint-disable-next-line no-undef
     return new Response(result)
   },
 }

--- a/packages/bundle-size/da-workers-pg/index.js
+++ b/packages/bundle-size/da-workers-pg/index.js
@@ -1,6 +1,6 @@
 import { PrismaPg } from '@prisma/adapter-pg'
 
-import { PrismaClient } from './client/wasm'
+import { PrismaClient } from './client/edge'
 
 export default {
   async fetch(request, env) {
@@ -10,7 +10,6 @@ export default {
     const users = await prisma.user.findMany()
     const result = JSON.stringify(users)
 
-    // eslint-disable-next-line no-undef
     return new Response(result)
   },
 }

--- a/packages/bundle-size/da-workers-planetscale/index.js
+++ b/packages/bundle-size/da-workers-planetscale/index.js
@@ -1,6 +1,6 @@
 import { PrismaPlanetScale } from '@prisma/adapter-planetscale'
 
-import { PrismaClient } from './client/wasm'
+import { PrismaClient } from './client/edge'
 
 export default {
   async fetch(request, env) {
@@ -16,7 +16,6 @@ export default {
     const users = await prisma.user.findMany()
     const result = JSON.stringify(users)
 
-    // eslint-disable-next-line no-undef
     return new Response(result)
   },
 }

--- a/packages/client-generator-js/src/generateClient.ts
+++ b/packages/client-generator-js/src/generateClient.ts
@@ -132,9 +132,9 @@ export async function buildClient({
   // to go from more specific to more generic.
   const exportsMapBase = {
     node: './index.js',
-    'edge-light': './wasm.js',
-    workerd: './wasm.js',
-    worker: './wasm.js',
+    'edge-light': './edge.js',
+    workerd: './edge.js',
+    worker: './edge.js',
     browser: './index-browser.js',
     default: './index.js',
   }
@@ -234,8 +234,8 @@ export async function buildClient({
     wasm: true,
   })
 
-  fileMap['wasm.js'] = JS(wasmClient)
-  fileMap['wasm.d.ts'] = TS(wasmClient)
+  fileMap['edge.js'] = JS(wasmClient)
+  fileMap['edge.d.ts'] = TS(wasmClient)
 
   if (typedSql && typedSql.length > 0) {
     const edgeRuntimeName = 'wasm-compiler-edge'

--- a/packages/client/edge.d.ts
+++ b/packages/client/edge.d.ts
@@ -1,0 +1,1 @@
+export * from '.prisma/client/edge'

--- a/packages/client/edge.js
+++ b/packages/client/edge.js
@@ -1,4 +1,4 @@
 module.exports = {
   // https://github.com/prisma/prisma/pull/12907
-  ...require('.prisma/client/wasm'),
+  ...require('.prisma/client/edge'),
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -71,11 +71,11 @@
       "import": "./index.js",
       "default": "./index.js"
     },
-    "./wasm": {
-      "types": "./wasm.d.ts",
-      "require": "./wasm.js",
-      "import": "./wasm.mjs",
-      "default": "./wasm.mjs"
+    "./edge": {
+      "types": "./edge.d.ts",
+      "require": "./edge.js",
+      "import": "./edge.mjs",
+      "default": "./edge.mjs"
     },
     "./runtime/client": {
       "types": "./runtime/client.d.ts",
@@ -152,8 +152,8 @@
     "runtime",
     "scripts",
     "generator-build",
-    "wasm.js",
-    "wasm.d.ts",
+    "edge.js",
+    "edge.d.ts",
     "index.js",
     "index.d.ts",
     "default.js",

--- a/packages/client/scripts/postinstall.js
+++ b/packages/client/scripts/postinstall.js
@@ -39,7 +39,7 @@ function findPackageRoot(startPath, limit = 10) {
         if (pkg.name && !['@prisma/cli', 'prisma'].includes(pkg.name)) {
           return pkgPath.replace('package.json', '')
         }
-      } catch {} // eslint-disable-line no-empty
+      } catch {}
     }
     currentPath = path.join(currentPath, '../')
   }
@@ -115,7 +115,7 @@ function getLocalPackagePath() {
     if (packagePath) {
       return require.resolve('prisma')
     }
-  } catch (e) {} // eslint-disable-line no-empty
+  } catch (e) {}
 
   // TODO: consider removing this
   try {
@@ -123,7 +123,7 @@ function getLocalPackagePath() {
     if (packagePath) {
       return require.resolve('@prisma/cli')
     }
-  } catch (e) {} // eslint-disable-line no-empty
+  } catch (e) {}
 
   return null
 }
@@ -216,7 +216,6 @@ async function createDefaultGeneratedThrowFiles() {
       index: defaultFileConfig,
       edge: defaultFileConfig,
       default: defaultFileConfig,
-      wasm: defaultFileConfig,
       'index-browser': {
         js: path.join(__dirname, 'default-index.js'),
         ts: undefined,

--- a/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
@@ -132,7 +132,7 @@ export async function setupTestSuiteClient({
 
   const clientPathForRuntime: Record<ClientRuntime, { client: string; sql: string }> = {
     'wasm-compiler-edge': {
-      client: generatorType === 'prisma-client-ts' ? 'generated/prisma/client' : 'generated/prisma/client/wasm',
+      client: generatorType === 'prisma-client-ts' ? 'generated/prisma/client' : 'generated/prisma/client/edge',
       sql: path.join(outputPath, 'sql', 'index.wasm-compiler-edge.js'),
     },
     client: {

--- a/packages/client/wasm.d.ts
+++ b/packages/client/wasm.d.ts
@@ -1,1 +1,0 @@
-export * from '.prisma/client/wasm'


### PR DESCRIPTION
Rename `/wasm` entrypoint to `/edge` to ensure smooth migration for Accelerate users.

Closes: https://linear.app/prisma-company/issue/TML-1566/rename-wasm-entrypoint-to-edge-in-prismaclient-and-old-generator
