### PR TITLE
refactor: remove `url` from `DataSource` structure

### DIFF
--- a/packages/cli/src/Studio.ts
+++ b/packages/cli/src/Studio.ts
@@ -93,7 +93,6 @@ ${bold('Examples')}
     const schemaContext = await loadSchemaContext({
       schemaPathFromArg: args['--schema'],
       schemaPathFromConfig: config.schema,
-      schemaEngineConfig: config,
     })
 
     const hostname = args['--hostname']

--- a/packages/generator/src/configuration.ts
+++ b/packages/generator/src/configuration.ts
@@ -53,7 +53,6 @@ export interface DataSource {
   provider: ConnectorType
   // In Rust, this comes from `Connector::provider_name()`
   activeProvider: ActiveConnectorType
-  url: EnvValue
   schemas: string[] | []
   sourceFilePath: string
 }

--- a/packages/internals/src/__tests__/directoryConfig.test.ts
+++ b/packages/internals/src/__tests__/directoryConfig.test.ts
@@ -20,7 +20,7 @@ async function testDirectoryConfig({
 
   const schemaContext = await loadSchemaContext({
     schemaPathFromArg: schemaPath,
-    schemaEngineConfig: config,
+
     cwd,
     allowNull: true,
   })
@@ -36,7 +36,7 @@ describe('with .config/prisma.ts', () => {
 
     const schemaContext = await loadSchemaContext({
       schemaPathFromArg: './prisma',
-      schemaEngineConfig: config.config,
+
       cwd,
       allowNull: true,
     })

--- a/packages/internals/src/cli/schemaContext.ts
+++ b/packages/internals/src/cli/schemaContext.ts
@@ -1,8 +1,8 @@
+import path from 'node:path'
+
 import { SchemaEngineConfigInternal } from '@prisma/config'
 import { ActiveConnectorType, DataSource, GeneratorConfig } from '@prisma/generator'
 import { GetSchemaResult, LoadedFile } from '@prisma/schema-files-loader'
-import path from 'path'
-import { match } from 'ts-pattern'
 
 import { getConfig } from '../engine-commands'
 import { getSchemaWithPath, getSchemaWithPathOptional, printSchemaLoadedMessage } from './getSchema'
@@ -62,14 +62,10 @@ type LoadSchemaContextOptions = {
 export async function loadSchemaContext(
   opts: LoadSchemaContextOptions & { allowNull: true },
 ): Promise<SchemaContext | null>
-export async function loadSchemaContext(
-  opts?: LoadSchemaContextOptions & { schemaEngineConfig: { engine: 'classic' } },
-): Promise<Omit<SchemaContext, 'primaryDatasource'> & { primaryDatasource: DataSource }>
 export async function loadSchemaContext(opts?: LoadSchemaContextOptions): Promise<SchemaContext>
 export async function loadSchemaContext({
   schemaPathFromArg,
   schemaPathFromConfig,
-  schemaEngineConfig,
   printLoadMessage = true,
   allowNull = false,
   schemaPathArgumentName = '--schema',
@@ -90,17 +86,15 @@ export async function loadSchemaContext({
     })
   }
 
-  return processSchemaResult({ schemaResult, schemaEngineConfig, printLoadMessage, cwd })
+  return processSchemaResult({ schemaResult, printLoadMessage, cwd })
 }
 
 export async function processSchemaResult({
   schemaResult,
-  schemaEngineConfig,
   printLoadMessage = true,
   cwd = process.cwd(),
 }: {
   schemaResult: GetSchemaResult
-  schemaEngineConfig?: SchemaEngineConfigInternal
   printLoadMessage?: boolean
   cwd?: string
 }): Promise<SchemaContext> {
@@ -113,22 +107,9 @@ export async function processSchemaResult({
 
   const configFromPsl = await getConfig({ datamodel: schemaResult.schemas })
 
-  const datasourceFromPsl = configFromPsl.datasources.at(0)
+  const primaryDatasource = configFromPsl.datasources.at(0)
 
-  const primaryDatasource = match(schemaEngineConfig)
-    .with({ engine: 'classic' }, ({ datasource }) => {
-      const { url } = datasource
-
-      const primaryDatasource: DataSource = {
-        ...datasourceFromPsl,
-        url: { fromEnvVar: null, value: url },
-      } as DataSource
-
-      return primaryDatasource
-    })
-    .otherwise(() => datasourceFromPsl)
-
-  const primaryDatasourceDirectory = getPrimaryDatasourceDirectory(datasourceFromPsl) || schemaRootDir
+  const primaryDatasourceDirectory = getPrimaryDatasourceDirectory(primaryDatasource) || schemaRootDir
 
   return {
     schemaFiles: schemaResult.schemas,

--- a/packages/migrate/src/commands/MigrateDiff.ts
+++ b/packages/migrate/src/commands/MigrateDiff.ts
@@ -210,7 +210,7 @@ ${bold('Examples')}
     } else if (args['--from-config-datasource']) {
       const schemaContext = await loadSchemaContext({
         schemaPathFromConfig: config.schema,
-        schemaEngineConfig: config,
+
         printLoadMessage: false,
       })
       from = {
@@ -240,7 +240,7 @@ ${bold('Examples')}
     } else if (args['--to-config-datasource']) {
       const schemaContext = await loadSchemaContext({
         schemaPathFromConfig: config.schema,
-        schemaEngineConfig: config,
+
         printLoadMessage: false,
       })
       to = {


### PR DESCRIPTION
Remove `url` from the JS representation of PSL datasource.

Ref: https://linear.app/prisma-company/issue/TML-1545/remove-url-datasource-attribute-from-psl
