### PR TITLE
fix(cli): improve type safety in simpleDebounce

### DIFF
--- a/packages/cli/src/utils/simpleDebounce.test.ts
+++ b/packages/cli/src/utils/simpleDebounce.test.ts
@@ -1,0 +1,62 @@
+import { simpleDebounce } from './simpleDebounce'
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+describe('simpleDebounce', () => {
+  test('executes immediately if not running', async () => {
+    const fn = jest.fn().mockResolvedValue('result')
+    const debounced = simpleDebounce(fn)
+
+    await debounced('arg1')
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(fn).toHaveBeenCalledWith('arg1')
+  })
+
+  test('queues last call if running', async () => {
+    let resolveFirst: (value?: any) => void
+    const firstCallPromise = new Promise((resolve) => {
+      resolveFirst = resolve
+    })
+
+    const fn = jest.fn().mockImplementation(async (arg) => {
+      if (arg === 'first') {
+        await firstCallPromise
+      }
+    })
+
+    const debounced = simpleDebounce(fn)
+
+    // First call starts execution
+    const p1 = debounced('first')
+    
+    // Second call should be queued
+    const p2 = debounced('second')
+    
+    // Third call should replace second in queue
+    const p3 = debounced('third')
+
+    // Finish first call
+    resolveFirst!()
+    await p1
+
+    // Wait for queue processing
+    await sleep(10)
+
+    expect(fn).toHaveBeenCalledTimes(2)
+    expect(fn).toHaveBeenNthCalledWith(1, 'first')
+    expect(fn).toHaveBeenNthCalledWith(2, 'third')
+  })
+
+  test('handles errors gracefully', async () => {
+    const fn = jest.fn().mockRejectedValue(new Error('fail'))
+    const debounced = simpleDebounce(fn)
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    await debounced()
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(consoleSpy).toHaveBeenCalled()
+    
+    consoleSpy.mockRestore()
+  })
+})

--- a/packages/cli/src/utils/simpleDebounce.test.ts
+++ b/packages/cli/src/utils/simpleDebounce.test.ts
@@ -28,12 +28,12 @@ describe('simpleDebounce', () => {
 
     // First call starts execution
     const p1 = debounced('first')
-    
+
     // Second call should be queued
-    const p2 = debounced('second')
-    
+    void debounced('second')
+
     // Third call should replace second in queue
-    const p3 = debounced('third')
+    void debounced('third')
 
     // Finish first call
     resolveFirst!()
@@ -56,7 +56,7 @@ describe('simpleDebounce', () => {
 
     expect(fn).toHaveBeenCalledTimes(1)
     expect(consoleSpy).toHaveBeenCalled()
-    
+
     consoleSpy.mockRestore()
   })
 })

--- a/packages/cli/src/utils/simpleDebounce.ts
+++ b/packages/cli/src/utils/simpleDebounce.ts
@@ -2,15 +2,14 @@
 // and the last invocation doesn't get lost (tail behavior of debounce)
 // mostly designed for watch mode, where it's fine if something fails, we just try catch it
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-export function simpleDebounce<T extends Function>(fn: T): T {
+export function simpleDebounce<T extends (...args: any[]) => any>(fn: T): T {
   let executing = false
-  let pendingExecution: any = null
-  return (async (...args) => {
+  let pendingExecution: Parameters<T> | null = null
+  return (async (...args: Parameters<T>) => {
     if (executing) {
       // if there are 2 executions 50ms apart, ignore the last one
       pendingExecution = args
-      return null as any
+      return
     }
     executing = true
     await fn(...args).catch((e) => console.error(e))
@@ -19,6 +18,5 @@ export function simpleDebounce<T extends Function>(fn: T): T {
       pendingExecution = null
     }
     executing = false
-  }) as any
+  }) as unknown as T
 }
-/* eslint-enable @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
# PR: Improve Type Safety in `simpleDebounce`

**PR #28816**
**Status:** Open
**Branch:** `fix/cli-simple-debounce-types`

## Overview

This Pull Request refactors the `simpleDebounce` utility in `packages/cli` to improve type safety. The original implementation relied on `any` types for the pending execution arguments and the return value, which bypassed TypeScript's type checking.

## Changes

- **File:** `packages/cli/src/utils/simpleDebounce.ts`
- **Refactor:**
  - Replaced `any` type for `pendingExecution` with `Parameters<T>`.
  - Removed `as any` cast on the returned function.
  - Added `as unknown as T` cast to satisfy the generic type constraint while maintaining the async wrapper behavior.
- **Tests:**
  - Created `packages/cli/src/utils/simpleDebounce.test.ts`.
  - Added unit tests to verify:
    - Immediate execution when not running.
    - Debouncing (queuing) when running.
    - Error handling.

## Verification

To verify the changes locally:

1. **Install dependencies:**

   ```bash
   pnpm install
   ```

2. **Run the new test:**

   ```bash
   pnpm --filter prisma test src/utils/simpleDebounce.test.ts
   ```

3. **Check types:**
   ```bash
   pnpm --filter prisma tsc
   ```

## Rationale

Using `any` defeats the purpose of TypeScript. By using `Parameters<T>`, we ensure that the debounced function preserves the argument types of the original function, leading to better developer experience and fewer potential runtime errors.