### PR TITLE
feat(cli): Studio now warns when SQLite file did not exist and was created.

### DIFF
--- a/packages/cli/src/Studio.ts
+++ b/packages/cli/src/Studio.ts
@@ -89,7 +89,7 @@ const CONNECTION_STRING_PROTOCOL_TO_STUDIO_STUFF: Record<string, StudioStuff | n
         await access(resolvedPath, constants.F_OK).catch(() => {
           console.warn(
             yellow(
-              `database file at "${resolvedPath}" was not found. a new file was created. if this is an unwanted side effect, it might mean that the URL you have provided is incorrect.`,
+              `Database file at "${resolvedPath}" was not found. A new file was created. If this is an unwanted side effect, it might mean that the URL you have provided is incorrect.`,
             ),
           )
         })


### PR DESCRIPTION
Hey :wave:

closes PTL-559.

This PR checks for the existence of the target SQLite file and if it didn't exist before, it prints a warning. This is to let users know that they might've provided a wrong path.