### PR TITLE
fix(adapter-d1): split node/workerd entrypoints

### DIFF
--- a/helpers/compile/configs.ts
+++ b/helpers/compile/configs.ts
@@ -1,25 +1,40 @@
+import path from 'node:path'
+
 import { BuildOptions } from './build'
 
-export const adapterConfig: BuildOptions[] = [
-  {
-    name: 'cjs',
-    format: 'cjs',
-    bundle: true,
-    entryPoints: ['src/index.ts'],
-    outfile: 'dist/index',
-    outExtension: { '.js': '.js' },
-    emitTypes: true,
-  },
-  {
-    name: 'esm',
-    format: 'esm',
-    bundle: true,
-    entryPoints: ['src/index.ts'],
-    outfile: 'dist/index',
-    outExtension: { '.js': '.mjs' },
-    emitTypes: true,
-  },
-]
+type AdapterEntry = {
+  entry: string
+  outfile: string
+}
+
+export function createAdapterConfig(entries: AdapterEntry[]): BuildOptions[] {
+  return entries.flatMap(({ entry, outfile }) => {
+    const baseName = path.basename(outfile)
+
+    return [
+      {
+        name: `${baseName}-cjs`,
+        format: 'cjs' as const,
+        bundle: true,
+        entryPoints: [entry],
+        outfile,
+        outExtension: { '.js': '.js' },
+        emitTypes: true,
+      },
+      {
+        name: `${baseName}-esm`,
+        format: 'esm' as const,
+        bundle: true,
+        entryPoints: [entry],
+        outfile,
+        outExtension: { '.js': '.mjs' },
+        emitTypes: true,
+      },
+    ]
+  })
+}
+
+export const adapterConfig = createAdapterConfig([{ entry: 'src/index.ts', outfile: 'dist/index' }])
 
 export const unbundledConfig: BuildOptions[] = [
   {

--- a/packages/adapter-d1/helpers/build.ts
+++ b/packages/adapter-d1/helpers/build.ts
@@ -1,4 +1,9 @@
 import { build } from '../../../helpers/compile/build'
-import { adapterConfig } from '../../../helpers/compile/configs'
+import { createAdapterConfig } from '../../../helpers/compile/configs'
 
-void build(adapterConfig)
+const bundleConfig = createAdapterConfig([
+  { entry: 'src/index-node.ts', outfile: 'dist/index-node' },
+  { entry: 'src/index-workerd.ts', outfile: 'dist/index-workerd' },
+])
+
+void build(bundleConfig)

--- a/packages/adapter-d1/package.json
+++ b/packages/adapter-d1/package.json
@@ -2,18 +2,31 @@
   "name": "@prisma/adapter-d1",
   "version": "0.0.0",
   "description": "Prisma's driver adapter for Cloudflare D1",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
+  "main": "dist/index-node.js",
+  "module": "dist/index-node.mjs",
+  "types": "dist/index-node.d.ts",
   "exports": {
     ".": {
-      "require": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
+      "types": "./dist/index-node.d.ts",
+      "node": {
+        "types": "./dist/index-node.d.ts",
+        "require": "./dist/index-node.js",
+        "import": "./dist/index-node.mjs"
       },
-      "import": {
-        "types": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
+      "workerd": {
+        "types": "./dist/index-workerd.d.ts",
+        "require": "./dist/index-workerd.js",
+        "import": "./dist/index-workerd.mjs"
+      },
+      "browser": {
+        "types": "./dist/index-workerd.d.ts",
+        "require": "./dist/index-workerd.js",
+        "import": "./dist/index-workerd.mjs"
+      },
+      "default": {
+        "types": "./dist/index-node.d.ts",
+        "require": "./dist/index-node.js",
+        "import": "./dist/index-node.mjs"
       }
     }
   },

--- a/packages/adapter-d1/src/d1.test.ts
+++ b/packages/adapter-d1/src/d1.test.ts
@@ -6,10 +6,10 @@ import {
 } from '@prisma/driver-adapter-utils'
 import { afterEach, describe, expect, expectTypeOf, test, vi } from 'vitest'
 
-import { PrismaD1Http } from '.'
 import { PrismaD1 } from './d1'
 import { PrismaD1HttpAdapterFactory } from './d1-http'
 import { PrismaD1WorkerAdapterFactory } from './d1-worker'
+import { PrismaD1Http } from './index-node'
 
 describe('D1 adapter instance creation', () => {
   afterEach(() => {

--- a/packages/adapter-d1/src/d1.ts
+++ b/packages/adapter-d1/src/d1.ts
@@ -1,6 +1,3 @@
-import fs from 'node:fs'
-import path from 'node:path'
-
 import { D1Database } from '@cloudflare/workers-types'
 import { SqlDriverAdapter, SqlDriverAdapterFactory } from '@prisma/driver-adapter-utils'
 
@@ -35,34 +32,4 @@ export class PrismaD1<Args extends D1Database | D1HttpParams = D1Database> imple
 
 type PrismaD1Interface<Params> = SqlDriverAdapterFactory & {
   connectToShadowDb: Params extends D1HttpParams ? () => Promise<SqlDriverAdapter> : undefined
-}
-
-const localD1DatabasePath = path.join('.wrangler', 'state', 'v3', 'd1', 'miniflare-D1DatabaseObject')
-
-/**
- * Lists all local D1 databases found in the Wrangler state directory.
- *
- * This function scans the `.wrangler/state/v3/d1/miniflare-D1DatabaseObject` directory
- * for SQLite database files and returns their paths.
- *
- * @returns An array of file paths to local D1 database files
- *
- * @example
- * ```typescript
- * import { defineConfig } from '@prisma/config'
- * import { listLocalDatabases } from '@prisma/adapter-d1'
- *
- * export default defineConfig({
- *   engine: 'classic',
- *   datasource: {
- *     url: `file:${listLocalDatabases().pop()}`,
- *   },
- * })
- * ```
- */
-export function listLocalDatabases(): string[] {
-  const cwd = process.cwd()
-  const d1DirPath = path.join(cwd, localD1DatabasePath)
-  const files = fs.readdirSync(d1DirPath)
-  return files.filter((file) => file.endsWith('.sqlite')).map((file) => path.join(d1DirPath, file))
 }

--- a/packages/adapter-d1/src/index-node.ts
+++ b/packages/adapter-d1/src/index-node.ts
@@ -1,0 +1,2 @@
+export * from './index-workerd'
+export { listLocalDatabases } from './node/list-local-databases'

--- a/packages/adapter-d1/src/index-workerd.ts
+++ b/packages/adapter-d1/src/index-workerd.ts
@@ -1,3 +1,3 @@
-export { listLocalDatabases, PrismaD1 } from './d1'
+export { PrismaD1 } from './d1'
 // exported for backwards compatibility
 export { PrismaD1HttpAdapterFactory as PrismaD1Http } from './d1-http'

--- a/packages/adapter-d1/src/node/list-local-databases.ts
+++ b/packages/adapter-d1/src/node/list-local-databases.ts
@@ -1,0 +1,32 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const localD1DatabasePath = path.join('.wrangler', 'state', 'v3', 'd1', 'miniflare-D1DatabaseObject')
+
+/**
+ * Lists all local D1 databases found in the Wrangler state directory.
+ *
+ * This function scans the `.wrangler/state/v3/d1/miniflare-D1DatabaseObject` directory
+ * for SQLite database files and returns their paths.
+ *
+ * @returns An array of file paths to local D1 database files
+ *
+ * @example
+ * ```typescript
+ * import { defineConfig } from '@prisma/config'
+ * import { listLocalDatabases } from '@prisma/adapter-d1'
+ *
+ * export default defineConfig({
+ *   engine: 'classic',
+ *   datasource: {
+ *     url: `file:${listLocalDatabases().pop()}`,
+ *   },
+ * })
+ * ```
+ */
+export function listLocalDatabases(): string[] {
+  const cwd = process.cwd()
+  const d1DirPath = path.join(cwd, localD1DatabasePath)
+  const files = fs.readdirSync(d1DirPath)
+  return files.filter((file) => file.endsWith('.sqlite')).map((file) => path.join(d1DirPath, file))
+}

--- a/tsconfig.build.bundle.json
+++ b/tsconfig.build.bundle.json
@@ -23,7 +23,7 @@
       "@prisma/engines": ["./packages/engines/src"],
       "@prisma/instrumentation": ["./packages/instrumentation/src"],
       "@prisma/driver-adapter-utils": ["./packages/driver-adapter-utils/src"],
-      "@prisma/adapter-d1": ["./packages/adapter-d1/src"],
+      "@prisma/adapter-d1": ["./packages/adapter-d1/src/index-node.ts"],
       "@prisma/adapter-libsql": ["./packages/adapter-libsql/src"],
       "@prisma/adapter-neon": ["./packages/adapter-neon/src"],
       "@prisma/adapter-pg": ["./packages/adapter-pg/src"],


### PR DESCRIPTION
`enum-import-in-edge` e2e test failed because importing `@prisma/adapter-d1` always pulled `node:fs`/`node:path` via the `listLocalDatabases` helper, which workerd doesn't support without a compatibility flag.

This change moves `listLocalDatabases` into a node-only module and adds separate `index-node`/`index-workerd` entrypoints wired through the exports map, build config, and TypeScript path alias so worker bundles stay free of `node:*` deps while Node consumers still get the helper.
