### PR TITLE
fix: update broken reference URL in P1013 error message

### DIFF
--- a/packages/cli/src/__tests__/__snapshots__/incomplete-schemas.test.ts.snap
+++ b/packages/cli/src/__tests__/__snapshots__/incomplete-schemas.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`[wasm] incomplete-schemas datasource-block-url-env-set-invalid db push 1`] = `"P1013: The provided database string is invalid. The scheme is not recognized in database URL. Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters."`;
+exports[`[wasm] incomplete-schemas datasource-block-url-env-set-invalid db push 1`] = `"P1013: The provided database string is invalid. The scheme is not recognized in database URL. Please refer to the documentation in https://www.prisma.io/docs/orm/reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters."`;

--- a/packages/cli/src/__tests__/incomplete-schemas.test.ts
+++ b/packages/cli/src/__tests__/incomplete-schemas.test.ts
@@ -69,7 +69,7 @@ describe('[wasm] incomplete-schemas', () => {
         expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
           "P1013
 
-          The provided database string is invalid. The scheme is not recognized in database URL. Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.
+          The provided database string is invalid. The scheme is not recognized in database URL. Please refer to the documentation in https://www.prisma.io/docs/orm/reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.
           "
         `)
       }
@@ -81,7 +81,7 @@ describe('[wasm] incomplete-schemas', () => {
         await MigrateReset.new().parse([], await ctx.config(), ctx.configDir())
       } catch (e) {
         expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(
-          `"P1013: The provided database string is invalid. The scheme is not recognized in database URL. Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters."`,
+          `"P1013: The provided database string is invalid. The scheme is not recognized in database URL. Please refer to the documentation in https://www.prisma.io/docs/orm/reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters."`,
         )
       }
     })
@@ -92,7 +92,7 @@ describe('[wasm] incomplete-schemas', () => {
         await MigrateDev.new().parse([], await ctx.config(), ctx.configDir())
       } catch (e) {
         expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(
-          `"P1013: The provided database string is invalid. The scheme is not recognized in database URL. Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters."`,
+          `"P1013: The provided database string is invalid. The scheme is not recognized in database URL. Please refer to the documentation in https://www.prisma.io/docs/orm/reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters."`,
         )
       }
     })

--- a/packages/client/src/__tests__/integration/errors/invalid-url/test.ts
+++ b/packages/client/src/__tests__/integration/errors/invalid-url/test.ts
@@ -29,7 +29,7 @@ describe('invalid connection string url parameter', () => {
           15 
           16 try {
         → 17   await prisma.user.findUnique(
-        The provided database string is invalid. The provided arguments are not supported in database URL. Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.
+        The provided database string is invalid. The provided arguments are not supported in database URL. Please refer to the documentation in https://www.prisma.io/docs/orm/reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.
       `)
     }
   })
@@ -40,7 +40,7 @@ describe('invalid connection string url parameter', () => {
       await prisma.$connect()
     } catch (err) {
       expect(err).toMatchInlineSnapshot(
-        `The provided database string is invalid. The provided arguments are not supported in database URL. Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.`,
+        `The provided database string is invalid. The provided arguments are not supported in database URL. Please refer to the documentation in https://www.prisma.io/docs/orm/reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.`,
       )
     }
   })

