### PR TITLE
fix(cli): move @prisma/migrate to dependencies and modernize imports

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -123,7 +123,6 @@
     "@prisma/generator": "workspace:*",
     "@prisma/get-platform": "workspace:*",
     "@prisma/internals": "workspace:*",
-    "@prisma/migrate": "workspace:*",
     "@swc/core": "1.11.5",
     "@swc/jest": "0.2.37",
     "@types/better-sqlite3": "7.6.12",
@@ -181,6 +180,7 @@
     "@prisma/config": "workspace:*",
     "@prisma/dev": "0.15.0",
     "@prisma/engines": "workspace:*",
+    "@prisma/migrate": "workspace:*",
     "@prisma/studio-core": "0.8.2",
     "mysql2": "3.15.3",
     "postgres": "3.4.7"

--- a/packages/cli/src/Studio.ts
+++ b/packages/cli/src/Studio.ts
@@ -19,7 +19,7 @@ import open from 'open'
 import { dirname, extname, join, resolve } from 'pathe'
 import { runtime } from 'std-env'
 
-import packageJson from '../package.json' assert { type: 'json' }
+import packageJson from '../package.json' with { type: 'json' }
 import { getPpgInfo } from './utils/ppgInfo'
 
 /**
@@ -123,10 +123,8 @@ const CONNECTION_STRING_PROTOCOL_TO_STUDIO_STUFF: Record<string, StudioStuff | n
       let database: InstanceType<Database> | undefined = undefined
 
       try {
-        // TODO: remove 'as' once Node.js v22 is the minimum supported version.
-        const { DatabaseSync } = (await import('node:sqlite' as never)) as {
-          DatabaseSync: Database
-        }
+        // @ts-expect-error - node:sqlite is only available in Node.js 22.5+, types are in @types/node 22+
+        const { DatabaseSync } = await import('node:sqlite')
 
         database = new DatabaseSync(resolvedPath)
       } catch (error: unknown) {

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -49,9 +49,11 @@ function cleanSnapshot(str: string, versionOverride?: string): string {
     'Loaded Prisma config from "sanitized prisma.config.ts path"',
   )
 
-  // TODO: replace '[a-z0-9]{40}' with 'ENGINE_VERSION'.
-  // Currently, the engine version of @prisma/prisma-schema-wasm isn't necessarily the same as the enginesVersion
-  str = str.replace(/([0-9]+\.[0-9]+\.[0-9]+-[0-9]+\.)([a-z0-9-]+)/g, 'CLI_VERSION.ENGINE_VERSION')
+  // Replace the version with 'CLI_VERSION.ENGINE_VERSION'
+  str = str.replace(
+    new RegExp(`([0-9]+\\.[0-9]+\\.[0-9]+-[0-9]+\\.)${enginesVersion}`, 'g'),
+    'CLI_VERSION.ENGINE_VERSION',
+  )
 
   // Replace locally built prisma-schema-wasm and schema-engine-wasm versions linked via package.json
   str = str.replace(/link:([A-Z]:)?(\/[\w-]+)+/g, 'CLI_VERSION.ENGINE_VERSION')

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -154,12 +154,9 @@ async function main(): Promise<number> {
       format: Format.new(),
       telemetry: Telemetry.new(),
       debug: DebugInfo.new(),
-      // TODO: add rules subcommand to --help after EA
       rules: new SubCommand('@prisma/cli-security-rules'),
       dev: new SubCommand('@prisma/cli-dev'),
-      // TODO: add deploy subcommand to --help after it works.
       deploy: new SubCommand('@prisma/cli-deploy'),
-      // TODO: add login subcommand to --help after it works.
       login: new SubCommand('@prisma/cli-login'),
       studio: Studio.new(),
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -428,6 +428,9 @@ importers:
       '@prisma/engines':
         specifier: workspace:*
         version: link:../engines
+      '@prisma/migrate':
+        specifier: workspace:*
+        version: link:../migrate
       '@prisma/studio-core':
         specifier: 0.8.2
         version: 0.8.2
@@ -489,9 +492,6 @@ importers:
       '@prisma/internals':
         specifier: workspace:*
         version: link:../internals
-      '@prisma/migrate':
-        specifier: workspace:*
-        version: link:../migrate
       '@swc/core':
         specifier: 1.11.5
         version: 1.11.5


### PR DESCRIPTION
- Move @prisma/migrate from devDependencies to dependencies as it's used at runtime
- Update JSON import syntax from 'assert' to 'with' (TC39 stage 3)
- Fix node:sqlite import with proper ts-expect-error comment
- Improve Version.test.ts regex to use template literal correctly
- Remove obsolete TODO comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * `@prisma/migrate` is now a runtime requirement for the CLI (previously development-only).

* **Chores**
  * Updated internal import handling and test snapshot validation.
  * Removed outdated TODO comments from CLI configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->