### PR TITLE
feat: TML-1618 add ppg local vs remote tracking for studio cli

### DIFF
--- a/packages/cli/src/Studio.ts
+++ b/packages/cli/src/Studio.ts
@@ -20,6 +20,7 @@ import { dirname, extname, join, resolve } from 'pathe'
 import { runtime } from 'std-env'
 
 import packageJson from '../package.json' assert { type: 'json' }
+import { getPpgInfo } from './utils/ppgInfo'
 
 /**
  * `prisma dev`'s `51_213 - 1`
@@ -367,6 +368,8 @@ ${bold('Examples')}
     let projectHash: string | null = null
     const version = packageJson.dependencies['@prisma/studio-core']
 
+    const ppgDbInfo = await getPpgInfo(connectionString)
+
     app.post('/telemetry', async (ctx) => {
       const { eventId, name, payload, timestamp } =
         await ctx.req.json<Parameters<NonNullable<StudioProps['onEvent']>>[0]>()
@@ -379,7 +382,11 @@ ${bold('Examples')}
         check_if_update_available: false,
         client_event_id: eventId,
         command: name,
-        information: JSON.stringify({ eventPayload: payload, protocol }),
+        information: JSON.stringify({
+          eventPayload: payload,
+          protocol,
+          ...ppgDbInfo,
+        }),
         local_timestamp: timestamp,
         product: 'prisma-studio-cli',
         project_hash: (projectHash ??= digest(process.cwd())),

--- a/packages/cli/src/utils/ppgInfo.test.ts
+++ b/packages/cli/src/utils/ppgInfo.test.ts
@@ -1,0 +1,164 @@
+import { ServerState } from '@prisma/dev/internal/state'
+
+import { getPpgInfo } from './ppgInfo'
+
+jest.mock('@prisma/dev/internal/state', () => ({
+  ServerState: {
+    scan: jest.fn(),
+  },
+}))
+
+describe('getPpgInfo', () => {
+  let mockScan: jest.MockedFunction<typeof ServerState.scan>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    mockScan = jest.mocked(ServerState.scan)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('remote connections', () => {
+    it('prisma+postgres with accelerate.prisma-data.net => remote', async () => {
+      const result = await getPpgInfo('prisma+postgres://accelerate.prisma-data.net/db?api_key=test')
+      expect(result).toEqual({ ppg: { type: 'remote' } })
+      expect(mockScan).not.toHaveBeenCalled()
+    })
+
+    it('postgres with db.prisma.io => remote', async () => {
+      const result = await getPpgInfo('postgres://db.prisma.io/db?api_key=test')
+      expect(result).toEqual({ ppg: { type: 'remote' } })
+      expect(mockScan).not.toHaveBeenCalled()
+    })
+
+    it('postgresql with db.prisma.io => remote', async () => {
+      const result = await getPpgInfo('postgresql://db.prisma.io/db?api_key=test')
+      expect(result).toEqual({ ppg: { type: 'remote' } })
+      expect(mockScan).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('local connections', () => {
+    it('prisma+postgres with localhost => local', async () => {
+      const result = await getPpgInfo('prisma+postgres://localhost:5432/db?api_key=test')
+      expect(result).toEqual({ ppg: { type: 'local' } })
+      expect(mockScan).not.toHaveBeenCalled()
+    })
+
+    it('prisma+postgres with 127.0.0.1 => local', async () => {
+      const result = await getPpgInfo('prisma+postgres://127.0.0.1:5432/db?api_key=test')
+      expect(result).toEqual({ ppg: { type: 'local' } })
+      expect(mockScan).not.toHaveBeenCalled()
+    })
+
+    it('postgres & localhost & local ppg server databasePort => local', async () => {
+      mockScan.mockResolvedValue([
+        {
+          databasePort: 5432,
+          shadowDatabasePort: 5433,
+          name: 'test-server',
+          port: 51213,
+          version: '1' as const,
+          status: 'running' as const,
+        },
+      ])
+
+      const result = await getPpgInfo('postgres://localhost:5432/db')
+      expect(result).toEqual({ ppg: { type: 'local' } })
+      expect(mockScan).toHaveBeenCalledTimes(1)
+    })
+
+    it('postgresql & localhost & local ppg server databasePort => local', async () => {
+      mockScan.mockResolvedValue([
+        {
+          databasePort: 5432,
+          shadowDatabasePort: 5433,
+          name: 'test-server',
+          port: 51213,
+          version: '1' as const,
+          status: 'running' as const,
+        },
+      ])
+
+      const result = await getPpgInfo('postgresql://localhost:5432/db')
+      expect(result).toEqual({ ppg: { type: 'local' } })
+      expect(mockScan).toHaveBeenCalledTimes(1)
+    })
+
+    it('postgres & localhost & local ppg server shadowDatabasePort => local', async () => {
+      mockScan.mockResolvedValue([
+        {
+          databasePort: 5432,
+          shadowDatabasePort: 5433,
+          name: 'test-server',
+          port: 51213,
+          version: '1' as const,
+          status: 'running' as const,
+        },
+      ])
+
+      const result = await getPpgInfo('postgres://localhost:5433/db')
+      expect(result).toEqual({ ppg: { type: 'local' } })
+      expect(mockScan).toHaveBeenCalledTimes(1)
+    })
+
+    it('postgres & 127.0.0.1 & local ppg server databasePort => local', async () => {
+      mockScan.mockResolvedValue([
+        {
+          databasePort: 5432,
+          shadowDatabasePort: 5433,
+          name: 'test-server',
+          port: 51213,
+          version: '1' as const,
+          status: 'running' as const,
+        },
+      ])
+
+      const result = await getPpgInfo('postgres://127.0.0.1:5432/db')
+      expect(result).toEqual({ ppg: { type: 'local' } })
+      expect(mockScan).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('unmatched connections', () => {
+    it('postgres & localhost & port does not match local ppg server => no ppg info', async () => {
+      mockScan.mockResolvedValue([
+        {
+          databasePort: 5432,
+          shadowDatabasePort: 5433,
+          name: 'test-server',
+          port: 51213,
+          version: '1' as const,
+          status: 'running' as const,
+        },
+      ])
+
+      const result = await getPpgInfo('postgres://localhost:9999/db')
+      expect(result).toEqual({})
+      expect(mockScan).toHaveBeenCalledTimes(1)
+    })
+
+    it('postgres & localhost & no local ppg servers => no ppg info', async () => {
+      mockScan.mockResolvedValue([])
+
+      const result = await getPpgInfo('postgres://localhost:5432/db')
+      expect(result).toEqual({})
+      expect(mockScan).toHaveBeenCalledTimes(1)
+    })
+
+    it('should return no ppg info for non-matching remote host', async () => {
+      const result = await getPpgInfo('postgres://example.com:5432/db')
+      expect(result).toEqual({})
+      expect(mockScan).not.toHaveBeenCalled()
+    })
+
+    it('should return no ppg info for non-postgres protocol', async () => {
+      const result = await getPpgInfo('mysql://localhost:3306/db')
+      expect(result).toEqual({})
+      expect(mockScan).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/cli/src/utils/ppgInfo.test.ts
+++ b/packages/cli/src/utils/ppgInfo.test.ts
@@ -121,6 +121,40 @@ describe('getPpgInfo', () => {
       expect(result).toEqual({ ppg: { type: 'local' } })
       expect(mockScan).toHaveBeenCalledTimes(1)
     })
+
+    it('postgres & ::1 & local ppg server databasePort => local', async () => {
+      mockScan.mockResolvedValue([
+        {
+          databasePort: 5432,
+          shadowDatabasePort: 5433,
+          name: 'test-server',
+          port: 51213,
+          version: '1' as const,
+          status: 'running' as const,
+        },
+      ])
+
+      const result = await getPpgInfo('postgres://[::1]:5432/db')
+      expect(result).toEqual({ ppg: { type: 'local' } })
+      expect(mockScan).toHaveBeenCalledTimes(1)
+    })
+
+    it('postgres & 0:0:0:0:0:0:0:1 & local ppg server databasePort => local', async () => {
+      mockScan.mockResolvedValue([
+        {
+          databasePort: 5432,
+          shadowDatabasePort: 5433,
+          name: 'test-server',
+          port: 51213,
+          version: '1' as const,
+          status: 'running' as const,
+        },
+      ])
+
+      const result = await getPpgInfo('postgres://[0:0:0:0:0:0:0:1]:5432/db')
+      expect(result).toEqual({ ppg: { type: 'local' } })
+      expect(mockScan).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('unmatched connections', () => {

--- a/packages/cli/src/utils/ppgInfo.ts
+++ b/packages/cli/src/utils/ppgInfo.ts
@@ -1,0 +1,31 @@
+import { ServerState } from '@prisma/dev/internal/state'
+
+/**
+ * Collects information about whether the given url connects to a Prisma Postgres remote or local database.
+ * Mimicking parts of the tracking logic in the Prisma VSCode extension.
+ */
+export async function getPpgInfo(connectionString: string) {
+  const url = new URL(connectionString)
+  const isLocalhost = url.hostname === 'localhost' || url.hostname === '127.0.0.1'
+
+  let type: 'remote' | 'local' | undefined
+  if (url.protocol === 'prisma+postgres:' && url.hostname === 'accelerate.prisma-data.net') {
+    type = 'remote'
+  } else if ((url.protocol === 'postgres:' || url.protocol === 'postgresql:') && url.hostname === 'db.prisma.io') {
+    type = 'remote'
+  } else if (url.protocol === 'prisma+postgres:' && isLocalhost) {
+    type = 'local'
+  } else if ((url.protocol === 'postgres:' || url.protocol === 'postgresql:') && isLocalhost) {
+    const servers = await ServerState.scan()
+    for (const server of servers) {
+      if (
+        server.status === 'running' &&
+        [server.databasePort, server.shadowDatabasePort].includes(parseInt(url.port ?? ''))
+      ) {
+        type = 'local'
+      }
+    }
+  }
+
+  return type ? { ppg: { type } } : {}
+}

--- a/packages/cli/src/utils/ppgInfo.ts
+++ b/packages/cli/src/utils/ppgInfo.ts
@@ -6,7 +6,11 @@ import { ServerState } from '@prisma/dev/internal/state'
  */
 export async function getPpgInfo(connectionString: string) {
   const url = new URL(connectionString)
-  const isLocalhost = url.hostname === 'localhost' || url.hostname === '127.0.0.1'
+  const isLocalhost =
+    url.hostname === 'localhost' ||
+    url.hostname === '127.0.0.1' ||
+    url.hostname === '[::1]' ||
+    url.hostname === '[0:0:0:0:0:0:0:1]'
 
   let type: 'remote' | 'local' | undefined
   if (url.protocol === 'prisma+postgres:' && url.hostname === 'accelerate.prisma-data.net') {


### PR DESCRIPTION
Detects whether studio connects to a local or remote ppg instance. Primarily by URL but to detect a local ppg we cross check a provided postgres url with the list of known local ppg instances to see if the ports match.

This information is then used in the telemetry data for studio. Tried to be analogous to the studio tracking implementation in the VSCode Extension.