--- a/packages/internals/src/__tests__/schemaEngineCommands.test.ts
+++ b/packages/internals/src/__tests__/schemaEngineCommands.test.ts
@@ -159,7 +159,7 @@ describe('createDatabase', () => {
 
   test('empty connection string', async () => {
     await expect(createDatabase('')).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"Connection url is empty. See https://www.prisma.io/docs/reference/database-reference/connection-urls"`,
+      `"Connection url is empty. See https://www.prisma.io/docs/orm/reference/connection-urls"`,
     )
   })
 })

--- a/packages/internals/src/convertCredentials.ts
+++ b/packages/internals/src/convertCredentials.ts
@@ -85,9 +85,7 @@ export function uriToCredentials(connectionString: string): DatabaseCredentials 
   try {
     uri = new NodeURL.URL(connectionString)
   } catch (e) {
-    throw new Error(
-      'Invalid data source URL, see https://www.prisma.io/docs/reference/database-reference/connection-urls',
-    )
+    throw new Error('Invalid data source URL, see https://www.prisma.io/docs/orm/reference/connection-urls')
   }
 
   const type = protocolToConnectorType(uri.protocol)

--- a/packages/internals/src/schemaEngineCommands.ts
+++ b/packages/internals/src/schemaEngineCommands.ts
@@ -71,9 +71,7 @@ export async function canConnectToDatabase(
   schemaEnginePath?: string,
 ): Promise<ConnectionResult> {
   if (!connectionString) {
-    throw new Error(
-      'Connection url is empty. See https://www.prisma.io/docs/reference/database-reference/connection-urls',
-    )
+    throw new Error('Connection url is empty. See https://www.prisma.io/docs/orm/reference/connection-urls')
   }
 
   try {

--- a/packages/migrate/src/__tests__/DbExecute.test.ts
+++ b/packages/migrate/src/__tests__/DbExecute.test.ts
@@ -192,7 +192,7 @@ COMMIT;`,
           expect(e.message).toMatchInlineSnapshot(`
                       "P1013
 
-                      The provided database string is invalid. The scheme is not recognized in database URL. Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.
+                      The provided database string is invalid. The scheme is not recognized in database URL. Please refer to the documentation in https://www.prisma.io/docs/orm/reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.
                       "
                   `)
         }
@@ -345,7 +345,7 @@ COMMIT;`,
         expect(e.message).toMatchInlineSnapshot(`
           "P1013
 
-          The provided database string is invalid. invalid port number in database URL. Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.
+          The provided database string is invalid. invalid port number in database URL. Please refer to the documentation in https://www.prisma.io/docs/orm/reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.
           "
         `)
       }
@@ -364,7 +364,7 @@ COMMIT;`,
         expect(e.message).toMatchInlineSnapshot(`
           "P1013
 
-          The provided database string is invalid. The scheme is not recognized in database URL. Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.
+          The provided database string is invalid. The scheme is not recognized in database URL. Please refer to the documentation in https://www.prisma.io/docs/orm/reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.
           "
         `)
       }
@@ -542,7 +542,7 @@ COMMIT;`,
         expect(e.message).toMatchInlineSnapshot(`
           "P1013
 
-          The provided database string is invalid. invalid port number in database URL. Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.
+          The provided database string is invalid. invalid port number in database URL. Please refer to the documentation in https://www.prisma.io/docs/orm/reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.
           "
         `)
       }
@@ -561,7 +561,7 @@ COMMIT;`,
         expect(e.message).toMatchInlineSnapshot(`
           "P1013
 
-          The provided database string is invalid. The scheme is not recognized in database URL. Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.
+          The provided database string is invalid. The scheme is not recognized in database URL. Please refer to the documentation in https://www.prisma.io/docs/orm/reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.
           "
         `)
       }
@@ -696,7 +696,7 @@ COMMIT;`,
         expect(e.message).toMatchInlineSnapshot(`
           "P1013
 
-          The provided database string is invalid. invalid port number in database URL. Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.
+          The provided database string is invalid. invalid port number in database URL. Please refer to the documentation in https://www.prisma.io/docs/orm/reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.
           "
         `)
       }
@@ -714,7 +714,7 @@ COMMIT;`,
         expect(e.message).toMatchInlineSnapshot(`
           "P1013
 
-          The provided database string is invalid. The scheme is not recognized in database URL. Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.
+          The provided database string is invalid. The scheme is not recognized in database URL. Please refer to the documentation in https://www.prisma.io/docs/orm/reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.
           "
         `)
       }
@@ -890,7 +890,7 @@ COMMIT;`,
         expect(e.message).toMatchInlineSnapshot(`
           "P1013
 
-          The provided database string is invalid. Error parsing connection string: Conversion error: Invalid property key in database URL. Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.
+          The provided database string is invalid. Error parsing connection string: Conversion error: Invalid property key in database URL. Please refer to the documentation in https://www.prisma.io/docs/orm/reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.
           "
         `)
       }
@@ -909,7 +909,7 @@ COMMIT;`,
         expect(e.message).toMatchInlineSnapshot(`
           "P1013
 
-          The provided database string is invalid. The scheme is not recognized in database URL. Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.
+          The provided database string is invalid. The scheme is not recognized in database URL. Please refer to the documentation in https://www.prisma.io/docs/orm/reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters.
           "
         `)
       }


### PR DESCRIPTION
Fixes: #28720 

The P1013 error message included a reference link to the database connection URL documentation that led to a [404 page](https://www.prisma.io/docs/reference/database-reference/connection-urls)

This PR updates the broken reference URL to the correct and working Prisma documentation for [Connection URLs](https://www.prisma.io/docs/orm/reference/connection-urls)

- Updated the reference URL in the P1013 error message.
- Verified that the new URL correctly directs to the database connection docs.

I've verified that this URL correctly references Prisma's connection URLs documentation. Please confirm if this is the preferred URL. Thank you.