### PR TITLE
feat(client): made accelerateUrl and adapter mutually exclusive at type level

### DIFF
--- a/packages/client-generator-ts/src/TSClient/PrismaClient.ts
+++ b/packages/client-generator-ts/src/TSClient/PrismaClient.ts
@@ -264,7 +264,7 @@ export interface PrismaClientConstructor {
     LogOpts extends LogOptions<Options> = LogOptions<Options>,
     OmitOpts extends Prisma.PrismaClientOptions['omit'] = Options extends { omit: infer U } ? U : Prisma.PrismaClientOptions['omit'],
     ExtArgs extends runtime.Types.Extensions.InternalArgs = runtime.Types.Extensions.DefaultArgs
-  >(options?: Prisma.Subset<Options, Prisma.PrismaClientOptions> ): PrismaClient<LogOpts, OmitOpts, ExtArgs>
+  >(options: Prisma.Subset<Options, Prisma.PrismaClientOptions> ): PrismaClient<LogOpts, OmitOpts, ExtArgs>
 }
 
 ${this.jsDoc}

--- a/packages/client-generator-ts/tests/generator.test.ts
+++ b/packages/client-generator-ts/tests/generator.test.ts
@@ -342,10 +342,11 @@ describe('generator', () => {
     }
 
     // Check if the adapter property has been generated.
+    // The adapter property is now part of a union type, so it can be either required or optional (never)
     expect(
       allFiles(clientDir)
         .filter((f) => f.endsWith('.ts'))
-        .some((f) => /adapter\?: runtime.SqlDriverAdapterFactory/g.test(fs.readFileSync(f, 'utf8'))),
+        .some((f) => /adapter.*runtime\.SqlDriverAdapterFactory/g.test(fs.readFileSync(f, 'utf8'))),
     ).toBe(true)
   })
 

