### PR TITLE
fix: fix missing cockroach wasm files

### DIFF
--- a/packages/client-generator-js/src/generateClient.ts
+++ b/packages/client-generator-js/src/generateClient.ts
@@ -421,6 +421,7 @@ function isWasmEngineSupported(provider: ConnectorType) {
   return (
     provider === 'postgresql' ||
     provider === 'postgres' ||
+    provider === 'cockroachdb' ||
     provider === 'mysql' ||
     provider === 'sqlite' ||
     provider === 'sqlserver'

--- a/packages/client-generator-js/tests/cockroachdb.prisma
+++ b/packages/client-generator-js/tests/cockroachdb.prisma
@@ -1,0 +1,12 @@
+datasource db {
+  provider = "cockroachdb"
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id   Int    @id @map("_id")
+  name String
+}


### PR DESCRIPTION
Discovered when fixing ecosystem tests. The cockroachdb provider is broken with the old generator due to a missing WASM file. Confirmed working via an integration release in ecosystem tests:
https://github.com/prisma/ecosystem-tests/actions/runs/19664459482/job/56317937872?pr=5984
https://github.com/prisma/ecosystem-tests/actions/runs/19664459482/job/56317939895?pr=5984