### PR TITLE
fix(ci): update FORCE_INTEGRATION_RELEASE input handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,8 @@ env:
   SKIP_PACKAGES: ${{ github.event.inputs.skipPackages }}
   ONLY_PACKAGES: ${{ github.event.inputs.onlyPackages }}
   DRY_RUN: ${{ github.event.inputs.dryRun || 'false' }}
-  FORCE_INTEGRATION_RELEASE: ${{ inputs.forceIntegrationRelease || 'false' }}
+  FORCE_INTEGRATION_RELEASE: ${{ github.event.inputs.forceIntegrationRelease || 'false' }}
+
   FAILURE_TITLE_TEMPLATE: >-
     ${{
       github.event.inputs.targetVersion &&


### PR DESCRIPTION
This PR fixes a minor bug in the `.github/workflows/release.yml` workflow:
- The environment variable `FORCE_INTEGRATION_RELEASE` was referencing `inputs.forceIntegrationRelease` instead of `github.event.inputs.forceIntegrationRelease`. This led to the value always being empty or false when the workflow was dispatched.
- This PR corrects the context so that workflow dispatch input for `forceIntegrationRelease` is properly passed to jobs and scripts.