### PR TITLE
fix(fetch-engine): skip native binary downloads when using Rust-free/…

### DIFF
--- a/packages/fetch-engine/src/download.ts
+++ b/packages/fetch-engine/src/download.ts
@@ -70,6 +70,16 @@ export async function download(options: DownloadOptions): Promise<BinaryPaths> {
   if (!options.binaries || Object.values(options.binaries).length === 0) {
     return {} // we don't download anything if nothing is provided
   }
+  // Skip native engine binaries when running with the Rust-free WASM engine
+const useRustFreeEngine =
+process.env.PRISMA_CLI_QUERY_ENGINE_TYPE === 'wasm' ||
+process.env.PRISMA_USE_WASM === 'true';
+
+if (useRustFreeEngine) {
+debug('Rust-free/WASM engine enabled — skipping native engine downloads.');
+return {};
+}
+
 
   if (enginesOverride?.['branch'] || enginesOverride?.['folder']) {
     // if this is true the engines have been fetched before and already cached


### PR DESCRIPTION
Fixes prisma/prisma#28503.

When `PRISMA_CLI_QUERY_ENGINE_TYPE=wasm` or `PRISMA_USE_WASM=true`, the CLI should
use the Rust-free engine and must not attempt to resolve or download native engine
binaries.

This PR adds an early return in `packages/fetch-engine/src/download.ts` to skip all
binary resolution, validation, and download logic when WASM mode is enabled.

This allows `prisma generate` to work properly in Rust-free mode on systems such as
NixOS where native engines are not available.
