### PR TITLE
ci: fix syntax error in bash script

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -57,7 +57,7 @@ runs:
         elif [ -f "$RELEASE_DIR/schema-engine.exe" ]; then
           WIN_RELEASE_DIR=$(cygpath -w $RELEASE_DIR)
           echo "PRISMA_SCHEMA_ENGINE_BINARY=$WIN_RELEASE_DIR\\\schema-engine.exe" >> $GITHUB_ENV
-        else
+        fi
       shell: bash
 
     - name: Override WASM modules


### PR DESCRIPTION
The script is now broken after some Prisma 7 related changes.

See https://github.com/prisma/prisma/actions/runs/19639665031/job/56241140496?pr=28598#step:4:411