### PR TITLE
feat(ci): add client-wasm-compiler-edge test suite

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -314,7 +314,7 @@ jobs:
           timeout_minutes: 10
           max_attempts: 5
           retry_wait_seconds: 120
-          command: docker compose -f docker/docker-compose.yml up --wait --detach postgres
+          command: docker compose -f docker/docker-compose.yml up --wait --detach postgres neon_wsproxy planetscale_proxy mssql mysql cockroachdb
 
       - name: Install & build
         uses: ./.github/actions/setup

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -221,7 +221,6 @@ jobs:
       fail-fast: false
       # Note: the maximum number of matrix configurations on Github Actions is 256
       matrix:
-        # TODO: add `wasm-compiler-edge` to `clientRuntime` once Prisma 7 is ready
         clientRuntime: ['client']
         flavor:
           [
@@ -248,6 +247,74 @@ jobs:
           max_attempts: 5
           retry_wait_seconds: 120
           command: docker compose -f docker/docker-compose.yml up --wait --detach postgres neon_wsproxy planetscale_proxy mssql mysql cockroachdb
+
+      - name: Install & build
+        uses: ./.github/actions/setup
+        with:
+          node-version: ${{ matrix.node }}
+          engine-hash: ${{ inputs.engineHash }}
+          skip-tsc: false
+
+      - run: pnpm run test:functional ${{ env.FUNCTIONAL_TEST_OPTIONS }} --adapter ${{ matrix.flavor }} --shard ${{ matrix.shard }} --generator-type prisma-client-ts --client-runtime ${{ matrix.clientRuntime }} --preview-features "${{ matrix.previewFeatures }}" --runInBand
+        working-directory: packages/client
+        env:
+          PRISMA_DISABLE_QUAINT_EXECUTORS: true, # ensures quaint runs no queries
+          NODE_NO_WARNINGS: 1 # hides undici websocket warnings
+          NODE_OPTIONS: '--max-old-space-size=8096'
+          JEST_JUNIT_SUITE_NAME: 'client/functional'
+          JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
+
+      - name: Upload test results to BuildPulse for flaky test detection
+        # Only run this step for branches where we have access to secrets.
+        # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse' && github.repository == 'prisma/prisma'
+        uses: buildpulse/buildpulse-action@v0.11.0
+        with:
+          account: 17219288
+          repository: 192925833
+          path: packages/*/junit*.xml
+          key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
+          secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
+
+  #
+  # CLIENT (functional tests with wasm-compiler-edge runtime and driver adapters)
+  #
+  client-wasm-compiler-edge:
+    name: Wasm Edge ${{ matrix.flavor }} [v${{ matrix.node }}] ${{ matrix.shard }}
+    timeout-minutes: ${{ inputs.driverAdapterTestJobTimeout }}
+    runs-on: ubuntu-latest
+    if: |
+      contains(inputs.jobsToRun, '-all-') ||
+      contains(inputs.jobsToRun, '-client-')
+    strategy:
+      fail-fast: false
+      matrix:
+        clientRuntime: ['wasm-compiler-edge']
+        flavor:
+          [
+            'js_pg',
+            'js_neon',
+            'js_libsql',
+            'js_planetscale',
+            'js_d1',
+            'js_better_sqlite3',
+            'js_mssql',
+            'js_mariadb',
+            'js_pg_cockroachdb',
+          ]
+        shard: ['1/4', '2/4', '3/4', '4/4']
+        node: ['20.19.0']
+        previewFeatures: ['', 'relationJoins']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Start Docker Compose Services
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 5
+          retry_wait_seconds: 120
+          command: docker compose -f docker/docker-compose.yml up --wait --detach postgres
 
       - name: Install & build
         uses: ./.github/actions/setup

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -189,7 +189,6 @@ jobs:
       - run: pnpm run test:functional ${{ env.FUNCTIONAL_TEST_OPTIONS }} --adapter ${{ matrix.flavor }} --shard ${{ matrix.shard }} --generator-type prisma-client-js --client-runtime client --runInBand
         working-directory: packages/client
         env:
-          PRISMA_DISABLE_QUAINT_EXECUTORS: true, # ensures quaint runs no queries
           NODE_NO_WARNINGS: 1 # hides undici websocket warnings
           NODE_OPTIONS: '--max-old-space-size=8096'
           JEST_JUNIT_SUITE_NAME: 'client/functional'
@@ -258,7 +257,6 @@ jobs:
       - run: pnpm run test:functional ${{ env.FUNCTIONAL_TEST_OPTIONS }} --adapter ${{ matrix.flavor }} --shard ${{ matrix.shard }} --generator-type prisma-client-ts --client-runtime ${{ matrix.clientRuntime }} --preview-features "${{ matrix.previewFeatures }}" --runInBand
         working-directory: packages/client
         env:
-          PRISMA_DISABLE_QUAINT_EXECUTORS: true, # ensures quaint runs no queries
           NODE_NO_WARNINGS: 1 # hides undici websocket warnings
           NODE_OPTIONS: '--max-old-space-size=8096'
           JEST_JUNIT_SUITE_NAME: 'client/functional'
@@ -326,7 +324,6 @@ jobs:
       - run: pnpm run test:functional ${{ env.FUNCTIONAL_TEST_OPTIONS }} --adapter ${{ matrix.flavor }} --shard ${{ matrix.shard }} --generator-type prisma-client-ts --client-runtime ${{ matrix.clientRuntime }} --preview-features "${{ matrix.previewFeatures }}" --runInBand
         working-directory: packages/client
         env:
-          PRISMA_DISABLE_QUAINT_EXECUTORS: true, # ensures quaint runs no queries
           NODE_NO_WARNINGS: 1 # hides undici websocket warnings
           NODE_OPTIONS: '--max-old-space-size=8096'
           JEST_JUNIT_SUITE_NAME: 'client/functional'
@@ -382,7 +379,6 @@ jobs:
       - run: pnpm run test:functional ${{ env.FUNCTIONAL_TEST_OPTIONS }} --provider ${{ matrix.provider }} --shard ${{ matrix.shard }} --generator-type prisma-client-ts --client-runtime client --remote-executor --runInBand
         working-directory: packages/client
         env:
-          PRISMA_DISABLE_QUAINT_EXECUTORS: true, # ensures quaint runs no queries
           NODE_NO_WARNINGS: 1 # hides undici websocket warnings
           NODE_OPTIONS: '--max-old-space-size=8096'
           JEST_JUNIT_SUITE_NAME: 'client/functional-qpe'

--- a/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteClient.ts
@@ -134,7 +134,10 @@ export async function setupTestSuiteClient({
   const clientPathForRuntime: Record<ClientRuntime, { client: string; sql: string }> = {
     'wasm-compiler-edge': {
       client: generatorType === 'prisma-client-ts' ? 'generated/prisma/client' : 'generated/prisma/client/edge',
-      sql: path.join(outputPath, 'sql', 'index.wasm-compiler-edge.js'),
+      sql:
+        generatorType === 'prisma-client-ts'
+          ? path.join(outputPath, 'sql.ts')
+          : path.join(outputPath, 'sql', 'index.wasm-compiler-edge.js'),
     },
     client: {
       client: 'generated/prisma/client',

--- a/packages/client/tests/functional/chunking-query/tests.ts
+++ b/packages/client/tests/functional/chunking-query/tests.ts
@@ -11,7 +11,7 @@ import type { PrismaClient, Tag } from './generated/prisma/client'
 declare let prisma: PrismaClient
 
 testMatrix.setupTestSuite(
-  ({ provider, driverAdapter, clientEngineExecutor }, _suiteMeta, { runtime }, cliMeta) => {
+  ({ provider, driverAdapter, clientEngineExecutor }, _suiteMeta, _clientMeta, cliMeta) => {
     const MAX_BIND_VALUES = MAX_BIND_VALUES_BY_PROVIDER[provider]
     const EXCESS_BIND_VALUES = EXCESS_BIND_VALUES_BY_PROVIDER[provider]
 
@@ -163,7 +163,7 @@ testMatrix.setupTestSuite(
       test('Selecting MAX ids at once in two inclusive disjunct filters results in error', async () => {
         const ids = generatedIds(MAX_BIND_VALUES)
 
-        if (!usesJsDrivers || (runtime === 'client' && clientEngineExecutor === 'local')) {
+        if (!usesJsDrivers || clientEngineExecutor === 'local') {
           // When using MAX ids, it fails both with relationJoins and without because the amount of query params that's computed is not beyond the limit.
           // To be clear: the root problem comes from the way the QE computes the amount of query params.
           await expect(selectWith2InFilters(ids)).rejects.toThrow()


### PR DESCRIPTION
This PR:
- adds new `client-wasm-compiler-edge` test workflow
- runs functional client tests against `--clientRuntime wasm-compiler-edge`
- closes [TML-1573](https://linear.app/prisma-company/issue/TML-1573/test-wasm-compiler-edge-runtime)