### PR TITLE
fix(ci): don't interpret explicit "false" as true in publish script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,12 +48,11 @@ env:
   PRISMA_HIDE_UPDATE_MESSAGE: 'true'
   # Environment variables based on trigger type and parameters
   RELEASE_VERSION: ${{ github.event.inputs.targetVersion }}
-  SKIP_ECOSYSTEMTESTS_CHECK: ${{ github.event.inputs.skipEcosystemTestsChecks || '' }}
+  SKIP_ECOSYSTEMTESTS_CHECK: ${{ github.event.inputs.skipEcosystemTestsChecks || 'false' }}
   SKIP_PACKAGES: ${{ github.event.inputs.skipPackages }}
   ONLY_PACKAGES: ${{ github.event.inputs.onlyPackages }}
-  DRY_RUN: ${{ github.event.inputs.dryRun || '' }}
-  FORCE_INTEGRATION_RELEASE: ${{ inputs.forceIntegrationRelease || '' }}
-  INCLUDE_FAILURE_NOTIFICATIONS: ${{ github.event.inputs.targetVersion && 'true' || '' }}
+  DRY_RUN: ${{ github.event.inputs.dryRun || 'false' }}
+  FORCE_INTEGRATION_RELEASE: ${{ inputs.forceIntegrationRelease || 'false' }}
   FAILURE_TITLE_TEMPLATE: >-
     ${{
       github.event.inputs.targetVersion &&

--- a/scripts/ci/publish.ts
+++ b/scripts/ci/publish.ts
@@ -469,7 +469,7 @@ async function publish() {
     throw new Error(`Missing env var GITHUB_REF_NAME`)
   }
 
-  if (process.env.DRY_RUN) {
+  if (process.env.DRY_RUN === 'true') {
     console.log(blue(bold(`\nThe DRY_RUN env var is set, so we'll do a dry run!\n`)))
     args['--dry-run'] = true
   }
@@ -531,7 +531,7 @@ async function publish() {
   console.log({ branch })
 
   // For branches that are named "integration/" we publish to the integration npm tag
-  if (branch && (process.env.FORCE_INTEGRATION_RELEASE || branch.startsWith('integration/'))) {
+  if (branch && (process.env.FORCE_INTEGRATION_RELEASE === 'true' || branch.startsWith('integration/'))) {
     prismaVersion = await getNewIntegrationVersion(packages, branch)
     tag = 'integration'
   }
@@ -583,7 +583,7 @@ async function publish() {
         throw new Error(`tagForEcosystemTestsCheck missing`)
       }
       const passing = await areEcosystemTestsPassing(tagForEcosystemTestsCheck)
-      if (!passing && !process.env.SKIP_ECOSYSTEMTESTS_CHECK) {
+      if (!passing && process.env.SKIP_ECOSYSTEMTESTS_CHECK !== 'true') {
         throw new Error(`We can't release, as the ecosystem-tests are not passing for the ${tag} npm tag!
 Check them out at https://github.com/prisma/ecosystem-tests/actions?query=workflow%3Atest+branch%3A${tag}`)
       }


### PR DESCRIPTION
Despite `type: boolean` in the descriptions of some workflow inputs, all these parameters are actually strings at run time. Thus, an explicit `"false"` value (e.g. from an unchecked checkbox in the GitHub UI) was being incorrectly interpreted as truthy in JavaScript.