### PR TITLE
fix(client-engine-runtime): abort transaction on `maxWait` timeout

### DIFF
--- a/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
+++ b/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
@@ -119,11 +119,13 @@ export class TransactionManager {
     startTimer?.unref?.()
 
     transaction.transaction = await Promise.race([
-      this.driverAdapter.startTransaction(options.isolationLevel).catch(rethrowAsUserFacing),
+      this.driverAdapter
+        .startTransaction(options.isolationLevel)
+        .catch(rethrowAsUserFacing)
+        .finally(() => clearTimeout(startTimer)),
       events.once(abortController.signal, 'abort').then(() => undefined),
     ])
 
-    clearTimeout(startTimer)
 
     // Transaction status might have timed out while waiting for transaction to start. => Check for it!
     switch (transaction.status) {

--- a/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
+++ b/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
@@ -1,5 +1,3 @@
-import events from 'node:events'
-
 import { Debug } from '@prisma/debug'
 import { SqlDriverAdapter, SqlQuery, SqlQueryable, Transaction } from '@prisma/driver-adapter-utils'
 
@@ -9,6 +7,7 @@ import type { SchemaProvider } from '../schema'
 import { TracingHelper, withQuerySpanAndEvent } from '../tracing'
 import { rethrowAsUserFacing } from '../user-facing-error'
 import { assertNever } from '../utils'
+import { once } from '../web-platform'
 import { Options, TransactionInfo } from './transaction'
 import {
   InvalidTransactionIsolationLevelError,
@@ -122,7 +121,7 @@ export class TransactionManager {
         .startTransaction(options.isolationLevel)
         .catch(rethrowAsUserFacing)
         .finally(() => clearTimeout(startTimer)),
-      events.once(abortController.signal, 'abort').then(() => undefined),
+      once(abortController.signal, 'abort').then(() => undefined),
     ])
 
     this.transactions.set(transaction.id, transaction)

--- a/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
+++ b/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
@@ -111,7 +111,6 @@ export class TransactionManager {
       startedAt: Date.now(),
       transaction: undefined,
     }
-    this.transactions.set(transaction.id, transaction)
 
     // Start timeout to wait for transaction to be started.
     const abortController = new AbortController()
@@ -126,6 +125,7 @@ export class TransactionManager {
       events.once(abortController.signal, 'abort').then(() => undefined),
     ])
 
+    this.transactions.set(transaction.id, transaction)
 
     // Transaction status might have timed out while waiting for transaction to start. => Check for it!
     switch (transaction.status) {

--- a/packages/client-engine-runtime/src/web-platform.ts
+++ b/packages/client-engine-runtime/src/web-platform.ts
@@ -1,0 +1,13 @@
+/**
+ * Equivalent to `once` from `node:events` for DOM {@link EventTarget}.
+ *
+ * It is useful, e.g., to wait for an `abort` event on {@link AbortSignal}.
+ * While in Node.js `AbortSignal` does implement `EventEmitter` interface
+ * and is compatible with the `once` utility in `node:events`, it is not
+ * necessarily the case in other JS runtimes.
+ */
+export async function once(target: EventTarget, event: string): Promise<Event> {
+  return new Promise((resolve) => {
+    target.addEventListener(event, resolve, { once: true })
+  })
+}

--- a/packages/client/tests/functional/issues/9678/tests.ts
+++ b/packages/client/tests/functional/issues/9678/tests.ts
@@ -74,13 +74,5 @@ testMatrix.setupTestSuite(
         mongo - isolation levels are not supported
       `,
     },
-    skip(when, { clientEngineExecutor }) {
-      when(
-        clientEngineExecutor === 'remote',
-        `
-        Tracked in https://linear.app/prisma-company/issue/ORM-1408/failing-issues9678-test-with-qcaccelerate
-        `,
-      )
-    },
   },
 )


### PR DESCRIPTION
When exceeding the `maxWait` time when trying to start a new transaction, we would incorrectly wait until the transaction is started after all (potentially hanging infinitely), and only then reject `startTransaction` after the fact if the overall time spent was larger than expected. This is not the intended behavior, `startTransaction` must reject as soon as the `maxWait` time is exceeded.

Additionally, we were potentially leaking the transaction timer and transaction object if starting the transaction timed out, and incorrectly issuing rollbacks on transactions that failed to start (and therefore cannot execute any commands including rollback).

This PR only implements what's necessary to fix the test, but there's a few more issues around that area I discovered during investigation that I'd like to fix in follow up PRs:
- Ideally `startTransaction` in driver adapter interface would accept an optional `AbortSignal` and abort starting the transaction on the driver level if it supports it.
- We should store the set of `AbortSignal`s for the transactions currently starting, and abort them in `cancelAllTransactions`.
- The reported time taken in `TransactionExecutionTimeoutError` is incorrect, it must only include the time since the actual start of the transaction.
- Type safety issue in `switch (transaction.status)` in `#startTransactionImpl`, TypeScript incorrectly narrows the type of `transaction` and the switch is missing the `closing` state (which should throw `TransactionInternalConsistencyError` if detected), see https://prisma-company.slack.com/archives/C058VM009HT/p1764084522869619
- Code flow can be substantially simplified, automatically resolving the previous two issues, if we don't use the same type for transactions that haven't yet started and don't store them in `this.transactions`, remove the `waiting` state and make `TransactionWrapper#transaction` a non-optional field.

Closes: https://linear.app/prisma-company/issue/ORM-1408/failing-issues9678-test-with-qcaccelerate