### PR TITLE
fix(generate): place usage instructions directly after generator output

### DIFF
--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -253,7 +253,26 @@ ${breakingChangesStr}${versionsWarning}`
         }
       }
 
-      const message = '\n' + this.logText + (hasJsClient && !this.hasGeneratorErrored ? hint : '')
+      if (hasJsClient && !this.hasGeneratorErrored && !hideHints && hint) {
+        try {
+          const clientName = prismaClientJSGenerator?.manifest?.prettyName ?? 'Prisma Client'
+          const generatedMarker = `✔ Generated ${clientName}`
+          const idx = this.logText.indexOf(generatedMarker)
+          if (idx !== -1) {
+            let afterLineIdx = this.logText.indexOf('\n', idx)
+            if (afterLineIdx === -1) {
+              afterLineIdx = this.logText.length
+            }
+            this.logText = this.logText.slice(0, afterLineIdx + 1) + '\n' + hint + this.logText.slice(afterLineIdx + 1)
+          } else {
+            this.logText += '\n' + hint
+          }
+        } catch (e) {
+          this.logText += '\n' + hint
+        }
+      }
+
+      const message = '\n' + this.logText
 
       if (this.hasGeneratorErrored) {
         throw new Error(message)


### PR DESCRIPTION
Fixes issue #1737

Problem:
When running prisma generate, the usage instructions (e.g.,
"You can now start using Prisma Client...") always appear at the very end of the CLI output.
This creates confusion when multiple generators are used, because the usage block does not appear next to the generator that actually produced the Prisma Client.

Solution:
Updates the prisma generate CLI so that the usage instructions are inserted immediately after the corresponding:

✔ Generated Prisma Client to ...
line.

This improves clarity by grouping the instructions with the generator that requires them.

Changes Made:
Updated Generate.ts to inject the usage block directly after the Prisma Client generator success message.

Maintains existing behavior for:
--no-hints
non-JS generators
watch mode
No functional changes to generator behavior or schema evaluation.

The output is now more readable and intuitive.
Instructions appear exactly where users expect them — directly after the Prisma Client generation step.