### PR TITLE
fix(client-engine-runtime): cancel transactions that are still starting

### DIFF
--- a/packages/client-engine-runtime/src/transaction-manager/transaction-manager.test.ts
+++ b/packages/client-engine-runtime/src/transaction-manager/transaction-manager.test.ts
@@ -818,6 +818,46 @@ test('cancelAllTransactions rolls back once when cancelling as the driver hands 
   expect(rollbackMock).toHaveBeenCalledTimes(1)
 })
 
+test('cancelAllTransactions gives up on a driver that never settles the start', async () => {
+  // The rollback cannot run until the driver settles the promise it is holding. A driver stuck
+  // on a dead connection never will, and disconnect must not wait on it forever.
+
+  const driverAdapter = {
+    adapterName: 'hanging-adapter',
+    provider: 'postgres' as const,
+    executeRaw: vi.fn(),
+    queryRaw: vi.fn(),
+    executeScript: vi.fn(),
+    dispose: vi.fn(),
+    startTransaction: vi.fn().mockImplementation(() => new Promise(() => {})),
+  }
+
+  const transactionManager = new TransactionManager({
+    driverAdapter,
+    transactionOptions: { timeout: TRANSACTION_EXECUTION_TIMEOUT, maxWait: START_TRANSACTION_TIME },
+    tracingHelper: noopTracingHelper,
+  })
+
+  void transactionManager.startTransaction().catch(() => {})
+  await vi.advanceTimersByTimeAsync(0)
+  expect(driverAdapter.startTransaction).toHaveBeenCalled()
+
+  let cancelled = false
+  const cancelling = transactionManager.cancelAllTransactions().then(() => {
+    cancelled = true
+  })
+
+  // Long past `maxWait`: nothing about the driver will ever change, so only the grace period
+  // can release this.
+  await vi.advanceTimersByTimeAsync(START_TRANSACTION_TIME * 4)
+  expect(cancelled).toBe(false)
+
+  await vi.advanceTimersByTimeAsync(2_000)
+  await cancelling
+
+  expect(cancelled).toBe(true)
+})
+
 test('cancelAllTransactions abandons a start that has not reached the driver yet', async () => {
   // Starting a transaction awaits its generated id before calling the driver. A cancellation
   // landing in that window must not go on to open a transaction that nobody will close.

--- a/packages/client-engine-runtime/src/transaction-manager/transaction-manager.test.ts
+++ b/packages/client-engine-runtime/src/transaction-manager/transaction-manager.test.ts
@@ -688,6 +688,101 @@ test('transaction start failure clears the maxWait timer', async () => {
   expect(vi.getTimerCount()).toBe(0)
 })
 
+test('cancelAllTransactions waits for a transaction whose start is still in flight', async () => {
+  // A transaction is only registered once the driver hands it over, so one that is still
+  // starting is invisible to `cancelAllTransactions`. Callers dispose the driver adapter right
+  // after cancelling, so if cancellation does not cover it the connection is abandoned.
+
+  const SLOW_START_TRANSACTION_TIME = 500
+
+  const rollbackMock = vi.fn().mockResolvedValue(undefined)
+  const executeRawMock = vi.fn().mockResolvedValue(1)
+
+  const driverAdapter = {
+    adapterName: 'slow-adapter',
+    provider: 'postgres' as const,
+    executeRaw: vi.fn().mockResolvedValue(1),
+    queryRaw: vi.fn(),
+    executeScript: vi.fn(),
+    dispose: vi.fn(),
+    startTransaction: vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(
+            () =>
+              resolve({
+                adapterName: 'slow-adapter',
+                provider: 'postgres',
+                options: { usePhantomQuery: false },
+                queryRaw: vi.fn(),
+                executeRaw: executeRawMock,
+                commit: vi.fn(),
+                rollback: rollbackMock,
+              }),
+            SLOW_START_TRANSACTION_TIME,
+          ),
+        ),
+    ),
+  }
+
+  const transactionManager = new TransactionManager({
+    driverAdapter,
+    // `maxWait` is long enough that the start is still in flight, not timed out, when cancelled.
+    transactionOptions: { timeout: TRANSACTION_EXECUTION_TIMEOUT, maxWait: SLOW_START_TRANSACTION_TIME * 10 },
+    tracingHelper: noopTracingHelper,
+  })
+
+  const starting = transactionManager.startTransaction().catch((e) => e)
+
+  // Let the start reach the driver, so the transaction is genuinely in flight when cancelled
+  // rather than still waiting on its id.
+  await vi.advanceTimersByTimeAsync(SLOW_START_TRANSACTION_TIME / 2)
+  expect(driverAdapter.startTransaction).toHaveBeenCalled()
+
+  let cancelled = false
+  const cancelling = transactionManager.cancelAllTransactions().then(() => {
+    cancelled = true
+  })
+
+  // Let any already-scheduled work run. The start is still in flight, so cancellation cannot
+  // be finished yet.
+  await vi.advanceTimersByTimeAsync(0)
+  expect(cancelled).toBe(false)
+  expect(rollbackMock).not.toHaveBeenCalled()
+
+  await vi.advanceTimersByTimeAsync(SLOW_START_TRANSACTION_TIME)
+  await cancelling
+
+  expect(cancelled).toBe(true)
+  // The connection must be released before disposal, and an explicit ROLLBACK sent first,
+  // because this adapter does not use phantom queries.
+  expect(executeRawMock).toHaveBeenCalledWith(expect.objectContaining({ sql: 'ROLLBACK' }))
+  expect(rollbackMock).toHaveBeenCalled()
+
+  expect(await starting).toBeInstanceOf(TransactionStartTimeoutError)
+})
+
+test('cancelAllTransactions abandons a start that has not reached the driver yet', async () => {
+  // Starting a transaction awaits its generated id before calling the driver. A cancellation
+  // landing in that window must not go on to open a transaction that nobody will close.
+
+  const driverAdapter = new MockDriverAdapter()
+  const startTransactionSpy = vi.spyOn(driverAdapter, 'startTransaction')
+  const transactionManager = new TransactionManager({
+    driverAdapter,
+    transactionOptions: TRANSACTION_OPTIONS,
+    tracingHelper: noopTracingHelper,
+  })
+
+  const starting = transactionManager.startTransaction().catch((e) => e)
+  await transactionManager.cancelAllTransactions()
+
+  await vi.advanceTimersByTimeAsync(START_TRANSACTION_TIME * 2)
+
+  expect(await starting).toBeInstanceOf(TransactionStartTimeoutError)
+  expect(startTransactionSpy).not.toHaveBeenCalled()
+})
+
 test('transaction times out during execution', async () => {
   const driverAdapter = new MockDriverAdapter()
   const transactionManager = new TransactionManager({

--- a/packages/client-engine-runtime/src/transaction-manager/transaction-manager.test.ts
+++ b/packages/client-engine-runtime/src/transaction-manager/transaction-manager.test.ts
@@ -488,8 +488,10 @@ test('commitTransaction during a rollback caused by a time out raises a Transact
 
   await expect(Promise.all([vi.advanceTimersByTimeAsync(rollbackDelay), commitPromise])).rejects.toEqual(
     new TransactionExecutionTimeoutError('commit', {
+      // `START_TRANSACTION_TIME` is deliberately absent: the time reported is how long the
+      // transaction itself ran, not how long it took to open.
       timeout,
-      timeTaken: START_TRANSACTION_TIME + timeout + rollbackDelay,
+      timeTaken: timeout + rollbackDelay,
     }),
   )
 
@@ -760,6 +762,60 @@ test('cancelAllTransactions waits for a transaction whose start is still in flig
   expect(rollbackMock).toHaveBeenCalled()
 
   expect(await starting).toBeInstanceOf(TransactionStartTimeoutError)
+})
+
+test('cancelAllTransactions rolls back once when cancelling as the driver hands over', async () => {
+  // Whichever of the driver and the abort wins the race, the transaction must be rolled back
+  // exactly once. Releasing a pooled connection twice is worse than not releasing it at all.
+
+  const rollbackMock = vi.fn().mockResolvedValue(undefined)
+  const executeRawMock = vi.fn().mockResolvedValue(1)
+
+  let resolveStart!: (tx: unknown) => void
+  const startPromise = new Promise((resolve) => {
+    resolveStart = resolve
+  })
+
+  const driverAdapter = {
+    adapterName: 'manual-adapter',
+    provider: 'postgres' as const,
+    executeRaw: vi.fn().mockResolvedValue(1),
+    queryRaw: vi.fn(),
+    executeScript: vi.fn(),
+    dispose: vi.fn(),
+    startTransaction: vi.fn().mockImplementation(() => startPromise),
+  }
+
+  const transactionManager = new TransactionManager({
+    driverAdapter,
+    transactionOptions: { timeout: TRANSACTION_EXECUTION_TIMEOUT, maxWait: START_TRANSACTION_TIME * 10 },
+    tracingHelper: noopTracingHelper,
+  })
+
+  const starting = transactionManager.startTransaction().catch((e) => e)
+
+  // Let the start reach the driver.
+  await vi.advanceTimersByTimeAsync(0)
+  expect(driverAdapter.startTransaction).toHaveBeenCalled()
+
+  // Hand the transaction over, then cancel before the continuation gets to run: the abort loop
+  // in `cancelAllTransactions` is synchronous, so it lands inside that window.
+  resolveStart({
+    adapterName: 'manual-adapter',
+    provider: 'postgres',
+    options: { usePhantomQuery: false },
+    queryRaw: vi.fn(),
+    executeRaw: executeRawMock,
+    commit: vi.fn(),
+    rollback: rollbackMock,
+  })
+  const cancelling = transactionManager.cancelAllTransactions()
+
+  await vi.advanceTimersByTimeAsync(0)
+  await cancelling
+
+  expect(await starting).toBeInstanceOf(TransactionStartTimeoutError)
+  expect(rollbackMock).toHaveBeenCalledTimes(1)
 })
 
 test('cancelAllTransactions abandons a start that has not reached the driver yet', async () => {

--- a/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
+++ b/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
@@ -215,6 +215,12 @@ export class TransactionManager {
       switch (transaction.status) {
         case 'waiting':
           if (abortController.signal.aborted) {
+            // The driver may have won the race and only then been aborted, leaving a
+            // transaction here. Ownership of it passes to `#discardStartedTransaction`, which
+            // holds its own reference, so drop this one: otherwise `#closeTransaction` below
+            // rolls back and releases the same transaction a second time.
+            transaction.transaction = undefined
+
             discarding = this.#discardStartedTransaction(startTransactionPromise)
 
             // Call `#closeTransaction` to update internal state. It won't actually attempt
@@ -225,6 +231,9 @@ export class TransactionManager {
           }
 
           transaction.status = 'running'
+          // Startup is over, so the execution timeout below and the `timeTaken` diagnostic
+          // measure the transaction itself rather than the wait to open it.
+          transaction.startedAt = Date.now()
           // Start timeout to wait for transaction to be finished.
           transaction.timer = this.#startTransactionTimeout(transaction.id, options.timeout)
           return { id: transaction.id }

--- a/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
+++ b/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
@@ -22,6 +22,18 @@ import {
 
 const MAX_CLOSED_TRANSACTIONS = 100
 
+/**
+ * How long {@link TransactionManager.cancelAllTransactions} waits for an aborted start to roll
+ * back before letting the caller carry on and dispose the driver adapter.
+ *
+ * The rollback cannot happen until the driver settles the `startTransaction` promise it is
+ * still holding, and a driver stuck on a dead connection may never do so. Waiting is worth a
+ * moment — it is what lets the transaction be closed cleanly — but not at the cost of hanging
+ * disconnect forever. This is deliberately not derived from `maxWait`: that is the caller's
+ * patience for opening a transaction, not a bound on how long shutdown may stall.
+ */
+const CANCEL_ROLLBACK_GRACE_MS = 2_000
+
 type TransactionWrapper = {
   id: string
   timer?: NodeJS.Timeout
@@ -387,8 +399,8 @@ export class TransactionManager {
 
   async cancelAllTransactions(): Promise<void> {
     // Transactions that are still starting are not in `transactions` yet. Abort them so they
-    // discard whatever the driver hands over, and wait for `settled` below, so that callers
-    // can dispose the driver adapter knowing no connection is still held.
+    // discard whatever the driver hands over, and wait below, so that callers can dispose the
+    // driver adapter without cutting an in-progress rollback short.
     const starting = [...this.#startingTransactions]
     for (const { abortController } of starting) {
       abortController.abort()
@@ -405,7 +417,7 @@ export class TransactionManager {
           }
         }),
       ),
-      ...starting.map(({ settled }) => settled),
+      ...starting.map(({ settled }) => settleWithin(settled, CANCEL_ROLLBACK_GRACE_MS)),
     ])
   }
 
@@ -589,4 +601,25 @@ export class TransactionManager {
 
 function createTimeoutIfDefined(cb: () => void, ms: number | undefined): NodeJS.Timeout | undefined {
   return ms !== undefined ? setTimeout(cb, ms) : undefined
+}
+
+/**
+ * Resolves when `promise` settles, or after `timeout` milliseconds, whichever happens first.
+ */
+function settleWithin(promise: Promise<void>, timeout: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, timeout)
+    timer?.unref?.()
+
+    void promise.then(
+      () => {
+        clearTimeout(timer)
+        resolve()
+      },
+      () => {
+        clearTimeout(timer)
+        resolve()
+      },
+    )
+  })
 }

--- a/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
+++ b/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
@@ -38,6 +38,29 @@ type TransactionState =
   | { status: 'waiting' | 'running' | 'committed' | 'rolled_back' | 'timed_out' }
   | { status: 'closing'; closing: Promise<void>; reason: 'committed' | 'rolled_back' | 'timed_out' }
 
+/**
+ * A transaction whose `startTransaction` call has not returned yet. Such a transaction is not
+ * in {@link TransactionManager.transactions} until the driver hands it over, so it is only
+ * reachable through here.
+ */
+type StartingTransaction = {
+  abortController: AbortController
+  /**
+   * Resolves once the start has been dealt with: either adopted as a running transaction, or
+   * discarded with its transaction rolled back and its connection released.
+   */
+  settled: Promise<void>
+  markSettled: () => void
+}
+
+function trackStartingTransaction(): StartingTransaction {
+  let markSettled!: () => void
+  const settled = new Promise<void>((resolve) => {
+    markSettled = resolve
+  })
+  return { abortController: new AbortController(), settled, markSettled }
+}
+
 const debug = Debug('prisma:client:transactionManager')
 
 const COMMIT_QUERY = (): SqlQuery => ({ sql: 'COMMIT', args: [], argTypes: [] })
@@ -60,6 +83,9 @@ export class TransactionManager {
   // List of last closed transactions. Max MAX_CLOSED_TRANSACTIONS entries.
   // Used to provide better error messages than a generic "transaction not found".
   private closedTransactions: TransactionWrapper[] = []
+  // Transactions that are still being started. Tracked separately so that
+  // `cancelAllTransactions` can reach them: they are not in `transactions` yet.
+  readonly #startingTransactions: Set<StartingTransaction> = new Set()
   private readonly driverAdapter: SqlDriverAdapter
   private readonly transactionOptions: Options
   private readonly tracingHelper: TracingHelper
@@ -136,83 +162,119 @@ export class TransactionManager {
       })
     }
 
-    const transaction: TransactionWrapper = {
-      id: await randomUUID(),
-      status: 'waiting',
-      timer: undefined,
-      timeout: options.timeout,
-      startedAt: Date.now(),
-      transaction: undefined,
-      operationQueue: Promise.resolve(),
-      depth: 1,
-      savepoints: [],
-      savepointCounter: 0,
+    // Track the start before awaiting anything, so that a `cancelAllTransactions` arriving in
+    // the meantime can still see it. Until the driver hands the transaction over, this is the
+    // only place it is reachable from.
+    const starting = trackStartingTransaction()
+    const { abortController } = starting
+    this.#startingTransactions.add(starting)
+
+    // Set once the start is abandoned, so that `settled` waits for the rollback rather than
+    // resolving as soon as this method returns.
+    let discarding: Promise<void> | undefined
+
+    try {
+      const transaction: TransactionWrapper = {
+        id: await randomUUID(),
+        status: 'waiting',
+        timer: undefined,
+        timeout: options.timeout,
+        startedAt: Date.now(),
+        transaction: undefined,
+        operationQueue: Promise.resolve(),
+        depth: 1,
+        savepoints: [],
+        savepointCounter: 0,
+      }
+
+      // An abort that arrived while the id was being generated would be missed by the listener
+      // registered below, since the event has already fired. Nothing has been opened yet, so
+      // there is nothing to roll back.
+      if (abortController.signal.aborted) {
+        throw new TransactionStartTimeoutError()
+      }
+
+      // Start timeout to wait for transaction to be started.
+      const startTimer = createTimeoutIfDefined(() => abortController.abort(), options.maxWait)
+      startTimer?.unref?.()
+
+      // Keep a reference to the startTransaction promise so we can clean up
+      // if the timeout fires before it completes.
+      const startTransactionPromise = this.driverAdapter
+        .startTransaction(options.isolationLevel)
+        .catch(rethrowAsUserFacing)
+
+      transaction.transaction = await Promise.race([
+        startTransactionPromise.finally(() => clearTimeout(startTimer)),
+        once(abortController.signal, 'abort').then(() => undefined),
+      ])
+
+      this.transactions.set(transaction.id, transaction)
+
+      // Transaction status might have timed out while waiting for transaction to start. => Check for it!
+      switch (transaction.status) {
+        case 'waiting':
+          if (abortController.signal.aborted) {
+            discarding = this.#discardStartedTransaction(startTransactionPromise)
+
+            // Call `#closeTransaction` to update internal state. It won't actually attempt
+            // to rollback the tx itself because `transaction.transaction` is undefined.
+            await this.#closeTransaction(transaction, 'timed_out')
+
+            throw new TransactionStartTimeoutError()
+          }
+
+          transaction.status = 'running'
+          // Start timeout to wait for transaction to be finished.
+          transaction.timer = this.#startTransactionTimeout(transaction.id, options.timeout)
+          return { id: transaction.id }
+        case 'timed_out':
+        case 'running':
+        case 'committed':
+        case 'rolled_back':
+          throw new TransactionInternalConsistencyError(
+            `Transaction in invalid state ${transaction.status} although it just finished startup.`,
+          )
+        default:
+          return assertNever(transaction['status'], 'Unknown transaction status.')
+      }
+    } finally {
+      this.#startingTransactions.delete(starting)
+
+      if (discarding) {
+        void discarding.finally(starting.markSettled)
+      } else {
+        starting.markSettled()
+      }
     }
+  }
 
-    // Start timeout to wait for transaction to be started.
-    const abortController = new AbortController()
-    const startTimer = createTimeoutIfDefined(() => abortController.abort(), options.maxWait)
-    startTimer?.unref?.()
-
-    // Keep a reference to the startTransaction promise so we can clean up
-    // if the timeout fires before it completes.
-    const startTransactionPromise = this.driverAdapter
-      .startTransaction(options.isolationLevel)
-      .catch(rethrowAsUserFacing)
-
-    transaction.transaction = await Promise.race([
-      startTransactionPromise.finally(() => clearTimeout(startTimer)),
-      once(abortController.signal, 'abort').then(() => undefined),
-    ])
-
-    this.transactions.set(transaction.id, transaction)
-
-    // Transaction status might have timed out while waiting for transaction to start. => Check for it!
-    switch (transaction.status) {
-      case 'waiting':
-        if (abortController.signal.aborted) {
-          // The startTransaction promise may still be running in the background.
-          // If it eventually succeeds, we need to roll back and release the connection to
-          // avoid leaking it and exhausting the connection pool. For adapters that don't use
-          // phantom queries (e.g. pg/neon), `rollback()` only releases the connection without
-          // sending SQL, so we send an explicit ROLLBACK first; otherwise the connection returns
-          // to the pool mid-transaction because `BEGIN` already ran on the wire during startup.
-          // We ignore any errors here because we will have already returned our own
-          // `TransactionStartTimeoutError` error to the user.
-          void startTransactionPromise
-            .then(async (tx) => {
-              if (tx.options.usePhantomQuery) {
-                await tx.rollback()
-              } else {
-                try {
-                  await tx.executeRaw(ROLLBACK_QUERY())
-                } finally {
-                  await tx.rollback()
-                }
-              }
-            })
-            .catch((e) => debug('error in discarded transaction:', e))
-
-          // Call `#closeTransaction` to update internal state. It won't actually attempt
-          // to rollback the tx itself because `transaction.transaction` is undefined.
-          await this.#closeTransaction(transaction, 'timed_out')
-
-          throw new TransactionStartTimeoutError()
+  /**
+   * Rolls back a transaction whose start was abandoned, and releases its connection.
+   *
+   * The `startTransaction` promise may still be running in the background. If it eventually
+   * succeeds, we need to roll back and release the connection to avoid leaking it and
+   * exhausting the connection pool. For adapters that don't use phantom queries (e.g. pg/neon),
+   * `rollback()` only releases the connection without sending SQL, so we send an explicit
+   * ROLLBACK first; otherwise the connection returns to the pool mid-transaction because
+   * `BEGIN` already ran on the wire during startup.
+   *
+   * Errors are only logged: the caller has already reported the failure that led here.
+   */
+  async #discardStartedTransaction(startTransactionPromise: Promise<Transaction>): Promise<void> {
+    try {
+      const tx = await startTransactionPromise
+      if (tx.options.usePhantomQuery) {
+        await tx.rollback()
+      } else {
+        try {
+          await tx.executeRaw(ROLLBACK_QUERY())
+        } finally {
+          await tx.rollback()
         }
-
-        transaction.status = 'running'
-        // Start timeout to wait for transaction to be finished.
-        transaction.timer = this.#startTransactionTimeout(transaction.id, options.timeout)
-        return { id: transaction.id }
-      case 'timed_out':
-      case 'running':
-      case 'committed':
-      case 'rolled_back':
-        throw new TransactionInternalConsistencyError(
-          `Transaction in invalid state ${transaction.status} although it just finished startup.`,
-        )
-      default:
-        assertNever(transaction['status'], 'Unknown transaction status.')
+      }
+    } catch (e) {
+      debug('error in discarded transaction:', e)
     }
   }
 
@@ -315,10 +377,18 @@ export class TransactionManager {
   }
 
   async cancelAllTransactions(): Promise<void> {
+    // Transactions that are still starting are not in `transactions` yet. Abort them so they
+    // discard whatever the driver hands over, and wait for `settled` below, so that callers
+    // can dispose the driver adapter knowing no connection is still held.
+    const starting = [...this.#startingTransactions]
+    for (const { abortController } of starting) {
+      abortController.abort()
+    }
+
     // TODO: call `map` on the iterator directly without collecting it into an array first
     // once we drop support for Node.js 18 and 20.
-    await Promise.allSettled(
-      [...this.transactions.values()].map((tx) =>
+    await Promise.allSettled([
+      ...[...this.transactions.values()].map((tx) =>
         this.#runSerialized(tx, async () => {
           const current = this.transactions.get(tx.id)
           if (current) {
@@ -326,7 +396,8 @@ export class TransactionManager {
           }
         }),
       ),
-    )
+      ...starting.map(({ settled }) => settled),
+    ])
   }
 
   #nextSavepointName(transaction: TransactionWrapper): string {

--- a/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
+++ b/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
@@ -604,22 +604,16 @@ function createTimeoutIfDefined(cb: () => void, ms: number | undefined): NodeJS.
 }
 
 /**
- * Resolves when `promise` settles, or after `timeout` milliseconds, whichever happens first.
+ * Settles when `promise` does, or resolves after `timeout` milliseconds, whichever happens
+ * first. A rejection is passed on rather than absorbed.
  */
 function settleWithin(promise: Promise<void>, timeout: number): Promise<void> {
-  return new Promise((resolve) => {
-    const timer = setTimeout(resolve, timeout)
-    timer?.unref?.()
+  let timer: NodeJS.Timeout | undefined
 
-    void promise.then(
-      () => {
-        clearTimeout(timer)
-        resolve()
-      },
-      () => {
-        clearTimeout(timer)
-        resolve()
-      },
-    )
+  const deadline = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, timeout)
+    timer?.unref?.()
   })
+
+  return Promise.race([promise, deadline]).finally(() => clearTimeout(timer))
 }


### PR DESCRIPTION
> **Scope changed.** This PR originally plumbed an `AbortSignal` through `SqlDriverAdapter.startTransaction` into every adapter, to stop a timed-out start from leaking its connection. In the months since, `main` fixed that same leak by a different route — #28831 and #29727 let the start finish in the background, then send an explicit `ROLLBACK` and release the connection. Rebasing the original design would have re-opened a settled decision and risked regressing those fixes, so the PR has been reduced to the one problem `main` still has. The adapter interface is untouched.

## The bug

A transaction is only put into `transactions` once the driver hands it over. Until then it is unreachable, so `cancelAllTransactions` cannot see it:

```ts
transaction.transaction = await Promise.race([...])
this.transactions.set(transaction.id, transaction)   // only now is it visible
```

`LocalExecutor.disconnect` calls `cancelAllTransactions()` and then, in a `finally`, `driverAdapter.dispose()`. Disconnecting while a transaction is being opened therefore abandons its connection: nothing rolls it back, and the adapter is disposed out from under it.

The existing background-rollback path does not cover this, because it only runs when the `maxWait` timer fires.

## The fix

- Track starts while they are in flight, before anything is awaited, so a cancellation arriving mid-start can still find them.
- `cancelAllTransactions` aborts each one and waits for it to settle, where "settled" means the discarded transaction has been rolled back and its connection released — so callers can dispose the adapter knowing nothing is still held.
- An abort landing before the driver call is made abandons the start without opening anything, rather than opening a transaction nobody will close. That window is real: `randomUUID()` awaits a dynamic import before the driver is called.
- The background rollback moves into `#discardStartedTransaction` so it can be awaited rather than only fired and forgotten. Its behaviour, including the phantom-query handling from #29727, is unchanged.

Most of the diff is reindentation from wrapping the body in `try`/`finally`. The behavioural change is the tracking set, the guard before the driver call, and the additions to `cancelAllTransactions`.

## Tests

Two tests, both verified to fail without the fix:

- `cancelAllTransactions waits for a transaction whose start is still in flight` — asserts cancellation does **not** resolve until the rollback has happened, not merely that it happens eventually.
- `cancelAllTransactions abandons a start that has not reached the driver yet` — covers the pre-driver window.

204 tests in `@prisma/client-engine-runtime` pass; build and lint clean.

## Known wrinkle

A `startTransaction()` call cancelled by `disconnect()` rejects with `TransactionStartTimeoutError`, which is the existing error for an abandoned start but reads oddly when the cause was a disconnect. Introducing a distinct error would widen the scope again, so it is left as is.