### PR TITLE
fix(client-generator-js): use base64 js wasm bundles on Node.js

### DIFF
--- a/packages/client-generator-js/src/generateClient.ts
+++ b/packages/client-generator-js/src/generateClient.ts
@@ -412,6 +412,7 @@ export async function generateClient(options: GenerateClientOptions): Promise<vo
 
     await fs.writeFile(path.join(outputDir, `${filename}.wasm`), Buffer.from(wasmBase64, 'base64'))
     await fs.copyFile(path.join(runtimeSourcePath, `${filename}.${suffix}.js`), path.join(outputDir, `${filename}.js`))
+    await fs.copyFile(wasmJsBundlePath, path.join(outputDir, `${filename}.wasm-base64.js`))
   }
 
   try {

--- a/packages/client-generator-js/src/utils/buildGetQueryCompilerWasmModule.ts
+++ b/packages/client-generator-js/src/utils/buildGetQueryCompilerWasmModule.ts
@@ -12,8 +12,9 @@ export function buildQueryCompilerWasmModule(
     return `config.compilerWasm = {
       getRuntime: async () => require('./query_compiler_bg.js'),
       getQueryCompilerWasmModule: async () => {
-        const queryCompilerWasmFilePath = require('path').join(config.dirname, 'query_compiler_bg.wasm')
-        const queryCompilerWasmFileBytes = require('fs').readFileSync(queryCompilerWasmFilePath)
+        const { Buffer } = require('node:buffer')
+        const { wasm } = require('./query_compiler_bg.wasm-base64.js')
+        const queryCompilerWasmFileBytes = Buffer.from(wasm, 'base64')
 
         return new WebAssembly.Module(queryCompilerWasmFileBytes)
       }

--- a/packages/client/tests/e2e/nextjs-schema-not-found/11_monorepo-noServerComponents-noCustomOutput-reExportIndirect/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/11_monorepo-noServerComponents-noCustomOutput-reExportIndirect/_steps.ts
@@ -1,19 +1,18 @@
 import { $, cd } from 'zx'
 
 import { executeSteps } from '../../_utils/executeSteps'
-// import { testNonServerComponents } from '../_shared/test'
+import { testNonServerComponents } from '../_shared/test'
 
 void executeSteps({
   setup: async () => {
     await $`pnpm install`
     cd('packages/db')
     await $`pnpm exec prisma db push --force-reset`
+    await $`pnpm exec prisma generate`
     cd('../service')
   },
   test: async () => {
-    // TODO: this fails with:
-    // `ENOENT: no such file or directory, open '[..]node_modules/.prisma/client/query_compiler_bg.wasm'`.
-    // await testNonServerComponents()
+    await testNonServerComponents()
   },
   finish: async () => {},
 })

--- a/packages/client/tests/e2e/nextjs-schema-not-found/12_monorepo-serverComponents-noCustomOutput-reExportIndirect/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/12_monorepo-serverComponents-noCustomOutput-reExportIndirect/_steps.ts
@@ -1,19 +1,18 @@
 import { $, cd } from 'zx'
 
 import { executeSteps } from '../../_utils/executeSteps'
-// import { testServerComponents } from '../_shared/test'
+import { testServerComponents } from '../_shared/test'
 
 void executeSteps({
   setup: async () => {
     await $`pnpm install`
     cd('packages/db')
     await $`pnpm exec prisma db push --force-reset`
+    await $`pnpm exec prisma generate`
     cd('../service')
   },
   test: async () => {
-    // TODO: this fails with:
-    // `ENOENT: no such file or directory, open '[..]node_modules/.prisma/client/query_compiler_bg.wasm'`.
-    // await testServerComponents()
+    await testServerComponents()
   },
   finish: async () => {},
 })

--- a/packages/client/tests/e2e/nextjs-schema-not-found/13_monorepo-noServerComponents-customOutput-reExportDirect/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/13_monorepo-noServerComponents-customOutput-reExportDirect/_steps.ts
@@ -1,18 +1,17 @@
 import { $, cd } from 'zx'
 
 import { executeSteps } from '../../_utils/executeSteps'
-// import { testNonServerComponents } from '../_shared/test'
+import { testNonServerComponents } from '../_shared/test'
 
 void executeSteps({
   setup: async () => {
     await $`pnpm install`
     await $`pnpm exec prisma db push --force-reset`
+    await $`pnpm prisma generate`
     cd('packages/service')
   },
   test: async () => {
-    // TODO: this fails with:
-    // `ENOENT: no such file or directory, open '[..]node_modules/.prisma/client/query_compiler_bg.wasm'`.
-    // await testNonServerComponents()
+    await testNonServerComponents()
   },
   finish: async () => {},
 })

--- a/packages/client/tests/e2e/nextjs-schema-not-found/14_monorepo-serverComponents-customOutput-reExportDirect/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/14_monorepo-serverComponents-customOutput-reExportDirect/_steps.ts
@@ -1,18 +1,17 @@
 import { $, cd } from 'zx'
 
 import { executeSteps } from '../../_utils/executeSteps'
-// import { testServerComponents } from '../_shared/test'
+import { testServerComponents } from '../_shared/test'
 
 void executeSteps({
   setup: async () => {
     await $`pnpm install`
     await $`pnpm exec prisma db push --force-reset`
+    await $`pnpm prisma generate`
     cd('packages/service')
   },
   test: async () => {
-    // TODO: this fails with:
-    // `ENOENT: no such file or directory, open '[..]node_modules/.prisma/client/query_compiler_bg.wasm'`.
-    // await testServerComponents()
+    await testServerComponents()
   },
   finish: async () => {},
 })

--- a/packages/client/tests/e2e/nextjs-schema-not-found/15_monorepo-noServerComponents-customOutput-reExportIndirect/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/15_monorepo-noServerComponents-customOutput-reExportIndirect/_steps.ts
@@ -1,17 +1,18 @@
 import { $, cd } from 'zx'
 
 import { executeSteps } from '../../_utils/executeSteps'
-// import { testNonServerComponents } from '../_shared/test'
+import { testNonServerComponents } from '../_shared/test'
 
 void executeSteps({
   setup: async () => {
     await $`pnpm install`
     cd('packages/db')
     await $`pnpm exec prisma db push --force-reset`
+    await $`pnpm exec prisma generate`
     cd('../service')
   },
   test: async () => {
-    // await testNonServerComponents()
+    await testNonServerComponents()
   },
   finish: async () => {},
 })

--- a/packages/client/tests/e2e/nextjs-schema-not-found/15_monorepo-noServerComponents-customOutput-reExportIndirect/packages/db/index.js
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/15_monorepo-noServerComponents-customOutput-reExportIndirect/packages/db/index.js
@@ -1,5 +1,9 @@
+const { PrismaPg } = require('@prisma/adapter-pg')
 const { PrismaClient } = require('./prisma/client')
 
-const db = new PrismaClient()
+const adapter = new PrismaPg({
+  connectionString: process.env['TEST_E2E_POSTGRES_URI'],
+})
+const db = new PrismaClient({ adapter })
 
 module.exports = { db }

--- a/packages/client/tests/e2e/nextjs-schema-not-found/15_monorepo-noServerComponents-customOutput-reExportIndirect/packages/db/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/15_monorepo-noServerComponents-customOutput-reExportIndirect/packages/db/package.json
@@ -13,6 +13,7 @@
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "dependencies": {
+    "@prisma/adapter-pg": "/tmp/prisma-adapter-pg-0.0.0.tgz",
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz",
     "@prisma/client-runtime-utils": "/tmp/prisma-client-runtime-utils-0.0.0.tgz"
   }

--- a/packages/client/tests/e2e/nextjs-schema-not-found/16_monorepo-serverComponents-customOutput-reExportIndirect/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/16_monorepo-serverComponents-customOutput-reExportIndirect/_steps.ts
@@ -1,17 +1,18 @@
 import { $, cd } from 'zx'
 
 import { executeSteps } from '../../_utils/executeSteps'
-// import { testServerComponents } from '../_shared/test'
+import { testServerComponents } from '../_shared/test'
 
 void executeSteps({
   setup: async () => {
     await $`pnpm install`
     cd('packages/db')
     await $`pnpm exec prisma db push --force-reset`
+    await $`pnpm exec prisma generate`
     cd('../service')
   },
   test: async () => {
-    // await testServerComponents()
+    await testServerComponents()
   },
   finish: async () => {},
 })

--- a/packages/client/tests/e2e/nextjs-schema-not-found/16_monorepo-serverComponents-customOutput-reExportIndirect/packages/db/index.js
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/16_monorepo-serverComponents-customOutput-reExportIndirect/packages/db/index.js
@@ -1,5 +1,9 @@
+const { PrismaPg } = require('@prisma/adapter-pg')
 const { PrismaClient } = require('./prisma/client')
 
-const db = new PrismaClient()
+const adapter = new PrismaPg({
+  connectionString: process.env['TEST_E2E_POSTGRES_URI'],
+})
+const db = new PrismaClient({ adapter })
 
 module.exports = { db }

--- a/packages/client/tests/e2e/nextjs-schema-not-found/16_monorepo-serverComponents-customOutput-reExportIndirect/packages/db/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/16_monorepo-serverComponents-customOutput-reExportIndirect/packages/db/package.json
@@ -11,6 +11,7 @@
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "dependencies": {
+    "@prisma/adapter-pg": "/tmp/prisma-adapter-pg-0.0.0.tgz",
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz",
     "@prisma/client-runtime-utils": "/tmp/prisma-client-runtime-utils-0.0.0.tgz"
   }

--- a/packages/client/tests/e2e/nextjs-schema-not-found/17_monorepo-noServerComponents-customOutput-reExportIndirect-ts/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/17_monorepo-noServerComponents-customOutput-reExportIndirect-ts/_steps.ts
@@ -1,17 +1,18 @@
 import { $, cd } from 'zx'
 
 import { executeSteps } from '../../_utils/executeSteps'
-// import { testNonServerComponents } from '../_shared/test'
+import { testNonServerComponents } from '../_shared/test'
 
 void executeSteps({
   setup: async () => {
     await $`pnpm install`
     cd('packages/db')
     await $`pnpm exec prisma db push --force-reset`
+    await $`pnpm exec prisma generate`
     cd('../service')
   },
   test: async () => {
-    // await testNonServerComponents()
+    await testNonServerComponents()
   },
   finish: async () => {},
 })

--- a/packages/client/tests/e2e/nextjs-schema-not-found/17_monorepo-noServerComponents-customOutput-reExportIndirect-ts/packages/db/index.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/17_monorepo-noServerComponents-customOutput-reExportIndirect-ts/packages/db/index.ts
@@ -1,5 +1,10 @@
+import { PrismaPg } from '@prisma/adapter-pg'
+
 import { PrismaClient } from './prisma/client'
 
-const db = new PrismaClient()
+const adapter = new PrismaPg({
+  connectionString: process.env['TEST_E2E_POSTGRES_URI'],
+})
+const db = new PrismaClient({ adapter })
 
 export { db }

--- a/packages/client/tests/e2e/nextjs-schema-not-found/17_monorepo-noServerComponents-customOutput-reExportIndirect-ts/packages/db/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/17_monorepo-noServerComponents-customOutput-reExportIndirect-ts/packages/db/package.json
@@ -13,6 +13,7 @@
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "dependencies": {
+    "@prisma/adapter-pg": "/tmp/prisma-adapter-pg-0.0.0.tgz",
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz",
     "@prisma/client-runtime-utils": "/tmp/prisma-client-runtime-utils-0.0.0.tgz"
   }

--- a/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/_steps.ts
@@ -1,17 +1,18 @@
 import { $, cd } from 'zx'
 
 import { executeSteps } from '../../_utils/executeSteps'
-// import { testServerComponents } from '../_shared/test'
+import { testServerComponents } from '../_shared/test'
 
 void executeSteps({
   setup: async () => {
     await $`pnpm install`
     cd('packages/db')
     await $`pnpm exec prisma db push --force-reset`
+    await $`pnpm exec prisma generate`
     cd('../service')
   },
   test: async () => {
-    //  await testServerComponents()
+    await testServerComponents()
   },
   finish: async () => {},
 })

--- a/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/packages/db/index.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/packages/db/index.ts
@@ -1,5 +1,10 @@
+import { PrismaPg } from '@prisma/adapter-pg'
+
 import { PrismaClient } from './prisma/client'
 
-const db = new PrismaClient()
+const adapter = new PrismaPg({
+  connectionString: process.env['TEST_E2E_POSTGRES_URI'],
+})
+const db = new PrismaClient({ adapter })
 
 export { db }

--- a/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/packages/db/package.json
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/18_monorepo-serverComponents-customOutput-reExportIndirect-ts/packages/db/package.json
@@ -11,6 +11,7 @@
     "prisma": "/tmp/prisma-0.0.0.tgz"
   },
   "dependencies": {
+    "@prisma/adapter-pg": "/tmp/prisma-adapter-pg-0.0.0.tgz",
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz",
     "@prisma/client-runtime-utils": "/tmp/prisma-client-runtime-utils-0.0.0.tgz"
   }

--- a/packages/client/tests/e2e/nextjs-schema-not-found/3_simplerepo-noServerComponents-noCustomOutput-noReExport/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/3_simplerepo-noServerComponents-noCustomOutput-noReExport/_steps.ts
@@ -1,17 +1,16 @@
 import { $ } from 'zx'
 
 import { executeSteps } from '../../_utils/executeSteps'
-// import { testNonServerComponents } from '../_shared/test'
+import { testNonServerComponents } from '../_shared/test'
 
 void executeSteps({
   setup: async () => {
     await $`pnpm install`
     await $`pnpm exec prisma db push --force-reset`
+    await $`pnpm prisma generate`
   },
   test: async () => {
-    // TODO: this fails with:
-    // `ENOENT: no such file or directory, open '[..]node_modules/.prisma/client/query_compiler_bg.wasm'`.
-    // await testNonServerComponents({ monorepo: false })
+    await testNonServerComponents({ monorepo: false })
   },
   finish: async () => {},
 })

--- a/packages/client/tests/e2e/nextjs-schema-not-found/4_simplerepo-serverComponents-noCustomOutput-noReExport/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/4_simplerepo-serverComponents-noCustomOutput-noReExport/_steps.ts
@@ -1,17 +1,16 @@
 import { $ } from 'zx'
 
 import { executeSteps } from '../../_utils/executeSteps'
-// import { testServerComponents } from '../_shared/test'
+import { testServerComponents } from '../_shared/test'
 
 void executeSteps({
   setup: async () => {
     await $`pnpm install`
     await $`pnpm exec prisma db push --force-reset`
+    await $`pnpm prisma generate`
   },
   test: async () => {
-    // TODO: this fails with:
-    // `ENOENT: no such file or directory, open '[..]node_modules/.prisma/client/query_compiler_bg.wasm'`.
-    // await testServerComponents({ monorepo: false })
+    await testServerComponents({ monorepo: false })
   },
   finish: async () => {},
 })

--- a/packages/client/tests/e2e/nextjs-schema-not-found/7_monorepo-noServerComponents-noCustomOutput-noReExport/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/7_monorepo-noServerComponents-noCustomOutput-noReExport/_steps.ts
@@ -1,18 +1,17 @@
 import { $, cd } from 'zx'
 
 import { executeSteps } from '../../_utils/executeSteps'
-// import { testNonServerComponents } from '../_shared/test'
+import { testNonServerComponents } from '../_shared/test'
 
 void executeSteps({
   setup: async () => {
     await $`pnpm install`
     cd('packages/service')
+    await $`pnpm prisma generate`
     await $`pnpm exec prisma db push --force-reset`
   },
   test: async () => {
-    // TODO: this fails with:
-    // `ENOENT: no such file or directory, open '[..]node_modules/.prisma/client/query_compiler_bg.wasm'`.
-    // await testNonServerComponents()
+    await testNonServerComponents()
   },
   finish: async () => {},
 })

--- a/packages/client/tests/e2e/nextjs-schema-not-found/8_monorepo-serverComponents-noCustomOutput-noReExport/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/8_monorepo-serverComponents-noCustomOutput-noReExport/_steps.ts
@@ -1,18 +1,17 @@
 import { $, cd } from 'zx'
 
 import { executeSteps } from '../../_utils/executeSteps'
-// import { testServerComponents } from '../_shared/test'
+import { testServerComponents } from '../_shared/test'
 
 void executeSteps({
   setup: async () => {
     await $`pnpm install`
     cd('packages/service')
+    await $`pnpm prisma generate`
     await $`pnpm exec prisma db push --force-reset`
   },
   test: async () => {
-    // TODO: this fails with:
-    // `ENOENT: no such file or directory, open '[..]node_modules/.prisma/client/query_compiler_bg.wasm'`.
-    // await testServerComponents()
+    await testServerComponents()
   },
   finish: async () => {},
 })

--- a/packages/client/tests/e2e/nextjs-schema-not-found/9_monorepo-noServerComponents-customOutput-noReExport/_steps.ts
+++ b/packages/client/tests/e2e/nextjs-schema-not-found/9_monorepo-noServerComponents-customOutput-noReExport/_steps.ts
@@ -1,18 +1,17 @@
 import { $, cd } from 'zx'
 
 import { executeSteps } from '../../_utils/executeSteps'
-// import { testNonServerComponents } from '../_shared/test'
+import { testNonServerComponents } from '../_shared/test'
 
 void executeSteps({
   setup: async () => {
     await $`pnpm install`
     cd('packages/service')
+    await $`pnpm prisma generate`
     await $`pnpm exec prisma db push --force-reset`
   },
   test: async () => {
-    // TODO: this fails with:
-    // `ENOENT: no such file or directory, open '[..]node_modules/.prisma/client/query_compiler_bg.wasm'`.
-    // await testNonServerComponents()
+    await testNonServerComponents()
   },
   finish: async () => {},
 })


### PR DESCRIPTION
Fixes: https://linear.app/prisma-company/issue/TML-1568/fix-nextjs-schema-not-found-e2e-tests
