### PR TITLE
fix(adepter-pg): normalize MONEY values for Decimal

### DIFF
--- a/packages/adapter-pg/src/conversion.ts
+++ b/packages/adapter-pg/src/conversion.ts
@@ -332,7 +332,26 @@ function normalize_timez(time: string): string {
 /******************/
 
 function normalize_money(money: string): string {
-  return money.slice(1)
+  if (money == null) return money;
+
+
+  let cleaned = money.replace(/[^0-9.,-]+/g, "");
+
+  const hasComma = cleaned.includes(",");
+  const hasDot = cleaned.includes(".");
+
+
+  if (hasComma && hasDot) {
+    if (cleaned.lastIndexOf(".") > cleaned.lastIndexOf(",")) {
+      cleaned = cleaned.replace(/,/g, "");
+    } else {
+      cleaned = cleaned.replace(/\./g, "").replace(",", ".");
+    }
+  }
+  else if (hasComma && !hasDot) {
+    cleaned = cleaned.replace(",", ".");
+  }
+  return cleaned;
 }
 
 /******************/


### PR DESCRIPTION
## Summary

This PR fixes the parsing of PostgreSQL `MONEY` values in `@prisma/adapter-pg`.  
Currently, `normalize_money` simply uses `money.slice(1)`, which only removes the
leading currency symbol and does not handle thousands separators, locale formats,
or values without a symbol. This causes Prisma to pass invalid strings such as
`"50,000.00"` to `Decimal`, resulting in:

`[DecimalError] Invalid argument: 50,000.00`

This behavior worked in Prisma 6 and regressed in Prisma 7.

## Changes

- Updated `normalize_money` to:
  - Strip currency symbols, spaces, and letters
  - Remove thousands separators
  - Detect locale decimal separators
  - Normalize all MONEY strings into valid `Decimal`-compatible numeric strings
- Supports both US-style (`$50,000.00`) and EU-style (`€1.234,56`) formats.

## Reproduction

Using PostgreSQL with a `MONEY` column:

```prisma
model Order {
  id        Int      @id @default(autoincrement())
  price     Decimal  @db.Money
  createdAt DateTime @default(now())
}
````

Aggregating:

```ts
await prisma.order.aggregate({
  _sum: { price: true }
});
```

### Before (Prisma 7.0.0)

Throws:
`[DecimalError] Invalid argument: 50,000.00`

### After (this PR)

Returns the correct aggregated decimal value with no errors.

## Regression

This issue did not exist in Prisma 6.x.
The regression appears after introduction of the new adapter conversion pipeline in Prisma 7.

## Testing

Verified locally using the PostgreSQL sandbox with MONEY values inserted such as:

* `$50,000.00`
* `€1.234,56`

Aggregate queries now succeed without errors and return correct numeric results.