### PR TITLE
fix(ci): add --no-hints to generate call in type-benchmark-tests

### DIFF
--- a/packages/type-benchmark-tests/test.ts
+++ b/packages/type-benchmark-tests/test.ts
@@ -111,7 +111,7 @@ function getBenchmarkFiles(dir: string) {
 
 async function runGenerate(dir: string, cwd: string) {
   console.log(`Running generate command in ${dir}...`)
-  await execa('tsx', ['../../cli/src/bin.ts', 'generate'], { cwd, stdio: 'inherit' })
+  await execa('tsx', ['../../cli/src/bin.ts', 'generate', '--no-hints'], { cwd, stdio: 'inherit' })
 }
 
 async function runBenchmark({


### PR DESCRIPTION
Without this the type benchmark tests on my machine would run into the NPS survey stuff. ;)