### PR TITLE
fix(instrumentation): make `@opentelemetry/api` as external

### DIFF
--- a/packages/instrumentation/helpers/build.ts
+++ b/packages/instrumentation/helpers/build.ts
@@ -5,7 +5,7 @@ const buildOptions = {
   bundle: true,
   outfile: 'dist/index',
   entryPoints: ['src/index.ts'],
-  external: ['@opentelemetry/instrumentation'],
+  external: ['@opentelemetry/api', '@opentelemetry/instrumentation'],
 } satisfies BuildOptions
 
 void build([


### PR DESCRIPTION
This package is specified as a peer dependency and should not be bundled (otherwise users end up with two copies of this package in their application).