### PR TITLE
fix(cli): lazy load @prisma/dev in Init.ts to prevent Node <22 crash

### DIFF
--- a/packages/cli/src/Init.ts
+++ b/packages/cli/src/Init.ts
@@ -3,8 +3,6 @@ import path from 'node:path'
 
 import { confirm, input, select } from '@inquirer/prompts'
 import { PrismaConfigInternal } from '@prisma/config'
-import { unstable_startServer } from '@prisma/dev'
-import { ServerState } from '@prisma/dev/internal/state'
 import type { ConnectorType } from '@prisma/generator'
 import {
   arg,
@@ -117,6 +115,9 @@ model User {
 
 export const defaultEnv = async (url: string | undefined, debug = false, comments = true) => {
   if (url === undefined) {
+    const { unstable_startServer } = await import('@prisma/dev')
+    const { ServerState } = await import('@prisma/dev/internal/state')
+
     let created = false
     const state =
       (await ServerState.fromServerDump({ debug })) ||


### PR DESCRIPTION
## fix(cli): lazy load `@prisma/dev` in `Init.ts` to fix Bun/Node compatibility

### Description
This PR fixes a crash that occurred when running `prisma generate` or `prisma -v` on Node.js versions < 22 (or Bun delegating to Node).  
The issue was caused by a top-level `require` of `@prisma/dev`, which depends on an ESM-only module (`zeptomatch`), causing incompatibility with older Node versions.

### Changes
- Lazy-loaded `@prisma/dev` and `@prisma/dev/internal/state` inside `packages/cli/src/Init.ts` within `defaultEnv`.
- Ensures `@prisma/dev` is only loaded when `prisma init` is executed and default environment variables need to be generated.
- Prevents unnecessary loading for other CLI commands, avoiding crashes.

### Fixes
- Fixes #28805
