### PR TITLE
fix(client): use `/edge` entrypoint in `enum-import-in-edge` test

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -74,8 +74,8 @@
     "./edge": {
       "types": "./edge.d.ts",
       "require": "./edge.js",
-      "import": "./edge.mjs",
-      "default": "./edge.mjs"
+      "import": "./edge.js",
+      "default": "./edge.js"
     },
     "./runtime/client": {
       "types": "./runtime/client.d.ts",

--- a/packages/client/tests/e2e/enum-import-in-edge/src/index.ts
+++ b/packages/client/tests/e2e/enum-import-in-edge/src/index.ts
@@ -1,5 +1,5 @@
 import { PrismaD1 } from '@prisma/adapter-d1'
-import { Prisma, PrismaClient, Role } from '@prisma/client'
+import { Prisma, PrismaClient, Role } from '@prisma/client/edge'
 
 export default {
   fetch() {


### PR DESCRIPTION
Use the `/edge` entrypoint in the `enum-import-in-edge` test.

Doesn't fix the failing e2e test by itself yet, only together with https://github.com/prisma/prisma/pull/28484 (these are two unrelated issues in this test).