### PR TITLE
fix: allow any node version higher than 24

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "triggerEmptyDevReleaseByIncrementingThisNumber": 0,
   "license": "Apache-2.0",
   "engines": {
-    "node": "^20.19 || ^22.12 || ^24.0",
+    "node": "^20.19 || ^22.12 || >=24.0",
     "pnpm": ">=10.15 <11"
   },
   "packageManager": "pnpm@10.15.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,7 +39,7 @@
   "bugs": "https://github.com/prisma/prisma/issues",
   "license": "Apache-2.0",
   "engines": {
-    "node": "^20.19 || ^22.12 || ^24.0"
+    "node": "^20.19 || ^22.12 || >=24.0"
   },
   "prisma": {
     "prismaCommit": "placeholder-for-commit-hash-replaced-during-publishing-in-publish-ts"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -121,7 +121,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": "^20.19 || ^22.12 || ^24.0"
+    "node": "^20.19 || ^22.12 || >=24.0"
   },
   "homepage": "https://www.prisma.io",
   "repository": {


### PR DESCRIPTION
The current configuration prevents consumers from using higher node versions, while having strict-engine checks enabled.
Higher node versions might not be officially supported, but I think they shouldn't be blocked, unless they are known to now work.

Resolves #28594