### PR TITLE
fix(cli): studio mishandles remote "prisma+postgres:" connection strings.

### DIFF
--- a/packages/cli/src/Studio.ts
+++ b/packages/cli/src/Studio.ts
@@ -182,7 +182,7 @@ Please use Node.js >=22.5, Deno >=2.2 or Bun >=1.0 or ensure you have the \`bett
     async createExecutor(connectionString, relativeTo) {
       const connectionURL = new URL(connectionString)
 
-      if (connectionURL.hostname === 'localhost' || connectionURL.hostname === '127.0.0.1') {
+      if (connectionURL.hostname === 'localhost' || connectionURL.hostname === '127.0.0.1' || connectionURL.hostname === '::1') {
         // TODO: support `prisma dev` accelerate URLs.
 
         throw new Error('The "prisma+postgres" protocol with localhost is not supported in Prisma Studio yet.')

--- a/packages/cli/src/Studio.ts
+++ b/packages/cli/src/Studio.ts
@@ -210,7 +210,7 @@ Please use Node.js >=22.5, Deno >=2.2 or Bun >=1.0 or ensure you have the \`bett
           !('tenant_id' in decodedPayload) ||
           typeof decodedPayload.tenant_id !== 'string'
         ) {
-          throw 'strucutare mismatch'
+          throw new Error('structure mismatch')
         }
 
         connectionURL.password = decodedPayload.secure_key

--- a/packages/cli/src/Studio.ts
+++ b/packages/cli/src/Studio.ts
@@ -182,7 +182,7 @@ Please use Node.js >=22.5, Deno >=2.2 or Bun >=1.0 or ensure you have the \`bett
     async createExecutor(connectionString, relativeTo) {
       const connectionURL = new URL(connectionString)
 
-      if (connectionURL.hostname === 'localhost' || connectionURL.hostname === '127.0.0.1' || connectionURL.hostname === '::1') {
+      if (['localhost', '127.0.0.1', '::1'].includes(connectionURL.hostname)) {
         // TODO: support `prisma dev` accelerate URLs.
 
         throw new Error('The "prisma+postgres" protocol with localhost is not supported in Prisma Studio yet.')

--- a/packages/cli/src/Studio.ts
+++ b/packages/cli/src/Studio.ts
@@ -180,13 +180,13 @@ Please use Node.js >=22.5, Deno >=2.2 or Bun >=1.0 or ensure you have the \`bett
   postgresql: POSTGRES_STUDIO_STUFF,
   'prisma+postgres': {
     async createExecutor(connectionString, relativeTo) {
-      if (connectionString.includes('localhost')) {
+      const connectionURL = new URL(connectionString)
+
+      if (connectionURL.hostname === 'localhost' || connectionURL.hostname === '127.0.0.1') {
         // TODO: support `prisma dev` accelerate URLs.
 
         throw new Error('The "prisma+postgres" protocol with localhost is not supported in Prisma Studio yet.')
       }
-
-      const connectionURL = new URL(connectionString)
 
       const apiKey = connectionURL.searchParams.get(ACCELERATE_API_KEY_QUERY_PARAMETER)
 

--- a/packages/cli/src/Studio.ts
+++ b/packages/cli/src/Studio.ts
@@ -182,7 +182,7 @@ Please use Node.js >=22.5, Deno >=2.2 or Bun >=1.0 or ensure you have the \`bett
     async createExecutor(connectionString, relativeTo) {
       const connectionURL = new URL(connectionString)
 
-      if (['localhost', '127.0.0.1', '::1'].includes(connectionURL.hostname)) {
+      if (['localhost', '127.0.0.1', '[::1]'].includes(connectionURL.hostname)) {
         // TODO: support `prisma dev` accelerate URLs.
 
         throw new Error('The "prisma+postgres" protocol with localhost is not supported in Prisma Studio yet.')


### PR DESCRIPTION
Hey :wave:

closes https://github.com/prisma/studio/issues/1409

This PR fixes handling of "prisma+postgres" remote URLs. Support for `prisma dev`'s version of "prisma+postgres" URLs will be added later based on demand (we haven't seen any yet).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Studio adds accelerated PostgreSQL connections via an API-key handshake that decodes a secure payload to populate credentials, rewrites connections to the hosted DB endpoint, and enforces SSL.

* **Bug Fixes / Reliability**
  * Improved validation and clearer errors for disallowed/localhost connections; sensitive query parameters are stripped before connecting to improve safety and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->