### PR TITLE
feat(cli): change custom generator example in help text

### DIFF
--- a/packages/cli/src/Init.ts
+++ b/packages/cli/src/Init.ts
@@ -266,8 +266,8 @@ export class Init implements Command {
   Set up a new Prisma project and specify MySQL as the datasource provider to use
     ${dim('$')} prisma init --datasource-provider mysql
 
-  Set up a new \`prisma dev\`-ready (local Prisma Postgres) Prisma project and specify \`prisma-client-go\` as the generator provider to use
-    ${dim('$')} prisma init --generator-provider prisma-client-go
+  Set up a new \`prisma dev\`-ready (local Prisma Postgres) Prisma project and specify \`prisma-client-js\` as the generator provider to use
+    ${dim('$')} prisma init --generator-provider prisma-client-js
 
   Set up a new \`prisma dev\`-ready (local Prisma Postgres) Prisma project and specify \`x\` and \`y\` as the preview features to use
     ${dim('$')} prisma init --preview-feature x --preview-feature y


### PR DESCRIPTION
`prisma-client-go` is no longer maintained and doesn't support Prisma 7.

The only two client generators that currently exist for Prisma 7 are `prisma-client` and `prisma-client-js`. Since `prisma-client` is the default, the help message for `--generator-provider` should use `prisma-client-js`.

Closes: https://linear.app/prisma-company/issue/TML-1592/fix-the-help-message-for-generator-provider-in-prisma-init