### PR TITLE
fix(client): reference the correct `edge.js` file

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -74,8 +74,8 @@
     "./edge": {
       "types": "./edge.d.ts",
       "require": "./edge.js",
-      "import": "./edge.mjs",
-      "default": "./edge.mjs"
+      "import": "./edge.js",
+      "default": "./edge.js"
     },
     "./runtime/client": {
       "types": "./runtime/client.d.ts",


### PR DESCRIPTION
`edge.mjs` doesn't exist, it should be `edge.js` for both `require` and `import`, like index, `default` and `extension` entrypoints do.

Well, it technically shouldn't, but let's make it consistent with the normal entrypoint for now, and change all of them later if needed.

Follow up to https://github.com/prisma/prisma/pull/28480
