### PR TITLE
fix: fix sqlite node 20 studio issues

### DIFF
--- a/packages/cli/src/Studio.ts
+++ b/packages/cli/src/Studio.ts
@@ -73,7 +73,7 @@ const CONNECTION_STRING_PROTOCOL_TO_STUDIO_STUFF: Record<string, StudioStuff | n
     async createExecutor(uri, relativeTo) {
       const path = uri.replace('file:', '')
 
-      const resolvedPath = path !== ':memory:' ? resolve(dirname(relativeTo), path) : path
+      const resolvedPath = path !== ':memory:' ? resolve(relativeTo, path) : path
 
       let database: import('better-sqlite3').Database | undefined = undefined
 
@@ -89,7 +89,7 @@ const CONNECTION_STRING_PROTOCOL_TO_STUDIO_STUFF: Record<string, StudioStuff | n
           const { default: Database } = await import('better-sqlite3')
 
           database = new Database(resolvedPath)
-        } catch {
+        } catch (error) {
           throw new Error(
             `Failed to open SQLite database at "${resolvedPath}".\nCaused by: ${(error as Error).message}\n\nPlease use Node.js >=22.5 or ensure you have \`better-sqlite3\` installed.`,
           )
@@ -221,7 +221,7 @@ ${bold('Examples')}
 
     const executor = await studioStuff.createExecutor(
       connectionString,
-      args['--url'] ? process.cwd() : config.loadedFromFile || process.cwd(),
+      getUrlBasePath(args['--url'], config.loadedFromFile),
     )
 
     const app = new Hono()
@@ -356,3 +356,7 @@ const INDEX_HTML =
     </script>
   </body>
 </html>`
+
+function getUrlBasePath(url: string | undefined, configPath: string | null): string {
+  return url ? process.cwd() : configPath ? dirname(configPath) : process.cwd()
+}

--- a/sandbox/pnpm-workspace.yaml
+++ b/sandbox/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
 packages:
   - '*'
+
+ignoredBuiltDependencies:
+  - better-sqlite3

--- a/sandbox/studio/package.json
+++ b/sandbox/studio/package.json
@@ -10,8 +10,8 @@
     "studio:mysql:debug": "PROVIDER=mysql pnpm studio:debug",
     "studio:postgres": "PROVIDER=postgres pnpm studio",
     "studio:postgres:debug": "PROVIDER=postgres pnpm studio:debug",
-    "studio:sqlite": "PROVIDER=sqlite NODE_OPTIONS=--experimental-sqlite pnpm studio",
-    "studio:sqlite:debug": "PROVIDER=sqlite NODE_OPTIONS=--experimental-sqlite pnpm studio:debug"
+    "studio:sqlite": "PROVIDER=sqlite pnpm studio",
+    "studio:sqlite:debug": "PROVIDER=sqlite pnpm studio:debug"
   },
   "keywords": [],
   "author": "",
@@ -23,8 +23,5 @@
     "@dotenvx/dotenvx": "^1.29.3",
     "tsx": "^4.20.6",
     "typescript": "5.9.3"
-  },
-  "engines": {
-    "node": ">=22.5.0"
   }
 }


### PR DESCRIPTION
[TML-1603](https://linear.app/prisma-company/issue/TML-1603/bug-node-20-users-cant-use-even-when-better-sqlite3-installed)

Node 20 is supported by running studio via: `npx -p better-sqlite3 -p prisma@dev prisma studio`. Better-sqlite3 is not available by default and needs to be added explicitly.