### PR TITLE
fix: clarify the message about supported Node.js versions

### DIFF
--- a/packages/cli/src/__tests__/preinstall.test.ts
+++ b/packages/cli/src/__tests__/preinstall.test.ts
@@ -12,13 +12,32 @@ it.each(['16.18.0', '18.20.8', '20.18.3', '22.11.0'] as const)(
     printMessageAndExitIfUnsupportedNodeVersion(version)
 
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`
-    "┌─────────────────────────────────────────────────────────────────┐
-    │    Prisma only supports Node.js versions 20.19, 22.12, 24.0.    │
-    │    Please upgrade your Node.js version.                         │
-    └─────────────────────────────────────────────────────────────────┘"
+    "┌────────────────────────────────────────────────────────────────────┐
+    │    Prisma only supports Node.js versions 20.19+, 22.12+, 24.0+.    │
+    │    Please upgrade your Node.js version.                            │
+    └────────────────────────────────────────────────────────────────────┘"
   `)
 
     expect(mockExit).toHaveBeenCalledWith(1)
+    mockExit.mockRestore()
+  },
+)
+
+it.each(['25.0.0', '30.1.0'] as const)(
+  'should exit 1 and print a message when Node.js major version is higher than supported - %s',
+  (version) => {
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation()
+
+    printMessageAndExitIfUnsupportedNodeVersion(version)
+
+    expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+    "┌────────────────────────────────────────────────────────────────────┐
+    │    Prisma only supports Node.js versions 20.19+, 22.12+, 24.0+.    │
+    │    Please use a supported Node.js version.                         │
+    └────────────────────────────────────────────────────────────────────┘"
+  `)
+
+    expect(mockExit).not.toHaveBeenCalled()
     mockExit.mockRestore()
   },
 )


### PR DESCRIPTION
* The error message states 'Node.js versions 20.19, 22.12, 24.0' but the test cases check versions like '20.19.5', '22.12.0', '22.20.0', '24.0.1', '24.10.0'. The message should clarify whether it means minimum versions (e.g., '20.19+, 22.12+, 24.0+') or be more specific about supported version ranges.

* If the current version is higher than supported (i.e. the major version is 25+), it shouldn't prompt the user to "upgrade" their version. It should also be a warning and not a hard error because while it's not officially supported, it will likely work and there can be legitimate reasons to use it. We've never prevented users from using newer than supported versions before and even accepted community pull requests to improve compatibility with them.

Closes: https://linear.app/prisma-company/issue/TML-1600/clarify-the-message-about-supported-nodejs-versions