### PR TITLE
fix(generator-js): fix potentially missing `adapter` option for edge builds

### DIFF
--- a/packages/client-generator-js/src/TSClient/PrismaClient.ts
+++ b/packages/client-generator-js/src/TSClient/PrismaClient.ts
@@ -620,7 +620,7 @@ export type TransactionClient = Omit<Prisma.DefaultPrismaClient, runtime.ITXClie
     )
 
     if (
-      ['library.js', 'client.js'].includes(this.runtimeNameTs) &&
+      ['client.js', 'wasm-compiler-edge.js'].includes(this.runtimeNameTs) &&
       // We don't support a custom adapter with MongoDB for now.
       this.internalDatasources.some((d) => d.provider !== 'mongodb')
     ) {


### PR DESCRIPTION
The edge build of the old JS client could be missing the `adapter` option in the client constructor. It actually wasn't because at the moment we only generate the types for the default `client` runtime and write stubs that re-export types from it for other targets, but it could be easily changed and break when refactoring code. This code was wrong locally even if the offending code path wasn't used in practice.
