### PR TITLE
feat(migrate): print helpful message when no `seed` property is defined

### DIFF
--- a/packages/migrate/src/__tests__/DbSeed.test.ts
+++ b/packages/migrate/src/__tests__/DbSeed.test.ts
@@ -7,6 +7,18 @@ const ctx = createDefaultTestContext()
 
 describe('seed', () => {
   describe('from prisma.config.ts', () => {
+    it('prints helpful message when no seed is configured', async () => {
+      ctx.fixture('prisma-config')
+
+      const result = DbSeed.new().parse([], await ctx.config())
+
+      await expect(result).resolves.toContain('No seed command configured')
+      await expect(result).resolves.toContain('migrations')
+      await expect(result).resolves.toContain('seed')
+      await expect(result).resolves.toContain('prisma.config.ts')
+      expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+    })
+
     it('skips deprecated package.json config', async () => {
       ctx.fixture('seed-from-prisma-config/seed-sqlite-skips-deprecated-package-json')
 

--- a/packages/migrate/src/commands/DbSeed.ts
+++ b/packages/migrate/src/commands/DbSeed.ts
@@ -65,12 +65,13 @@ ${bold('Example')}
 
   ${dim('// prisma.config.ts')}
   export default defineConfig({
-    migrations: {
-      seed: ${dim('// e.g.')} ${bold('"bun ./prisma/seed.ts"')},
-    },
-    datasource: {
-      url: '<database-url>',
-    },
+    ${bold('migrations: {')}
+      ${bold(`seed: 'bun·./prisma/seed.ts'`)},
+    ${bold('}')},
+    ${dim('datasource: {')}
+      ${dim(`url: '[your database URL]'`)},
+    ${dim('}')},
+    ${bold('}')},
   })
 `)
     }

--- a/packages/migrate/src/commands/DbSeed.ts
+++ b/packages/migrate/src/commands/DbSeed.ts
@@ -71,7 +71,6 @@ ${bold('Example')}
     ${dim('datasource: {')}
       ${dim(`url: '[your database URL]'`)},
     ${dim('}')},
-    ${bold('}')},
   })
 `)
     }

--- a/packages/migrate/src/commands/DbSeed.ts
+++ b/packages/migrate/src/commands/DbSeed.ts
@@ -56,7 +56,24 @@ ${dim('$')} prisma db seed -- --arg1 value1 --arg2 value2`)
 
     const seedCommand = config.migrations?.seed
 
-    if (!seedCommand) return ``
+    if (!seedCommand) {
+      return format(`⚠️ ${bold('No seed command configured')}
+
+To seed your database, add a ${bold('seed')} property to the ${bold('migrations')} section in your ${bold('Prisma config')} file.
+
+${bold('Example')}
+
+  ${dim('// prisma.config.ts')}
+  export default defineConfig({
+    migrations: {
+      seed: ${dim('// e.g.')} ${bold('"bun ./prisma/seed.ts"')},
+    },
+    datasource: {
+      url: '<database-url>',
+    },
+  })
+`)
+    }
 
     // We pass the extra params after a -- separator
     // Example: db seed -- --custom-param


### PR DESCRIPTION
This PR:
- closes [TML-1605](https://linear.app/prisma-company/issue/TML-1605/prisma-db-seed-should-print-a-message-when-no-seed-attribute-is)
- adds a helpful message when `prisma db seed` is run, but `migrate.seed` is not defined in the Prisma config file.

## Output

Plain text:

```
❯ p prisma db seed                     
Loaded Prisma config from prisma.config.ts.

⚠️ No seed command configured

To seed your database, add a seed property to the migrations section in your Prisma config file.

Example

  // prisma.config.ts
  export default defineConfig({
    migrations: {
      seed: 'bun·./prisma/seed.ts',
    },
    datasource: {
      url: '[your database URL]',
    },
  })
```

Rendered:

<img width="976" height="382" alt="Screenshot 2025-11-20 at 3 45 39 PM" src="https://github.com/user-attachments/assets/2c76be6f-be90-4346-9f97-cb4349afc26a" />


