### PR TITLE
chore: remove outdated comment

### DIFF
--- a/packages/migrate/src/commands/MigrateResolve.ts
+++ b/packages/migrate/src/commands/MigrateResolve.ts
@@ -117,7 +117,6 @@ ${bold(green(getCommandWithExecutor('prisma migrate resolve --rolled-back 202012
         )
       }
 
-      // `ensureCanConnectToDatabase` is not compatible with WebAssembly.
       // TODO: check why the output and error handling here is different than in `MigrateDeploy`.
       await ensureCanConnectToDatabase(schemaContext.primaryDatasourceDirectory, validatedConfig)
 


### PR DESCRIPTION
While the comment is technically true, it was there to describe an if statement that's no longer there in that file. The necessary Wasm checks and the explanations in code comments are now in the function being called itself.
