### PR TITLE
chore(deps): bump better-sqlite3

### DIFF
--- a/packages/adapter-better-sqlite3/package.json
+++ b/packages/adapter-better-sqlite3/package.json
@@ -36,7 +36,7 @@
   "sideEffects": false,
   "dependencies": {
     "@prisma/driver-adapter-utils": "workspace:*",
-    "better-sqlite3": "^11.10.0"
+    "better-sqlite3": "^12.4.5"
   },
   "devDependencies": {
     "@types/better-sqlite3": "7.6.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,8 +221,8 @@ importers:
         specifier: workspace:*
         version: link:../driver-adapter-utils
       better-sqlite3:
-        specifier: ^11.10.0
-        version: 11.10.0
+        specifier: ^12.4.5
+        version: 12.4.5
     devDependencies:
       '@types/better-sqlite3':
         specifier: 7.6.12
@@ -4460,6 +4460,10 @@ packages:
 
   better-sqlite3@11.10.0:
     resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+
+  better-sqlite3@12.4.5:
+    resolution: {integrity: sha512-4NejwX2llfdKYK7Tzwwre/qKzTXiqcbycIagtqMH9oE7Es3LCUGGGXvhw8rWbZ2alx1C/Nh0MeJyYEZKUFs4sw==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
@@ -11170,6 +11174,14 @@ snapshots:
       platform: 1.3.6
 
   better-sqlite3@11.10.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+
+  better-sqlite3@12.4.5:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3


### PR DESCRIPTION
Fixes #28624 

This PR updates the dependency to the latest `better-sqlite3` version to allow installation on Node.js v24 without `node-gyp`.

Upgrading `better-sqlite3` to v12.4.5 resolves this issue, as the [v12 branch](https://github.com/WiseLibs/better-sqlite3/releases/tag/v12.0.0) includes support for Node.js v24. While v12 drops support for Node v18, Prisma itself supports Node v20+ from its recent releases, so this should not introduce compatibility issues.