### PR TITLE
docs(sqlcommenter): add missing `sql` field information

### DIFF
--- a/packages/sqlcommenter/README.md
+++ b/packages/sqlcommenter/README.md
@@ -135,11 +135,10 @@ interface SqlCommenterContext {
 }
 ```
 
-- **`query`**: Information about the Prisma query being executed. See [`SqlCommenterQueryInfo`](#sqlcommenterqueryinfo).
-- **`sql`**: The SQL query being executed. It is only available when using driver adapters but not when using Accelerate.
-
 Context provided to plugins containing information about the query.
 
+- **`query`**: Information about the Prisma query being executed. See [`SqlCommenterQueryInfo`](#sqlcommenterqueryinfo).
+- **`sql`**: The SQL query being executed. It is only available when using driver adapters but not when using Accelerate.
 ### `SqlCommenterQueryInfo`
 
 ```typescript

--- a/packages/sqlcommenter/README.md
+++ b/packages/sqlcommenter/README.md
@@ -139,6 +139,7 @@ Context provided to plugins containing information about the query.
 
 - **`query`**: Information about the Prisma query being executed. See [`SqlCommenterQueryInfo`](#sqlcommenterqueryinfo).
 - **`sql`**: The SQL query being executed. It is only available when using driver adapters but not when using Accelerate.
+
 ### `SqlCommenterQueryInfo`
 
 ```typescript

--- a/packages/sqlcommenter/README.md
+++ b/packages/sqlcommenter/README.md
@@ -131,8 +131,12 @@ A function that receives query context and returns key-value pairs. Return an em
 ```typescript
 interface SqlCommenterContext {
   query: SqlCommenterQueryInfo
+  sql?: string
 }
 ```
+
+- **`query`**: Information about the Prisma query being executed. See [`SqlCommenterQueryInfo`](#sqlcommenterqueryinfo).
+- **`sql`**: The SQL query being executed. It is only available when using driver adapters but not when using Accelerate.
 
 Context provided to plugins containing information about the query.
 


### PR DESCRIPTION
Add a field missing in the docs.