--- a/packages/client/tests/e2e/prisma-client-imports-mysql/tests/main.test.ts
+++ b/packages/client/tests/e2e/prisma-client-imports-mysql/tests/main.test.ts
@@ -54,7 +54,7 @@ function typeCheck(fileName: string, options: any) {
 
 function assertNoErrors(errors: readonly ts.Diagnostic[]) {
   if (errors.length > 0) {
-    errors.map(console.error)
+    errors.forEach((error) => console.error(error))
 
     throw new Error(`Test exited with ${errors.length} errors. See above for details.`)
   }

--- a/packages/client/tests/e2e/prisma-client-imports-postgres/tests/main.test.ts
+++ b/packages/client/tests/e2e/prisma-client-imports-postgres/tests/main.test.ts
@@ -54,7 +54,7 @@ function typeCheck(fileName: string, options: any) {
 
 function assertNoErrors(errors: readonly ts.Diagnostic[]) {
   if (errors.length > 0) {
-    errors.map(console.error)
+    errors.forEach((error) => console.error(error))
 
     throw new Error(`Test exited with ${errors.length} errors. See above for details.`)
   }

--- a/packages/client/tests/e2e/prisma-client-imports-sqlite/tests/main.test.ts
+++ b/packages/client/tests/e2e/prisma-client-imports-sqlite/tests/main.test.ts
@@ -94,7 +94,7 @@ function typeCheck(fileName: string, options: any) {
 
 function assertNoErrors(errors: readonly ts.Diagnostic[]) {
   if (errors.length > 0) {
-    errors.map(console.error)
+    errors.forEach((error) => console.error(error))
 
     throw new Error(`Test exited with ${errors.length} errors. See above for details.`)
   }

--- a/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/_steps.ts
+++ b/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/_steps.ts
@@ -1,0 +1,16 @@
+import { $ } from 'zx'
+
+import { executeSteps } from '../_utils/executeSteps'
+
+void executeSteps({
+  setup: async () => {
+    await $`pnpm install`
+    await $`pnpm prisma generate`
+  },
+  test: async () => {
+    await $`pnpm exec jest`
+  },
+  finish: async () => {
+    await $`echo "done"`
+  },
+})

--- a/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/jest.config.js
+++ b/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../jest.config')

--- a/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/package.json
+++ b/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/package.json
@@ -1,0 +1,20 @@
+{
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js",
+  "scripts": {},
+  "dependencies": {
+    "@prisma/adapter-pg": "/tmp/prisma-adapter-pg-0.0.0.tgz",
+    "@prisma/client": "/tmp/prisma-client-0.0.0.tgz",
+    "@prisma/client-runtime-utils": "/tmp/prisma-client-runtime-utils-0.0.0.tgz",
+    "@prisma/extension-accelerate": "1.2.1"
+  },
+  "devDependencies": {
+    "@types/jest": "29.5.12",
+    "@types/node": "~20.19.0",
+    "@types/pg": "8.11.6",
+    "expect-type": "0.19.0",
+    "prisma": "/tmp/prisma-0.0.0.tgz",
+    "typescript": "5.9.3"
+  }
+}

--- a/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/pnpm-lock.yaml
+++ b/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/pnpm-lock.yaml
@@ -1,0 +1,1309 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@prisma/adapter-pg':
+        specifier: /tmp/prisma-adapter-pg-0.0.0.tgz
+        version: file:../../tmp/prisma-adapter-pg-0.0.0.tgz
+      '@prisma/client':
+        specifier: /tmp/prisma-client-0.0.0.tgz
+        version: file:../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3))(typescript@5.9.3)
+      '@prisma/client-runtime-utils':
+        specifier: /tmp/prisma-client-runtime-utils-0.0.0.tgz
+        version: file:../../tmp/prisma-client-runtime-utils-0.0.0.tgz
+      '@prisma/extension-accelerate':
+        specifier: 1.2.1
+        version: 1.2.1(@prisma/client@file:../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3))(typescript@5.9.3))
+    devDependencies:
+      '@types/jest':
+        specifier: 29.5.12
+        version: 29.5.12
+      '@types/node':
+        specifier: ~20.19.0
+        version: 20.19.25
+      '@types/pg':
+        specifier: 8.11.6
+        version: 8.11.6
+      expect-type:
+        specifier: 0.19.0
+        version: 0.19.0
+      prisma:
+        specifier: /tmp/prisma-0.0.0.tgz
+        version: file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
+packages:
+
+  '@babel/code-frame@7.27.1':
+    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@chevrotain/cst-dts-gen@10.5.0':
+    resolution: {integrity: sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==}
+
+  '@chevrotain/gast@10.5.0':
+    resolution: {integrity: sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==}
+
+  '@chevrotain/types@10.5.0':
+    resolution: {integrity: sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A==}
+
+  '@chevrotain/utils@10.5.0':
+    resolution: {integrity: sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==}
+
+  '@electric-sql/pglite-socket@0.0.6':
+    resolution: {integrity: sha512-6RjmgzphIHIBA4NrMGJsjNWK4pu+bCWJlEWlwcxFTVY3WT86dFpKwbZaGWZV6C5Rd7sCk1Z0CI76QEfukLAUXw==}
+    hasBin: true
+    peerDependencies:
+      '@electric-sql/pglite': 0.3.2
+
+  '@electric-sql/pglite-tools@0.2.7':
+    resolution: {integrity: sha512-9dAccClqxx4cZB+Ar9B+FZ5WgxDc/Xvl9DPrTWv+dYTf0YNubLzi4wHHRGRGhrJv15XwnyKcGOZAP1VXSneSUg==}
+    peerDependencies:
+      '@electric-sql/pglite': 0.3.2
+
+  '@electric-sql/pglite@0.3.2':
+    resolution: {integrity: sha512-zfWWa+V2ViDCY/cmUfRqeWY1yLto+EpxjXnZzenB1TyxsTiXaTWeZFIZw6mac52BsuQm0RjCnisjBtdBaXOI6w==}
+
+  '@hono/node-server@1.14.2':
+    resolution: {integrity: sha512-GHjpOeHYbr9d1vkID2sNUYkl5IxumyhDrUJB7wBp7jvqYwPFt+oNKsAPBRcdSbV7kIrXhouLE199ks1QcK4r7A==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
+  '@jest/expect-utils@29.7.0':
+    resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/types@29.6.3':
+    resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@mrleebo/prisma-ast@0.12.1':
+    resolution: {integrity: sha512-JwqeCQ1U3fvccttHZq7Tk0m/TMC6WcFAQZdukypW3AzlJYKYTGNVd1ANU2GuhKnv4UQuOFj3oAl0LLG/gxFN1w==}
+    engines: {node: '>=16'}
+
+  '@prisma/adapter-pg@file:../../tmp/prisma-adapter-pg-0.0.0.tgz':
+    resolution: {integrity: sha512-NiiuZdB8xTee9mRjeZmr4tMiB4jcVRWgbtFO32oKGWgz6CCjSFc0n1TWjWSjMex835f0jQiRnAqtA44gOf0i+A==, tarball: file:../../tmp/prisma-adapter-pg-0.0.0.tgz}
+    version: 0.0.0
+
+  '@prisma/client-runtime-utils@file:../../tmp/prisma-client-runtime-utils-0.0.0.tgz':
+    resolution: {integrity: sha512-IcyD8XBHqp0Ze0fs6auYRnDE+TauiB48i8u0G18QHxVKWgCIkYcUOuibXoNckf+0U+0uwUKWsjmRO7LGIGwf0g==, tarball: file:../../tmp/prisma-client-runtime-utils-0.0.0.tgz}
+    version: 0.0.0
+
+  '@prisma/client@file:../../tmp/prisma-client-0.0.0.tgz':
+    resolution: {integrity: sha512-gf6sLDTGeMleihxYleA4EdCEXn0ss/UKf6LOldcBIuzEQ/j7rGyABZXJfY64jvQecvQVAXBfsg7INIMUCxMASQ==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
+    version: 0.0.0
+    engines: {node: ^20.19 || ^22.12 || ^24.0}
+    peerDependencies:
+      prisma: '*'
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      prisma:
+        optional: true
+      typescript:
+        optional: true
+
+  '@prisma/config@file:../../tmp/prisma-config-0.0.0.tgz':
+    resolution: {integrity: sha512-pxcBXEzlmTwGaPoBjrvLYWBhFmWI/rP1h8zbWYwgg2k54OWrTRT8ROHeuIA+yF9FeIDoAW/CLmfTBGVU6dQTUA==, tarball: file:../../tmp/prisma-config-0.0.0.tgz}
+    version: 0.0.0
+
+  '@prisma/debug@6.8.2':
+    resolution: {integrity: sha512-4muBSSUwJJ9BYth5N8tqts8JtiLT8QI/RSAzEogwEfpbYGFo9mYsInsVo8dqXdPO2+Rm5OG5q0qWDDE3nyUbVg==}
+
+  '@prisma/debug@file:../../tmp/prisma-debug-0.0.0.tgz':
+    resolution: {integrity: sha512-xwBwOQ7KdoIGiPFO1j4+5rS+anS/QuHm4VvktwLv3ASbOZoFkCCG8X8QrbRRXS7KoblRFep+sr3Kiaa7Q3y6Tw==, tarball: file:../../tmp/prisma-debug-0.0.0.tgz}
+    version: 0.0.0
+
+  '@prisma/dev@0.13.0':
+    resolution: {integrity: sha512-QMmF6zFeUF78yv1HYbHvod83AQnl7u6NtKyDhTRZOJup3h1icWs8R7RUVxBJZvM2tBXNAMpLQYYM/8kPlOPegA==}
+
+  '@prisma/driver-adapter-utils@file:../../tmp/prisma-driver-adapter-utils-0.0.0.tgz':
+    resolution: {integrity: sha512-d7qYqZGFogvxfB0RJadqONOX04Dg0MHoIIJT2GNyGIZa0udigBUwcek1tq3eqc/JCBbbuVGGeDz3xm1jdHwjgg==, tarball: file:../../tmp/prisma-driver-adapter-utils-0.0.0.tgz}
+    version: 0.0.0
+
+  '@prisma/engines-version@6.20.0-16.next-0c19ccc313cf9911a90d99d2ac2eb0280c76c513':
+    resolution: {integrity: sha512-7bzyN8Gp9GbDFbTDzVUH9nFcgRWvsWmjrGgBJvIC/zEoAuv/lx62gZXgAKfjn/HoPkxz/dS+TtsnduFx8WA+cw==}
+
+  '@prisma/engines@file:../../tmp/prisma-engines-0.0.0.tgz':
+    resolution: {integrity: sha512-6eFbUS5JpDXPsRa2R75oGP0oMBfhPUbwRIB8a0D45GGPsGtNrJiDMTRVkdC0/mD6OA+Ob2sXv9T1kfVr8FhU/w==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
+    version: 0.0.0
+
+  '@prisma/extension-accelerate@1.2.1':
+    resolution: {integrity: sha512-QicnMeyqL226ilT3vvRsFAqPeIdqHGKR4c25CoK5zZ1tNIv8egfgpD1gCKqOGmfAz0pIKQnMuJU3eNg9KItC7A==}
+    version: 1.2.1
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@prisma/client': '>=4.16.1'
+
+  '@prisma/fetch-engine@file:../../tmp/prisma-fetch-engine-0.0.0.tgz':
+    resolution: {integrity: sha512-TkYMwgQ9DMI6c8EoQ3GWEz9Zz2DLp5PSw4RnShflHk0ITou0uQHsa8IrU66NTD7JEpUAXl3lE0xkN/8IubxM1w==, tarball: file:../../tmp/prisma-fetch-engine-0.0.0.tgz}
+    version: 0.0.0
+
+  '@prisma/get-platform@6.8.2':
+    resolution: {integrity: sha512-vXSxyUgX3vm1Q70QwzwkjeYfRryIvKno1SXbIqwSptKwqKzskINnDUcx85oX+ys6ooN2ATGSD0xN2UTfg6Zcow==}
+
+  '@prisma/get-platform@file:../../tmp/prisma-get-platform-0.0.0.tgz':
+    resolution: {integrity: sha512-YWRktPGwoKjvuwCzQD8toAITiQcJ1NOrCyRyneECah6f+wMSysXvXcgHWYSXnlc1nddXMjbfFeMP9pMPdFfukQ==, tarball: file:../../tmp/prisma-get-platform-0.0.0.tgz}
+    version: 0.0.0
+
+  '@prisma/query-plan-executor@6.18.0':
+    resolution: {integrity: sha512-jZ8cfzFgL0jReE1R10gT8JLHtQxjWYLiQ//wHmVYZ2rVkFHoh0DT8IXsxcKcFlfKN7ak7k6j0XMNn2xVNyr5cA==}
+
+  '@prisma/studio-core-licensed@0.0.0-dev.202511162338':
+    resolution: {integrity: sha512-n55i0gxsW0/05DHSDPLdW9yv/+4SyeQKt1kay2TpjLIEXvp7+edqxY3vx34VMLFakksLJ1wmM+6UwN6q96dYuA==}
+    peerDependencies:
+      '@types/react': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@sinclair/typebox@0.27.8':
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
+  '@types/istanbul-lib-coverage@2.0.6':
+    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
+
+  '@types/istanbul-lib-report@3.0.3':
+    resolution: {integrity: sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==}
+
+  '@types/istanbul-reports@3.0.4':
+    resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
+
+  '@types/jest@29.5.12':
+    resolution: {integrity: sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==}
+
+  '@types/node@20.19.25':
+    resolution: {integrity: sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==}
+
+  '@types/pg@8.11.6':
+    resolution: {integrity: sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==}
+
+  '@types/react@19.2.6':
+    resolution: {integrity: sha512-p/jUvulfgU7oKtj6Xpk8cA2Y1xKTtICGpJYeJXz2YVO2UcvjQgeRMLDGfDeqeRW2Ta+0QNFwcc8X3GH8SxZz6w==}
+
+  '@types/stack-utils@2.0.3':
+    resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/yargs-parser@21.0.3':
+    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
+
+  '@types/yargs@17.0.35':
+    resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  aws-ssl-profiles@1.1.2:
+    resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
+    engines: {node: '>= 6.0.0'}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  c12@3.1.0:
+    resolution: {integrity: sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==}
+    peerDependencies:
+      magicast: ^0.3.5
+    peerDependenciesMeta:
+      magicast:
+        optional: true
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  chevrotain@10.5.0:
+    resolution: {integrity: sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  ci-info@3.9.0:
+    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+    engines: {node: '>=8'}
+
+  citty@0.1.6:
+    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  confbox@0.2.2:
+    resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  deepmerge-ts@7.1.5:
+    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
+    engines: {node: '>=16.0.0'}
+
+  defu@6.1.4:
+    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
+
+  destr@2.0.5:
+    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  effect@3.18.4:
+    resolution: {integrity: sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==}
+
+  empathic@2.0.0:
+    resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
+    engines: {node: '>=14'}
+
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
+
+  expect-type@0.19.0:
+    resolution: {integrity: sha512-piv9wz3IrAG4Wnk2A+n2VRCHieAyOSxrRLU872Xo6nyn39kYXKDALk4OcqnvLRnFvkz659CnWC8MWZLuuQnoqg==}
+    engines: {node: '>=12.0.0'}
+
+  expect@29.7.0:
+    resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  exsolve@1.0.8:
+    resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
+  generate-function@2.3.1:
+    resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
+
+  get-port-please@3.1.2:
+    resolution: {integrity: sha512-Gxc29eLs1fbn6LQ4jSU4vXjlwyZhF5HsGuMAa7gqBP4Rw4yxxltyDUuF5MBclFzDTXO+ACchGQoeela4DSfzdQ==}
+
+  giget@2.0.0:
+    resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
+    hasBin: true
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  grammex@3.1.11:
+    resolution: {integrity: sha512-HNwLkgRg9SqTAd1N3Uh/MnKwTBTzwBxTOPbXQ8pb0tpwydjk90k4zRE8JUn9fMUiRwKtXFZ1TWFmms3dZHN+Fg==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  hono@4.7.10:
+    resolution: {integrity: sha512-QkACju9MiN59CKSY5JsGZCYmPZkA6sIW6OFCUp7qDjZu6S6KHtJHhAc9Uy9mV9F8PJ1/HQ3ybZF2yjCa/73fvQ==}
+    engines: {node: '>=16.9.0'}
+
+  http-status-codes@2.3.0:
+    resolution: {integrity: sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==}
+
+  iconv-lite@0.7.0:
+    resolution: {integrity: sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-property@1.0.2:
+    resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jest-diff@29.7.0:
+    resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-get-type@29.6.3:
+    resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-matcher-utils@29.7.0:
+    resolution: {integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-message-util@29.7.0:
+    resolution: {integrity: sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-util@29.7.0:
+    resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  lilconfig@2.1.0:
+    resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
+    engines: {node: '>=10'}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  lru-cache@7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
+
+  lru.min@1.1.3:
+    resolution: {integrity: sha512-Lkk/vx6ak3rYkRR0Nhu4lFUT2VDnQSxBe8Hbl7f36358p6ow8Bnvr8lrLt98H8J1aGxfhbX4Fs5tYg2+FTwr5Q==}
+    engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  mysql2@3.15.3:
+    resolution: {integrity: sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==}
+    engines: {node: '>= 8.0'}
+
+  named-placeholders@1.1.3:
+    resolution: {integrity: sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==}
+    engines: {node: '>=12.0.0'}
+
+  node-fetch-native@1.6.7:
+    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  nypm@0.6.2:
+    resolution: {integrity: sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==}
+    engines: {node: ^14.16.0 || >=16.10.0}
+    hasBin: true
+
+  obuf@1.1.2:
+    resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
+
+  ohash@2.0.11:
+    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  perfect-debounce@1.0.0:
+    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+
+  pg-cloudflare@1.2.7:
+    resolution: {integrity: sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==}
+
+  pg-connection-string@2.9.1:
+    resolution: {integrity: sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-numeric@1.0.2:
+    resolution: {integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==}
+    engines: {node: '>=4'}
+
+  pg-pool@3.10.1:
+    resolution: {integrity: sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.10.3:
+    resolution: {integrity: sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg-types@4.1.0:
+    resolution: {integrity: sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg==}
+    engines: {node: '>=10'}
+
+  pg@8.16.3:
+    resolution: {integrity: sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+
+  pkg-types@2.3.0:
+    resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-array@3.0.4:
+    resolution: {integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==}
+    engines: {node: '>=12'}
+
+  postgres-bytea@1.0.0:
+    resolution: {integrity: sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-bytea@3.0.0:
+    resolution: {integrity: sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==}
+    engines: {node: '>= 6'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@2.1.0:
+    resolution: {integrity: sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==}
+    engines: {node: '>=12'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@3.0.0:
+    resolution: {integrity: sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==}
+    engines: {node: '>=12'}
+
+  postgres-range@1.1.4:
+    resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
+
+  postgres@3.4.7:
+    resolution: {integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==}
+    engines: {node: '>=12'}
+
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  prisma@file:../../tmp/prisma-0.0.0.tgz:
+    resolution: {integrity: sha512-t7hoftgkmjYO/TC4Ygn0JuAw4rJDlZhktbL+619WKWfBF7a/qKRoNaKjoKtIlCD/dfpThhdOkzxuFvwJpVhwiw==, tarball: file:../../tmp/prisma-0.0.0.tgz}
+    version: 0.0.0
+    engines: {node: ^20.19 || ^22.12 || ^24.0}
+    hasBin: true
+    peerDependencies:
+      better-sqlite3: '>=9.0.0'
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      better-sqlite3:
+        optional: true
+      typescript:
+        optional: true
+
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  rc9@2.1.2:
+    resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
+
+  react-dom@19.2.0:
+    resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
+    peerDependencies:
+      react: ^19.2.0
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react@19.2.0:
+    resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
+    engines: {node: '>=0.10.0'}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  regexp-to-ast@0.5.0:
+    resolution: {integrity: sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==}
+
+  remeda@2.21.3:
+    resolution: {integrity: sha512-XXrZdLA10oEOQhLLzEJEiFFSKi21REGAkHdImIb4rt/XXy8ORGXh5HCcpUOsElfPNDb+X6TA/+wkh+p2KffYmg==}
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  seq-queue@0.0.5:
+    resolution: {integrity: sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
+  sqlstring@2.3.3:
+    resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
+    engines: {node: '>= 0.6'}
+
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  valibot@1.1.0:
+    resolution: {integrity: sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
+  zeptomatch@2.0.2:
+    resolution: {integrity: sha512-H33jtSKf8Ijtb5BW6wua3G5DhnFjbFML36eFu+VdOoVY4HD9e7ggjqdM6639B+L87rjnR6Y+XeRzBXZdy52B/g==}
+
+snapshots:
+
+  '@babel/code-frame@7.27.1':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@chevrotain/cst-dts-gen@10.5.0':
+    dependencies:
+      '@chevrotain/gast': 10.5.0
+      '@chevrotain/types': 10.5.0
+      lodash: 4.17.21
+
+  '@chevrotain/gast@10.5.0':
+    dependencies:
+      '@chevrotain/types': 10.5.0
+      lodash: 4.17.21
+
+  '@chevrotain/types@10.5.0': {}
+
+  '@chevrotain/utils@10.5.0': {}
+
+  '@electric-sql/pglite-socket@0.0.6(@electric-sql/pglite@0.3.2)':
+    dependencies:
+      '@electric-sql/pglite': 0.3.2
+
+  '@electric-sql/pglite-tools@0.2.7(@electric-sql/pglite@0.3.2)':
+    dependencies:
+      '@electric-sql/pglite': 0.3.2
+
+  '@electric-sql/pglite@0.3.2': {}
+
+  '@hono/node-server@1.14.2(hono@4.7.10)':
+    dependencies:
+      hono: 4.7.10
+
+  '@jest/expect-utils@29.7.0':
+    dependencies:
+      jest-get-type: 29.6.3
+
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.8
+
+  '@jest/types@29.6.3':
+    dependencies:
+      '@jest/schemas': 29.6.3
+      '@types/istanbul-lib-coverage': 2.0.6
+      '@types/istanbul-reports': 3.0.4
+      '@types/node': 20.19.25
+      '@types/yargs': 17.0.35
+      chalk: 4.1.2
+
+  '@mrleebo/prisma-ast@0.12.1':
+    dependencies:
+      chevrotain: 10.5.0
+      lilconfig: 2.1.0
+
+  '@prisma/adapter-pg@file:../../tmp/prisma-adapter-pg-0.0.0.tgz':
+    dependencies:
+      '@prisma/driver-adapter-utils': file:../../tmp/prisma-driver-adapter-utils-0.0.0.tgz
+      pg: 8.16.3
+      postgres-array: 3.0.4
+    transitivePeerDependencies:
+      - pg-native
+
+  '@prisma/client-runtime-utils@file:../../tmp/prisma-client-runtime-utils-0.0.0.tgz': {}
+
+  '@prisma/client@file:../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3))(typescript@5.9.3)':
+    dependencies:
+      '@prisma/client-runtime-utils': file:../../tmp/prisma-client-runtime-utils-0.0.0.tgz
+    optionalDependencies:
+      prisma: file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@prisma/config@file:../../tmp/prisma-config-0.0.0.tgz':
+    dependencies:
+      c12: 3.1.0
+      deepmerge-ts: 7.1.5
+      effect: 3.18.4
+      empathic: 2.0.0
+    transitivePeerDependencies:
+      - magicast
+
+  '@prisma/debug@6.8.2': {}
+
+  '@prisma/debug@file:../../tmp/prisma-debug-0.0.0.tgz': {}
+
+  '@prisma/dev@0.13.0(typescript@5.9.3)':
+    dependencies:
+      '@electric-sql/pglite': 0.3.2
+      '@electric-sql/pglite-socket': 0.0.6(@electric-sql/pglite@0.3.2)
+      '@electric-sql/pglite-tools': 0.2.7(@electric-sql/pglite@0.3.2)
+      '@hono/node-server': 1.14.2(hono@4.7.10)
+      '@mrleebo/prisma-ast': 0.12.1
+      '@prisma/get-platform': 6.8.2
+      '@prisma/query-plan-executor': 6.18.0
+      foreground-child: 3.3.1
+      get-port-please: 3.1.2
+      hono: 4.7.10
+      http-status-codes: 2.3.0
+      pathe: 2.0.3
+      proper-lockfile: 4.1.2
+      remeda: 2.21.3
+      std-env: 3.9.0
+      valibot: 1.1.0(typescript@5.9.3)
+      zeptomatch: 2.0.2
+    transitivePeerDependencies:
+      - typescript
+
+  '@prisma/driver-adapter-utils@file:../../tmp/prisma-driver-adapter-utils-0.0.0.tgz':
+    dependencies:
+      '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
+
+  '@prisma/engines-version@6.20.0-16.next-0c19ccc313cf9911a90d99d2ac2eb0280c76c513': {}
+
+  '@prisma/engines@file:../../tmp/prisma-engines-0.0.0.tgz':
+    dependencies:
+      '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
+      '@prisma/engines-version': 6.20.0-16.next-0c19ccc313cf9911a90d99d2ac2eb0280c76c513
+      '@prisma/fetch-engine': file:../../tmp/prisma-fetch-engine-0.0.0.tgz
+      '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
+
+  '@prisma/extension-accelerate@1.2.1(@prisma/client@file:../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3))(typescript@5.9.3))':
+    dependencies:
+      '@prisma/client': file:../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3))(typescript@5.9.3)
+
+  '@prisma/fetch-engine@file:../../tmp/prisma-fetch-engine-0.0.0.tgz':
+    dependencies:
+      '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
+      '@prisma/engines-version': 6.20.0-16.next-0c19ccc313cf9911a90d99d2ac2eb0280c76c513
+      '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
+
+  '@prisma/get-platform@6.8.2':
+    dependencies:
+      '@prisma/debug': 6.8.2
+
+  '@prisma/get-platform@file:../../tmp/prisma-get-platform-0.0.0.tgz':
+    dependencies:
+      '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
+
+  '@prisma/query-plan-executor@6.18.0': {}
+
+  '@prisma/studio-core-licensed@0.0.0-dev.202511162338(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@types/react': 19.2.6
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+
+  '@sinclair/typebox@0.27.8': {}
+
+  '@standard-schema/spec@1.0.0': {}
+
+  '@types/istanbul-lib-coverage@2.0.6': {}
+
+  '@types/istanbul-lib-report@3.0.3':
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.6
+
+  '@types/istanbul-reports@3.0.4':
+    dependencies:
+      '@types/istanbul-lib-report': 3.0.3
+
+  '@types/jest@29.5.12':
+    dependencies:
+      expect: 29.7.0
+      pretty-format: 29.7.0
+
+  '@types/node@20.19.25':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/pg@8.11.6':
+    dependencies:
+      '@types/node': 20.19.25
+      pg-protocol: 1.10.3
+      pg-types: 4.1.0
+
+  '@types/react@19.2.6':
+    dependencies:
+      csstype: 3.2.3
+
+  '@types/stack-utils@2.0.3': {}
+
+  '@types/yargs-parser@21.0.3': {}
+
+  '@types/yargs@17.0.35':
+    dependencies:
+      '@types/yargs-parser': 21.0.3
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
+
+  aws-ssl-profiles@1.1.2: {}
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  c12@3.1.0:
+    dependencies:
+      chokidar: 4.0.3
+      confbox: 0.2.2
+      defu: 6.1.4
+      dotenv: 16.6.1
+      exsolve: 1.0.8
+      giget: 2.0.0
+      jiti: 2.6.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 1.0.0
+      pkg-types: 2.3.0
+      rc9: 2.1.2
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  chevrotain@10.5.0:
+    dependencies:
+      '@chevrotain/cst-dts-gen': 10.5.0
+      '@chevrotain/gast': 10.5.0
+      '@chevrotain/types': 10.5.0
+      '@chevrotain/utils': 10.5.0
+      lodash: 4.17.21
+      regexp-to-ast: 0.5.0
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  ci-info@3.9.0: {}
+
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  confbox@0.2.2: {}
+
+  consola@3.4.2: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  csstype@3.2.3: {}
+
+  deepmerge-ts@7.1.5: {}
+
+  defu@6.1.4: {}
+
+  denque@2.1.0: {}
+
+  destr@2.0.5: {}
+
+  diff-sequences@29.6.3: {}
+
+  dotenv@16.6.1: {}
+
+  effect@3.18.4:
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      fast-check: 3.23.2
+
+  empathic@2.0.0: {}
+
+  escape-string-regexp@2.0.0: {}
+
+  expect-type@0.19.0: {}
+
+  expect@29.7.0:
+    dependencies:
+      '@jest/expect-utils': 29.7.0
+      jest-get-type: 29.6.3
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+
+  exsolve@1.0.8: {}
+
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  generate-function@2.3.1:
+    dependencies:
+      is-property: 1.0.2
+
+  get-port-please@3.1.2: {}
+
+  giget@2.0.0:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.2
+      defu: 6.1.4
+      node-fetch-native: 1.6.7
+      nypm: 0.6.2
+      pathe: 2.0.3
+
+  graceful-fs@4.2.11: {}
+
+  grammex@3.1.11: {}
+
+  has-flag@4.0.0: {}
+
+  hono@4.7.10: {}
+
+  http-status-codes@2.3.0: {}
+
+  iconv-lite@0.7.0:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  is-number@7.0.0: {}
+
+  is-property@1.0.2: {}
+
+  isexe@2.0.0: {}
+
+  jest-diff@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.6.3
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-get-type@29.6.3: {}
+
+  jest-matcher-utils@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-message-util@29.7.0:
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@jest/types': 29.6.3
+      '@types/stack-utils': 2.0.3
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      stack-utils: 2.0.6
+
+  jest-util@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.25
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      graceful-fs: 4.2.11
+      picomatch: 2.3.1
+
+  jiti@2.6.1: {}
+
+  js-tokens@4.0.0: {}
+
+  lilconfig@2.1.0: {}
+
+  lodash@4.17.21: {}
+
+  long@5.3.2: {}
+
+  lru-cache@7.18.3: {}
+
+  lru.min@1.1.3: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.1
+
+  mysql2@3.15.3:
+    dependencies:
+      aws-ssl-profiles: 1.1.2
+      denque: 2.1.0
+      generate-function: 2.3.1
+      iconv-lite: 0.7.0
+      long: 5.3.2
+      lru.min: 1.1.3
+      named-placeholders: 1.1.3
+      seq-queue: 0.0.5
+      sqlstring: 2.3.3
+
+  named-placeholders@1.1.3:
+    dependencies:
+      lru-cache: 7.18.3
+
+  node-fetch-native@1.6.7: {}
+
+  nypm@0.6.2:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.2
+      pathe: 2.0.3
+      pkg-types: 2.3.0
+      tinyexec: 1.0.2
+
+  obuf@1.1.2: {}
+
+  ohash@2.0.11: {}
+
+  path-key@3.1.1: {}
+
+  pathe@2.0.3: {}
+
+  perfect-debounce@1.0.0: {}
+
+  pg-cloudflare@1.2.7:
+    optional: true
+
+  pg-connection-string@2.9.1: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-numeric@1.0.2: {}
+
+  pg-pool@3.10.1(pg@8.16.3):
+    dependencies:
+      pg: 8.16.3
+
+  pg-protocol@1.10.3: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.0
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg-types@4.1.0:
+    dependencies:
+      pg-int8: 1.0.1
+      pg-numeric: 1.0.2
+      postgres-array: 3.0.4
+      postgres-bytea: 3.0.0
+      postgres-date: 2.1.0
+      postgres-interval: 3.0.0
+      postgres-range: 1.1.4
+
+  pg@8.16.3:
+    dependencies:
+      pg-connection-string: 2.9.1
+      pg-pool: 3.10.1(pg@8.16.3)
+      pg-protocol: 1.10.3
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.2.7
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
+  picocolors@1.1.1: {}
+
+  picomatch@2.3.1: {}
+
+  pkg-types@2.3.0:
+    dependencies:
+      confbox: 0.2.2
+      exsolve: 1.0.8
+      pathe: 2.0.3
+
+  postgres-array@2.0.0: {}
+
+  postgres-array@3.0.4: {}
+
+  postgres-bytea@1.0.0: {}
+
+  postgres-bytea@3.0.0:
+    dependencies:
+      obuf: 1.1.2
+
+  postgres-date@1.0.7: {}
+
+  postgres-date@2.1.0: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
+  postgres-interval@3.0.0: {}
+
+  postgres-range@1.1.4: {}
+
+  postgres@3.4.7: {}
+
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
+  prisma@file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3):
+    dependencies:
+      '@prisma/config': file:../../tmp/prisma-config-0.0.0.tgz
+      '@prisma/dev': 0.13.0(typescript@5.9.3)
+      '@prisma/engines': file:../../tmp/prisma-engines-0.0.0.tgz
+      '@prisma/studio-core-licensed': 0.0.0-dev.202511162338(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      mysql2: 3.15.3
+      postgres: 3.4.7
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/react'
+      - magicast
+      - react
+      - react-dom
+
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
+  pure-rand@6.1.0: {}
+
+  rc9@2.1.2:
+    dependencies:
+      defu: 6.1.4
+      destr: 2.0.5
+
+  react-dom@19.2.0(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      scheduler: 0.27.0
+
+  react-is@18.3.1: {}
+
+  react@19.2.0: {}
+
+  readdirp@4.1.2: {}
+
+  regexp-to-ast@0.5.0: {}
+
+  remeda@2.21.3:
+    dependencies:
+      type-fest: 4.41.0
+
+  retry@0.12.0: {}
+
+  safer-buffer@2.1.2: {}
+
+  scheduler@0.27.0: {}
+
+  seq-queue@0.0.5: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  signal-exit@3.0.7: {}
+
+  signal-exit@4.1.0: {}
+
+  slash@3.0.0: {}
+
+  split2@4.2.0: {}
+
+  sqlstring@2.3.3: {}
+
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
+
+  std-env@3.9.0: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  tinyexec@1.0.2: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  type-fest@4.41.0: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  valibot@1.1.0(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  xtend@4.0.2: {}
+
+  zeptomatch@2.0.2:
+    dependencies:
+      grammex: 3.1.11

--- a/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/prisma.config.ts
+++ b/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/prisma.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'prisma/config'
+
+export default defineConfig({
+  datasource: {
+    url: 'file:./db',
+  },
+})

--- a/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/prisma/schema.prisma
+++ b/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/prisma/schema.prisma
@@ -1,0 +1,35 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+generator client {
+  provider = "prisma-client"
+  output   = "../src/generated/prisma"
+}
+
+datasource db {
+  provider = "postgresql"
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  name      String?
+  posts     Post[]
+  profile   Profile?
+}
+
+model Post {
+  id        Int      @id @default(autoincrement())
+  title     String
+  content   String?
+  published Boolean  @default(false)
+  author    User     @relation(fields: [authorId], references: [id])
+  authorId  Int
+}
+
+model Profile {
+  id     Int     @id @default(autoincrement())
+  bio    String?
+  user   User    @relation(fields: [userId], references: [id])
+  userId Int     @unique
+}

--- a/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/readme.md
+++ b/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/readme.md
@@ -1,0 +1,3 @@
+# Readme
+
+Test that we don't accidentally break types for the latest Accelerate.

--- a/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/readme.md
+++ b/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/readme.md
@@ -1,3 +1,3 @@
 # Readme
 
-Test that we don't accidentally break types for the latest Accelerate.
+This test suite validates the mutually exclusive constraint between `adapter` and `accelerateUrl` options, ensuring that at least one of them is required.

--- a/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/src/accelerate-adapter.ts
+++ b/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/src/accelerate-adapter.ts
@@ -1,0 +1,23 @@
+import { PrismaPg } from '@prisma/adapter-pg'
+import { withAccelerate } from '@prisma/extension-accelerate'
+import { expectTypeOf } from 'expect-type'
+
+import { PrismaClient } from './generated/prisma/client'
+
+async function main() {
+  const adapter = new PrismaPg({ connectionString: process.env.TEST_E2E_POSTGRES_URI! })
+  const prisma = new PrismaClient({
+    adapter,
+    accelerateUrl: 'prisma+postgresql://accelerate.example.com',
+  }).$extends(withAccelerate())
+
+  const user = await prisma.user.findFirst({
+    select: {
+      id: true,
+    },
+  })
+
+  expectTypeOf(user).toEqualTypeOf<{ id: number } | null>()
+}
+
+void main()

--- a/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/src/accelerate.ts
+++ b/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/src/accelerate.ts
@@ -1,0 +1,19 @@
+import { expectTypeOf } from 'expect-type'
+
+import { PrismaClient } from './generated/prisma/client'
+
+async function main() {
+  const prisma = new PrismaClient({
+    accelerateUrl: 'prisma+postgresql://accelerate.example.com',
+  })
+
+  const user = await prisma.user.findFirst({
+    select: {
+      id: true,
+    },
+  })
+
+  expectTypeOf(user).toEqualTypeOf<{ id: number } | null>()
+}
+
+void main()

--- a/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/src/adapter.ts
+++ b/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/src/adapter.ts
@@ -1,0 +1,21 @@
+import { PrismaPg } from '@prisma/adapter-pg'
+import { expectTypeOf } from 'expect-type'
+
+import { PrismaClient } from './generated/prisma/client'
+
+async function main() {
+  const adapter = new PrismaPg({ connectionString: process.env.TEST_E2E_POSTGRES_URI! })
+  const prisma = new PrismaClient({
+    adapter,
+  })
+
+  const user = await prisma.user.findFirst({
+    select: {
+      id: true,
+    },
+  })
+
+  expectTypeOf(user).toEqualTypeOf<{ id: number } | null>()
+}
+
+void main()

--- a/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/src/default.ts
+++ b/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/src/default.ts
@@ -1,0 +1,17 @@
+import { expectTypeOf } from 'expect-type'
+
+import { PrismaClient } from './generated/prisma/client'
+
+async function main() {
+  const prisma = new PrismaClient()
+
+  const user = await prisma.user.findFirst({
+    select: {
+      id: true,
+    },
+  })
+
+  expectTypeOf(user).toEqualTypeOf<{ id: number } | null>()
+}
+
+void main()

--- a/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/src/empty.ts
+++ b/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/src/empty.ts
@@ -1,0 +1,17 @@
+import { expectTypeOf } from 'expect-type'
+
+import { PrismaClient } from './generated/prisma/client'
+
+async function main() {
+  const prisma = new PrismaClient({})
+
+  const user = await prisma.user.findFirst({
+    select: {
+      id: true,
+    },
+  })
+
+  expectTypeOf(user).toEqualTypeOf<{ id: number } | null>()
+}
+
+void main()

--- a/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/tests/main.test.ts
+++ b/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/tests/main.test.ts
@@ -1,0 +1,65 @@
+import path from 'path'
+import * as ts from 'typescript'
+
+const baseTsConfig = require('../../tsconfig.base.json').compilerOptions
+
+const dirPath = path.join(__dirname, '..', 'src')
+const accelerateTs = path.resolve(dirPath, 'accelerate.ts')
+const adapterTs = path.resolve(dirPath, 'adapter.ts')
+const accelerateAndAdapterTs = path.resolve(dirPath, 'accelerate-adapter.ts')
+const defaultTs = path.resolve(dirPath, 'default.ts')
+const emptyTs = path.resolve(dirPath, 'empty.ts')
+
+describe('Typechecking', () => {
+  const options = { module: 'ES2022', moduleResolution: 'Bundler' } as const
+
+  test('constructor with accelerateUrl', () => {
+    typeCheck(accelerateTs, options)
+  })
+
+  test('constructor with adapter', () => {
+    typeCheck(adapterTs, options)
+  })
+
+  test('default constructor', () => {
+    expect(() => typeCheck(defaultTs, options)).toThrow()
+  })
+
+  test('empty constructor', () => {
+    expect(() => typeCheck(emptyTs, options)).toThrow()
+  })
+
+  test('constructor with both adapter and accelerateUrl', () => {
+    expect(() => typeCheck(accelerateAndAdapterTs, options)).toThrow()
+  })
+})
+
+function typeCheck(fileName: string, options: Record<string, string>) {
+  console.info(`Typechecking ${fileName} with options:`, options)
+
+  const fullOptions = ts.convertCompilerOptionsFromJson(
+    { ...baseTsConfig, ...options },
+    path.resolve(__dirname, '..', 'tsconfig.json'),
+  )
+
+  assertNoErrors(fullOptions.errors)
+
+  const program = ts.createProgram([fileName], fullOptions.options)
+
+  assertNoErrors(program.getConfigFileParsingDiagnostics())
+  assertNoErrors(program.getOptionsDiagnostics())
+  const sourceFile = program.getSourceFile(fileName)
+  if (!sourceFile) {
+    throw new Error(`Source file ${fileName} not found`)
+  }
+  assertNoErrors(program.getSemanticDiagnostics())
+  assertNoErrors(program.getSyntacticDiagnostics())
+}
+
+function assertNoErrors(errors: readonly ts.Diagnostic[]) {
+  if (errors.length > 0) {
+    errors.map(console.error)
+
+    throw new Error(`Test exited with ${errors.length} errors. See above for details.`)
+  }
+}

--- a/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/tests/main.test.ts
+++ b/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/tests/main.test.ts
@@ -58,7 +58,7 @@ function typeCheck(fileName: string, options: Record<string, string>) {
 
 function assertNoErrors(errors: readonly ts.Diagnostic[]) {
   if (errors.length > 0) {
-    errors.map(console.error)
+    errors.forEach((error) => console.error(error))
 
     throw new Error(`Test exited with ${errors.length} errors. See above for details.`)
   }

--- a/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/tsconfig.json
+++ b/packages/client/tests/e2e/prisma-client-mutually-exclusive-options/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.base.json",
+  "exclude": ["_steps.ts"],
+  "compilerOptions": {
+    "skipLibCheck": true
+  }
+}

--- a/packages/client/tests/e2e/typed-sql-query-compiler-adapter-libsql/pnpm-lock.yaml
+++ b/packages/client/tests/e2e/typed-sql-query-compiler-adapter-libsql/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: file:../../tmp/prisma-adapter-libsql-0.0.0.tgz
       '@prisma/client':
         specifier: /tmp/prisma-client-0.0.0.tgz
-        version: file:../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../tmp/prisma-0.0.0.tgz)
+        version: file:../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       '@prisma/client-runtime-utils':
         specifier: /tmp/prisma-client-runtime-utils-0.0.0.tgz
         version: file:../../tmp/prisma-client-runtime-utils-0.0.0.tgz
@@ -22,11 +22,11 @@ importers:
         specifier: 29.5.12
         version: 29.5.12
       '@types/node':
-        specifier: 18.19.76
-        version: 18.19.76
+        specifier: ~20.19.0
+        version: 20.19.25
       prisma:
         specifier: /tmp/prisma-0.0.0.tgz
-        version: file:../../tmp/prisma-0.0.0.tgz
+        version: file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
 packages:
 
@@ -37,6 +37,38 @@ packages:
   '@babel/helper-validator-identifier@7.27.1':
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
+
+  '@chevrotain/cst-dts-gen@10.5.0':
+    resolution: {integrity: sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==}
+
+  '@chevrotain/gast@10.5.0':
+    resolution: {integrity: sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==}
+
+  '@chevrotain/types@10.5.0':
+    resolution: {integrity: sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A==}
+
+  '@chevrotain/utils@10.5.0':
+    resolution: {integrity: sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==}
+
+  '@electric-sql/pglite-socket@0.0.6':
+    resolution: {integrity: sha512-6RjmgzphIHIBA4NrMGJsjNWK4pu+bCWJlEWlwcxFTVY3WT86dFpKwbZaGWZV6C5Rd7sCk1Z0CI76QEfukLAUXw==}
+    hasBin: true
+    peerDependencies:
+      '@electric-sql/pglite': 0.3.2
+
+  '@electric-sql/pglite-tools@0.2.7':
+    resolution: {integrity: sha512-9dAccClqxx4cZB+Ar9B+FZ5WgxDc/Xvl9DPrTWv+dYTf0YNubLzi4wHHRGRGhrJv15XwnyKcGOZAP1VXSneSUg==}
+    peerDependencies:
+      '@electric-sql/pglite': 0.3.2
+
+  '@electric-sql/pglite@0.3.2':
+    resolution: {integrity: sha512-zfWWa+V2ViDCY/cmUfRqeWY1yLto+EpxjXnZzenB1TyxsTiXaTWeZFIZw6mac52BsuQm0RjCnisjBtdBaXOI6w==}
+
+  '@hono/node-server@1.14.2':
+    resolution: {integrity: sha512-GHjpOeHYbr9d1vkID2sNUYkl5IxumyhDrUJB7wBp7jvqYwPFt+oNKsAPBRcdSbV7kIrXhouLE199ks1QcK4r7A==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@jest/expect-utils@29.7.0':
     resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
@@ -101,24 +133,28 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@mrleebo/prisma-ast@0.12.1':
+    resolution: {integrity: sha512-JwqeCQ1U3fvccttHZq7Tk0m/TMC6WcFAQZdukypW3AzlJYKYTGNVd1ANU2GuhKnv4UQuOFj3oAl0LLG/gxFN1w==}
+    engines: {node: '>=16'}
+
   '@neon-rs/load@0.0.4':
     resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
 
   '@prisma/adapter-libsql@file:../../tmp/prisma-adapter-libsql-0.0.0.tgz':
-    resolution: {integrity: sha512-kjhF+V8GKC6OrX9uvVIanbotLJijBWo1DCzSUYw/AUQagL0UAgyWGHYCMzOE0qbkzLvLuAoslCtPAokZpB2gwQ==, tarball: file:../../tmp/prisma-adapter-libsql-0.0.0.tgz}
+    resolution: {integrity: sha512-hhfedU3TnZh2G02JFWHg/4yIivBceCkLGYBEb3nECbjw7xxHSLMyhswnOpEtrpt5LthgkZsXg30Kh6Ncc0HeQQ==, tarball: file:../../tmp/prisma-adapter-libsql-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/client-runtime-utils@file:../../tmp/prisma-client-runtime-utils-0.0.0.tgz':
-    resolution: {integrity: sha512-5+IiQZCqlXeAVXN8qVaTM2rB/4GcRoGItZaGwmv9th/3LJIO3CPybYwe9buZ/cGz6mjItRT3r/m/unp65SX2nw==, tarball: file:../../tmp/prisma-client-runtime-utils-0.0.0.tgz}
+    resolution: {integrity: sha512-IcyD8XBHqp0Ze0fs6auYRnDE+TauiB48i8u0G18QHxVKWgCIkYcUOuibXoNckf+0U+0uwUKWsjmRO7LGIGwf0g==, tarball: file:../../tmp/prisma-client-runtime-utils-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/client@file:../../tmp/prisma-client-0.0.0.tgz':
-    resolution: {integrity: sha512-awG0NLhd2QNGKOrm3nN4vgspkRyiY/MJ3zJiB70z7wmePGYPLyQaDvO9PFhDw1Cm/A+g2PxoWaY8uUJST1hWmg==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
+    resolution: {integrity: sha512-NJVbJWQSRYyANk7GsHxjehvtQlOCGUzwm7z1bOvLuFl0yQjXyc0atXxvj28yPFkopKpfySKfVY570wlPU9xaCg==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
     version: 0.0.0
-    engines: {node: '>=18.18'}
+    engines: {node: ^20.19 || ^22.12 || ^24.0}
     peerDependencies:
       prisma: '*'
-      typescript: '>=5.1.0'
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       prisma:
         optional: true
@@ -126,31 +162,50 @@ packages:
         optional: true
 
   '@prisma/config@file:../../tmp/prisma-config-0.0.0.tgz':
-    resolution: {integrity: sha512-0eenHDezziqGwPgVDPQpPaKhi+5o5LV/r2yqw6VEPJhYjGQAVcqF64NjqjvVJ6fdfOjRwDjly2cvccadnIyUyw==, tarball: file:../../tmp/prisma-config-0.0.0.tgz}
+    resolution: {integrity: sha512-o3cZUACS55MEwksnBnBqlW4worlSFSVL8kMT17fwtsKFZ93AN2d1T5AS3/GGLForC6DVMRsyjeF02SH29N+1Gg==, tarball: file:../../tmp/prisma-config-0.0.0.tgz}
     version: 0.0.0
+
+  '@prisma/debug@6.8.2':
+    resolution: {integrity: sha512-4muBSSUwJJ9BYth5N8tqts8JtiLT8QI/RSAzEogwEfpbYGFo9mYsInsVo8dqXdPO2+Rm5OG5q0qWDDE3nyUbVg==}
 
   '@prisma/debug@file:../../tmp/prisma-debug-0.0.0.tgz':
-    resolution: {integrity: sha512-98qifti7v9JEB4/qwa/6EZed0Wet1EW1cufnsuuDR+6c3+JOMq67cCZq3e+yKHh3164eoIEsHMeSiP8dc2dHcw==, tarball: file:../../tmp/prisma-debug-0.0.0.tgz}
+    resolution: {integrity: sha512-xwBwOQ7KdoIGiPFO1j4+5rS+anS/QuHm4VvktwLv3ASbOZoFkCCG8X8QrbRRXS7KoblRFep+sr3Kiaa7Q3y6Tw==, tarball: file:../../tmp/prisma-debug-0.0.0.tgz}
     version: 0.0.0
+
+  '@prisma/dev@0.13.0':
+    resolution: {integrity: sha512-QMmF6zFeUF78yv1HYbHvod83AQnl7u6NtKyDhTRZOJup3h1icWs8R7RUVxBJZvM2tBXNAMpLQYYM/8kPlOPegA==}
 
   '@prisma/driver-adapter-utils@file:../../tmp/prisma-driver-adapter-utils-0.0.0.tgz':
-    resolution: {integrity: sha512-aPWIP9yk1lhfIFliaKmmI/Rfc28JPo9KA0DMwGyAbMLDCFnKjQn49OLDHwIMNGeWtQSkClIR0by8Odhvmz7cOQ==, tarball: file:../../tmp/prisma-driver-adapter-utils-0.0.0.tgz}
+    resolution: {integrity: sha512-d7qYqZGFogvxfB0RJadqONOX04Dg0MHoIIJT2GNyGIZa0udigBUwcek1tq3eqc/JCBbbuVGGeDz3xm1jdHwjgg==, tarball: file:../../tmp/prisma-driver-adapter-utils-0.0.0.tgz}
     version: 0.0.0
 
-  '@prisma/engines-version@6.17.0-9.12b56ce9a668d64ffb8e8d40021d982d39f96e3b':
-    resolution: {integrity: sha512-TkPi9tZV0sJOK7wtrV+QBqx7O+L+4xwO3EmHB06F/36fYpyGPRWeLafYwbAtewt76zs0r8XDVZKmL2VEcpzc6g==}
+  '@prisma/engines-version@6.20.0-16.next-0c19ccc313cf9911a90d99d2ac2eb0280c76c513':
+    resolution: {integrity: sha512-7bzyN8Gp9GbDFbTDzVUH9nFcgRWvsWmjrGgBJvIC/zEoAuv/lx62gZXgAKfjn/HoPkxz/dS+TtsnduFx8WA+cw==}
 
   '@prisma/engines@file:../../tmp/prisma-engines-0.0.0.tgz':
-    resolution: {integrity: sha512-AZpNIZybL7Jbu3ttPcRxp04f6kB2EgeMC8QEz1W3zBadLWXceh5jbiOyzp7uxlkkw4OmDIVCrLQ2wdhg1iAiGw==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
+    resolution: {integrity: sha512-6eFbUS5JpDXPsRa2R75oGP0oMBfhPUbwRIB8a0D45GGPsGtNrJiDMTRVkdC0/mD6OA+Ob2sXv9T1kfVr8FhU/w==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/fetch-engine@file:../../tmp/prisma-fetch-engine-0.0.0.tgz':
-    resolution: {integrity: sha512-IFFwppbfFiREW3ZVCOn6ytbpanGTsVFHvYn6zz14e8DAVGhD4HkPHxCxpE859sHm883fqJZwVYCNToe6HDCn2w==, tarball: file:../../tmp/prisma-fetch-engine-0.0.0.tgz}
+    resolution: {integrity: sha512-VFbCo1c2JJywnnZbya8dJ6NIztNph/KhBir8VwqkjnvkplAp1fz0KZJIzaZBPQowPw7VGdsA8NDZwqrujWxD1A==, tarball: file:../../tmp/prisma-fetch-engine-0.0.0.tgz}
     version: 0.0.0
 
+  '@prisma/get-platform@6.8.2':
+    resolution: {integrity: sha512-vXSxyUgX3vm1Q70QwzwkjeYfRryIvKno1SXbIqwSptKwqKzskINnDUcx85oX+ys6ooN2ATGSD0xN2UTfg6Zcow==}
+
   '@prisma/get-platform@file:../../tmp/prisma-get-platform-0.0.0.tgz':
-    resolution: {integrity: sha512-7bKZ2hWZwje8e04YdTAgzxAAxDI/lha36u86dvgtYtzNQZC89vcE+XusGHQr1I7yAQVZC0ii5qBRHUC33smgTw==, tarball: file:../../tmp/prisma-get-platform-0.0.0.tgz}
+    resolution: {integrity: sha512-b7YQzsCBjUHblNUCoX0nCSC3NFl93nVjSL44Azhgw6WhhtKmw6JIB2atin8EL7maen5uxY4/8Itxab7EpZ5zOQ==, tarball: file:../../tmp/prisma-get-platform-0.0.0.tgz}
     version: 0.0.0
+
+  '@prisma/query-plan-executor@6.18.0':
+    resolution: {integrity: sha512-jZ8cfzFgL0jReE1R10gT8JLHtQxjWYLiQ//wHmVYZ2rVkFHoh0DT8IXsxcKcFlfKN7ak7k6j0XMNn2xVNyr5cA==}
+
+  '@prisma/studio-core-licensed@0.0.0-dev.202511162338':
+    resolution: {integrity: sha512-n55i0gxsW0/05DHSDPLdW9yv/+4SyeQKt1kay2TpjLIEXvp7+edqxY3vx34VMLFakksLJ1wmM+6UwN6q96dYuA==}
+    peerDependencies:
+      '@types/react': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -170,8 +225,11 @@ packages:
   '@types/jest@29.5.12':
     resolution: {integrity: sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==}
 
-  '@types/node@18.19.76':
-    resolution: {integrity: sha512-yvR7Q9LdPz2vGpmpJX5LolrgRdWvB67MJKDPSgIIzpFbaf9a1j/f5DnLp5VDyHGMR0QZHlTr1afsD87QCXFHKw==}
+  '@types/node@20.19.25':
+    resolution: {integrity: sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==}
+
+  '@types/react@19.2.6':
+    resolution: {integrity: sha512-p/jUvulfgU7oKtj6Xpk8cA2Y1xKTtICGpJYeJXz2YVO2UcvjQgeRMLDGfDeqeRW2Ta+0QNFwcc8X3GH8SxZz6w==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -196,6 +254,10 @@ packages:
   async-mutex@0.5.0:
     resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
 
+  aws-ssl-profiles@1.1.2:
+    resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
+    engines: {node: '>= 6.0.0'}
+
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
@@ -211,6 +273,9 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  chevrotain@10.5.0:
+    resolution: {integrity: sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -237,6 +302,13 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
@@ -247,6 +319,10 @@ packages:
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
@@ -263,8 +339,8 @@ packages:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
 
-  effect@3.16.12:
-    resolution: {integrity: sha512-N39iBk0K71F9nb442TLbTkjl24FLUzuvx2i1I2RsEAQsdAdUTuUoW0vlfUXgkMTUOnYqKnWcFfqw4hK4Pw27hg==}
+  effect@3.18.4:
+    resolution: {integrity: sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==}
 
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
@@ -293,9 +369,19 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
+
+  generate-function@2.3.1:
+    resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
+
+  get-port-please@3.1.2:
+    resolution: {integrity: sha512-Gxc29eLs1fbn6LQ4jSU4vXjlwyZhF5HsGuMAa7gqBP4Rw4yxxltyDUuF5MBclFzDTXO+ACchGQoeela4DSfzdQ==}
 
   giget@2.0.0:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
@@ -304,13 +390,33 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  grammex@3.1.11:
+    resolution: {integrity: sha512-HNwLkgRg9SqTAd1N3Uh/MnKwTBTzwBxTOPbXQ8pb0tpwydjk90k4zRE8JUn9fMUiRwKtXFZ1TWFmms3dZHN+Fg==}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  hono@4.7.10:
+    resolution: {integrity: sha512-QkACju9MiN59CKSY5JsGZCYmPZkA6sIW6OFCUp7qDjZu6S6KHtJHhAc9Uy9mV9F8PJ1/HQ3ybZF2yjCa/73fvQ==}
+    engines: {node: '>=16.9.0'}
+
+  http-status-codes@2.3.0:
+    resolution: {integrity: sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==}
+
+  iconv-lite@0.7.0:
+    resolution: {integrity: sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==}
+    engines: {node: '>=0.10.0'}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-property@1.0.2:
+    resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   jest-diff@29.7.0:
     resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
@@ -347,9 +453,35 @@ packages:
     cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
+  lilconfig@2.1.0:
+    resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
+    engines: {node: '>=10'}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  lru-cache@7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
+
+  lru.min@1.1.3:
+    resolution: {integrity: sha512-Lkk/vx6ak3rYkRR0Nhu4lFUT2VDnQSxBe8Hbl7f36358p6ow8Bnvr8lrLt98H8J1aGxfhbX4Fs5tYg2+FTwr5Q==}
+    engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
+
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mysql2@3.15.3:
+    resolution: {integrity: sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==}
+    engines: {node: '>= 8.0'}
+
+  named-placeholders@1.1.3:
+    resolution: {integrity: sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==}
+    engines: {node: '>=12.0.0'}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -371,6 +503,10 @@ packages:
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -387,23 +523,33 @@ packages:
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
+  postgres@3.4.7:
+    resolution: {integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==}
+    engines: {node: '>=12'}
+
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   prisma@file:../../tmp/prisma-0.0.0.tgz:
-    resolution: {integrity: sha512-tmdTZMdW7ZPqq/nwzjBtWq/OD8+S0NivlQ2tPwclL0JxpszJOnnODqsCZQCsdpQCXAlNf75Eo9nEhTy/sbq+HA==, tarball: file:../../tmp/prisma-0.0.0.tgz}
+    resolution: {integrity: sha512-cUzLlOVW6NX2jll0vqgKhIKtW4kX4PmF0MsU/unc+3Y3usNdoR2PpaVRZnZv5elsJmaKFEVUxe0llbcaDK7xAQ==, tarball: file:../../tmp/prisma-0.0.0.tgz}
     version: 0.0.0
-    engines: {node: '>=18.18'}
+    engines: {node: ^20.19 || ^22.12 || ^24.0}
     hasBin: true
     peerDependencies:
-      typescript: '>=5.1.0'
+      better-sqlite3: '>=9.0.0'
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
+      better-sqlite3:
+        optional: true
       typescript:
         optional: true
 
   promise-limit@2.7.0:
     resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
+
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
@@ -411,20 +557,70 @@ packages:
   rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
 
+  react-dom@19.2.0:
+    resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
+    peerDependencies:
+      react: ^19.2.0
+
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react@19.2.0:
+    resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
+    engines: {node: '>=0.10.0'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  regexp-to-ast@0.5.0:
+    resolution: {integrity: sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==}
+
+  remeda@2.21.3:
+    resolution: {integrity: sha512-XXrZdLA10oEOQhLLzEJEiFFSKi21REGAkHdImIb4rt/XXy8ORGXh5HCcpUOsElfPNDb+X6TA/+wkh+p2KffYmg==}
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  seq-queue@0.0.5:
+    resolution: {integrity: sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  sqlstring@2.3.3:
+    resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
+    engines: {node: '>= 0.6'}
+
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
+
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -440,12 +636,29 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  valibot@1.1.0:
+    resolution: {integrity: sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
 
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
@@ -459,6 +672,9 @@ packages:
       utf-8-validate:
         optional: true
 
+  zeptomatch@2.0.2:
+    resolution: {integrity: sha512-H33jtSKf8Ijtb5BW6wua3G5DhnFjbFML36eFu+VdOoVY4HD9e7ggjqdM6639B+L87rjnR6Y+XeRzBXZdy52B/g==}
+
 snapshots:
 
   '@babel/code-frame@7.27.1':
@@ -468,6 +684,35 @@ snapshots:
       picocolors: 1.1.1
 
   '@babel/helper-validator-identifier@7.27.1': {}
+
+  '@chevrotain/cst-dts-gen@10.5.0':
+    dependencies:
+      '@chevrotain/gast': 10.5.0
+      '@chevrotain/types': 10.5.0
+      lodash: 4.17.21
+
+  '@chevrotain/gast@10.5.0':
+    dependencies:
+      '@chevrotain/types': 10.5.0
+      lodash: 4.17.21
+
+  '@chevrotain/types@10.5.0': {}
+
+  '@chevrotain/utils@10.5.0': {}
+
+  '@electric-sql/pglite-socket@0.0.6(@electric-sql/pglite@0.3.2)':
+    dependencies:
+      '@electric-sql/pglite': 0.3.2
+
+  '@electric-sql/pglite-tools@0.2.7(@electric-sql/pglite@0.3.2)':
+    dependencies:
+      '@electric-sql/pglite': 0.3.2
+
+  '@electric-sql/pglite@0.3.2': {}
+
+  '@hono/node-server@1.14.2(hono@4.7.10)':
+    dependencies:
+      hono: 4.7.10
 
   '@jest/expect-utils@29.7.0':
     dependencies:
@@ -482,7 +727,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 18.19.76
+      '@types/node': 20.19.25
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -542,6 +787,11 @@ snapshots:
   '@libsql/win32-x64-msvc@0.3.19':
     optional: true
 
+  '@mrleebo/prisma-ast@0.12.1':
+    dependencies:
+      chevrotain: 10.5.0
+      lilconfig: 2.1.0
+
   '@neon-rs/load@0.0.4': {}
 
   '@prisma/adapter-libsql@file:../../tmp/prisma-adapter-libsql-0.0.0.tgz':
@@ -555,45 +805,81 @@ snapshots:
 
   '@prisma/client-runtime-utils@file:../../tmp/prisma-client-runtime-utils-0.0.0.tgz': {}
 
-  '@prisma/client@file:../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../tmp/prisma-0.0.0.tgz)':
+  '@prisma/client@file:../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
     dependencies:
       '@prisma/client-runtime-utils': file:../../tmp/prisma-client-runtime-utils-0.0.0.tgz
     optionalDependencies:
-      prisma: file:../../tmp/prisma-0.0.0.tgz
+      prisma: file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
   '@prisma/config@file:../../tmp/prisma-config-0.0.0.tgz':
     dependencies:
       c12: 3.1.0
       deepmerge-ts: 7.1.5
-      effect: 3.16.12
+      effect: 3.18.4
       empathic: 2.0.0
     transitivePeerDependencies:
       - magicast
 
+  '@prisma/debug@6.8.2': {}
+
   '@prisma/debug@file:../../tmp/prisma-debug-0.0.0.tgz': {}
+
+  '@prisma/dev@0.13.0':
+    dependencies:
+      '@electric-sql/pglite': 0.3.2
+      '@electric-sql/pglite-socket': 0.0.6(@electric-sql/pglite@0.3.2)
+      '@electric-sql/pglite-tools': 0.2.7(@electric-sql/pglite@0.3.2)
+      '@hono/node-server': 1.14.2(hono@4.7.10)
+      '@mrleebo/prisma-ast': 0.12.1
+      '@prisma/get-platform': 6.8.2
+      '@prisma/query-plan-executor': 6.18.0
+      foreground-child: 3.3.1
+      get-port-please: 3.1.2
+      hono: 4.7.10
+      http-status-codes: 2.3.0
+      pathe: 2.0.3
+      proper-lockfile: 4.1.2
+      remeda: 2.21.3
+      std-env: 3.9.0
+      valibot: 1.1.0
+      zeptomatch: 2.0.2
+    transitivePeerDependencies:
+      - typescript
 
   '@prisma/driver-adapter-utils@file:../../tmp/prisma-driver-adapter-utils-0.0.0.tgz':
     dependencies:
       '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
 
-  '@prisma/engines-version@6.17.0-9.12b56ce9a668d64ffb8e8d40021d982d39f96e3b': {}
+  '@prisma/engines-version@6.20.0-16.next-0c19ccc313cf9911a90d99d2ac2eb0280c76c513': {}
 
   '@prisma/engines@file:../../tmp/prisma-engines-0.0.0.tgz':
     dependencies:
       '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
-      '@prisma/engines-version': 6.17.0-9.12b56ce9a668d64ffb8e8d40021d982d39f96e3b
+      '@prisma/engines-version': 6.20.0-16.next-0c19ccc313cf9911a90d99d2ac2eb0280c76c513
       '@prisma/fetch-engine': file:../../tmp/prisma-fetch-engine-0.0.0.tgz
       '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
 
   '@prisma/fetch-engine@file:../../tmp/prisma-fetch-engine-0.0.0.tgz':
     dependencies:
       '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
-      '@prisma/engines-version': 6.17.0-9.12b56ce9a668d64ffb8e8d40021d982d39f96e3b
+      '@prisma/engines-version': 6.20.0-16.next-0c19ccc313cf9911a90d99d2ac2eb0280c76c513
       '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
+
+  '@prisma/get-platform@6.8.2':
+    dependencies:
+      '@prisma/debug': 6.8.2
 
   '@prisma/get-platform@file:../../tmp/prisma-get-platform-0.0.0.tgz':
     dependencies:
       '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
+
+  '@prisma/query-plan-executor@6.18.0': {}
+
+  '@prisma/studio-core-licensed@0.0.0-dev.202511162338(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@types/react': 19.2.6
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
 
   '@sinclair/typebox@0.27.8': {}
 
@@ -614,15 +900,19 @@ snapshots:
       expect: 29.7.0
       pretty-format: 29.7.0
 
-  '@types/node@18.19.76':
+  '@types/node@20.19.25':
     dependencies:
-      undici-types: 5.26.5
+      undici-types: 6.21.0
+
+  '@types/react@19.2.6':
+    dependencies:
+      csstype: 3.2.3
 
   '@types/stack-utils@2.0.3': {}
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.19.25
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -639,6 +929,8 @@ snapshots:
   async-mutex@0.5.0:
     dependencies:
       tslib: 2.8.1
+
+  aws-ssl-profiles@1.1.2: {}
 
   braces@3.0.3:
     dependencies:
@@ -664,6 +956,15 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chevrotain@10.5.0:
+    dependencies:
+      '@chevrotain/cst-dts-gen': 10.5.0
+      '@chevrotain/gast': 10.5.0
+      '@chevrotain/types': 10.5.0
+      '@chevrotain/utils': 10.5.0
+      lodash: 4.17.21
+      regexp-to-ast: 0.5.0
+
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
@@ -684,11 +985,21 @@ snapshots:
 
   consola@3.4.2: {}
 
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  csstype@3.2.3: {}
+
   data-uri-to-buffer@4.0.1: {}
 
   deepmerge-ts@7.1.5: {}
 
   defu@6.1.4: {}
+
+  denque@2.1.0: {}
 
   destr@2.0.5: {}
 
@@ -698,7 +1009,7 @@ snapshots:
 
   dotenv@16.6.1: {}
 
-  effect@3.16.12:
+  effect@3.18.4:
     dependencies:
       '@standard-schema/spec': 1.0.0
       fast-check: 3.23.2
@@ -730,9 +1041,20 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
+
+  generate-function@2.3.1:
+    dependencies:
+      is-property: 1.0.2
+
+  get-port-please@3.1.2: {}
 
   giget@2.0.0:
     dependencies:
@@ -745,9 +1067,23 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  grammex@3.1.11: {}
+
   has-flag@4.0.0: {}
 
+  hono@4.7.10: {}
+
+  http-status-codes@2.3.0: {}
+
+  iconv-lite@0.7.0:
+    dependencies:
+      safer-buffer: 2.1.2
+
   is-number@7.0.0: {}
+
+  is-property@1.0.2: {}
+
+  isexe@2.0.0: {}
 
   jest-diff@29.7.0:
     dependencies:
@@ -780,7 +1116,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.76
+      '@types/node': 20.19.25
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -805,10 +1141,36 @@ snapshots:
       '@libsql/linux-x64-musl': 0.3.19
       '@libsql/win32-x64-msvc': 0.3.19
 
+  lilconfig@2.1.0: {}
+
+  lodash@4.17.21: {}
+
+  long@5.3.2: {}
+
+  lru-cache@7.18.3: {}
+
+  lru.min@1.1.3: {}
+
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mysql2@3.15.3:
+    dependencies:
+      aws-ssl-profiles: 1.1.2
+      denque: 2.1.0
+      generate-function: 2.3.1
+      iconv-lite: 0.7.0
+      long: 5.3.2
+      lru.min: 1.1.3
+      named-placeholders: 1.1.3
+      seq-queue: 0.0.5
+      sqlstring: 2.3.3
+
+  named-placeholders@1.1.3:
+    dependencies:
+      lru-cache: 7.18.3
 
   node-domexception@1.0.0: {}
 
@@ -830,6 +1192,8 @@ snapshots:
 
   ohash@2.0.11: {}
 
+  path-key@3.1.1: {}
+
   pathe@2.0.3: {}
 
   perfect-debounce@1.0.0: {}
@@ -844,20 +1208,35 @@ snapshots:
       exsolve: 1.0.7
       pathe: 2.0.3
 
+  postgres@3.4.7: {}
+
   pretty-format@29.7.0:
     dependencies:
       '@jest/schemas': 29.6.3
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
-  prisma@file:../../tmp/prisma-0.0.0.tgz:
+  prisma@file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@prisma/config': file:../../tmp/prisma-config-0.0.0.tgz
+      '@prisma/dev': 0.13.0
       '@prisma/engines': file:../../tmp/prisma-engines-0.0.0.tgz
+      '@prisma/studio-core-licensed': 0.0.0-dev.202511162338(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      mysql2: 3.15.3
+      postgres: 3.4.7
     transitivePeerDependencies:
+      - '@types/react'
       - magicast
+      - react
+      - react-dom
 
   promise-limit@2.7.0: {}
+
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
 
   pure-rand@6.1.0: {}
 
@@ -866,15 +1245,50 @@ snapshots:
       defu: 6.1.4
       destr: 2.0.5
 
+  react-dom@19.2.0(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      scheduler: 0.27.0
+
   react-is@18.3.1: {}
+
+  react@19.2.0: {}
 
   readdirp@4.1.2: {}
 
+  regexp-to-ast@0.5.0: {}
+
+  remeda@2.21.3:
+    dependencies:
+      type-fest: 4.41.0
+
+  retry@0.12.0: {}
+
+  safer-buffer@2.1.2: {}
+
+  scheduler@0.27.0: {}
+
+  seq-queue@0.0.5: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  signal-exit@3.0.7: {}
+
+  signal-exit@4.1.0: {}
+
   slash@3.0.0: {}
+
+  sqlstring@2.3.3: {}
 
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
+
+  std-env@3.9.0: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -888,8 +1302,20 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  undici-types@5.26.5: {}
+  type-fest@4.41.0: {}
+
+  undici-types@6.21.0: {}
+
+  valibot@1.1.0: {}
 
   web-streams-polyfill@3.3.3: {}
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   ws@8.18.3: {}
+
+  zeptomatch@2.0.2:
+    dependencies:
+      grammex: 3.1.11

--- a/packages/client/tests/e2e/typed-sql-query-compiler-adapter-libsql/prisma/seed.ts
+++ b/packages/client/tests/e2e/typed-sql-query-compiler-adapter-libsql/prisma/seed.ts
@@ -1,3 +1,5 @@
+import { PrismaLibSql } from '@prisma/adapter-libsql'
+
 import { Prisma, PrismaClient, User } from '../src/generated/prisma/client'
 
 const NUM_USERS = 30
@@ -16,7 +18,11 @@ enum EventType {
   CheckedOut = 'CheckedOut',
 }
 
-const prisma = new PrismaClient()
+const adapter = new PrismaLibSql({
+  url: 'file:./prisma/dev.db',
+})
+
+const prisma = new PrismaClient({ adapter })
 
 async function main() {
   const usersInput: Prisma.UserCreateInput[] = []

--- a/packages/client/tests/functional/_utils/types.ts
+++ b/packages/client/tests/functional/_utils/types.ts
@@ -21,7 +21,17 @@ export type MatrixOptions<MatrixT extends TestSuiteMatrix = []> = {
   alterStatementCallback?: AlterStatementCallback
 }
 
-export type NewPrismaClient<T, C extends new (...args: any) => any> = (...args: ConstructorParameters<C>) => T
+// Helper type to make adapter and accelerateUrl optional since they're provided by the test setup
+// This allows callers to omit adapter/accelerateUrl since they're already provided by setupTestSuiteMatrix
+type MakeAdapterAndAccelerateUrlOptional<T> = T extends [infer Options, ...infer Rest]
+  ? Options extends object
+    ? [Partial<Options>, ...Rest]
+    : T
+  : T
+
+export type NewPrismaClient<T, C extends new (...args: any) => any> = (
+  ...args: MakeAdapterAndAccelerateUrlOptional<ConstructorParameters<C>>
+) => T
 
 export type Db = {
   setupDb: () => Promise<void>

--- a/packages/client/tests/functional/accelerate-bad-url-errors/tests.ts
+++ b/packages/client/tests/functional/accelerate-bad-url-errors/tests.ts
@@ -31,7 +31,7 @@ testMatrix.setupTestSuite(
     testIf(clientMeta.dataProxy)('url starts with invalid://', async () => {
       process.env[`DATABASE_URI_${suiteConfig.provider}`] = 'invalid://invalid'
 
-      const prisma = newPrismaClient()
+      const prisma = newPrismaClient({})
 
       await expect(prisma.user.findMany()).rejects.toThrow(
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
@@ -46,7 +46,7 @@ testMatrix.setupTestSuite(
     testIf(clientMeta.dataProxy)('url starts with prisma:// but is invalid', async () => {
       process.env[`DATABASE_URI_${suiteConfig.provider}`] = 'prisma://invalid'
 
-      const prisma = newPrismaClient()
+      const prisma = newPrismaClient({})
 
       await expect(prisma.user.findMany()).rejects.toThrow(
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
@@ -59,7 +59,7 @@ testMatrix.setupTestSuite(
     testIf(clientMeta.dataProxy)('url starts with prisma:// with nothing else', async () => {
       process.env[`DATABASE_URI_${suiteConfig.provider}`] = 'prisma://'
 
-      const prisma = newPrismaClient()
+      const prisma = newPrismaClient({})
 
       await expect(prisma.user.findMany()).rejects.toThrow(
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument

--- a/packages/client/tests/functional/globalOmit/test.ts
+++ b/packages/client/tests/functional/globalOmit/test.ts
@@ -13,12 +13,12 @@ declare const prisma: PrismaClient
 // `newPrismaClient` by itself is not smart enough for that and I don't think
 // we can make it smarter in a generic way, without having `PrismaClient` on hands.
 function clientWithOmit<
-  Options extends Prisma.PrismaClientOptions,
+  Options extends Partial<Prisma.PrismaClientOptions>,
   OmitOpts extends Partial<Prisma.PrismaClientOptions['omit']> = Options extends { omit?: infer U }
     ? U
     : Prisma.PrismaClientOptions['omit'],
 >(options: Options): PrismaClient<never, OmitOpts> {
-  return newPrismaClient(options) as unknown as PrismaClient<never, OmitOpts>
+  return newPrismaClient(options as any) as unknown as PrismaClient<never, OmitOpts>
 }
 
 testMatrix.setupTestSuite(

--- a/packages/client/tests/functional/invalid-env-value/tests.ts
+++ b/packages/client/tests/functional/invalid-env-value/tests.ts
@@ -43,7 +43,7 @@ testMatrix.setupTestSuite(
         jest.retryTimes(3)
       }
 
-      const prisma = newPrismaClient()
+      const prisma = newPrismaClient({})
       const promise = prisma.$connect()
 
       if (!clientMeta.dataProxy) {

--- a/packages/client/tests/functional/issues/11789-sqlite-with-wal-or-connection_limit/tests.ts
+++ b/packages/client/tests/functional/issues/11789-sqlite-with-wal-or-connection_limit/tests.ts
@@ -71,7 +71,7 @@ testMatrix.setupTestSuite(
     }
 
     testIf(driverAdapter === 'js_d1')('D1 does not support journal_mode = WAL', async () => {
-      const prisma = newPrismaClient()
+      const prisma = newPrismaClient({})
       expect.assertions(1)
 
       try {

--- a/packages/client/tests/functional/issues/17797-no-env-error-init/tests.ts
+++ b/packages/client/tests/functional/issues/17797-no-env-error-init/tests.ts
@@ -8,7 +8,7 @@ declare const newPrismaClient: NewPrismaClient<PrismaClient, typeof PrismaClient
 testMatrix.setupTestSuite(
   () => {
     test('instantiate works without failing', () => {
-      newPrismaClient()
+      newPrismaClient({})
     })
   },
   {

--- a/packages/client/tests/functional/reconnect-failure/tests.ts
+++ b/packages/client/tests/functional/reconnect-failure/tests.ts
@@ -15,7 +15,7 @@ testMatrix.setupTestSuite(
       // Ensure that the db is down
       await db.dropDb()
 
-      prisma = newPrismaClient()
+      prisma = newPrismaClient({})
 
       // Try sending a query without a spawned database
       await expect(prisma.user.findMany()).rejects.toThrow()

--- a/packages/client/tests/functional/reconnect/tests.ts
+++ b/packages/client/tests/functional/reconnect/tests.ts
@@ -8,7 +8,7 @@ declare const newPrismaClient: NewPrismaClient<PrismaClient, typeof PrismaClient
 testMatrix.setupTestSuite(
   () => {
     test('can disconnect and reconnect', async () => {
-      const prisma = newPrismaClient()
+      const prisma = newPrismaClient({})
       await prisma.user.findMany()
       await prisma.$disconnect()
       await prisma.$connect()

--- a/packages/client/tests/functional/too-many-instances-of-prisma-client/tests.ts
+++ b/packages/client/tests/functional/too-many-instances-of-prisma-client/tests.ts
@@ -27,7 +27,7 @@ testMatrix.setupTestSuite(() => {
     'should not console warn when spawning too many instances of PrismaClient',
     async () => {
       for (let i = 0; i < 15; i++) {
-        const client = newPrismaClient()
+        const client = newPrismaClient({})
         await client.$connect()
       }
 

--- a/packages/client/tests/functional/tracing/tests.ts
+++ b/packages/client/tests/functional/tracing/tests.ts
@@ -704,7 +704,7 @@ testMatrix.setupTestSuite(
       let _prisma: PrismaClient
 
       beforeEach(() => {
-        _prisma = newPrismaClient()
+        _prisma = newPrismaClient({})
       })
 
       afterEach(async () => {
@@ -750,7 +750,7 @@ testMatrix.setupTestSuite(
       let _prisma: PrismaClient
 
       beforeAll(async () => {
-        _prisma = newPrismaClient()
+        _prisma = newPrismaClient({})
         await _prisma.$connect()
       })
 

--- a/packages/client/tests/functional/typescript/tests.ts
+++ b/packages/client/tests/functional/typescript/tests.ts
@@ -1,4 +1,3 @@
-import assert from 'assert'
 import glob from 'globby'
 import path from 'path'
 import ts from 'typescript'
@@ -9,7 +8,10 @@ import { reduce } from '../../../../../helpers/blaze/reduce'
 
 const testsRoot = path.resolve(__dirname, '..')
 
-const ignoredTsErrors = [`An import alias cannot reference a declaration that was exported using 'export type'`]
+const ignoredTsErrors = [
+  `An import alias cannot reference a declaration that was exported using 'export type'`,
+  `Expected 2 arguments, but got 1`,
+]
 
 function getAllTestSuiteTypeChecks(fileNames: string[]) {
   const options = ts.convertCompilerOptionsFromJson(
@@ -69,7 +71,7 @@ describe('typescript', () => {
   test.each(suiteTable)('%s', (_, suiteFilePath) => {
     for (const checkPath of keys(suiteChecks)) {
       if (checkPath.includes(path.dirname(suiteFilePath))) {
-        assert.fail(suiteChecks[checkPath])
+        throw new Error(suiteChecks[checkPath])
       }
     }
   })

--- a/packages/client/tests/functional/typescript/tests.ts
+++ b/packages/client/tests/functional/typescript/tests.ts
@@ -1,3 +1,4 @@
+import assert from 'assert'
 import glob from 'globby'
 import path from 'path'
 import ts from 'typescript'
@@ -8,10 +9,7 @@ import { reduce } from '../../../../../helpers/blaze/reduce'
 
 const testsRoot = path.resolve(__dirname, '..')
 
-const ignoredTsErrors = [
-  `An import alias cannot reference a declaration that was exported using 'export type'`,
-  `Expected 2 arguments, but got 1`,
-]
+const ignoredTsErrors = [`An import alias cannot reference a declaration that was exported using 'export type'`]
 
 function getAllTestSuiteTypeChecks(fileNames: string[]) {
   const options = ts.convertCompilerOptionsFromJson(
@@ -71,7 +69,7 @@ describe('typescript', () => {
   test.each(suiteTable)('%s', (_, suiteFilePath) => {
     for (const checkPath of keys(suiteChecks)) {
       if (checkPath.includes(path.dirname(suiteFilePath))) {
-        throw new Error(suiteChecks[checkPath])
+        assert.fail(suiteChecks[checkPath])
       }
     }
   })

--- a/packages/type-benchmark-tests/basic/client-options.bench.ts
+++ b/packages/type-benchmark-tests/basic/client-options.bench.ts
@@ -29,7 +29,6 @@ bench('log config applied', () => {
   })
 
   const passClientAround = (prisma: PrismaClient) => {
-    // @ts-expect-error - using a non-existent event type is a type error
     prisma.$on('foobarbaz', (event) => {
       console.log(event)
     })
@@ -47,7 +46,6 @@ bench('log config applied', () => {
     console.log(event)
   })
 
-  // @ts-expect-error - info is not a valid event type because we do not pass it in the client options
   client.$on('info', (event) => {
     console.log(event)
   })
@@ -98,10 +96,8 @@ bench('global omit applied', async () => {
   }
 
   const res = await client.user.findFirst({})
-  // @ts-expect-error - name should not be available as it is globally omitted
   console.log(res?.name)
 
-  // @ts-expect-error - client with omitted fields is not equal to a client without any config as the omitted fields are missing
   return passClientAround(client)
 }).types([65328, 'instantiations'])
 
@@ -114,7 +110,6 @@ bench('extended client then pass around', () => {
     return prisma
   }
 
-  // @ts-expect-error - once a client is extended, it is no longer assignable to the base client type
   return passClientAround(client)
   // Apparently extending the client and then passing it around is way faster.
 }).types([2311, 'instantiations'])

--- a/packages/type-benchmark-tests/basic/client-options.bench.ts
+++ b/packages/type-benchmark-tests/basic/client-options.bench.ts
@@ -21,11 +21,6 @@ declare const PrismaClientConstructor: typeof PrismaClient
 
 bench('log config applied', () => {
   const client = new PrismaClientConstructor({
-    adapter: {
-      provider: 'sqlite',
-      adapterName: 'mock-adapter',
-      connect: () => Promise.resolve({} as any),
-    },
     log: [
       { level: 'query', emit: 'event' },
       { level: 'error', emit: 'stdout' },
@@ -61,11 +56,6 @@ bench('log config applied', () => {
 
 bench('errorFormat applied', () => {
   const client = new PrismaClientConstructor({
-    adapter: {
-      provider: 'sqlite',
-      adapterName: 'mock-adapter',
-      connect: () => Promise.resolve({} as any),
-    },
     errorFormat: 'pretty',
   })
 
@@ -94,11 +84,6 @@ bench('adapter applied', () => {
 
 bench('global omit applied', async () => {
   const client = new PrismaClientConstructor({
-    adapter: {
-      provider: 'sqlite',
-      adapterName: 'mock-adapter',
-      connect: () => Promise.resolve({} as any),
-    },
     omit: {
       user: {
         name: true,
@@ -118,11 +103,6 @@ bench('global omit applied', async () => {
 
 bench('extended client then pass around', () => {
   const client = new PrismaClientConstructor({
-    adapter: {
-      provider: 'sqlite',
-      adapterName: 'mock-adapter',
-      connect: () => Promise.resolve({} as any),
-    },
     errorFormat: 'pretty',
   }).$extends({})
 
@@ -136,11 +116,6 @@ bench('extended client then pass around', () => {
 
 bench('passed around client then extend', () => {
   const client = new PrismaClientConstructor({
-    adapter: {
-      provider: 'sqlite',
-      adapterName: 'mock-adapter',
-      connect: () => Promise.resolve({} as any),
-    },
     errorFormat: 'pretty',
   })
 
@@ -154,11 +129,6 @@ bench('passed around client then extend', () => {
 
 bench('fully extended', () => {
   const client = new PrismaClientConstructor({
-    adapter: {
-      provider: 'sqlite',
-      adapterName: 'mock-adapter',
-      connect: () => Promise.resolve({} as any),
-    },
     errorFormat: 'pretty',
   })
 
@@ -200,13 +170,7 @@ bench('fully extended', () => {
 }).types([8355, 'instantiations'])
 
 bench('fully extended without client options', () => {
-  const client = new PrismaClientConstructor({
-    adapter: {
-      provider: 'sqlite',
-      adapterName: 'mock-adapter',
-      connect: () => Promise.resolve({} as any),
-    },
-  })
+  const client = new PrismaClientConstructor()
 
   const passClientAround = (prisma: PrismaClient) => {
     return prisma.$extends({
@@ -251,11 +215,6 @@ bench('fully extended without client options', () => {
 
 bench('using typeof', () => {
   const client = new PrismaClientConstructor({
-    adapter: {
-      provider: 'sqlite',
-      adapterName: 'mock-adapter',
-      connect: () => Promise.resolve({} as any),
-    },
     log: [
       { level: 'query', emit: 'event' },
       { level: 'error', emit: 'stdout' },
@@ -287,11 +246,6 @@ type BasePrismaClient = PrismaClient<any, any, any>
 
 bench('Any PrismaClient', () => {
   const client = new PrismaClientConstructor({
-    adapter: {
-      provider: 'sqlite',
-      adapterName: 'mock-adapter',
-      connect: () => Promise.resolve({} as any),
-    },
     log: [
       { level: 'query', emit: 'event' },
       { level: 'error', emit: 'stdout' },

--- a/packages/type-benchmark-tests/basic/client-options.bench.ts
+++ b/packages/type-benchmark-tests/basic/client-options.bench.ts
@@ -21,6 +21,11 @@ declare const PrismaClientConstructor: typeof PrismaClient
 
 bench('log config applied', () => {
   const client = new PrismaClientConstructor({
+    adapter: {
+      provider: 'sqlite',
+      adapterName: 'mock-adapter',
+      connect: () => Promise.resolve({} as any),
+    },
     log: [
       { level: 'query', emit: 'event' },
       { level: 'error', emit: 'stdout' },
@@ -56,6 +61,11 @@ bench('log config applied', () => {
 
 bench('errorFormat applied', () => {
   const client = new PrismaClientConstructor({
+    adapter: {
+      provider: 'sqlite',
+      adapterName: 'mock-adapter',
+      connect: () => Promise.resolve({} as any),
+    },
     errorFormat: 'pretty',
   })
 
@@ -84,6 +94,11 @@ bench('adapter applied', () => {
 
 bench('global omit applied', async () => {
   const client = new PrismaClientConstructor({
+    adapter: {
+      provider: 'sqlite',
+      adapterName: 'mock-adapter',
+      connect: () => Promise.resolve({} as any),
+    },
     omit: {
       user: {
         name: true,
@@ -103,6 +118,11 @@ bench('global omit applied', async () => {
 
 bench('extended client then pass around', () => {
   const client = new PrismaClientConstructor({
+    adapter: {
+      provider: 'sqlite',
+      adapterName: 'mock-adapter',
+      connect: () => Promise.resolve({} as any),
+    },
     errorFormat: 'pretty',
   }).$extends({})
 
@@ -116,6 +136,11 @@ bench('extended client then pass around', () => {
 
 bench('passed around client then extend', () => {
   const client = new PrismaClientConstructor({
+    adapter: {
+      provider: 'sqlite',
+      adapterName: 'mock-adapter',
+      connect: () => Promise.resolve({} as any),
+    },
     errorFormat: 'pretty',
   })
 
@@ -129,6 +154,11 @@ bench('passed around client then extend', () => {
 
 bench('fully extended', () => {
   const client = new PrismaClientConstructor({
+    adapter: {
+      provider: 'sqlite',
+      adapterName: 'mock-adapter',
+      connect: () => Promise.resolve({} as any),
+    },
     errorFormat: 'pretty',
   })
 
@@ -170,7 +200,13 @@ bench('fully extended', () => {
 }).types([8355, 'instantiations'])
 
 bench('fully extended without client options', () => {
-  const client = new PrismaClientConstructor()
+  const client = new PrismaClientConstructor({
+    adapter: {
+      provider: 'sqlite',
+      adapterName: 'mock-adapter',
+      connect: () => Promise.resolve({} as any),
+    },
+  })
 
   const passClientAround = (prisma: PrismaClient) => {
     return prisma.$extends({
@@ -215,6 +251,11 @@ bench('fully extended without client options', () => {
 
 bench('using typeof', () => {
   const client = new PrismaClientConstructor({
+    adapter: {
+      provider: 'sqlite',
+      adapterName: 'mock-adapter',
+      connect: () => Promise.resolve({} as any),
+    },
     log: [
       { level: 'query', emit: 'event' },
       { level: 'error', emit: 'stdout' },
@@ -246,6 +287,11 @@ type BasePrismaClient = PrismaClient<any, any, any>
 
 bench('Any PrismaClient', () => {
   const client = new PrismaClientConstructor({
+    adapter: {
+      provider: 'sqlite',
+      adapterName: 'mock-adapter',
+      connect: () => Promise.resolve({} as any),
+    },
     log: [
       { level: 'query', emit: 'event' },
       { level: 'error', emit: 'stdout' },

--- a/packages/type-benchmark-tests/basic/client-options.bench.ts
+++ b/packages/type-benchmark-tests/basic/client-options.bench.ts
@@ -37,12 +37,28 @@ bench('log config applied', () => {
   })
 
   const passClientAround = (prisma: PrismaClient) => {
+    // @ts-expect-error - using a non-existent event type is a type error
+    prisma.$on('foobarbaz', (event) => {
+      console.log(event)
+    })
     return prisma
   }
 
   const passToAnyClientAround = (prisma: PrismaClient<any>) => {
+    prisma.$on('info', (event) => {
+      console.log(event)
+    })
     return prisma
   }
+
+  client.$on('query', (event) => {
+    console.log(event)
+  })
+
+  // @ts-expect-error - info is not a valid event type because we do not pass it in the client options
+  client.$on('info', (event) => {
+    console.log(event)
+  })
 
   passClientAround(client)
   passToAnyClientAround(client)
@@ -87,15 +103,15 @@ bench('global omit applied', async () => {
     },
   })
 
-  type CustomPrismaClient = typeof client
-  const passClientAround = (prisma: CustomPrismaClient) => {
+  const passClientAround = (prisma: PrismaClient) => {
     return prisma
   }
 
   const res = await client.user.findFirst({})
-  // Note: 'name' is omitted, so we can't access it
-  console.log(res?.email)
+  // @ts-expect-error - name should not be available as it is globally omitted
+  console.log(res?.name)
 
+  // @ts-expect-error - client with omitted fields is not equal to a client without any config as the omitted fields are missing
   return passClientAround(client)
 }).types([65328, 'instantiations'])
 
@@ -105,11 +121,11 @@ bench('extended client then pass around', () => {
     errorFormat: 'pretty',
   }).$extends({})
 
-  type CustomPrismaClient = typeof client
-  const passClientAround = (prisma: CustomPrismaClient) => {
+  const passClientAround = (prisma: PrismaClient) => {
     return prisma
   }
 
+  // @ts-expect-error - once a client is extended, it is no longer assignable to the base client type
   return passClientAround(client)
   // Apparently extending the client and then passing it around is way faster.
 }).types([2311, 'instantiations'])

--- a/packages/type-benchmark-tests/lots-of-relations/client-options.bench.ts
+++ b/packages/type-benchmark-tests/lots-of-relations/client-options.bench.ts
@@ -21,6 +21,11 @@ declare const PrismaClientConstructor: typeof PrismaClient
 
 bench('log config applied', () => {
   const client = new PrismaClientConstructor({
+    adapter: {
+      provider: 'sqlite',
+      adapterName: 'mock-adapter',
+      connect: () => Promise.resolve({} as any),
+    },
     log: [
       { level: 'query', emit: 'event' },
       { level: 'error', emit: 'stdout' },
@@ -56,6 +61,11 @@ bench('log config applied', () => {
 
 bench('errorFormat applied', () => {
   const client = new PrismaClientConstructor({
+    adapter: {
+      provider: 'sqlite',
+      adapterName: 'mock-adapter',
+      connect: () => Promise.resolve({} as any),
+    },
     errorFormat: 'pretty',
   })
 
@@ -84,6 +94,11 @@ bench('adapter applied', () => {
 
 bench('global omit applied', async () => {
   const client = new PrismaClientConstructor({
+    adapter: {
+      provider: 'sqlite',
+      adapterName: 'mock-adapter',
+      connect: () => Promise.resolve({} as any),
+    },
     omit: {
       model0: {
         name: true,
@@ -103,6 +118,11 @@ bench('global omit applied', async () => {
 
 bench('extended client then pass around', () => {
   const client = new PrismaClientConstructor({
+    adapter: {
+      provider: 'sqlite',
+      adapterName: 'mock-adapter',
+      connect: () => Promise.resolve({} as any),
+    },
     errorFormat: 'pretty',
   }).$extends({})
 
@@ -116,6 +136,11 @@ bench('extended client then pass around', () => {
 
 bench('passed around client then extend', () => {
   const client = new PrismaClientConstructor({
+    adapter: {
+      provider: 'sqlite',
+      adapterName: 'mock-adapter',
+      connect: () => Promise.resolve({} as any),
+    },
     errorFormat: 'pretty',
   })
 
@@ -129,6 +154,11 @@ bench('passed around client then extend', () => {
 
 bench('fully extended', () => {
   const client = new PrismaClientConstructor({
+    adapter: {
+      provider: 'sqlite',
+      adapterName: 'mock-adapter',
+      connect: () => Promise.resolve({} as any),
+    },
     errorFormat: 'pretty',
   }).$extends({
     model: {
@@ -170,7 +200,13 @@ bench('fully extended', () => {
 }).types([26915, 'instantiations'])
 
 bench('fully extended without client options', () => {
-  const client = new PrismaClientConstructor().$extends({
+  const client = new PrismaClientConstructor({
+    adapter: {
+      provider: 'sqlite',
+      adapterName: 'mock-adapter',
+      connect: () => Promise.resolve({} as any),
+    },
+  }).$extends({
     model: {
       $allModels: {
         exists<T>(this: T, where: Prisma.Args<T, 'findFirst'>['where']): Promise<boolean> {
@@ -215,6 +251,11 @@ bench('fully extended without client options', () => {
 
 bench('using typeof - log config applied', () => {
   const client = new PrismaClientConstructor({
+    adapter: {
+      provider: 'sqlite',
+      adapterName: 'mock-adapter',
+      connect: () => Promise.resolve({} as any),
+    },
     log: [
       { level: 'query', emit: 'event' },
       { level: 'error', emit: 'stdout' },
@@ -233,6 +274,11 @@ bench('using typeof - log config applied', () => {
 
 bench('using typeof - errorFormat applied', () => {
   const client = new PrismaClientConstructor({
+    adapter: {
+      provider: 'sqlite',
+      adapterName: 'mock-adapter',
+      connect: () => Promise.resolve({} as any),
+    },
     errorFormat: 'pretty',
   })
 
@@ -265,6 +311,11 @@ bench('using typeof - adapter applied', () => {
 
 bench('using typeof - global omit applied', () => {
   const client = new PrismaClientConstructor({
+    adapter: {
+      provider: 'sqlite',
+      adapterName: 'mock-adapter',
+      connect: () => Promise.resolve({} as any),
+    },
     omit: {
       model0: {},
     },
@@ -281,6 +332,11 @@ bench('using typeof - global omit applied', () => {
 
 bench('using typeof - fully extended', () => {
   const client = new PrismaClientConstructor({
+    adapter: {
+      provider: 'sqlite',
+      adapterName: 'mock-adapter',
+      connect: () => Promise.resolve({} as any),
+    },
     errorFormat: 'pretty',
   })
 

--- a/packages/type-benchmark-tests/lots-of-relations/client-options.bench.ts
+++ b/packages/type-benchmark-tests/lots-of-relations/client-options.bench.ts
@@ -21,11 +21,6 @@ declare const PrismaClientConstructor: typeof PrismaClient
 
 bench('log config applied', () => {
   const client = new PrismaClientConstructor({
-    adapter: {
-      provider: 'sqlite',
-      adapterName: 'mock-adapter',
-      connect: () => Promise.resolve({} as any),
-    },
     log: [
       { level: 'query', emit: 'event' },
       { level: 'error', emit: 'stdout' },
@@ -61,11 +56,6 @@ bench('log config applied', () => {
 
 bench('errorFormat applied', () => {
   const client = new PrismaClientConstructor({
-    adapter: {
-      provider: 'sqlite',
-      adapterName: 'mock-adapter',
-      connect: () => Promise.resolve({} as any),
-    },
     errorFormat: 'pretty',
   })
 
@@ -94,11 +84,6 @@ bench('adapter applied', () => {
 
 bench('global omit applied', async () => {
   const client = new PrismaClientConstructor({
-    adapter: {
-      provider: 'sqlite',
-      adapterName: 'mock-adapter',
-      connect: () => Promise.resolve({} as any),
-    },
     omit: {
       model0: {
         name: true,
@@ -118,11 +103,6 @@ bench('global omit applied', async () => {
 
 bench('extended client then pass around', () => {
   const client = new PrismaClientConstructor({
-    adapter: {
-      provider: 'sqlite',
-      adapterName: 'mock-adapter',
-      connect: () => Promise.resolve({} as any),
-    },
     errorFormat: 'pretty',
   }).$extends({})
 
@@ -136,11 +116,6 @@ bench('extended client then pass around', () => {
 
 bench('passed around client then extend', () => {
   const client = new PrismaClientConstructor({
-    adapter: {
-      provider: 'sqlite',
-      adapterName: 'mock-adapter',
-      connect: () => Promise.resolve({} as any),
-    },
     errorFormat: 'pretty',
   })
 
@@ -154,11 +129,6 @@ bench('passed around client then extend', () => {
 
 bench('fully extended', () => {
   const client = new PrismaClientConstructor({
-    adapter: {
-      provider: 'sqlite',
-      adapterName: 'mock-adapter',
-      connect: () => Promise.resolve({} as any),
-    },
     errorFormat: 'pretty',
   }).$extends({
     model: {
@@ -200,13 +170,7 @@ bench('fully extended', () => {
 }).types([26915, 'instantiations'])
 
 bench('fully extended without client options', () => {
-  const client = new PrismaClientConstructor({
-    adapter: {
-      provider: 'sqlite',
-      adapterName: 'mock-adapter',
-      connect: () => Promise.resolve({} as any),
-    },
-  }).$extends({
+  const client = new PrismaClientConstructor().$extends({
     model: {
       $allModels: {
         exists<T>(this: T, where: Prisma.Args<T, 'findFirst'>['where']): Promise<boolean> {
@@ -251,11 +215,6 @@ bench('fully extended without client options', () => {
 
 bench('using typeof - log config applied', () => {
   const client = new PrismaClientConstructor({
-    adapter: {
-      provider: 'sqlite',
-      adapterName: 'mock-adapter',
-      connect: () => Promise.resolve({} as any),
-    },
     log: [
       { level: 'query', emit: 'event' },
       { level: 'error', emit: 'stdout' },
@@ -274,11 +233,6 @@ bench('using typeof - log config applied', () => {
 
 bench('using typeof - errorFormat applied', () => {
   const client = new PrismaClientConstructor({
-    adapter: {
-      provider: 'sqlite',
-      adapterName: 'mock-adapter',
-      connect: () => Promise.resolve({} as any),
-    },
     errorFormat: 'pretty',
   })
 
@@ -311,11 +265,6 @@ bench('using typeof - adapter applied', () => {
 
 bench('using typeof - global omit applied', () => {
   const client = new PrismaClientConstructor({
-    adapter: {
-      provider: 'sqlite',
-      adapterName: 'mock-adapter',
-      connect: () => Promise.resolve({} as any),
-    },
     omit: {
       model0: {},
     },
@@ -332,11 +281,6 @@ bench('using typeof - global omit applied', () => {
 
 bench('using typeof - fully extended', () => {
   const client = new PrismaClientConstructor({
-    adapter: {
-      provider: 'sqlite',
-      adapterName: 'mock-adapter',
-      connect: () => Promise.resolve({} as any),
-    },
     errorFormat: 'pretty',
   })
 

--- a/packages/type-benchmark-tests/lots-of-relations/client-options.bench.ts
+++ b/packages/type-benchmark-tests/lots-of-relations/client-options.bench.ts
@@ -29,7 +29,6 @@ bench('log config applied', () => {
   })
 
   const passClientAround = (prisma: PrismaClient) => {
-    // @ts-expect-error - using a non-existent event type is a type error
     prisma.$on('foobarbaz', (event) => {
       console.log(event)
     })
@@ -47,7 +46,6 @@ bench('log config applied', () => {
     console.log(event)
   })
 
-  // @ts-expect-error - info is not a valid event type because we do not pass it in the client options
   client.$on('info', (event) => {
     console.log(event)
   })
@@ -98,10 +96,8 @@ bench('global omit applied', async () => {
   }
 
   const res = await client.model0.findFirst({})
-  // @ts-expect-error - name should not be available as it is globally omitted
   console.log(res?.name)
 
-  // @ts-expect-error - client with omitted fields is not equal to a client without any config as the omitted fields are missing
   return passClientAround(client)
 }).types([88887, 'instantiations'])
 
@@ -114,7 +110,6 @@ bench('extended client then pass around', () => {
     return prisma
   }
 
-  // @ts-expect-error - once a client is extended, it is no longer assignable to the base client type
   return passClientAround(client)
   // Apparently extending the client and then passing it around is way faster.
 }).types([3202, 'instantiations'])
@@ -171,7 +166,6 @@ bench('fully extended', () => {
     return prisma
   }
 
-  // @ts-expect-error - once a client is extended, it is no longer assignable to the base client type
   return passClientAround(client)
 }).types([26915, 'instantiations'])
 
@@ -212,7 +206,6 @@ bench('fully extended without client options', () => {
     return prisma
   }
 
-  // @ts-expect-error - once a client is extended, it is no longer assignable to the base client type
   return passClientAround(client)
 }).types([26843, 'instantiations'])
 

--- a/packages/type-benchmark-tests/lots-of-relations/client-options.bench.ts
+++ b/packages/type-benchmark-tests/lots-of-relations/client-options.bench.ts
@@ -5,6 +5,13 @@ import type { Prisma, PrismaClient } from './generated/client'
 
 declare const PrismaClientConstructor: typeof PrismaClient
 
+// Mock adapter for type benchmark tests (these tests don't actually run, so a mock is sufficient)
+const mockAdapter = {
+  provider: 'sqlite' as const,
+  adapterName: 'mock-adapter',
+  connect: () => Promise.resolve({} as any),
+}
+
 /**
  * These tests check the type performance of the PrismaClient constructor which can get complex due to passed client options.
  * The client options can have an impact on the structural assignability of the PrismaClientConstructor as they might change the available APIs.
@@ -21,6 +28,7 @@ declare const PrismaClientConstructor: typeof PrismaClient
 
 bench('log config applied', () => {
   const client = new PrismaClientConstructor({
+    adapter: mockAdapter,
     log: [
       { level: 'query', emit: 'event' },
       { level: 'error', emit: 'stdout' },
@@ -29,26 +37,12 @@ bench('log config applied', () => {
   })
 
   const passClientAround = (prisma: PrismaClient) => {
-    prisma.$on('foobarbaz', (event) => {
-      console.log(event)
-    })
     return prisma
   }
 
   const passToAnyClientAround = (prisma: PrismaClient<any>) => {
-    prisma.$on('info', (event) => {
-      console.log(event)
-    })
     return prisma
   }
-
-  client.$on('query', (event) => {
-    console.log(event)
-  })
-
-  client.$on('info', (event) => {
-    console.log(event)
-  })
 
   passClientAround(client)
   passToAnyClientAround(client)
@@ -56,6 +50,7 @@ bench('log config applied', () => {
 
 bench('errorFormat applied', () => {
   const client = new PrismaClientConstructor({
+    adapter: mockAdapter,
     errorFormat: 'pretty',
   })
 
@@ -84,6 +79,7 @@ bench('adapter applied', () => {
 
 bench('global omit applied', async () => {
   const client = new PrismaClientConstructor({
+    adapter: mockAdapter,
     omit: {
       model0: {
         name: true,
@@ -91,22 +87,26 @@ bench('global omit applied', async () => {
     },
   })
 
-  const passClientAround = (prisma: PrismaClient) => {
+  type CustomPrismaClient = typeof client
+  const passClientAround = (prisma: CustomPrismaClient) => {
     return prisma
   }
 
   const res = await client.model0.findFirst({})
-  console.log(res?.name)
+  // Note: 'name' is omitted, so we can't access it
+  console.log(res?.id)
 
   return passClientAround(client)
 }).types([88887, 'instantiations'])
 
 bench('extended client then pass around', () => {
   const client = new PrismaClientConstructor({
+    adapter: mockAdapter,
     errorFormat: 'pretty',
   }).$extends({})
 
-  const passClientAround = (prisma: PrismaClient) => {
+  type CustomPrismaClient = typeof client
+  const passClientAround = (prisma: CustomPrismaClient) => {
     return prisma
   }
 
@@ -116,6 +116,7 @@ bench('extended client then pass around', () => {
 
 bench('passed around client then extend', () => {
   const client = new PrismaClientConstructor({
+    adapter: mockAdapter,
     errorFormat: 'pretty',
   })
 
@@ -129,6 +130,7 @@ bench('passed around client then extend', () => {
 
 bench('fully extended', () => {
   const client = new PrismaClientConstructor({
+    adapter: mockAdapter,
     errorFormat: 'pretty',
   }).$extends({
     model: {
@@ -162,7 +164,8 @@ bench('fully extended', () => {
     },
   })
 
-  const passClientAround = (prisma: PrismaClient) => {
+  type CustomPrismaClient = typeof client
+  const passClientAround = (prisma: CustomPrismaClient) => {
     return prisma
   }
 
@@ -170,7 +173,9 @@ bench('fully extended', () => {
 }).types([26915, 'instantiations'])
 
 bench('fully extended without client options', () => {
-  const client = new PrismaClientConstructor().$extends({
+  const client = new PrismaClientConstructor({
+    adapter: mockAdapter,
+  }).$extends({
     model: {
       $allModels: {
         exists<T>(this: T, where: Prisma.Args<T, 'findFirst'>['where']): Promise<boolean> {
@@ -202,7 +207,8 @@ bench('fully extended without client options', () => {
     },
   })
 
-  const passClientAround = (prisma: PrismaClient) => {
+  type CustomPrismaClient = typeof client
+  const passClientAround = (prisma: CustomPrismaClient) => {
     return prisma
   }
 
@@ -215,6 +221,7 @@ bench('fully extended without client options', () => {
 
 bench('using typeof - log config applied', () => {
   const client = new PrismaClientConstructor({
+    adapter: mockAdapter,
     log: [
       { level: 'query', emit: 'event' },
       { level: 'error', emit: 'stdout' },
@@ -233,6 +240,7 @@ bench('using typeof - log config applied', () => {
 
 bench('using typeof - errorFormat applied', () => {
   const client = new PrismaClientConstructor({
+    adapter: mockAdapter,
     errorFormat: 'pretty',
   })
 
@@ -265,6 +273,7 @@ bench('using typeof - adapter applied', () => {
 
 bench('using typeof - global omit applied', () => {
   const client = new PrismaClientConstructor({
+    adapter: mockAdapter,
     omit: {
       model0: {},
     },
@@ -281,6 +290,7 @@ bench('using typeof - global omit applied', () => {
 
 bench('using typeof - fully extended', () => {
   const client = new PrismaClientConstructor({
+    adapter: mockAdapter,
     errorFormat: 'pretty',
   })
 

--- a/packages/type-benchmark-tests/lots-of-relations/client-options.bench.ts
+++ b/packages/type-benchmark-tests/lots-of-relations/client-options.bench.ts
@@ -37,12 +37,28 @@ bench('log config applied', () => {
   })
 
   const passClientAround = (prisma: PrismaClient) => {
+    // @ts-expect-error - using a non-existent event type is a type error
+    prisma.$on('foobarbaz', (event) => {
+      console.log(event)
+    })
     return prisma
   }
 
   const passToAnyClientAround = (prisma: PrismaClient<any>) => {
+    prisma.$on('info', (event) => {
+      console.log(event)
+    })
     return prisma
   }
+
+  client.$on('query', (event) => {
+    console.log(event)
+  })
+
+  // @ts-expect-error - info is not a valid event type because we do not pass it in the client options
+  client.$on('info', (event) => {
+    console.log(event)
+  })
 
   passClientAround(client)
   passToAnyClientAround(client)
@@ -87,15 +103,15 @@ bench('global omit applied', async () => {
     },
   })
 
-  type CustomPrismaClient = typeof client
-  const passClientAround = (prisma: CustomPrismaClient) => {
+  const passClientAround = (prisma: PrismaClient) => {
     return prisma
   }
 
   const res = await client.model0.findFirst({})
-  // Note: 'name' is omitted, so we can't access it
-  console.log(res?.id)
+  // @ts-expect-error - name should not be available as it is globally omitted
+  console.log(res?.name)
 
+  // @ts-expect-error - client with omitted fields is not equal to a client without any config as the omitted fields are missing
   return passClientAround(client)
 }).types([88887, 'instantiations'])
 
@@ -105,11 +121,11 @@ bench('extended client then pass around', () => {
     errorFormat: 'pretty',
   }).$extends({})
 
-  type CustomPrismaClient = typeof client
-  const passClientAround = (prisma: CustomPrismaClient) => {
+  const passClientAround = (prisma: PrismaClient) => {
     return prisma
   }
 
+  // @ts-expect-error - once a client is extended, it is no longer assignable to the base client type
   return passClientAround(client)
   // Apparently extending the client and then passing it around is way faster.
 }).types([3202, 'instantiations'])
@@ -164,11 +180,11 @@ bench('fully extended', () => {
     },
   })
 
-  type CustomPrismaClient = typeof client
-  const passClientAround = (prisma: CustomPrismaClient) => {
+  const passClientAround = (prisma: PrismaClient) => {
     return prisma
   }
 
+  // @ts-expect-error - once a client is extended, it is no longer assignable to the base client type
   return passClientAround(client)
 }).types([26915, 'instantiations'])
 
@@ -207,11 +223,11 @@ bench('fully extended without client options', () => {
     },
   })
 
-  type CustomPrismaClient = typeof client
-  const passClientAround = (prisma: CustomPrismaClient) => {
+  const passClientAround = (prisma: PrismaClient) => {
     return prisma
   }
 
+  // @ts-expect-error - once a client is extended, it is no longer assignable to the base client type
   return passClientAround(client)
 }).types([26843, 'instantiations'])
 


### PR DESCRIPTION
This PR:
- closes [TML-1558](https://linear.app/prisma-company/issue/TML-1588/make-adapter-xor-accelerateurl-required-in-types)
- makes `accelerateUrl` and `adapter` mutually exclusive at type-level, and add new type-level tests matching this
- as a consequence, `new PrismaClient()` and `new PrismaClient({})` are no longer valid constructs in Prisma 7
  - this would already yield a runtime error. Now, it yields a type error
---

I also had to spend considerable time fixing the client tests at the type-level.