### PR TITLE
test(e2e): run prisma generate inside nextjs service fixture

### DIFF
--- a/packages/client/tests/e2e/nextjs-schema-not-found/10_monorepo-serverComponents-customOutput-noReExport/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/10_monorepo-serverComponents-customOutput-noReExport/_steps.ts
@@ -6,8 +6,8 @@ import { testServerComponents } from '../_shared/test'
 void executeSteps({
   setup: async () => {
     await $`pnpm install`
-    await $`pnpm prisma generate`
     cd('packages/service')
+    await $`pnpm prisma generate`
     await $`pnpm exec prisma db push --force-reset`
   },
   test: async () => {


### PR DESCRIPTION
Fixes the `10_monorepo-serverComponents-customOutput-noReExport` ecosystem test failing on `next` with `ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND` error.
