### PR TITLE
feat: add `sqlcommenter-query-insights` plugin

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -964,6 +964,10 @@ jobs:
         name: 'sqlcommenter-trace-context'
         working-directory: packages/sqlcommenter-trace-context
 
+      - run: pnpm run test
+        name: 'sqlcommenter-query-insights'
+        working-directory: packages/sqlcommenter-query-insights
+
   #
   # Driver Adapter Unit Tests
   #
@@ -1342,6 +1346,11 @@ jobs:
         if: contains(inputs.jobsToRun, '-all-')
         name: 'sqlcommenter-trace-context'
         working-directory: packages/sqlcommenter-trace-context
+
+      - run: pnpm run test
+        if: contains(inputs.jobsToRun, '-all-')
+        name: 'sqlcommenter-query-insights'
+        working-directory: packages/sqlcommenter-query-insights
 
       - name: Upload test results to BuildPulse for flaky test detection
         # Only run this step for branches where we have access to secrets.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 - **Repository scope**: Monorepo for Prisma ORM, CLI, client, tests, etc. Many packages use TypeScript, Rust and WebAssembly (via engines), TSX, and Jest; automation relies on `pnpm`. Expect large fixture directories and generated files.
 - **Workspace layout**: Managed via pnpm workspaces and Turborepo (`turbo.json`). Node 20+/22+/24+ and pnpm ≥10.15 are required (see root `package.json`). Top-level scripts (`pnpm build`, `pnpm dev`, `pnpm test`) delegate into `scripts/ci/publish.ts`; package-specific commands run with `pnpm --filter @prisma/<pkg> <script>`. Turborepo caches builds; run `pnpm build` from root to build all packages in dependency order.
-- **Key packages**: `packages/cli` (Prisma CLI entry point), `packages/migrate` (migrate/db namespace + fixtures), `packages/client` (client runtime), `packages/client-generator-ts` (new `prisma-client` generator), `packages/client-generator-js` (traditional `prisma-client-js` generator), `packages/client-engine-runtime` (the core part of the new Rust binary free client based on Wasm query compiler, used by `ClientEngine` class in `packages/client`), `packages/config` (`PrismaConfigInternal` + loader), `packages/internals` (shared CLI + engine glue), `packages/engines` (Rust binaries download wrapper), `packages/integration-tests` (matrix suites), `packages/query-plan-executor` (standalone query plan executor service for Prisma Accelerate), and numerous driver adapters under `packages/adapter-*`.
+- **Key packages**: `packages/cli` (Prisma CLI entry point), `packages/migrate` (migrate/db namespace + fixtures), `packages/client` (client runtime), `packages/client-generator-ts` (new `prisma-client` generator), `packages/client-generator-js` (traditional `prisma-client-js` generator), `packages/client-engine-runtime` (the core part of the new Rust binary free client based on Wasm query compiler, used by `ClientEngine` class in `packages/client`), `packages/config` (`PrismaConfigInternal` + loader), `packages/internals` (shared CLI + engine glue), `packages/engines` (Rust binaries download wrapper), `packages/integration-tests` (matrix suites), `packages/query-plan-executor` (standalone query plan executor service for Prisma Accelerate), sqlcommenter packages under `packages/sqlcommenter*`, and numerous driver adapters under `packages/adapter-*`.
 - **Driver adapters & runtimes**: `packages/bundled-js-drivers` plus the `adapter-*` packages ship experimental JS driver adapters (Planetscale, Neon, libsql, D1, etc.) built on helpers in `driver-adapter-utils`; migrate/client fixtures exercise them, so adapter changes typically require fixture/test updates.
 - **Build & tooling**: Typescript-first repo with WASM/Rust assets (downloaded by `@prisma/engines`). Multiple `tsconfig.*` drive bundle vs runtime builds. Lint via `pnpm lint`, format via `pnpm format`. Maintenance scripts live in `scripts/` (e.g. `bump-engines.ts`, `bench.ts`, `ci/publish.ts` orchestrates build/test/publish flows). Build configuration uses esbuild via `helpers/compile/build.ts` with configs in `helpers/compile/configs.ts`. Most packages use `adapterConfig` which bundles to both CJS and ESM with type declarations.
 - **Testing & databases**: `TESTING.md` covers Jest/Vitest usage. Most suites run as `pnpm --filter @prisma/<pkg> test <pattern>`. DB-backed tests expect `.db.env` and Docker services from `docker/docker-compose.yml` (`docker compose up -d`). Client functional tests sit in `packages/client/tests/functional`—run them via `pnpm --filter @prisma/client test:functional` (with typechecking) or `pnpm --filter @prisma/client test:functional:code` (code only); `helpers/functional-test/run-tests.ts` documents CLI flags to target providers, drivers, etc. Client e2e suites require a fresh `pnpm build` at repo root, then `pnpm --filter @prisma/client test:e2e --verbose --runInBand`. The legacy `pnpm --filter @prisma/client test` command primarily runs the older Jest unit tests plus `tsd` type checks. Migrate CLI suites live in `packages/migrate/src/__tests__`, the CLI runs both Jest (legacy suites) and Vitest (new subcommand coverage) via `pnpm --filter prisma test`, and end-to-end coverage lives in `packages/integration-tests`.
@@ -48,6 +48,15 @@
 
 - **Environment loading**: Prisma 7 removes automatic `.env` loading.
 
+- **SQL Commenter packages**:
+  - `@prisma/sqlcommenter`: Core types (`SqlCommenterPlugin`, `SqlCommenterContext`, `SqlCommenterQueryInfo`, `SqlCommenterTags`) for building sqlcommenter plugins.
+  - `@prisma/sqlcommenter-query-tags`: AsyncLocalStorage-based plugin for adding ad-hoc tags via `withQueryTags()` and `withMergedQueryTags()`.
+  - `@prisma/sqlcommenter-trace-context`: Plugin for adding W3C Trace Context `traceparent` header to queries.
+  - `@prisma/sqlcommenter-query-insights`: Plugin for adding parameterized query shapes to comments (format: `Model.action:base64Payload`).
+  - Plugins are registered via `PrismaClient({ comments: [plugin1(), plugin2()] })`.
+  - E2E tests for sqlcommenter plugins live in `packages/client/tests/e2e/sqlcommenter*` directories.
+  - `SqlCommenterQueryInfo` distinguishes `type: 'single'` (single query) vs `type: 'compacted'` (batched queries merged into one SQL statement).
+
 - **Codebase helpers to know**:
   - `@prisma/internals` exports CLI utilities: `arg`, `loadSchemaContext` (less used now).
   - `packages/migrate/src/__tests__/__helpers__/context.ts` sets up Jest helpers including config contributors.
@@ -55,6 +64,10 @@
   - `@prisma/ts-builders` provides a fluent API for generating TypeScript code (interfaces, types, properties with doc comments).
   - `@prisma/driver-adapter-utils` defines core interfaces: `SqlQuery`, `SqlQueryable`, `SqlDriverAdapter`, `SqlDriverAdapterFactory`.
   - `@prisma/client-engine-runtime` exports query interpreter, transaction manager, and related utilities.
+
+- **Coding conventions**:
+  - Use **kebab-case** for new file names (e.g., `query-utils.ts`, `filter-operators.test.ts`).
+  - **Avoid creating barrel files** (`index.ts` that re-export from other modules). Import directly from the source file (e.g., `import { foo } from './utils/query-utils'` not `import { foo } from './utils'`), unless `./utils/index.ts` file already exists (in which case use it for consistency with surrounding code).
 
 - **Workflow reminders**:
   - Respect existing structure: modifications often require updating both command implementation and tests/fixtures.

--- a/packages/client/tests/e2e/sqlcommenter-query-insights/_steps.cts
+++ b/packages/client/tests/e2e/sqlcommenter-query-insights/_steps.cts
@@ -1,0 +1,20 @@
+import { $ } from 'zx'
+
+import { executeSteps } from '../_utils/executeSteps'
+
+void executeSteps({
+  setup: async () => {
+    await $`pnpm install`
+    await $`pnpm prisma generate`
+    await $`pnpm exec prisma db push --force-reset`
+  },
+  test: async () => {
+    await $`pnpm exec prisma -v`
+    await $`tsx src/index.ts`
+    await $`pnpm exec tsc --noEmit`
+  },
+  finish: async () => {
+    await $`echo "done"`
+  },
+  // keep: true, // keep docker open to debug it
+})

--- a/packages/client/tests/e2e/sqlcommenter-query-insights/package.json
+++ b/packages/client/tests/e2e/sqlcommenter-query-insights/package.json
@@ -7,7 +7,6 @@
   "dependencies": {
     "@prisma/adapter-better-sqlite3": "/tmp/prisma-adapter-better-sqlite3-0.0.0.tgz",
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz",
-    "@prisma/client-runtime-utils": "/tmp/prisma-client-runtime-utils-0.0.0.tgz",
     "@prisma/sqlcommenter": "/tmp/prisma-sqlcommenter-0.0.0.tgz",
     "@prisma/sqlcommenter-query-insights": "/tmp/prisma-sqlcommenter-query-insights-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/sqlcommenter-query-insights/package.json
+++ b/packages/client/tests/e2e/sqlcommenter-query-insights/package.json
@@ -1,0 +1,24 @@
+{
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {},
+  "dependencies": {
+    "@prisma/adapter-better-sqlite3": "/tmp/prisma-adapter-better-sqlite3-0.0.0.tgz",
+    "@prisma/client": "/tmp/prisma-client-0.0.0.tgz",
+    "@prisma/client-runtime-utils": "/tmp/prisma-client-runtime-utils-0.0.0.tgz",
+    "@prisma/sqlcommenter": "/tmp/prisma-sqlcommenter-0.0.0.tgz",
+    "@prisma/sqlcommenter-query-insights": "/tmp/prisma-sqlcommenter-query-insights-0.0.0.tgz"
+  },
+  "devDependencies": {
+    "@types/node": "~20.19.0",
+    "@types/better-sqlite3": "^7.6.13",
+    "prisma": "/tmp/prisma-0.0.0.tgz"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3"
+    ]
+  }
+}

--- a/packages/client/tests/e2e/sqlcommenter-query-insights/pnpm-lock.yaml
+++ b/packages/client/tests/e2e/sqlcommenter-query-insights/pnpm-lock.yaml
@@ -13,16 +13,16 @@ importers:
         version: file:../../tmp/prisma-adapter-better-sqlite3-0.0.0.tgz
       '@prisma/client':
         specifier: /tmp/prisma-client-0.0.0.tgz
-        version: file:../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.7)(better-sqlite3@12.5.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+        version: file:../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.7)(better-sqlite3@12.5.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       '@prisma/client-runtime-utils':
         specifier: /tmp/prisma-client-runtime-utils-0.0.0.tgz
         version: file:../../tmp/prisma-client-runtime-utils-0.0.0.tgz
       '@prisma/sqlcommenter':
         specifier: /tmp/prisma-sqlcommenter-0.0.0.tgz
         version: file:../../tmp/prisma-sqlcommenter-0.0.0.tgz
-      '@prisma/sqlcommenter-query-tags':
-        specifier: /tmp/prisma-sqlcommenter-query-tags-0.0.0.tgz
-        version: file:../../tmp/prisma-sqlcommenter-query-tags-0.0.0.tgz
+      '@prisma/sqlcommenter-query-insights':
+        specifier: /tmp/prisma-sqlcommenter-query-insights-0.0.0.tgz
+        version: file:../../tmp/prisma-sqlcommenter-query-insights-0.0.0.tgz
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.13
@@ -32,7 +32,7 @@ importers:
         version: 20.19.25
       prisma:
         specifier: /tmp/prisma-0.0.0.tgz
-        version: file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.7)(better-sqlite3@12.5.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.7)(better-sqlite3@12.5.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
 
 packages:
 
@@ -81,7 +81,7 @@ packages:
     version: 0.0.0
 
   '@prisma/client@file:../../tmp/prisma-client-0.0.0.tgz':
-    resolution: {integrity: sha512-tMO68mUuX9AMWs2UpUTKALW9RoaSEoHvZViZ4NxWP3HrEVe4B12Y7AiA0mfofh2ksUZV8gDqE8BMIYLYCBLGxw==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
+    resolution: {integrity: sha512-XH4xI+T0FMnoTrNc2n/RPfKj2+CohIpdCdVvgUnyKP1fQ7nK5Q2Uz0Qu2L+/im39EcuCK81PquJeeDKHfgQrhQ==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
     version: 0.0.0
     engines: {node: ^20.19 || ^22.12 || >=24.0}
     peerDependencies:
@@ -94,7 +94,7 @@ packages:
         optional: true
 
   '@prisma/config@file:../../tmp/prisma-config-0.0.0.tgz':
-    resolution: {integrity: sha512-x8H46vS3sOeFFUWFF/jleprCGRJq3B0cjXdC+MT88OJWKj+9npfw5/02FTBOyRLusk8Q4hqXWzfWHzHO/k/3mA==, tarball: file:../../tmp/prisma-config-0.0.0.tgz}
+    resolution: {integrity: sha512-X20NglHhDKsIKeYpxh5KYFHphfSZx+9Fg6KG5fft65ynn6mW45f9y0FC7J31qT6J2GYTCaiSZ6f4Orc6K72d4w==, tarball: file:../../tmp/prisma-config-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/debug@6.8.2':
@@ -111,15 +111,15 @@ packages:
     resolution: {integrity: sha512-d7qYqZGFogvxfB0RJadqONOX04Dg0MHoIIJT2GNyGIZa0udigBUwcek1tq3eqc/JCBbbuVGGeDz3xm1jdHwjgg==, tarball: file:../../tmp/prisma-driver-adapter-utils-0.0.0.tgz}
     version: 0.0.0
 
-  '@prisma/engines-version@7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba':
-    resolution: {integrity: sha512-qZUevUh+yPhGT28rDQnV8V2kLnFjirzhVD67elRPIJHRsUV/mkII10HSrJrhK/U2GYgAxXR2VEREtq7AsfS8qw==}
+  '@prisma/engines-version@7.2.0-1.3f298657b368429158ee75de33d3dc7ca4b307a5':
+    resolution: {integrity: sha512-8hl0zGwU+0sYKJlbT5Waq5Ti5yIEJhWVrA29vjkbEpf4ZdnbuDaemTDl+99rb5kWrmE0+mbLycB7pOMBFanWXA==}
 
   '@prisma/engines@file:../../tmp/prisma-engines-0.0.0.tgz':
-    resolution: {integrity: sha512-6pI5a8M4Bi4+m/QfpZNYjogpkwA3sTIlVfe7i1g6RiDr16WeXexgiVKqGhFQCe22z9w7EklAeL/3PTEeW+bDAA==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
+    resolution: {integrity: sha512-1hlthReof1W/Mbb9qU0ID+lHl0Ae9+QsrNFsdKGMXvq1X41xuoWcYWAT6FKhGndSmQnzgO9qV38xa2WtZ63hDw==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/fetch-engine@file:../../tmp/prisma-fetch-engine-0.0.0.tgz':
-    resolution: {integrity: sha512-/TNwA9h/zt7Q19WSLanOa/Hle+MfXfC6twWIsC7hdonWY8HT7AgNB3JfZ2VHLJ056TkWiQevLOooxdZNrS3teg==, tarball: file:../../tmp/prisma-fetch-engine-0.0.0.tgz}
+    resolution: {integrity: sha512-SilD4nK5eXV62pkcVsSfVbQMSKofBSdQTZn8gCjjr75HaVdAr4vd6axrimnmV9kicmEOwpYKI3NPr0rcfAVjug==, tarball: file:../../tmp/prisma-fetch-engine-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/get-platform@6.8.2':
@@ -132,12 +132,12 @@ packages:
   '@prisma/query-plan-executor@6.18.0':
     resolution: {integrity: sha512-jZ8cfzFgL0jReE1R10gT8JLHtQxjWYLiQ//wHmVYZ2rVkFHoh0DT8IXsxcKcFlfKN7ak7k6j0XMNn2xVNyr5cA==}
 
-  '@prisma/sqlcommenter-query-tags@file:../../tmp/prisma-sqlcommenter-query-tags-0.0.0.tgz':
-    resolution: {integrity: sha512-N5DwqFoohxJwazqo88gEyiauLgw9OPGz+UBnIqmR73EtA6mWf1IoDbDe+Tuie6NnCQjxF5QIk16LlxYDYDczzQ==, tarball: file:../../tmp/prisma-sqlcommenter-query-tags-0.0.0.tgz}
+  '@prisma/sqlcommenter-query-insights@file:../../tmp/prisma-sqlcommenter-query-insights-0.0.0.tgz':
+    resolution: {integrity: sha512-nfx33VZ5tN25Jfu9a8wIkaF01GK0cUTBNDRMvS8pAlXpwGngoAsUPChg9vkZxBRYHfQ1eSZ7C2e32+dVVl1wqA==, tarball: file:../../tmp/prisma-sqlcommenter-query-insights-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/sqlcommenter@file:../../tmp/prisma-sqlcommenter-0.0.0.tgz':
-    resolution: {integrity: sha512-KqS4u1+B4OvdpU663iUGBPeImrcjvTWEe19lHhe0TesF9sV6rgrPVwjPcvHH4gotnTiWuOb9YinnZbPcLNe0Gw==, tarball: file:../../tmp/prisma-sqlcommenter-0.0.0.tgz}
+    resolution: {integrity: sha512-MYpPelKt9XrBMXuDWDEHAkgVfTNeKT+2ZC5rm8gPh5QijYe+oyeKrx4QqnYX/m2d0E42b7C9L9vocvXj3pKgLA==, tarball: file:../../tmp/prisma-sqlcommenter-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/studio-core@0.8.2':
@@ -404,7 +404,7 @@ packages:
     hasBin: true
 
   prisma@file:../../tmp/prisma-0.0.0.tgz:
-    resolution: {integrity: sha512-moomFa99vTu6Ymb6wmjvdPUrSiKSn/eTcCWlh3uP9oQtDiZ1DNn7BJIROYD74NdFK66tCXZwMjZNp7UqYvm8fQ==, tarball: file:../../tmp/prisma-0.0.0.tgz}
+    resolution: {integrity: sha512-wDnySJK4Q3FEqMfa7SaCJQasOv/FP5DWWW3LrdX92TGrQy02+Bw0iGYUKPXJDhCoKtP2vXOE5RjSJG+Y7VTbSw==, tarball: file:../../tmp/prisma-0.0.0.tgz}
     version: 0.0.0
     engines: {node: ^20.19 || ^22.12 || >=24.0}
     hasBin: true
@@ -433,13 +433,13 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  react-dom@19.2.0:
-    resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
+  react-dom@19.2.1:
+    resolution: {integrity: sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==}
     peerDependencies:
-      react: ^19.2.0
+      react: ^19.2.1
 
-  react@19.2.0:
-    resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
+  react@19.2.1:
+    resolution: {integrity: sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==}
     engines: {node: '>=0.10.0'}
 
   readable-stream@3.6.2:
@@ -598,11 +598,11 @@ snapshots:
 
   '@prisma/client-runtime-utils@file:../../tmp/prisma-client-runtime-utils-0.0.0.tgz': {}
 
-  '@prisma/client@file:../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.7)(better-sqlite3@12.5.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
+  '@prisma/client@file:../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.7)(better-sqlite3@12.5.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
     dependencies:
       '@prisma/client-runtime-utils': file:../../tmp/prisma-client-runtime-utils-0.0.0.tgz
     optionalDependencies:
-      prisma: file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.7)(better-sqlite3@12.5.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      prisma: file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.7)(better-sqlite3@12.5.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
 
   '@prisma/config@file:../../tmp/prisma-config-0.0.0.tgz':
     dependencies:
@@ -643,19 +643,19 @@ snapshots:
     dependencies:
       '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
 
-  '@prisma/engines-version@7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba': {}
+  '@prisma/engines-version@7.2.0-1.3f298657b368429158ee75de33d3dc7ca4b307a5': {}
 
   '@prisma/engines@file:../../tmp/prisma-engines-0.0.0.tgz':
     dependencies:
       '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
-      '@prisma/engines-version': 7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba
+      '@prisma/engines-version': 7.2.0-1.3f298657b368429158ee75de33d3dc7ca4b307a5
       '@prisma/fetch-engine': file:../../tmp/prisma-fetch-engine-0.0.0.tgz
       '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
 
   '@prisma/fetch-engine@file:../../tmp/prisma-fetch-engine-0.0.0.tgz':
     dependencies:
       '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
-      '@prisma/engines-version': 7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba
+      '@prisma/engines-version': 7.2.0-1.3f298657b368429158ee75de33d3dc7ca4b307a5
       '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
 
   '@prisma/get-platform@6.8.2':
@@ -668,15 +668,15 @@ snapshots:
 
   '@prisma/query-plan-executor@6.18.0': {}
 
-  '@prisma/sqlcommenter-query-tags@file:../../tmp/prisma-sqlcommenter-query-tags-0.0.0.tgz': {}
+  '@prisma/sqlcommenter-query-insights@file:../../tmp/prisma-sqlcommenter-query-insights-0.0.0.tgz': {}
 
   '@prisma/sqlcommenter@file:../../tmp/prisma-sqlcommenter-0.0.0.tgz': {}
 
-  '@prisma/studio-core@0.8.2(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@prisma/studio-core@0.8.2(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@types/react': 19.2.7
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
   '@standard-schema/spec@1.0.0': {}
 
@@ -932,12 +932,12 @@ snapshots:
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
 
-  prisma@file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.7)(better-sqlite3@12.5.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  prisma@file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.7)(better-sqlite3@12.5.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       '@prisma/config': file:../../tmp/prisma-config-0.0.0.tgz
       '@prisma/dev': 0.15.0
       '@prisma/engines': file:../../tmp/prisma-engines-0.0.0.tgz
-      '@prisma/studio-core': 0.8.2(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@prisma/studio-core': 0.8.2(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       mysql2: 3.15.3
       postgres: 3.4.7
     optionalDependencies:
@@ -973,12 +973,12 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-dom@19.2.0(react@19.2.0):
+  react-dom@19.2.1(react@19.2.1):
     dependencies:
-      react: 19.2.0
+      react: 19.2.1
       scheduler: 0.27.0
 
-  react@19.2.0: {}
+  react@19.2.1: {}
 
   readable-stream@3.6.2:
     dependencies:

--- a/packages/client/tests/e2e/sqlcommenter-query-insights/pnpm-lock.yaml
+++ b/packages/client/tests/e2e/sqlcommenter-query-insights/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@prisma/client':
         specifier: /tmp/prisma-client-0.0.0.tgz
         version: file:../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.7)(better-sqlite3@12.5.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
-      '@prisma/client-runtime-utils':
-        specifier: /tmp/prisma-client-runtime-utils-0.0.0.tgz
-        version: file:../../tmp/prisma-client-runtime-utils-0.0.0.tgz
       '@prisma/sqlcommenter':
         specifier: /tmp/prisma-sqlcommenter-0.0.0.tgz
         version: file:../../tmp/prisma-sqlcommenter-0.0.0.tgz
@@ -81,7 +78,7 @@ packages:
     version: 0.0.0
 
   '@prisma/client@file:../../tmp/prisma-client-0.0.0.tgz':
-    resolution: {integrity: sha512-XH4xI+T0FMnoTrNc2n/RPfKj2+CohIpdCdVvgUnyKP1fQ7nK5Q2Uz0Qu2L+/im39EcuCK81PquJeeDKHfgQrhQ==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
+    resolution: {integrity: sha512-TjyZ/c9R57AaH0jjZwRxsjpbMn36Z9IAcGWM1xbOlabFya4vsOuTwSBUcSyx6yTOJmD13yF6nhTd8hSw7VgSwA==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
     version: 0.0.0
     engines: {node: ^20.19 || ^22.12 || >=24.0}
     peerDependencies:
@@ -94,7 +91,7 @@ packages:
         optional: true
 
   '@prisma/config@file:../../tmp/prisma-config-0.0.0.tgz':
-    resolution: {integrity: sha512-X20NglHhDKsIKeYpxh5KYFHphfSZx+9Fg6KG5fft65ynn6mW45f9y0FC7J31qT6J2GYTCaiSZ6f4Orc6K72d4w==, tarball: file:../../tmp/prisma-config-0.0.0.tgz}
+    resolution: {integrity: sha512-x8H46vS3sOeFFUWFF/jleprCGRJq3B0cjXdC+MT88OJWKj+9npfw5/02FTBOyRLusk8Q4hqXWzfWHzHO/k/3mA==, tarball: file:../../tmp/prisma-config-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/debug@6.8.2':
@@ -404,7 +401,7 @@ packages:
     hasBin: true
 
   prisma@file:../../tmp/prisma-0.0.0.tgz:
-    resolution: {integrity: sha512-wDnySJK4Q3FEqMfa7SaCJQasOv/FP5DWWW3LrdX92TGrQy02+Bw0iGYUKPXJDhCoKtP2vXOE5RjSJG+Y7VTbSw==, tarball: file:../../tmp/prisma-0.0.0.tgz}
+    resolution: {integrity: sha512-AORCO9DIz38tWAnWXMAu+hqgCb6qj9eblk/CuqXcVTuU6tJibViTmyjx0cDFAtghEs+d8sm0kH8yl2+pcDdjVQ==, tarball: file:../../tmp/prisma-0.0.0.tgz}
     version: 0.0.0
     engines: {node: ^20.19 || ^22.12 || >=24.0}
     hasBin: true

--- a/packages/client/tests/e2e/sqlcommenter-query-insights/prisma.config.ts
+++ b/packages/client/tests/e2e/sqlcommenter-query-insights/prisma.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'prisma/config'
+
+export default defineConfig({
+  datasource: {
+    url: 'file:./dev.db',
+  },
+})

--- a/packages/client/tests/e2e/sqlcommenter-query-insights/prisma/schema.prisma
+++ b/packages/client/tests/e2e/sqlcommenter-query-insights/prisma/schema.prisma
@@ -1,0 +1,26 @@
+generator client {
+  provider = "prisma-client"
+  output   = "../src/generated/prisma"
+}
+
+datasource db {
+  provider = "sqlite"
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  name      String?
+  posts     Post[]
+  createdAt DateTime @default(now())
+}
+
+model Post {
+  id        Int      @id @default(autoincrement())
+  title     String
+  content   String?
+  published Boolean  @default(false)
+  author    User     @relation(fields: [authorId], references: [id])
+  authorId  Int
+  createdAt DateTime @default(now())
+}

--- a/packages/client/tests/e2e/sqlcommenter-query-insights/readme.md
+++ b/packages/client/tests/e2e/sqlcommenter-query-insights/readme.md
@@ -1,0 +1,20 @@
+# SQL Commenter Query Insights E2E Test
+
+This test verifies that the `@prisma/sqlcommenter-query-insights` plugin correctly adds parameterized query shape information to SQL comments.
+
+## What it tests
+
+1. Query shapes are correctly formatted as `Model.action:base64Payload`
+2. Raw queries are formatted as just the action (e.g., `queryRaw`)
+3. User data values are parameterized (replaced with `{"$type":"Param"}`)
+4. Structural values (pagination, sort directions) are preserved
+5. Compacted batch queries include all queries in the payload array
+
+## Running locally
+
+```bash
+pnpm install
+pnpm prisma generate
+pnpm exec prisma db push --force-reset
+tsx src/index.ts
+```

--- a/packages/client/tests/e2e/sqlcommenter-query-insights/src/index.ts
+++ b/packages/client/tests/e2e/sqlcommenter-query-insights/src/index.ts
@@ -1,0 +1,313 @@
+import assert from 'node:assert/strict'
+
+import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
+import { prismaQueryInsights } from '@prisma/sqlcommenter-query-insights'
+
+import { Prisma, PrismaClient } from './generated/prisma/client.js'
+
+// Helper to decode base64url and parse JSON
+function decodePayload(base64url: string): unknown {
+  const json = Buffer.from(base64url, 'base64url').toString('utf-8')
+  return JSON.parse(json)
+}
+
+// Helper to parse prismaQuery comment value
+function parsePrismaQuery(value: string): { prefix: string; payload?: unknown } {
+  const colonIndex = value.indexOf(':')
+  if (colonIndex === -1) {
+    return { prefix: value }
+  }
+  const prefix = value.slice(0, colonIndex)
+  const encoded = value.slice(colonIndex + 1)
+  const payload = decodePayload(encoded)
+  return { prefix, payload }
+}
+
+// Helper to extract prismaQuery from SQL comment
+function extractPrismaQuery(sql: string): string | null {
+  // Match /*...prismaQuery='...'...*/
+  const match = sql.match(/prismaQuery='((?:[^'\\]|\\.)*)'/s)
+  if (!match) return null
+  // Unescape single quotes and URL-decode
+  return decodeURIComponent(match[1].replace(/\\'/g, "'"))
+}
+
+const PARAM_PLACEHOLDER = { $type: 'Param' }
+
+const adapter = new PrismaBetterSqlite3({
+  url: './dev.db',
+})
+
+const capturedQueries: string[] = []
+
+const prisma = new PrismaClient({
+  adapter,
+  comments: [prismaQueryInsights()],
+  log: [{ emit: 'event', level: 'query' }],
+})
+
+prisma.$on('query', (event: Prisma.QueryEvent) => {
+  capturedQueries.push(event.query)
+})
+
+// Helper to clear captured queries and return what was captured
+function flushQueries(): string[] {
+  const queries = [...capturedQueries]
+  capturedQueries.length = 0
+  return queries
+}
+
+// Helper to verify queries from an operation
+function verifyQueries(
+  description: string,
+  queries: string[],
+  checks: {
+    expectedCount?: number
+    prefix?: string
+    queryIndex?: number
+    containsInPayload?: (payload: unknown) => boolean
+    notContains?: string[]
+  },
+) {
+  const queryIndex = checks.queryIndex ?? 0
+
+  if (checks.expectedCount !== undefined) {
+    assert.strictEqual(
+      queries.length,
+      checks.expectedCount,
+      `${description}: expected ${checks.expectedCount} queries, got ${queries.length}`,
+    )
+  }
+
+  const sql = queries[queryIndex]
+  assert(sql, `${description}: query at index ${queryIndex} not found (got ${queries.length} queries)`)
+
+  const prismaQuery = extractPrismaQuery(sql)
+  assert(prismaQuery, `${description}: should have prismaQuery comment`)
+
+  const parsed = parsePrismaQuery(prismaQuery)
+
+  if (checks.prefix) {
+    assert.strictEqual(parsed.prefix, checks.prefix, `${description}: prefix mismatch`)
+  }
+
+  if (checks.containsInPayload) {
+    assert(
+      checks.containsInPayload(parsed.payload),
+      `${description}: payload check failed: ${JSON.stringify(parsed.payload, null, 2)}`,
+    )
+  }
+
+  if (checks.notContains) {
+    for (const value of checks.notContains) {
+      assert(!prismaQuery.includes(value), `${description}: should not contain "${value}"`)
+    }
+  }
+
+  console.log(`✓ ${description}`)
+}
+
+// We need to store the user id for the post creation test
+let createdUserId: number
+
+// Test 1: Simple findMany - should have Model.action format with empty payload (all scalars)
+{
+  console.log('Test 1: Simple findMany')
+
+  await prisma.user.findMany()
+
+  verifyQueries('findMany', flushQueries(), {
+    expectedCount: 1,
+    prefix: 'User.findMany',
+    containsInPayload: (p) => {
+      const payload = p as Record<string, unknown>
+      return Object.keys(payload).length === 0
+    },
+  })
+}
+
+// Test 2: Create with data - data values should be parameterized
+{
+  console.log('Test 2: Create with data')
+
+  const user = await prisma.user.create({
+    data: { email: 'secret@private.com', name: 'Secret Name' },
+  })
+
+  createdUserId = user.id
+
+  verifyQueries('create with data', flushQueries(), {
+    expectedCount: 1,
+    prefix: 'User.createOne',
+    containsInPayload: (p) => {
+      const payload = p as { data?: { email?: unknown; name?: unknown } }
+      const data = payload.data
+      return (
+        data !== undefined &&
+        JSON.stringify(data.email) === JSON.stringify(PARAM_PLACEHOLDER) &&
+        JSON.stringify(data.name) === JSON.stringify(PARAM_PLACEHOLDER)
+      )
+    },
+    notContains: ['secret@private.com', 'Secret Name'],
+  })
+}
+
+// Test 3: findFirst with where clause - filter values should be parameterized
+{
+  console.log('Test 3: findFirst with where clause')
+
+  await prisma.user.findFirst({
+    where: { email: 'secret@private.com' },
+  })
+
+  verifyQueries('findFirst with where', flushQueries(), {
+    expectedCount: 1,
+    prefix: 'User.findFirst',
+    containsInPayload: (p) => {
+      const payload = p as { where?: { email?: unknown } }
+      return JSON.stringify(payload.where?.email) === JSON.stringify(PARAM_PLACEHOLDER)
+    },
+    notContains: ['secret@private.com'],
+  })
+}
+
+// Test 4: findMany with pagination - take/skip should be preserved
+{
+  console.log('Test 4: findMany with pagination')
+
+  await prisma.user.findMany({
+    take: 10,
+    skip: 5,
+  })
+
+  verifyQueries('findMany with pagination', flushQueries(), {
+    expectedCount: 1,
+    prefix: 'User.findMany',
+    containsInPayload: (p) => {
+      const payload = p as { take?: number; skip?: number }
+      return payload.take === 10 && payload.skip === 5
+    },
+  })
+}
+
+// Test 5: findMany with orderBy - sort direction should be preserved
+{
+  console.log('Test 5: findMany with orderBy')
+
+  await prisma.user.findMany({
+    orderBy: { createdAt: 'desc' },
+  })
+
+  verifyQueries('findMany with orderBy', flushQueries(), {
+    expectedCount: 1,
+    prefix: 'User.findMany',
+    containsInPayload: (p) => {
+      const payload = p as { orderBy?: { createdAt?: string } }
+      return payload.orderBy?.createdAt === 'desc'
+    },
+  })
+}
+
+// Test 6: Create post with relation - nested data should be parameterized
+{
+  console.log('Test 6: Create with relation')
+
+  await prisma.post.create({
+    data: {
+      title: 'Secret Title',
+      content: 'Secret Content',
+      authorId: createdUserId,
+    },
+  })
+
+  verifyQueries('create post', flushQueries(), {
+    expectedCount: 1,
+    prefix: 'Post.createOne',
+    containsInPayload: (p) => {
+      const payload = p as { data?: { title?: unknown; content?: unknown } }
+      const data = payload.data
+      return (
+        data !== undefined &&
+        JSON.stringify(data.title) === JSON.stringify(PARAM_PLACEHOLDER) &&
+        JSON.stringify(data.content) === JSON.stringify(PARAM_PLACEHOLDER)
+      )
+    },
+    notContains: ['Secret Title', 'Secret Content'],
+  })
+}
+
+// Test 7: findMany with include - relation selection should use include
+// Note: include generates 2 SQL queries (one for User, one for Post), both with the same comment
+{
+  console.log('Test 7: findMany with include')
+
+  await prisma.user.findMany({
+    include: { posts: true },
+  })
+
+  verifyQueries('findMany with include', flushQueries(), {
+    expectedCount: 2,
+    queryIndex: 0,
+    prefix: 'User.findMany',
+    containsInPayload: (p) => {
+      const payload = p as { include?: { posts?: unknown } }
+      return payload.include?.posts === true
+    },
+  })
+}
+
+// Test 8: Complex where with AND/OR - all values should be parameterized
+{
+  console.log('Test 8: Complex where with AND/OR')
+
+  await prisma.user.findMany({
+    where: {
+      AND: [{ email: { contains: '@private.com' } }, { OR: [{ name: 'Alice' }, { name: 'Bob' }] }],
+    },
+  })
+
+  verifyQueries('complex where', flushQueries(), {
+    expectedCount: 1,
+    prefix: 'User.findMany',
+    containsInPayload: (p) => {
+      const payload = p as {
+        where?: { AND?: Array<{ email?: { contains?: unknown }; OR?: Array<{ name?: unknown }> }> }
+      }
+      const and = payload.where?.AND
+      if (!and || !Array.isArray(and)) return false
+
+      // Check email.contains is parameterized
+      const emailCondition = and[0]?.email?.contains
+      if (JSON.stringify(emailCondition) !== JSON.stringify(PARAM_PLACEHOLDER)) return false
+
+      // Check OR conditions are parameterized
+      const orConditions = and[1]?.OR
+      if (!orConditions || !Array.isArray(orConditions)) return false
+
+      return orConditions.every((cond) => JSON.stringify(cond.name) === JSON.stringify(PARAM_PLACEHOLDER))
+    },
+    notContains: ['@private.com', 'Alice', 'Bob'],
+  })
+}
+
+// Test 9: findMany with select - verify select is in payload
+{
+  console.log('Test 9: findMany with select')
+
+  await prisma.user.findMany({
+    select: { id: true, email: true },
+  })
+
+  verifyQueries('findMany with select', flushQueries(), {
+    expectedCount: 1,
+    prefix: 'User.findMany',
+    containsInPayload: (p) => {
+      const payload = p as { select?: { id?: boolean; email?: boolean } }
+      return payload.select?.id === true && payload.select?.email === true
+    },
+  })
+}
+
+await prisma.$disconnect()
+
+console.log('\n✅ SQL commenter query insights e2e test passed!')

--- a/packages/client/tests/e2e/sqlcommenter-query-insights/tsconfig.json
+++ b/packages/client/tests/e2e/sqlcommenter-query-insights/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.base.json",
+  "exclude": ["_steps.cts"],
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext"
+  }
+}

--- a/packages/client/tests/e2e/sqlcommenter-query-tags/package.json
+++ b/packages/client/tests/e2e/sqlcommenter-query-tags/package.json
@@ -7,7 +7,6 @@
   "dependencies": {
     "@prisma/adapter-better-sqlite3": "/tmp/prisma-adapter-better-sqlite3-0.0.0.tgz",
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz",
-    "@prisma/client-runtime-utils": "/tmp/prisma-client-runtime-utils-0.0.0.tgz",
     "@prisma/sqlcommenter": "/tmp/prisma-sqlcommenter-0.0.0.tgz",
     "@prisma/sqlcommenter-query-tags": "/tmp/prisma-sqlcommenter-query-tags-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/sqlcommenter-query-tags/pnpm-lock.yaml
+++ b/packages/client/tests/e2e/sqlcommenter-query-tags/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@prisma/client':
         specifier: /tmp/prisma-client-0.0.0.tgz
         version: file:../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.7)(better-sqlite3@12.5.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
-      '@prisma/client-runtime-utils':
-        specifier: /tmp/prisma-client-runtime-utils-0.0.0.tgz
-        version: file:../../tmp/prisma-client-runtime-utils-0.0.0.tgz
       '@prisma/sqlcommenter':
         specifier: /tmp/prisma-sqlcommenter-0.0.0.tgz
         version: file:../../tmp/prisma-sqlcommenter-0.0.0.tgz
@@ -81,7 +78,7 @@ packages:
     version: 0.0.0
 
   '@prisma/client@file:../../tmp/prisma-client-0.0.0.tgz':
-    resolution: {integrity: sha512-tMO68mUuX9AMWs2UpUTKALW9RoaSEoHvZViZ4NxWP3HrEVe4B12Y7AiA0mfofh2ksUZV8gDqE8BMIYLYCBLGxw==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
+    resolution: {integrity: sha512-TjyZ/c9R57AaH0jjZwRxsjpbMn36Z9IAcGWM1xbOlabFya4vsOuTwSBUcSyx6yTOJmD13yF6nhTd8hSw7VgSwA==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
     version: 0.0.0
     engines: {node: ^20.19 || ^22.12 || >=24.0}
     peerDependencies:
@@ -111,15 +108,15 @@ packages:
     resolution: {integrity: sha512-d7qYqZGFogvxfB0RJadqONOX04Dg0MHoIIJT2GNyGIZa0udigBUwcek1tq3eqc/JCBbbuVGGeDz3xm1jdHwjgg==, tarball: file:../../tmp/prisma-driver-adapter-utils-0.0.0.tgz}
     version: 0.0.0
 
-  '@prisma/engines-version@7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba':
-    resolution: {integrity: sha512-qZUevUh+yPhGT28rDQnV8V2kLnFjirzhVD67elRPIJHRsUV/mkII10HSrJrhK/U2GYgAxXR2VEREtq7AsfS8qw==}
+  '@prisma/engines-version@7.2.0-1.3f298657b368429158ee75de33d3dc7ca4b307a5':
+    resolution: {integrity: sha512-8hl0zGwU+0sYKJlbT5Waq5Ti5yIEJhWVrA29vjkbEpf4ZdnbuDaemTDl+99rb5kWrmE0+mbLycB7pOMBFanWXA==}
 
   '@prisma/engines@file:../../tmp/prisma-engines-0.0.0.tgz':
-    resolution: {integrity: sha512-6pI5a8M4Bi4+m/QfpZNYjogpkwA3sTIlVfe7i1g6RiDr16WeXexgiVKqGhFQCe22z9w7EklAeL/3PTEeW+bDAA==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
+    resolution: {integrity: sha512-1hlthReof1W/Mbb9qU0ID+lHl0Ae9+QsrNFsdKGMXvq1X41xuoWcYWAT6FKhGndSmQnzgO9qV38xa2WtZ63hDw==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/fetch-engine@file:../../tmp/prisma-fetch-engine-0.0.0.tgz':
-    resolution: {integrity: sha512-/TNwA9h/zt7Q19WSLanOa/Hle+MfXfC6twWIsC7hdonWY8HT7AgNB3JfZ2VHLJ056TkWiQevLOooxdZNrS3teg==, tarball: file:../../tmp/prisma-fetch-engine-0.0.0.tgz}
+    resolution: {integrity: sha512-SilD4nK5eXV62pkcVsSfVbQMSKofBSdQTZn8gCjjr75HaVdAr4vd6axrimnmV9kicmEOwpYKI3NPr0rcfAVjug==, tarball: file:../../tmp/prisma-fetch-engine-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/get-platform@6.8.2':
@@ -137,7 +134,7 @@ packages:
     version: 0.0.0
 
   '@prisma/sqlcommenter@file:../../tmp/prisma-sqlcommenter-0.0.0.tgz':
-    resolution: {integrity: sha512-KqS4u1+B4OvdpU663iUGBPeImrcjvTWEe19lHhe0TesF9sV6rgrPVwjPcvHH4gotnTiWuOb9YinnZbPcLNe0Gw==, tarball: file:../../tmp/prisma-sqlcommenter-0.0.0.tgz}
+    resolution: {integrity: sha512-MYpPelKt9XrBMXuDWDEHAkgVfTNeKT+2ZC5rm8gPh5QijYe+oyeKrx4QqnYX/m2d0E42b7C9L9vocvXj3pKgLA==, tarball: file:../../tmp/prisma-sqlcommenter-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/studio-core@0.8.2':
@@ -404,7 +401,7 @@ packages:
     hasBin: true
 
   prisma@file:../../tmp/prisma-0.0.0.tgz:
-    resolution: {integrity: sha512-moomFa99vTu6Ymb6wmjvdPUrSiKSn/eTcCWlh3uP9oQtDiZ1DNn7BJIROYD74NdFK66tCXZwMjZNp7UqYvm8fQ==, tarball: file:../../tmp/prisma-0.0.0.tgz}
+    resolution: {integrity: sha512-AORCO9DIz38tWAnWXMAu+hqgCb6qj9eblk/CuqXcVTuU6tJibViTmyjx0cDFAtghEs+d8sm0kH8yl2+pcDdjVQ==, tarball: file:../../tmp/prisma-0.0.0.tgz}
     version: 0.0.0
     engines: {node: ^20.19 || ^22.12 || >=24.0}
     hasBin: true
@@ -643,19 +640,19 @@ snapshots:
     dependencies:
       '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
 
-  '@prisma/engines-version@7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba': {}
+  '@prisma/engines-version@7.2.0-1.3f298657b368429158ee75de33d3dc7ca4b307a5': {}
 
   '@prisma/engines@file:../../tmp/prisma-engines-0.0.0.tgz':
     dependencies:
       '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
-      '@prisma/engines-version': 7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba
+      '@prisma/engines-version': 7.2.0-1.3f298657b368429158ee75de33d3dc7ca4b307a5
       '@prisma/fetch-engine': file:../../tmp/prisma-fetch-engine-0.0.0.tgz
       '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
 
   '@prisma/fetch-engine@file:../../tmp/prisma-fetch-engine-0.0.0.tgz':
     dependencies:
       '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
-      '@prisma/engines-version': 7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba
+      '@prisma/engines-version': 7.2.0-1.3f298657b368429158ee75de33d3dc7ca4b307a5
       '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
 
   '@prisma/get-platform@6.8.2':

--- a/packages/client/tests/e2e/sqlcommenter-trace-context/package.json
+++ b/packages/client/tests/e2e/sqlcommenter-trace-context/package.json
@@ -12,7 +12,6 @@
     "@opentelemetry/semantic-conventions": "1.38.0",
     "@prisma/adapter-better-sqlite3": "/tmp/prisma-adapter-better-sqlite3-0.0.0.tgz",
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz",
-    "@prisma/client-runtime-utils": "/tmp/prisma-client-runtime-utils-0.0.0.tgz",
     "@prisma/instrumentation": "/tmp/prisma-instrumentation-0.0.0.tgz",
     "@prisma/sqlcommenter-trace-context": "/tmp/prisma-sqlcommenter-trace-context-0.0.0.tgz"
   },

--- a/packages/client/tests/e2e/sqlcommenter-trace-context/pnpm-lock.yaml
+++ b/packages/client/tests/e2e/sqlcommenter-trace-context/pnpm-lock.yaml
@@ -29,9 +29,6 @@ importers:
       '@prisma/client':
         specifier: /tmp/prisma-client-0.0.0.tgz
         version: file:../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.7)(better-sqlite3@12.5.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
-      '@prisma/client-runtime-utils':
-        specifier: /tmp/prisma-client-runtime-utils-0.0.0.tgz
-        version: file:../../tmp/prisma-client-runtime-utils-0.0.0.tgz
       '@prisma/instrumentation':
         specifier: /tmp/prisma-instrumentation-0.0.0.tgz
         version: file:../../tmp/prisma-instrumentation-0.0.0.tgz(@opentelemetry/api@1.9.0)
@@ -138,7 +135,7 @@ packages:
     version: 0.0.0
 
   '@prisma/client@file:../../tmp/prisma-client-0.0.0.tgz':
-    resolution: {integrity: sha512-tMO68mUuX9AMWs2UpUTKALW9RoaSEoHvZViZ4NxWP3HrEVe4B12Y7AiA0mfofh2ksUZV8gDqE8BMIYLYCBLGxw==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
+    resolution: {integrity: sha512-TjyZ/c9R57AaH0jjZwRxsjpbMn36Z9IAcGWM1xbOlabFya4vsOuTwSBUcSyx6yTOJmD13yF6nhTd8hSw7VgSwA==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
     version: 0.0.0
     engines: {node: ^20.19 || ^22.12 || >=24.0}
     peerDependencies:
@@ -168,15 +165,15 @@ packages:
     resolution: {integrity: sha512-d7qYqZGFogvxfB0RJadqONOX04Dg0MHoIIJT2GNyGIZa0udigBUwcek1tq3eqc/JCBbbuVGGeDz3xm1jdHwjgg==, tarball: file:../../tmp/prisma-driver-adapter-utils-0.0.0.tgz}
     version: 0.0.0
 
-  '@prisma/engines-version@7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba':
-    resolution: {integrity: sha512-qZUevUh+yPhGT28rDQnV8V2kLnFjirzhVD67elRPIJHRsUV/mkII10HSrJrhK/U2GYgAxXR2VEREtq7AsfS8qw==}
+  '@prisma/engines-version@7.2.0-1.3f298657b368429158ee75de33d3dc7ca4b307a5':
+    resolution: {integrity: sha512-8hl0zGwU+0sYKJlbT5Waq5Ti5yIEJhWVrA29vjkbEpf4ZdnbuDaemTDl+99rb5kWrmE0+mbLycB7pOMBFanWXA==}
 
   '@prisma/engines@file:../../tmp/prisma-engines-0.0.0.tgz':
-    resolution: {integrity: sha512-6pI5a8M4Bi4+m/QfpZNYjogpkwA3sTIlVfe7i1g6RiDr16WeXexgiVKqGhFQCe22z9w7EklAeL/3PTEeW+bDAA==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
+    resolution: {integrity: sha512-1hlthReof1W/Mbb9qU0ID+lHl0Ae9+QsrNFsdKGMXvq1X41xuoWcYWAT6FKhGndSmQnzgO9qV38xa2WtZ63hDw==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/fetch-engine@file:../../tmp/prisma-fetch-engine-0.0.0.tgz':
-    resolution: {integrity: sha512-/TNwA9h/zt7Q19WSLanOa/Hle+MfXfC6twWIsC7hdonWY8HT7AgNB3JfZ2VHLJ056TkWiQevLOooxdZNrS3teg==, tarball: file:../../tmp/prisma-fetch-engine-0.0.0.tgz}
+    resolution: {integrity: sha512-SilD4nK5eXV62pkcVsSfVbQMSKofBSdQTZn8gCjjr75HaVdAr4vd6axrimnmV9kicmEOwpYKI3NPr0rcfAVjug==, tarball: file:../../tmp/prisma-fetch-engine-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/get-platform@6.8.2':
@@ -494,7 +491,7 @@ packages:
     hasBin: true
 
   prisma@file:../../tmp/prisma-0.0.0.tgz:
-    resolution: {integrity: sha512-moomFa99vTu6Ymb6wmjvdPUrSiKSn/eTcCWlh3uP9oQtDiZ1DNn7BJIROYD74NdFK66tCXZwMjZNp7UqYvm8fQ==, tarball: file:../../tmp/prisma-0.0.0.tgz}
+    resolution: {integrity: sha512-AORCO9DIz38tWAnWXMAu+hqgCb6qj9eblk/CuqXcVTuU6tJibViTmyjx0cDFAtghEs+d8sm0kH8yl2+pcDdjVQ==, tarball: file:../../tmp/prisma-0.0.0.tgz}
     version: 0.0.0
     engines: {node: ^20.19 || ^22.12 || >=24.0}
     hasBin: true
@@ -776,19 +773,19 @@ snapshots:
     dependencies:
       '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
 
-  '@prisma/engines-version@7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba': {}
+  '@prisma/engines-version@7.2.0-1.3f298657b368429158ee75de33d3dc7ca4b307a5': {}
 
   '@prisma/engines@file:../../tmp/prisma-engines-0.0.0.tgz':
     dependencies:
       '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
-      '@prisma/engines-version': 7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba
+      '@prisma/engines-version': 7.2.0-1.3f298657b368429158ee75de33d3dc7ca4b307a5
       '@prisma/fetch-engine': file:../../tmp/prisma-fetch-engine-0.0.0.tgz
       '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
 
   '@prisma/fetch-engine@file:../../tmp/prisma-fetch-engine-0.0.0.tgz':
     dependencies:
       '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
-      '@prisma/engines-version': 7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba
+      '@prisma/engines-version': 7.2.0-1.3f298657b368429158ee75de33d3dc7ca4b307a5
       '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
 
   '@prisma/get-platform@6.8.2':

--- a/packages/client/tests/e2e/sqlcommenter-trace-context/pnpm-lock.yaml
+++ b/packages/client/tests/e2e/sqlcommenter-trace-context/pnpm-lock.yaml
@@ -138,7 +138,7 @@ packages:
     version: 0.0.0
 
   '@prisma/client@file:../../tmp/prisma-client-0.0.0.tgz':
-    resolution: {integrity: sha512-cLFCxb7r8eYc72+pFisCmx+yAPOipgvxOM8yGIbORnpWg02qnbNd0/enVwsZIjBSY9pHGyGBI/IyS9J9BJ/q9Q==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
+    resolution: {integrity: sha512-tMO68mUuX9AMWs2UpUTKALW9RoaSEoHvZViZ4NxWP3HrEVe4B12Y7AiA0mfofh2ksUZV8gDqE8BMIYLYCBLGxw==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
     version: 0.0.0
     engines: {node: ^20.19 || ^22.12 || >=24.0}
     peerDependencies:
@@ -151,7 +151,7 @@ packages:
         optional: true
 
   '@prisma/config@file:../../tmp/prisma-config-0.0.0.tgz':
-    resolution: {integrity: sha512-pxcBXEzlmTwGaPoBjrvLYWBhFmWI/rP1h8zbWYwgg2k54OWrTRT8ROHeuIA+yF9FeIDoAW/CLmfTBGVU6dQTUA==, tarball: file:../../tmp/prisma-config-0.0.0.tgz}
+    resolution: {integrity: sha512-x8H46vS3sOeFFUWFF/jleprCGRJq3B0cjXdC+MT88OJWKj+9npfw5/02FTBOyRLusk8Q4hqXWzfWHzHO/k/3mA==, tarball: file:../../tmp/prisma-config-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/debug@6.8.2':
@@ -168,15 +168,15 @@ packages:
     resolution: {integrity: sha512-d7qYqZGFogvxfB0RJadqONOX04Dg0MHoIIJT2GNyGIZa0udigBUwcek1tq3eqc/JCBbbuVGGeDz3xm1jdHwjgg==, tarball: file:../../tmp/prisma-driver-adapter-utils-0.0.0.tgz}
     version: 0.0.0
 
-  '@prisma/engines-version@7.1.0-5.ab17e348034e9823a063101c707b39f4ba1e6dd4':
-    resolution: {integrity: sha512-ybU0jGIOpg44e15vweKIUaRyB1e8oXdoqtAAZGuO0vBnQmzFGIkdQ8h939s+t7B0qgOlxsNzYZJq+fQ0F4QBCQ==}
+  '@prisma/engines-version@7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba':
+    resolution: {integrity: sha512-qZUevUh+yPhGT28rDQnV8V2kLnFjirzhVD67elRPIJHRsUV/mkII10HSrJrhK/U2GYgAxXR2VEREtq7AsfS8qw==}
 
   '@prisma/engines@file:../../tmp/prisma-engines-0.0.0.tgz':
-    resolution: {integrity: sha512-kDo42er1rAA6D0JG5RHZxXQm+X9doYUaV8V/DOo/XsnTlJbAG+9lsZ0Et/Bqt4HVkPtZDkYJfmWoXCkfvRrYJA==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
+    resolution: {integrity: sha512-6pI5a8M4Bi4+m/QfpZNYjogpkwA3sTIlVfe7i1g6RiDr16WeXexgiVKqGhFQCe22z9w7EklAeL/3PTEeW+bDAA==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/fetch-engine@file:../../tmp/prisma-fetch-engine-0.0.0.tgz':
-    resolution: {integrity: sha512-GLp0cFYPC/GcAVWKfcRr9dSifYIKYoFe2jDMDkiXaVYcFSxxZ1uigDkc7mpcZkWTLh+HwPZqq3qKUN/S1rYuLg==, tarball: file:../../tmp/prisma-fetch-engine-0.0.0.tgz}
+    resolution: {integrity: sha512-/TNwA9h/zt7Q19WSLanOa/Hle+MfXfC6twWIsC7hdonWY8HT7AgNB3JfZ2VHLJ056TkWiQevLOooxdZNrS3teg==, tarball: file:../../tmp/prisma-fetch-engine-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/get-platform@6.8.2':
@@ -187,7 +187,7 @@ packages:
     version: 0.0.0
 
   '@prisma/instrumentation@file:../../tmp/prisma-instrumentation-0.0.0.tgz':
-    resolution: {integrity: sha512-EOGbT9ADnhyRyDP+l3Pf5yOjjaNPDD7TNMgks67GJKQcrJP30zwvyb8+bqChhj5mG2jgUB9nOnCRkFL8SldhQg==, tarball: file:../../tmp/prisma-instrumentation-0.0.0.tgz}
+    resolution: {integrity: sha512-y7iFHeZSlzqEwOwKaPONY/VEZV6v/rebpYnIp5agEJnVSIAKOby9o3Efs5s9Q8RyuD3o40OelyVcOPseHpWHgQ==, tarball: file:../../tmp/prisma-instrumentation-0.0.0.tgz}
     version: 0.0.0
     peerDependencies:
       '@opentelemetry/api': ^1.8
@@ -196,7 +196,7 @@ packages:
     resolution: {integrity: sha512-jZ8cfzFgL0jReE1R10gT8JLHtQxjWYLiQ//wHmVYZ2rVkFHoh0DT8IXsxcKcFlfKN7ak7k6j0XMNn2xVNyr5cA==}
 
   '@prisma/sqlcommenter-trace-context@file:../../tmp/prisma-sqlcommenter-trace-context-0.0.0.tgz':
-    resolution: {integrity: sha512-3UaShvI9SjBFnaNkW9TVDyX33WCIqrHooJKXCiq+csnKflZmX7wEuEc2aohjWVkfyVjtbkS0Poy2HND/VLSvsg==, tarball: file:../../tmp/prisma-sqlcommenter-trace-context-0.0.0.tgz}
+    resolution: {integrity: sha512-eTBs+GI/0haavY8rLR7/bqXCFgdKU8ZFLwJxSVaVNCjYuoqAWbGqSwdxrU6BrKmvDsJdkotW2E5mx6SSFbMQ0g==, tarball: file:../../tmp/prisma-sqlcommenter-trace-context-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/studio-core@0.8.2':
@@ -494,7 +494,7 @@ packages:
     hasBin: true
 
   prisma@file:../../tmp/prisma-0.0.0.tgz:
-    resolution: {integrity: sha512-0aROXlwdLpvlQyoS1PcCPtNQlOvBdXAITsHRPmm+4LdwzTyUClMgvZQWc6XzIhiBnaC0d7vwB0W+9+Mhc035Jw==, tarball: file:../../tmp/prisma-0.0.0.tgz}
+    resolution: {integrity: sha512-moomFa99vTu6Ymb6wmjvdPUrSiKSn/eTcCWlh3uP9oQtDiZ1DNn7BJIROYD74NdFK66tCXZwMjZNp7UqYvm8fQ==, tarball: file:../../tmp/prisma-0.0.0.tgz}
     version: 0.0.0
     engines: {node: ^20.19 || ^22.12 || >=24.0}
     hasBin: true
@@ -776,19 +776,19 @@ snapshots:
     dependencies:
       '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
 
-  '@prisma/engines-version@7.1.0-5.ab17e348034e9823a063101c707b39f4ba1e6dd4': {}
+  '@prisma/engines-version@7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba': {}
 
   '@prisma/engines@file:../../tmp/prisma-engines-0.0.0.tgz':
     dependencies:
       '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
-      '@prisma/engines-version': 7.1.0-5.ab17e348034e9823a063101c707b39f4ba1e6dd4
+      '@prisma/engines-version': 7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba
       '@prisma/fetch-engine': file:../../tmp/prisma-fetch-engine-0.0.0.tgz
       '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
 
   '@prisma/fetch-engine@file:../../tmp/prisma-fetch-engine-0.0.0.tgz':
     dependencies:
       '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
-      '@prisma/engines-version': 7.1.0-5.ab17e348034e9823a063101c707b39f4ba1e6dd4
+      '@prisma/engines-version': 7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba
       '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
 
   '@prisma/get-platform@6.8.2':

--- a/packages/client/tests/e2e/sqlcommenter/package.json
+++ b/packages/client/tests/e2e/sqlcommenter/package.json
@@ -7,7 +7,6 @@
   "dependencies": {
     "@prisma/adapter-better-sqlite3": "/tmp/prisma-adapter-better-sqlite3-0.0.0.tgz",
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz",
-    "@prisma/client-runtime-utils": "/tmp/prisma-client-runtime-utils-0.0.0.tgz",
     "@prisma/sqlcommenter": "/tmp/prisma-sqlcommenter-0.0.0.tgz"
   },
   "devDependencies": {

--- a/packages/client/tests/e2e/sqlcommenter/pnpm-lock.yaml
+++ b/packages/client/tests/e2e/sqlcommenter/pnpm-lock.yaml
@@ -78,7 +78,7 @@ packages:
     version: 0.0.0
 
   '@prisma/client@file:../../tmp/prisma-client-0.0.0.tgz':
-    resolution: {integrity: sha512-cLFCxb7r8eYc72+pFisCmx+yAPOipgvxOM8yGIbORnpWg02qnbNd0/enVwsZIjBSY9pHGyGBI/IyS9J9BJ/q9Q==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
+    resolution: {integrity: sha512-tMO68mUuX9AMWs2UpUTKALW9RoaSEoHvZViZ4NxWP3HrEVe4B12Y7AiA0mfofh2ksUZV8gDqE8BMIYLYCBLGxw==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
     version: 0.0.0
     engines: {node: ^20.19 || ^22.12 || >=24.0}
     peerDependencies:
@@ -91,7 +91,7 @@ packages:
         optional: true
 
   '@prisma/config@file:../../tmp/prisma-config-0.0.0.tgz':
-    resolution: {integrity: sha512-pxcBXEzlmTwGaPoBjrvLYWBhFmWI/rP1h8zbWYwgg2k54OWrTRT8ROHeuIA+yF9FeIDoAW/CLmfTBGVU6dQTUA==, tarball: file:../../tmp/prisma-config-0.0.0.tgz}
+    resolution: {integrity: sha512-x8H46vS3sOeFFUWFF/jleprCGRJq3B0cjXdC+MT88OJWKj+9npfw5/02FTBOyRLusk8Q4hqXWzfWHzHO/k/3mA==, tarball: file:../../tmp/prisma-config-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/debug@6.8.2':
@@ -108,15 +108,15 @@ packages:
     resolution: {integrity: sha512-d7qYqZGFogvxfB0RJadqONOX04Dg0MHoIIJT2GNyGIZa0udigBUwcek1tq3eqc/JCBbbuVGGeDz3xm1jdHwjgg==, tarball: file:../../tmp/prisma-driver-adapter-utils-0.0.0.tgz}
     version: 0.0.0
 
-  '@prisma/engines-version@7.1.0-5.ab17e348034e9823a063101c707b39f4ba1e6dd4':
-    resolution: {integrity: sha512-ybU0jGIOpg44e15vweKIUaRyB1e8oXdoqtAAZGuO0vBnQmzFGIkdQ8h939s+t7B0qgOlxsNzYZJq+fQ0F4QBCQ==}
+  '@prisma/engines-version@7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba':
+    resolution: {integrity: sha512-qZUevUh+yPhGT28rDQnV8V2kLnFjirzhVD67elRPIJHRsUV/mkII10HSrJrhK/U2GYgAxXR2VEREtq7AsfS8qw==}
 
   '@prisma/engines@file:../../tmp/prisma-engines-0.0.0.tgz':
-    resolution: {integrity: sha512-kDo42er1rAA6D0JG5RHZxXQm+X9doYUaV8V/DOo/XsnTlJbAG+9lsZ0Et/Bqt4HVkPtZDkYJfmWoXCkfvRrYJA==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
+    resolution: {integrity: sha512-6pI5a8M4Bi4+m/QfpZNYjogpkwA3sTIlVfe7i1g6RiDr16WeXexgiVKqGhFQCe22z9w7EklAeL/3PTEeW+bDAA==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/fetch-engine@file:../../tmp/prisma-fetch-engine-0.0.0.tgz':
-    resolution: {integrity: sha512-GLp0cFYPC/GcAVWKfcRr9dSifYIKYoFe2jDMDkiXaVYcFSxxZ1uigDkc7mpcZkWTLh+HwPZqq3qKUN/S1rYuLg==, tarball: file:../../tmp/prisma-fetch-engine-0.0.0.tgz}
+    resolution: {integrity: sha512-/TNwA9h/zt7Q19WSLanOa/Hle+MfXfC6twWIsC7hdonWY8HT7AgNB3JfZ2VHLJ056TkWiQevLOooxdZNrS3teg==, tarball: file:../../tmp/prisma-fetch-engine-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/get-platform@6.8.2':
@@ -130,7 +130,7 @@ packages:
     resolution: {integrity: sha512-jZ8cfzFgL0jReE1R10gT8JLHtQxjWYLiQ//wHmVYZ2rVkFHoh0DT8IXsxcKcFlfKN7ak7k6j0XMNn2xVNyr5cA==}
 
   '@prisma/sqlcommenter@file:../../tmp/prisma-sqlcommenter-0.0.0.tgz':
-    resolution: {integrity: sha512-sdJ+cmrTelMdjfr07/ZFbDdG6UeanpT42N4QF0w0y5K01neCpSQ7jSPOUQiXCooCHQFzaPZrklSW8LgW/S/1Cw==, tarball: file:../../tmp/prisma-sqlcommenter-0.0.0.tgz}
+    resolution: {integrity: sha512-KqS4u1+B4OvdpU663iUGBPeImrcjvTWEe19lHhe0TesF9sV6rgrPVwjPcvHH4gotnTiWuOb9YinnZbPcLNe0Gw==, tarball: file:../../tmp/prisma-sqlcommenter-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/studio-core@0.8.2':
@@ -397,7 +397,7 @@ packages:
     hasBin: true
 
   prisma@file:../../tmp/prisma-0.0.0.tgz:
-    resolution: {integrity: sha512-0aROXlwdLpvlQyoS1PcCPtNQlOvBdXAITsHRPmm+4LdwzTyUClMgvZQWc6XzIhiBnaC0d7vwB0W+9+Mhc035Jw==, tarball: file:../../tmp/prisma-0.0.0.tgz}
+    resolution: {integrity: sha512-moomFa99vTu6Ymb6wmjvdPUrSiKSn/eTcCWlh3uP9oQtDiZ1DNn7BJIROYD74NdFK66tCXZwMjZNp7UqYvm8fQ==, tarball: file:../../tmp/prisma-0.0.0.tgz}
     version: 0.0.0
     engines: {node: ^20.19 || ^22.12 || >=24.0}
     hasBin: true
@@ -636,19 +636,19 @@ snapshots:
     dependencies:
       '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
 
-  '@prisma/engines-version@7.1.0-5.ab17e348034e9823a063101c707b39f4ba1e6dd4': {}
+  '@prisma/engines-version@7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba': {}
 
   '@prisma/engines@file:../../tmp/prisma-engines-0.0.0.tgz':
     dependencies:
       '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
-      '@prisma/engines-version': 7.1.0-5.ab17e348034e9823a063101c707b39f4ba1e6dd4
+      '@prisma/engines-version': 7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba
       '@prisma/fetch-engine': file:../../tmp/prisma-fetch-engine-0.0.0.tgz
       '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
 
   '@prisma/fetch-engine@file:../../tmp/prisma-fetch-engine-0.0.0.tgz':
     dependencies:
       '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
-      '@prisma/engines-version': 7.1.0-5.ab17e348034e9823a063101c707b39f4ba1e6dd4
+      '@prisma/engines-version': 7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba
       '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
 
   '@prisma/get-platform@6.8.2':

--- a/packages/client/tests/e2e/sqlcommenter/pnpm-lock.yaml
+++ b/packages/client/tests/e2e/sqlcommenter/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@prisma/client':
         specifier: /tmp/prisma-client-0.0.0.tgz
         version: file:../../tmp/prisma-client-0.0.0.tgz(prisma@file:../../tmp/prisma-0.0.0.tgz(@types/react@19.2.7)(better-sqlite3@12.5.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
-      '@prisma/client-runtime-utils':
-        specifier: /tmp/prisma-client-runtime-utils-0.0.0.tgz
-        version: file:../../tmp/prisma-client-runtime-utils-0.0.0.tgz
       '@prisma/sqlcommenter':
         specifier: /tmp/prisma-sqlcommenter-0.0.0.tgz
         version: file:../../tmp/prisma-sqlcommenter-0.0.0.tgz
@@ -78,7 +75,7 @@ packages:
     version: 0.0.0
 
   '@prisma/client@file:../../tmp/prisma-client-0.0.0.tgz':
-    resolution: {integrity: sha512-tMO68mUuX9AMWs2UpUTKALW9RoaSEoHvZViZ4NxWP3HrEVe4B12Y7AiA0mfofh2ksUZV8gDqE8BMIYLYCBLGxw==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
+    resolution: {integrity: sha512-TjyZ/c9R57AaH0jjZwRxsjpbMn36Z9IAcGWM1xbOlabFya4vsOuTwSBUcSyx6yTOJmD13yF6nhTd8hSw7VgSwA==, tarball: file:../../tmp/prisma-client-0.0.0.tgz}
     version: 0.0.0
     engines: {node: ^20.19 || ^22.12 || >=24.0}
     peerDependencies:
@@ -108,15 +105,15 @@ packages:
     resolution: {integrity: sha512-d7qYqZGFogvxfB0RJadqONOX04Dg0MHoIIJT2GNyGIZa0udigBUwcek1tq3eqc/JCBbbuVGGeDz3xm1jdHwjgg==, tarball: file:../../tmp/prisma-driver-adapter-utils-0.0.0.tgz}
     version: 0.0.0
 
-  '@prisma/engines-version@7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba':
-    resolution: {integrity: sha512-qZUevUh+yPhGT28rDQnV8V2kLnFjirzhVD67elRPIJHRsUV/mkII10HSrJrhK/U2GYgAxXR2VEREtq7AsfS8qw==}
+  '@prisma/engines-version@7.2.0-1.3f298657b368429158ee75de33d3dc7ca4b307a5':
+    resolution: {integrity: sha512-8hl0zGwU+0sYKJlbT5Waq5Ti5yIEJhWVrA29vjkbEpf4ZdnbuDaemTDl+99rb5kWrmE0+mbLycB7pOMBFanWXA==}
 
   '@prisma/engines@file:../../tmp/prisma-engines-0.0.0.tgz':
-    resolution: {integrity: sha512-6pI5a8M4Bi4+m/QfpZNYjogpkwA3sTIlVfe7i1g6RiDr16WeXexgiVKqGhFQCe22z9w7EklAeL/3PTEeW+bDAA==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
+    resolution: {integrity: sha512-1hlthReof1W/Mbb9qU0ID+lHl0Ae9+QsrNFsdKGMXvq1X41xuoWcYWAT6FKhGndSmQnzgO9qV38xa2WtZ63hDw==, tarball: file:../../tmp/prisma-engines-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/fetch-engine@file:../../tmp/prisma-fetch-engine-0.0.0.tgz':
-    resolution: {integrity: sha512-/TNwA9h/zt7Q19WSLanOa/Hle+MfXfC6twWIsC7hdonWY8HT7AgNB3JfZ2VHLJ056TkWiQevLOooxdZNrS3teg==, tarball: file:../../tmp/prisma-fetch-engine-0.0.0.tgz}
+    resolution: {integrity: sha512-SilD4nK5eXV62pkcVsSfVbQMSKofBSdQTZn8gCjjr75HaVdAr4vd6axrimnmV9kicmEOwpYKI3NPr0rcfAVjug==, tarball: file:../../tmp/prisma-fetch-engine-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/get-platform@6.8.2':
@@ -130,7 +127,7 @@ packages:
     resolution: {integrity: sha512-jZ8cfzFgL0jReE1R10gT8JLHtQxjWYLiQ//wHmVYZ2rVkFHoh0DT8IXsxcKcFlfKN7ak7k6j0XMNn2xVNyr5cA==}
 
   '@prisma/sqlcommenter@file:../../tmp/prisma-sqlcommenter-0.0.0.tgz':
-    resolution: {integrity: sha512-KqS4u1+B4OvdpU663iUGBPeImrcjvTWEe19lHhe0TesF9sV6rgrPVwjPcvHH4gotnTiWuOb9YinnZbPcLNe0Gw==, tarball: file:../../tmp/prisma-sqlcommenter-0.0.0.tgz}
+    resolution: {integrity: sha512-MYpPelKt9XrBMXuDWDEHAkgVfTNeKT+2ZC5rm8gPh5QijYe+oyeKrx4QqnYX/m2d0E42b7C9L9vocvXj3pKgLA==, tarball: file:../../tmp/prisma-sqlcommenter-0.0.0.tgz}
     version: 0.0.0
 
   '@prisma/studio-core@0.8.2':
@@ -397,7 +394,7 @@ packages:
     hasBin: true
 
   prisma@file:../../tmp/prisma-0.0.0.tgz:
-    resolution: {integrity: sha512-moomFa99vTu6Ymb6wmjvdPUrSiKSn/eTcCWlh3uP9oQtDiZ1DNn7BJIROYD74NdFK66tCXZwMjZNp7UqYvm8fQ==, tarball: file:../../tmp/prisma-0.0.0.tgz}
+    resolution: {integrity: sha512-AORCO9DIz38tWAnWXMAu+hqgCb6qj9eblk/CuqXcVTuU6tJibViTmyjx0cDFAtghEs+d8sm0kH8yl2+pcDdjVQ==, tarball: file:../../tmp/prisma-0.0.0.tgz}
     version: 0.0.0
     engines: {node: ^20.19 || ^22.12 || >=24.0}
     hasBin: true
@@ -636,19 +633,19 @@ snapshots:
     dependencies:
       '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
 
-  '@prisma/engines-version@7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba': {}
+  '@prisma/engines-version@7.2.0-1.3f298657b368429158ee75de33d3dc7ca4b307a5': {}
 
   '@prisma/engines@file:../../tmp/prisma-engines-0.0.0.tgz':
     dependencies:
       '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
-      '@prisma/engines-version': 7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba
+      '@prisma/engines-version': 7.2.0-1.3f298657b368429158ee75de33d3dc7ca4b307a5
       '@prisma/fetch-engine': file:../../tmp/prisma-fetch-engine-0.0.0.tgz
       '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
 
   '@prisma/fetch-engine@file:../../tmp/prisma-fetch-engine-0.0.0.tgz':
     dependencies:
       '@prisma/debug': file:../../tmp/prisma-debug-0.0.0.tgz
-      '@prisma/engines-version': 7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba
+      '@prisma/engines-version': 7.2.0-1.3f298657b368429158ee75de33d3dc7ca4b307a5
       '@prisma/get-platform': file:../../tmp/prisma-get-platform-0.0.0.tgz
 
   '@prisma/get-platform@6.8.2':

--- a/packages/sqlcommenter-query-insights/README.md
+++ b/packages/sqlcommenter-query-insights/README.md
@@ -1,0 +1,120 @@
+# @prisma/sqlcommenter-query-insights
+
+A SQL commenter plugin for Prisma ORM that adds query shape information to SQL comments. This enables observability tools to analyze and group queries by their structural patterns rather than specific values.
+
+## Installation
+
+```bash
+npm install @prisma/sqlcommenter-query-insights
+```
+
+## Usage
+
+```typescript
+import { prismaQueryInsights } from '@prisma/sqlcommenter-query-insights'
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient({
+  adapter: myAdapter, // Driver adapter required (alternatively, Accelerate URL)
+  comments: [prismaQueryInsights()],
+})
+```
+
+The resulting SQL will include comments like:
+
+```sql
+SELECT ... FROM "User" /*prismaQuery='User.findMany:eyJ3aGVyZSI6eyJhY3RpdmUiOnsiJHR5cGUiOiJQYXJhbSJ9fSwiaW5jbHVkZSI6eyJwb3N0cyI6dHJ1ZX19'*/
+```
+
+## What It Does
+
+This plugin adds a `prismaQuery` comment tag to every SQL query. The tag contains:
+
+- **Model name**: The Prisma model being queried (e.g., `User`, `Post`)
+- **Action**: The Prisma operation (e.g., `findMany`, `createOne`, `updateOne`)
+- **Query shape**: A parameterized representation of the query structure (base64url encoded)
+
+### Example Outputs
+
+| Query Type               | Output Format                                                      |
+| ------------------------ | ------------------------------------------------------------------ |
+| Raw query                | `queryRaw`                                                         |
+| Simple find (all fields) | `User.findMany:e30`                                                |
+| Find with where          | `User.findUnique:eyJ3aGVyZSI6eyJpZCI6eyIkdHlwZSI6IlBhcmFtIn19fQ`   |
+| Find with include        | `User.findMany:eyJpbmNsdWRlIjp7InBvc3RzIjp0cnVlfX0`                |
+| Find with select         | `User.findMany:eyJzZWxlY3QiOnsibmFtZSI6dHJ1ZX19`                   |
+| Batched queries          | `User.findUnique:W3sid2hlcmUiOnsiaWQiOnsiJHR5cGUiOiJQYXJhbSJ9fX1d` |
+
+## Security
+
+**User data is never included in the comments.** All values that could contain user data are replaced with placeholder markers before encoding. This includes:
+
+- Filter values (in `where` clauses)
+- Data values (in `create`/`update` operations)
+- Values in all filter operators (`equals`, `contains`, `in`, etc.)
+- Tagged values (DateTime, Decimal, BigInt, Bytes, Json)
+
+Only structural information is preserved:
+
+- Field names and relationships
+- Query structure (selection, filters, ordering)
+- Pagination parameters (`take`, `skip`)
+- Sort directions and null handling options
+
+## Use Cases
+
+### Query Analysis
+
+Group queries by their shape to identify:
+
+- Most frequently executed query patterns
+- Slow query patterns that need optimization
+- Unusual query patterns that might indicate bugs
+
+### Observability Integration
+
+The `prismaQuery` tag can be parsed by observability tools to:
+
+- Create dashboards showing query pattern distribution
+- Set up alerts for specific query patterns
+- Correlate application behavior with database load
+
+### Debugging
+
+Quickly identify which Prisma operation generated a specific SQL query in your database logs.
+
+## Combining with Other Plugins
+
+```typescript
+import { prismaQueryInsights } from '@prisma/sqlcommenter-query-insights'
+import { traceContext } from '@prisma/sqlcommenter-trace-context'
+import { queryTags, withQueryTags } from '@prisma/sqlcommenter-query-tags'
+
+const prisma = new PrismaClient({
+  adapter: myAdapter,
+  comments: [prismaQueryInsights(), traceContext(), queryTags()],
+})
+
+// All tags are merged into the SQL comment
+await withQueryTags({ route: '/api/users' }, () => prisma.user.findMany())
+```
+
+## API
+
+### `prismaQueryInsights()`
+
+Creates a SQL commenter plugin that adds query shape information.
+
+```typescript
+function prismaQueryInsights(): SqlCommenterPlugin
+```
+
+**Returns:** A `SqlCommenterPlugin` that adds the `prismaQuery` tag.
+
+## Technical Details
+
+For integrators building observability tools that parse these comments, see the [Embedder Documentation](./docs/embedder-guide.md).
+
+## License
+
+Apache-2.0

--- a/packages/sqlcommenter-query-insights/docs/embedder-guide.md
+++ b/packages/sqlcommenter-query-insights/docs/embedder-guide.md
@@ -24,11 +24,11 @@ The `prismaQuery` value has the following format:
 
 ### Components
 
-| Component                 | Required        | Description                                                                              |
-| ------------------------- | --------------- | ---------------------------------------------------------------------------------------- |
-| `ModelName`               | No<sup>\*</sup> | The Prisma model name (e.g., `User`, `Post`). Absent for raw queries.                    |
-| `Action`                  | Yes             | The Prisma operation type (see [Actions](#actions) below).                               |
-| `Base64UrlEncodedPayload` | No<sup>\*</sup> | Base64url-encoded JSON containing the parameterized query shape. Absent for raw queries. |
+| Component                 | Required        | Description                                                      |
+| ------------------------- | --------------- | ---------------------------------------------------------------- |
+| `ModelName`               | No<sup>\*</sup> | The Prisma model name (e.g., `User`, `Post`).                    |
+| `Action`                  | Yes             | The Prisma operation type (see [Actions](#actions) below).       |
+| `Base64UrlEncodedPayload` | No<sup>\*</sup> | Base64url-encoded JSON containing the parameterized query shape. |
 
 <sup>\*</sup> Raw queries (`queryRaw`, `executeRaw`) have no model name or payload.
 

--- a/packages/sqlcommenter-query-insights/docs/embedder-guide.md
+++ b/packages/sqlcommenter-query-insights/docs/embedder-guide.md
@@ -1,0 +1,305 @@
+# Prisma Query Insights - Embedder Guide
+
+This document is for developers building observability tools, database monitoring solutions, or query analyzers that want to parse and utilize the `prismaQuery` SQL comment tags.
+
+## Overview
+
+The `@prisma/sqlcommenter-query-insights` plugin adds a `prismaQuery` comment tag to SQL queries. This tag contains structured information about the Prisma operation that generated the query, encoded in a compact format suitable for SQL comments.
+
+## Comment Format
+
+The comment follows the [sqlcommenter specification](https://google.github.io/sqlcommenter/spec/):
+
+```sql
+SELECT ... FROM "User" /*prismaQuery='User.findMany:eyJ3aGVyZSI6eyJhY3RpdmUiOnsiJHR5cGUiOiJQYXJhbSJ9fSwiaW5jbHVkZSI6eyJwb3N0cyI6dHJ1ZX19'*/
+```
+
+## Tag Structure
+
+The `prismaQuery` value has the following format:
+
+```text
+[ModelName.]Action[:Base64UrlEncodedPayload]
+```
+
+### Components
+
+| Component                 | Required        | Description                                                                              |
+| ------------------------- | --------------- | ---------------------------------------------------------------------------------------- |
+| `ModelName`               | No<sup>\*</sup> | The Prisma model name (e.g., `User`, `Post`). Absent for raw queries.                    |
+| `Action`                  | Yes             | The Prisma operation type (see [Actions](#actions) below).                               |
+| `Base64UrlEncodedPayload` | No<sup>\*</sup> | Base64url-encoded JSON containing the parameterized query shape. Absent for raw queries. |
+
+<sup>\*</sup> Raw queries (`queryRaw`, `executeRaw`) have no model name or payload.
+
+### Examples
+
+| Prisma Operation                                               | prismaQuery Value                                                  |
+| -------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `prisma.$queryRaw()`                                           | `queryRaw`                                                         |
+| `prisma.$executeRaw()`                                         | `executeRaw`                                                       |
+| `prisma.user.findMany()`                                       | `User.findMany:e30`                                                |
+| `prisma.user.findUnique({ where: { id: 1 } })`                 | `User.findUnique:eyJ3aGVyZSI6eyJpZCI6eyIkdHlwZSI6IlBhcmFtIn19fQ`   |
+| `prisma.user.findMany({ include: { posts: true } })`           | `User.findMany:eyJpbmNsdWRlIjp7InBvc3RzIjp0cnVlfX0`                |
+| `prisma.user.findMany({ select: { name: true, email: true }})` | `User.findMany:eyJzZWxlY3QiOnsibmFtZSI6dHJ1ZSwiZW1haWwiOnRydWV9fQ` |
+| Batched `findUnique` calls                                     | `User.findUnique:W3sid2hlcmUiOnsiaWQiOnsiJHR5cGUiOiJQYXJhbSJ9fX1d` |
+
+## Actions
+
+The following Prisma actions may appear:
+
+| Action                | Description                                 |
+| --------------------- | ------------------------------------------- |
+| `findUnique`          | Find a single record by unique identifier   |
+| `findUniqueOrThrow`   | Find a single record or throw if not found  |
+| `findFirst`           | Find the first matching record              |
+| `findFirstOrThrow`    | Find the first matching record or throw     |
+| `findMany`            | Find multiple records                       |
+| `createOne`           | Create a single record                      |
+| `createMany`          | Create multiple records                     |
+| `createManyAndReturn` | Create multiple records and return them     |
+| `updateOne`           | Update a single record                      |
+| `updateMany`          | Update multiple records                     |
+| `updateManyAndReturn` | Update multiple records and return them     |
+| `deleteOne`           | Delete a single record                      |
+| `deleteMany`          | Delete multiple records                     |
+| `upsertOne`           | Update or create a single record            |
+| `aggregate`           | Perform aggregation (count, sum, avg, etc.) |
+| `groupBy`             | Group records by fields                     |
+| `queryRaw`            | Execute raw SQL query                       |
+| `executeRaw`          | Execute raw SQL statement                   |
+
+## Decoding the Payload
+
+### Step 1: Parse the Tag Value
+
+```javascript
+// Helper to decode base64url
+function fromBase64Url(data) {
+  // Node.js
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(data, 'base64url').toString('utf-8')
+  }
+  // Browser: convert base64url to base64
+  let base64 = data.replace(/-/g, '+').replace(/_/g, '/')
+  // Add padding if needed
+  const padding = (4 - (base64.length % 4)) % 4
+  base64 += '='.repeat(padding)
+  return atob(base64)
+}
+
+function parsePrismaQueryTag(value) {
+  // URL-decode the value (sqlcommenter spec)
+  const decoded = decodeURIComponent(value)
+
+  const colonIndex = decoded.indexOf(':')
+
+  if (colonIndex === -1) {
+    // Raw query - no payload
+    return {
+      modelName: undefined,
+      action: decoded,
+      payload: undefined,
+      isRaw: true,
+    }
+  }
+
+  const prefix = decoded.slice(0, colonIndex)
+  const base64UrlPayload = decoded.slice(colonIndex + 1)
+
+  const dotIndex = prefix.indexOf('.')
+  const modelName = prefix.slice(0, dotIndex)
+  const action = prefix.slice(dotIndex + 1)
+
+  // Decode base64url
+  const jsonString = fromBase64Url(base64UrlPayload)
+  const payload = JSON.parse(jsonString)
+
+  return {
+    modelName,
+    action,
+    payload,
+    isRaw: false,
+  }
+}
+```
+
+### Step 2: Understand the Payload Structure
+
+The payload is a JSON object representing the Prisma query in a format similar to the Prisma Client API. For single queries:
+
+```typescript
+interface QueryPayload {
+  where?: FilterObject
+  data?: DataObject
+  orderBy?: OrderByObject
+  take?: number
+  skip?: number
+  cursor?: CursorObject
+  distinct?: string[]
+  select?: SelectObject
+  include?: IncludeObject
+  // ... other arguments
+}
+```
+
+For compacted (batched) queries, the payload is an array:
+
+```typescript
+type CompactedPayload = QueryPayload[]
+```
+
+## Query Shape Transformation
+
+The plugin transforms the internal JSON protocol format into a Prisma-like query format for better readability.
+
+## Parameterized Values
+
+**Important:** All user data values are replaced with placeholder objects to ensure no sensitive data appears in SQL comments.
+
+### Placeholder Format
+
+```json
+{ "$type": "Param" }
+```
+
+### Future Extension
+
+In future versions, the placeholder may include additional metadata (field names are for illustration purposes only):
+
+```json
+{
+  "$type": "Param",
+  "name": "p1",
+  "valueType": "String"
+}
+```
+
+Your parser should handle both the current simple format and potential future extensions by checking for the `$type` field.
+
+### Example: Parameterized Query
+
+Original Prisma query:
+
+```typescript
+prisma.user.findMany({
+  where: {
+    email: { contains: 'secret@company.com' },
+    age: { gte: 18 },
+  },
+  take: 10,
+})
+```
+
+Decoded payload:
+
+```json
+{
+  "where": {
+    "email": { "contains": { "$type": "Param" } },
+    "age": { "gte": { "$type": "Param" } }
+  },
+  "take": 10
+}
+```
+
+Note: Structural values like `take` and `skip` are preserved, while user data values are parameterized.
+
+## Preserved vs. Parameterized Values
+
+### Preserved (Structural)
+
+These values are part of the query shape and are NOT parameterized:
+
+| Category           | Examples                                                                            |
+| ------------------ | ----------------------------------------------------------------------------------- |
+| Pagination         | `take`, `skip`                                                                      |
+| Sort directions    | `"asc"`, `"desc"`                                                                   |
+| Null handling      | `"first"`, `"last"`                                                                 |
+| Query mode         | `"insensitive"`, `"default"`                                                        |
+| Field references   | `{ "$type": "FieldRef", "value": { "_ref": "otherField", "_container": "Model" } }` |
+| Selection booleans | `true` in field selections                                                          |
+
+### Parameterized (User Data)
+
+These values are replaced with `{ "$type": "Param" }`:
+
+| Category       | Examples                                   |
+| -------------- | ------------------------------------------ |
+| Filter values  | String, number, boolean in `where` clauses |
+| Data values    | All values in `create`/`update` data       |
+| Tagged values  | DateTime, Decimal, BigInt, Bytes, Json     |
+| Array elements | Values in `in`, `notIn` arrays             |
+
+## Best Practices
+
+### 1. Handle Unknown Actions Gracefully
+
+New Prisma versions may introduce new actions. Parse unknown actions without failing:
+
+```javascript
+const KNOWN_ACTIONS = new Set([
+  'findUnique',
+  'findFirst',
+  'findMany',
+  'createOne',
+  'updateOne',
+  'deleteOne',
+  // ... etc
+])
+
+function parseAction(action) {
+  return {
+    action,
+    isKnown: KNOWN_ACTIONS.has(action),
+  }
+}
+```
+
+### 2. Handle Compacted Batches
+
+When Prisma batches multiple queries into one SQL statement, the payload is an array. Check for this:
+
+```javascript
+function isCompactedBatch(payload) {
+  return Array.isArray(payload)
+}
+
+function getQueryCount(parsed) {
+  if (!parsed.payload) return 1
+  if (Array.isArray(parsed.payload)) return parsed.payload.length
+  return 1
+}
+```
+
+## Version Compatibility
+
+| ORM Version | Payload Format                 |
+| ----------- | ------------------------------ |
+| 7.x         | Current format documented here |
+
+Additive changes (new action types, new fields in special objects like params, etc) are not considered breaking changes.
+
+## Troubleshooting
+
+### Invalid Base64url
+
+If payload decoding fails:
+
+1. Make sure you are decoding it as base64url and not standard base64
+2. Convert base64url to standard base64 if your decoder doesn't support base64url natively (replace `-` with `+`, `_` with `/`, add padding)
+
+### Unrecognized Payload Structure
+
+If the payload structure doesn't match expectations:
+
+1. Check the Prisma version — newer versions may have additional fields
+2. Parse defensively with optional chaining
+3. Report unrecognized fields rather than failing
+
+## Support
+
+For issues or questions:
+
+- [GitHub](https://github.com/prisma/prisma/issues)
+- [Documentation](https://www.prisma.io/docs)

--- a/packages/sqlcommenter-query-insights/helpers/build.ts
+++ b/packages/sqlcommenter-query-insights/helpers/build.ts
@@ -1,0 +1,4 @@
+import { build } from '../../../helpers/compile/build'
+import { adapterConfig } from '../../../helpers/compile/configs'
+
+void build(adapterConfig)

--- a/packages/sqlcommenter-query-insights/package.json
+++ b/packages/sqlcommenter-query-insights/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@prisma/sqlcommenter-query-insights",
+  "version": "0.0.0",
+  "description": "Query insights plugin for Prisma SQL commenter",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      }
+    }
+  },
+  "license": "Apache-2.0",
+  "homepage": "https://www.prisma.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/prisma/prisma.git",
+    "directory": "packages/sqlcommenter-query-insights"
+  },
+  "bugs": "https://github.com/prisma/prisma/issues",
+  "scripts": {
+    "dev": "DEV=true tsx helpers/build.ts",
+    "build": "tsx helpers/build.ts",
+    "prepublishOnly": "pnpm run build",
+    "test": "vitest run"
+  },
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
+  "devDependencies": {
+    "@prisma/sqlcommenter": "workspace:*",
+    "fast-check": "4.3.0"
+  }
+}

--- a/packages/sqlcommenter-query-insights/src/format/format.test.ts
+++ b/packages/sqlcommenter-query-insights/src/format/format.test.ts
@@ -1,0 +1,356 @@
+import type { SqlCommenterQueryInfo } from '@prisma/sqlcommenter'
+import { describe, expect, it } from 'vitest'
+
+import { PARAM_PLACEHOLDER } from '../parameterize/parameterize'
+import { formatQueryInsight, toBase64Url } from './format'
+
+// Helper to decode base64url for test assertions
+function fromBase64Url(data: string): string {
+  return Buffer.from(data, 'base64url').toString('utf-8')
+}
+
+// Helper to parse the prismaQuery value and extract the payload
+function parseQueryInsight(insight: string): { prefix: string; payload?: unknown } {
+  const colonIndex = insight.indexOf(':')
+  if (colonIndex === -1) {
+    return { prefix: insight }
+  }
+  const prefix = insight.slice(0, colonIndex)
+  const encoded = insight.slice(colonIndex + 1)
+  const payload = JSON.parse(fromBase64Url(encoded))
+  return { prefix, payload }
+}
+
+describe('toBase64Url', () => {
+  it('encodes simple strings without padding', () => {
+    expect(toBase64Url('hello')).toBe('aGVsbG8')
+  })
+
+  it('encodes JSON objects', () => {
+    const json = JSON.stringify({ foo: 'bar' })
+    const encoded = toBase64Url(json)
+    expect(fromBase64Url(encoded)).toBe(json)
+  })
+
+  it('handles unicode characters', () => {
+    const text = 'héllo wörld 你好世界'
+    const encoded = toBase64Url(text)
+    expect(fromBase64Url(encoded)).toBe(text)
+  })
+
+  it('produces URL-safe output without + / or =', () => {
+    // This string produces + and / in standard base64
+    const data = '>>>???'
+    const encoded = toBase64Url(data)
+    expect(encoded).not.toContain('+')
+    expect(encoded).not.toContain('/')
+    expect(encoded).not.toContain('=')
+    expect(fromBase64Url(encoded)).toBe(data)
+  })
+})
+
+describe('formatQueryInsight', () => {
+  describe('raw queries', () => {
+    it('formats queryRaw without payload', () => {
+      const queryInfo: SqlCommenterQueryInfo = {
+        type: 'single',
+        action: 'queryRaw',
+        query: {},
+      }
+      expect(formatQueryInsight(queryInfo)).toBe('queryRaw')
+    })
+
+    it('formats executeRaw without payload', () => {
+      const queryInfo: SqlCommenterQueryInfo = {
+        type: 'single',
+        action: 'executeRaw',
+        query: {},
+      }
+      expect(formatQueryInsight(queryInfo)).toBe('executeRaw')
+    })
+  })
+
+  describe('single queries', () => {
+    it('formats findMany query with $scalars to empty object', () => {
+      const queryInfo: SqlCommenterQueryInfo = {
+        type: 'single',
+        modelName: 'User',
+        action: 'findMany',
+        query: { selection: { $scalars: true } },
+      }
+      const result = formatQueryInsight(queryInfo)
+      const parsed = parseQueryInsight(result)
+
+      expect(parsed.prefix).toBe('User.findMany')
+      // After shaping: $scalars only = no select/include needed
+      expect(parsed.payload).toEqual({})
+    })
+
+    it('formats findUnique query with shaped where clause', () => {
+      const queryInfo: SqlCommenterQueryInfo = {
+        type: 'single',
+        modelName: 'User',
+        action: 'findUnique',
+        query: {
+          arguments: { where: { id: 123 } },
+          selection: { $scalars: true },
+        },
+      }
+      const result = formatQueryInsight(queryInfo)
+      const parsed = parseQueryInsight(result)
+
+      expect(parsed.prefix).toBe('User.findUnique')
+      // After shaping: arguments spread to top level, $scalars only = no select/include
+      expect(parsed.payload).toEqual({
+        where: { id: PARAM_PLACEHOLDER },
+      })
+    })
+
+    it('formats createOne query with shaped data', () => {
+      const queryInfo: SqlCommenterQueryInfo = {
+        type: 'single',
+        modelName: 'User',
+        action: 'createOne',
+        query: {
+          arguments: {
+            data: { email: 'test@example.com', name: 'Test User' },
+          },
+          selection: { $scalars: true },
+        },
+      }
+      const result = formatQueryInsight(queryInfo)
+      const parsed = parseQueryInsight(result)
+
+      expect(parsed.prefix).toBe('User.createOne')
+      // After shaping: arguments spread to top level, $scalars only = no select/include
+      expect(parsed.payload).toEqual({
+        data: { email: PARAM_PLACEHOLDER, name: PARAM_PLACEHOLDER },
+      })
+    })
+
+    it('formats query with relation using include', () => {
+      const queryInfo: SqlCommenterQueryInfo = {
+        type: 'single',
+        modelName: 'User',
+        action: 'findMany',
+        query: {
+          arguments: { where: { active: true } },
+          selection: {
+            $scalars: true,
+            $composites: true,
+            posts: {
+              $scalars: true,
+              $composites: true,
+            },
+          },
+        },
+      }
+      const result = formatQueryInsight(queryInfo)
+      const parsed = parseQueryInsight(result)
+
+      expect(parsed.prefix).toBe('User.findMany')
+      // After shaping: $scalars + relation = include
+      expect(parsed.payload).toEqual({
+        where: { active: PARAM_PLACEHOLDER },
+        include: { posts: true },
+      })
+    })
+
+    it('formats query with explicit field selection using select', () => {
+      const queryInfo: SqlCommenterQueryInfo = {
+        type: 'single',
+        modelName: 'User',
+        action: 'findMany',
+        query: {
+          arguments: {},
+          selection: {
+            name: true,
+            email: true,
+          },
+        },
+      }
+      const result = formatQueryInsight(queryInfo)
+      const parsed = parseQueryInsight(result)
+
+      expect(parsed.prefix).toBe('User.findMany')
+      // After shaping: explicit fields without $scalars = select
+      expect(parsed.payload).toEqual({
+        select: { name: true, email: true },
+      })
+    })
+  })
+
+  describe('compacted queries', () => {
+    it('formats compacted findUnique batch with shaped queries', () => {
+      const queryInfo: SqlCommenterQueryInfo = {
+        type: 'compacted',
+        modelName: 'User',
+        action: 'findUnique',
+        queries: [
+          { arguments: { where: { id: 1 } }, selection: { $scalars: true } },
+          { arguments: { where: { id: 2 } }, selection: { $scalars: true } },
+        ],
+      }
+      const result = formatQueryInsight(queryInfo)
+      const parsed = parseQueryInsight(result)
+
+      expect(parsed.prefix).toBe('User.findUnique')
+      // After shaping: each query has arguments spread and $scalars removed
+      expect(parsed.payload).toEqual([{ where: { id: PARAM_PLACEHOLDER } }, { where: { id: PARAM_PLACEHOLDER } }])
+    })
+
+    it('formats compacted batch with relations', () => {
+      const queryInfo: SqlCommenterQueryInfo = {
+        type: 'compacted',
+        modelName: 'User',
+        action: 'findUnique',
+        queries: [
+          {
+            arguments: { where: { id: 1 } },
+            selection: { $scalars: true, posts: { $scalars: true, $composites: true } },
+          },
+          {
+            arguments: { where: { id: 2 } },
+            selection: { $scalars: true, posts: { $scalars: true, $composites: true } },
+          },
+        ],
+      }
+      const result = formatQueryInsight(queryInfo)
+      const parsed = parseQueryInsight(result)
+
+      expect(parsed.prefix).toBe('User.findUnique')
+      expect(parsed.payload).toEqual([
+        { where: { id: PARAM_PLACEHOLDER }, include: { posts: true } },
+        { where: { id: PARAM_PLACEHOLDER }, include: { posts: true } },
+      ])
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles empty query object', () => {
+      const queryInfo: SqlCommenterQueryInfo = {
+        type: 'single',
+        modelName: 'User',
+        action: 'findMany',
+        query: {},
+      }
+      const result = formatQueryInsight(queryInfo)
+      expect(result).toMatch(/^User\.findMany:/)
+      const parsed = parseQueryInsight(result)
+      expect(parsed.payload).toEqual({})
+    })
+
+    it('handles query with only explicit field selection', () => {
+      const queryInfo: SqlCommenterQueryInfo = {
+        type: 'single',
+        modelName: 'User',
+        action: 'findMany',
+        query: { selection: { id: true, email: true } },
+      }
+      const result = formatQueryInsight(queryInfo)
+      const parsed = parseQueryInsight(result)
+      expect(parsed.prefix).toBe('User.findMany')
+      // After shaping: explicit fields = select
+      expect(parsed.payload).toEqual({ select: { id: true, email: true } })
+    })
+
+    it('handles empty compacted queries array', () => {
+      const queryInfo: SqlCommenterQueryInfo = {
+        type: 'compacted',
+        modelName: 'User',
+        action: 'findUnique',
+        queries: [],
+      }
+      const result = formatQueryInsight(queryInfo)
+      const parsed = parseQueryInsight(result)
+      expect(parsed.prefix).toBe('User.findUnique')
+      expect(parsed.payload).toEqual([])
+    })
+
+    it('handles very long queries with explicit field selection', () => {
+      const manyFields: Record<string, boolean> = {}
+      for (let i = 0; i < 100; i++) {
+        manyFields[`field${i}`] = true
+      }
+
+      const queryInfo: SqlCommenterQueryInfo = {
+        type: 'single',
+        modelName: 'LargeModel',
+        action: 'findMany',
+        query: { selection: manyFields },
+      }
+
+      const result = formatQueryInsight(queryInfo)
+      expect(result).toMatch(/^LargeModel\.findMany:/)
+      // Should not throw and should produce valid base64url
+      const parsed = parseQueryInsight(result)
+      // After shaping: explicit fields = select with all 100 fields
+      expect(Object.keys((parsed.payload as Record<string, unknown>).select as object).length).toBe(100)
+    })
+
+    it('handles special characters in values', () => {
+      const specialValue = 'test\'value"with<special>chars&more'
+
+      const queryInfo: SqlCommenterQueryInfo = {
+        type: 'single',
+        modelName: 'User',
+        action: 'findFirst',
+        query: {
+          arguments: { where: { name: specialValue } },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result = formatQueryInsight(queryInfo)
+      // Should not contain the special value
+      expect(result).not.toContain(specialValue)
+      // Should still be valid
+      expect(() => parseQueryInsight(result)).not.toThrow()
+    })
+
+    it('handles nested relations with mixed select/include', () => {
+      const queryInfo: SqlCommenterQueryInfo = {
+        type: 'single',
+        modelName: 'User',
+        action: 'findMany',
+        query: {
+          arguments: { where: { active: true } },
+          selection: {
+            name: true,
+            posts: {
+              arguments: { take: 10 },
+              selection: {
+                $scalars: true,
+                $composites: true,
+                comments: {
+                  arguments: {},
+                  selection: {
+                    $scalars: true,
+                    $composites: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      }
+      const result = formatQueryInsight(queryInfo)
+      const parsed = parseQueryInsight(result)
+
+      expect(parsed.prefix).toBe('User.findMany')
+      // After shaping: top level uses select (no $scalars), posts uses include ($scalars)
+      expect(parsed.payload).toEqual({
+        where: { active: PARAM_PLACEHOLDER },
+        select: {
+          name: true,
+          posts: {
+            take: 10, // take is preserved as structural pagination value
+            include: {
+              comments: true,
+            },
+          },
+        },
+      })
+    })
+  })
+})

--- a/packages/sqlcommenter-query-insights/src/format/format.ts
+++ b/packages/sqlcommenter-query-insights/src/format/format.ts
@@ -1,0 +1,50 @@
+import type { SqlCommenterQueryInfo } from '@prisma/sqlcommenter'
+
+import { parameterizeQuery } from '../parameterize/parameterize'
+import { shapeQuery } from '../shape/shape'
+
+/**
+ * Encodes data to base64url (URL-safe base64 without padding)
+ */
+export function toBase64Url(data: string): string {
+  return Buffer.from(data, 'utf-8').toString('base64url')
+}
+
+/**
+ * Formats query info into the compact prismaQuery format.
+ *
+ * Format: [modelName].action[:base64urlEncodedPayload]
+ *
+ * - Raw queries: just the action (e.g., "queryRaw", "executeRaw")
+ * - Single queries: Model.action:base64url(query)
+ * - Compacted batches: Model.action:base64url(queries)
+ */
+export function formatQueryInsight(queryInfo: SqlCommenterQueryInfo): string {
+  switch (queryInfo.type) {
+    case 'single': {
+      const { modelName, action, query } = queryInfo
+
+      if (!modelName) {
+        return action
+      }
+
+      const parameterizedQuery = parameterizeQuery(query)
+      const shapedQuery = shapeQuery(parameterizedQuery)
+      const encoded = toBase64Url(JSON.stringify(shapedQuery))
+
+      return `${modelName}.${action}:${encoded}`
+    }
+
+    case 'compacted': {
+      const { modelName, action, queries } = queryInfo
+
+      const shapedQueries = queries.map((q) => shapeQuery(parameterizeQuery(q)))
+      const encoded = toBase64Url(JSON.stringify(shapedQueries))
+
+      return `${modelName}.${action}:${encoded}`
+    }
+
+    default:
+      throw new Error(`invalid queryInfo.type=${(queryInfo satisfies never as SqlCommenterQueryInfo).type}`)
+  }
+}

--- a/packages/sqlcommenter-query-insights/src/index.test.ts
+++ b/packages/sqlcommenter-query-insights/src/index.test.ts
@@ -1,0 +1,165 @@
+import type { SqlCommenterContext, SqlCommenterQueryInfo } from '@prisma/sqlcommenter'
+import { describe, expect, it } from 'vitest'
+
+import { prismaQueryInsights } from './index'
+
+// Helper to create a mock context
+function createMockContext(queryInfo: SqlCommenterQueryInfo): SqlCommenterContext {
+  return {
+    query: queryInfo,
+  }
+}
+
+// Helper to decode base64url for test assertions
+function fromBase64Url(data: string): string {
+  return Buffer.from(data, 'base64url').toString('utf-8')
+}
+
+// Helper to parse the prismaQuery value and extract the payload
+function parseQueryInsight(insight: string): { prefix: string; payload?: unknown } {
+  const colonIndex = insight.indexOf(':')
+  if (colonIndex === -1) {
+    return { prefix: insight }
+  }
+  const prefix = insight.slice(0, colonIndex)
+  const encoded = insight.slice(colonIndex + 1)
+  const payload = JSON.parse(fromBase64Url(encoded))
+  return { prefix, payload }
+}
+
+describe('prismaQueryInsights plugin', () => {
+  it('returns prismaQuery tag', () => {
+    const plugin = prismaQueryInsights()
+    const context = createMockContext({
+      type: 'single',
+      modelName: 'User',
+      action: 'findMany',
+      query: { selection: { $scalars: true } },
+    })
+
+    const result = plugin(context)
+    expect(result).toHaveProperty('prismaQuery')
+    expect(typeof result.prismaQuery).toBe('string')
+  })
+
+  it('formats raw queries correctly', () => {
+    const plugin = prismaQueryInsights()
+    const context = createMockContext({
+      type: 'single',
+      action: 'queryRaw',
+      query: {},
+    })
+
+    const result = plugin(context)
+    expect(result.prismaQuery).toBe('queryRaw')
+  })
+
+  it('includes model and action in output', () => {
+    const plugin = prismaQueryInsights()
+    const context = createMockContext({
+      type: 'single',
+      modelName: 'Post',
+      action: 'findFirst',
+      query: { selection: { $scalars: true } },
+    })
+
+    const result = plugin(context)
+    expect(result.prismaQuery).toMatch(/^Post\.findFirst:/)
+  })
+
+  it('parameterizes user data in queries', () => {
+    const plugin = prismaQueryInsights()
+    const context = createMockContext({
+      type: 'single',
+      modelName: 'User',
+      action: 'findMany',
+      query: {
+        arguments: {
+          where: { email: 'secret@example.com' },
+        },
+        selection: { $scalars: true },
+      },
+    })
+
+    const result = plugin(context)
+    // The actual email should not appear in the output
+    expect(result.prismaQuery).not.toContain('secret@example.com')
+    // But the structure should be preserved (base64url encoded)
+    expect(result.prismaQuery).toMatch(/^User\.findMany:[A-Za-z0-9_-]+$/)
+  })
+
+  it('handles compacted batch queries', () => {
+    const plugin = prismaQueryInsights()
+    const context = createMockContext({
+      type: 'compacted',
+      modelName: 'User',
+      action: 'findUnique',
+      queries: [
+        { arguments: { where: { id: 1 } }, selection: { $scalars: true } },
+        { arguments: { where: { id: 2 } }, selection: { $scalars: true } },
+      ],
+    })
+
+    const result = plugin(context)
+    expect(result.prismaQuery).toMatch(/^User\.findUnique:[A-Za-z0-9_-]+$/)
+
+    // Decode and verify it's an array
+    const parsed = parseQueryInsight(result.prismaQuery!)
+    expect(Array.isArray(parsed.payload)).toBe(true)
+    expect((parsed.payload as unknown[]).length).toBe(2)
+  })
+
+  it('creates new plugin instance each time', () => {
+    const plugin1 = prismaQueryInsights()
+    const plugin2 = prismaQueryInsights()
+    expect(plugin1).not.toBe(plugin2)
+  })
+
+  it('preserves orderBy shorthand sort direction', () => {
+    const plugin = prismaQueryInsights()
+    const context = createMockContext({
+      type: 'single',
+      modelName: 'User',
+      action: 'findMany',
+      query: {
+        arguments: {
+          orderBy: { createdAt: 'desc' },
+        },
+        selection: { $scalars: true },
+      },
+    })
+
+    const result = plugin(context)
+    const parsed = parseQueryInsight(result.prismaQuery!)
+
+    expect(parsed.prefix).toBe('User.findMany')
+    // The orderBy with shorthand format should preserve 'desc'
+    expect(parsed.payload).toEqual({
+      orderBy: { createdAt: 'desc' },
+    })
+  })
+
+  it('preserves orderBy long format sort direction', () => {
+    const plugin = prismaQueryInsights()
+    const context = createMockContext({
+      type: 'single',
+      modelName: 'User',
+      action: 'findMany',
+      query: {
+        arguments: {
+          orderBy: { createdAt: { sort: 'desc', nulls: 'last' } },
+        },
+        selection: { $scalars: true },
+      },
+    })
+
+    const result = plugin(context)
+    const parsed = parseQueryInsight(result.prismaQuery!)
+
+    expect(parsed.prefix).toBe('User.findMany')
+    // The orderBy with long format should preserve sort and nulls
+    expect(parsed.payload).toEqual({
+      orderBy: { createdAt: { sort: 'desc', nulls: 'last' } },
+    })
+  })
+})

--- a/packages/sqlcommenter-query-insights/src/index.ts
+++ b/packages/sqlcommenter-query-insights/src/index.ts
@@ -1,0 +1,33 @@
+import type { SqlCommenterPlugin } from '@prisma/sqlcommenter'
+
+import { formatQueryInsight } from './format/format'
+
+/**
+ * Creates a SQL commenter plugin that adds Prisma query shape information
+ * to SQL queries as `prismaQuery` comments.
+ *
+ * The query shapes are parameterized to remove user data, making them safe
+ * for logging and observability while still providing useful structural
+ * information about the queries being executed.
+ *
+ * @example
+ * ```ts
+ * import { prismaQueryInsights } from '@prisma/sqlcommenter-query-insights'
+ *
+ * const prisma = new PrismaClient({
+ *   adapter: myAdapter,
+ *   comments: [prismaQueryInsights()],
+ * })
+ * ```
+ *
+ * Output examples:
+ * - Raw query: `/*prismaQuery='queryRaw'* /`
+ * - Single query: `/*prismaQuery='User.findMany:eyJzZWxlY3Rpb24iOnsiJHNjYWxhcnMiOnRydWV9fX0'* /`
+ * - Batched queries: `/*prismaQuery='User.findUnique:W3siYXJndW1lbnRzIjp7IndoZXJlIjp7ImlkIjp7IiR0eXBlIjoiUGFyYW0ifX19fV0'* /`
+ */
+export function prismaQueryInsights(): SqlCommenterPlugin {
+  return (context) => {
+    const insight = formatQueryInsight(context.query)
+    return { prismaQuery: insight }
+  }
+}

--- a/packages/sqlcommenter-query-insights/src/parameterize/parameterize.ts
+++ b/packages/sqlcommenter-query-insights/src/parameterize/parameterize.ts
@@ -1,0 +1,165 @@
+/**
+ * Query parameterization logic for Prisma query insights.
+ *
+ * This module handles the conversion of Prisma queries into parameterized shapes
+ * where user data values are replaced with placeholder markers.
+ *
+ * Design principle: when in doubt, parameterize. We're building query shapes
+ * for observability, not actual query parameterization for the query compiler.
+ */
+
+/**
+ * Placeholder object used to replace parameterized values in query shapes.
+ */
+export const PARAM_PLACEHOLDER = { $type: 'Param' }
+
+/**
+ * Keys that represent nested relation operations within data contexts.
+ * These switch back from data context to default context.
+ */
+const RELATION_OPERATION_KEYS = new Set([
+  'connect',
+  'connectOrCreate',
+  'disconnect',
+  'set',
+  'create',
+  'createMany',
+  'update',
+  'updateMany',
+  'upsert',
+  'delete',
+  'deleteMany',
+])
+
+/**
+ * Keys that switch from data context back to default context.
+ */
+const STRUCTURAL_KEYS_IN_DATA = new Set([
+  'where',
+  'select',
+  'include',
+  'omit',
+  '_count',
+  '_sum',
+  '_avg',
+  '_min',
+  '_max',
+])
+
+/**
+ * Keys whose primitive values are structural (not user data).
+ */
+const STRUCTURAL_VALUE_KEYS = new Set(['take', 'skip', 'sort', 'nulls', 'mode', 'relationLoadStrategy', 'distinct'])
+
+type Context = 'default' | 'selection' | 'orderBy' | 'data'
+
+function isTaggedValue(value: unknown): value is { $type: string; value: unknown } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    '$type' in value &&
+    typeof (value as { $type: unknown }).$type === 'string'
+  )
+}
+
+function isSelectionMarker(key: string): boolean {
+  return key === '$scalars' || key === '$composites'
+}
+
+function isSortDirection(value: string): boolean {
+  return value === 'asc' || value === 'desc'
+}
+
+/**
+ * Get the context for a child key's value based on the key name and parent context.
+ */
+function getChildContext(key: string, parentContext: Context): Context {
+  // These keys always introduce their specific context
+  if (key === 'arguments') return 'default'
+  if (key === 'selection') return 'selection'
+  if (key === 'orderBy') return 'orderBy'
+  if (key === 'data' || key === 'create' || key === 'update') return 'data'
+
+  // In data context, certain keys escape back to default
+  if (parentContext === 'data') {
+    if (RELATION_OPERATION_KEYS.has(key) || STRUCTURAL_KEYS_IN_DATA.has(key)) {
+      return 'default'
+    }
+  }
+
+  // Otherwise inherit parent context
+  return parentContext
+}
+
+/**
+ * Recursively parameterize a value based on its context.
+ */
+function parameterize(value: unknown, context: Context, key?: string): unknown {
+  // null and undefined always pass through
+  if (value === null || value === undefined) {
+    return value
+  }
+
+  // Handle tagged values
+  if (isTaggedValue(value)) {
+    // FieldRef is structural - references a field, not user data
+    return value.$type === 'FieldRef' ? value : PARAM_PLACEHOLDER
+  }
+
+  // Handle arrays - recurse into each element
+  if (Array.isArray(value)) {
+    return value.map((item) => parameterize(item, context, key))
+  }
+
+  // Handle objects
+  if (typeof value === 'object') {
+    return parameterizeObject(value as Record<string, unknown>, context)
+  }
+
+  // Handle primitives
+
+  // Structural value keys have preserved values
+  if (key && STRUCTURAL_VALUE_KEYS.has(key)) {
+    return value
+  }
+
+  // In selection context, booleans indicate field selection
+  if (context === 'selection' && typeof value === 'boolean') {
+    return value
+  }
+
+  // In orderBy context, sort directions are preserved
+  if (context === 'orderBy' && typeof value === 'string' && isSortDirection(value)) {
+    return value
+  }
+
+  // Everything else is parameterized
+  return PARAM_PLACEHOLDER
+}
+
+/**
+ * Parameterize an object by processing each key-value pair.
+ */
+function parameterizeObject(obj: Record<string, unknown>, context: Context): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+
+  for (const [key, value] of Object.entries(obj)) {
+    // Selection markers pass through unchanged
+    if (isSelectionMarker(key)) {
+      result[key] = value
+      continue
+    }
+
+    const childContext = getChildContext(key, context)
+    result[key] = parameterize(value, childContext, key)
+  }
+
+  return result
+}
+
+/**
+ * Parameterizes a query object, replacing all user data values with placeholders.
+ */
+export function parameterizeQuery(query: unknown): unknown {
+  return parameterize(query, 'default')
+}

--- a/packages/sqlcommenter-query-insights/src/parameterize/parameterize.ts
+++ b/packages/sqlcommenter-query-insights/src/parameterize/parameterize.ts
@@ -78,7 +78,7 @@ function getChildContext(key: string, parentContext: Context): Context {
   if (key === 'arguments') return 'default'
   if (key === 'selection') return 'selection'
   if (key === 'orderBy') return 'orderBy'
-  if (key === 'data' || key === 'create' || key === 'update') return 'data'
+  if (key === 'data') return 'data'
 
   // In data context, certain keys escape back to default
   if (parentContext === 'data') {

--- a/packages/sqlcommenter-query-insights/src/parameterize/parameterize.ts
+++ b/packages/sqlcommenter-query-insights/src/parameterize/parameterize.ts
@@ -95,30 +95,22 @@ function getChildContext(key: string, parentContext: Context): Context {
  * Recursively parameterize a value based on its context.
  */
 function parameterize(value: unknown, context: Context, key?: string): unknown {
-  // null and undefined always pass through
   if (value === null || value === undefined) {
     return value
   }
 
-  // Handle tagged values
   if (isTaggedValue(value)) {
-    // FieldRef is structural - references a field, not user data
     return value.$type === 'FieldRef' ? value : PARAM_PLACEHOLDER
   }
 
-  // Handle arrays - recurse into each element
   if (Array.isArray(value)) {
     return value.map((item) => parameterize(item, context, key))
   }
 
-  // Handle objects
   if (typeof value === 'object') {
     return parameterizeObject(value as Record<string, unknown>, context)
   }
 
-  // Handle primitives
-
-  // Structural value keys have preserved values
   if (key && STRUCTURAL_VALUE_KEYS.has(key)) {
     return value
   }
@@ -128,12 +120,10 @@ function parameterize(value: unknown, context: Context, key?: string): unknown {
     return value
   }
 
-  // In orderBy context, sort directions are preserved
   if (context === 'orderBy' && typeof value === 'string' && isSortDirection(value)) {
     return value
   }
 
-  // Everything else is parameterized
   return PARAM_PLACEHOLDER
 }
 
@@ -144,7 +134,6 @@ function parameterizeObject(obj: Record<string, unknown>, context: Context): Rec
   const result: Record<string, unknown> = {}
 
   for (const [key, value] of Object.entries(obj)) {
-    // Selection markers pass through unchanged
     if (isSelectionMarker(key)) {
       result[key] = value
       continue

--- a/packages/sqlcommenter-query-insights/src/parameterize/tests/basic-values.test.ts
+++ b/packages/sqlcommenter-query-insights/src/parameterize/tests/basic-values.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+
+import { PARAM_PLACEHOLDER, parameterizeQuery } from '../parameterize'
+
+describe('parameterizeQuery - basic values', () => {
+  it('parameterizes string values in filter context', () => {
+    const query = {
+      arguments: {
+        where: {
+          email: 'user@example.com',
+        },
+      },
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: {
+          email: PARAM_PLACEHOLDER,
+        },
+      },
+      selection: { $scalars: true },
+    })
+  })
+
+  it('parameterizes number values in filter context', () => {
+    const query = {
+      arguments: {
+        where: {
+          id: 123,
+        },
+      },
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: {
+          id: PARAM_PLACEHOLDER,
+        },
+      },
+      selection: { $scalars: true },
+    })
+  })
+
+  it('parameterizes boolean values in filter context', () => {
+    const query = {
+      arguments: {
+        where: {
+          isActive: true,
+        },
+      },
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: {
+          isActive: PARAM_PLACEHOLDER,
+        },
+      },
+      selection: { $scalars: true },
+    })
+  })
+
+  it('preserves null values', () => {
+    const query = {
+      arguments: {
+        where: {
+          deletedAt: null,
+        },
+      },
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: {
+          deletedAt: null,
+        },
+      },
+      selection: { $scalars: true },
+    })
+  })
+
+  it('preserves undefined values', () => {
+    const query = {
+      arguments: {
+        where: {
+          field: undefined,
+        },
+      },
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: {
+          field: undefined,
+        },
+      },
+      selection: { $scalars: true },
+    })
+  })
+})

--- a/packages/sqlcommenter-query-insights/src/parameterize/tests/complex-queries.test.ts
+++ b/packages/sqlcommenter-query-insights/src/parameterize/tests/complex-queries.test.ts
@@ -1,0 +1,553 @@
+import { describe, expect, it } from 'vitest'
+
+import { PARAM_PLACEHOLDER, parameterizeQuery } from '../parameterize'
+
+describe('parameterizeQuery - complex nested queries', () => {
+  it('handles deeply nested structure with all features', () => {
+    const query = {
+      arguments: {
+        where: {
+          AND: [
+            { email: { contains: '@company.com' } },
+            {
+              OR: [{ role: 'ADMIN' }, { permissions: { some: { name: 'WRITE' } } }],
+            },
+          ],
+        },
+        take: 10,
+        skip: 0,
+      },
+      selection: {
+        $scalars: true,
+        posts: {
+          arguments: {
+            where: { published: true },
+            orderBy: { createdAt: { sort: 'desc' } },
+          },
+          selection: { $scalars: true },
+        },
+      },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: {
+          AND: [
+            { email: { contains: PARAM_PLACEHOLDER } },
+            {
+              OR: [{ role: PARAM_PLACEHOLDER }, { permissions: { some: { name: PARAM_PLACEHOLDER } } }],
+            },
+          ],
+        },
+        take: 10,
+        skip: 0,
+      },
+      selection: {
+        $scalars: true,
+        posts: {
+          arguments: {
+            where: { published: PARAM_PLACEHOLDER },
+            orderBy: { createdAt: { sort: 'desc' } },
+          },
+          selection: { $scalars: true },
+        },
+      },
+    })
+  })
+
+  it('handles query with multiple nested selections and filters', () => {
+    const query = {
+      arguments: {
+        where: {
+          id: 1,
+          isActive: true,
+        },
+      },
+      selection: {
+        $scalars: true,
+        profile: {
+          selection: {
+            $scalars: true,
+            avatar: {
+              selection: { $scalars: true },
+            },
+          },
+        },
+        posts: {
+          arguments: {
+            where: {
+              OR: [{ published: true }, { authorId: 1 }],
+            },
+            take: 5,
+            orderBy: { createdAt: { sort: 'desc' } },
+          },
+          selection: {
+            $scalars: true,
+            comments: {
+              arguments: {
+                where: { approved: true },
+                take: 10,
+              },
+              selection: {
+                $scalars: true,
+                author: {
+                  selection: { $scalars: true },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: {
+          id: PARAM_PLACEHOLDER,
+          isActive: PARAM_PLACEHOLDER,
+        },
+      },
+      selection: {
+        $scalars: true,
+        profile: {
+          selection: {
+            $scalars: true,
+            avatar: {
+              selection: { $scalars: true },
+            },
+          },
+        },
+        posts: {
+          arguments: {
+            where: {
+              OR: [{ published: PARAM_PLACEHOLDER }, { authorId: PARAM_PLACEHOLDER }],
+            },
+            take: 5,
+            orderBy: { createdAt: { sort: 'desc' } },
+          },
+          selection: {
+            $scalars: true,
+            comments: {
+              arguments: {
+                where: { approved: PARAM_PLACEHOLDER },
+                take: 10,
+              },
+              selection: {
+                $scalars: true,
+                author: {
+                  selection: { $scalars: true },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+  })
+
+  it('handles create with nested relations and where conditions', () => {
+    const query = {
+      arguments: {
+        data: {
+          email: 'user@example.com',
+          name: 'Test User',
+          profile: {
+            create: {
+              bio: 'Hello world',
+              settings: {
+                create: {
+                  theme: 'dark',
+                  notifications: true,
+                },
+              },
+            },
+          },
+          posts: {
+            create: [
+              {
+                title: 'First Post',
+                content: 'Content here',
+                tags: {
+                  connect: [{ id: 1 }, { id: 2 }],
+                },
+              },
+            ],
+          },
+        },
+      },
+      selection: {
+        $scalars: true,
+        profile: {
+          selection: { $scalars: true },
+        },
+        posts: {
+          selection: {
+            $scalars: true,
+            tags: {
+              selection: { $scalars: true },
+            },
+          },
+        },
+      },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        data: {
+          email: PARAM_PLACEHOLDER,
+          name: PARAM_PLACEHOLDER,
+          profile: {
+            create: {
+              bio: PARAM_PLACEHOLDER,
+              settings: {
+                create: {
+                  theme: PARAM_PLACEHOLDER,
+                  notifications: PARAM_PLACEHOLDER,
+                },
+              },
+            },
+          },
+          posts: {
+            create: [
+              {
+                title: PARAM_PLACEHOLDER,
+                content: PARAM_PLACEHOLDER,
+                tags: {
+                  connect: [{ id: PARAM_PLACEHOLDER }, { id: PARAM_PLACEHOLDER }],
+                },
+              },
+            ],
+          },
+        },
+      },
+      selection: {
+        $scalars: true,
+        profile: {
+          selection: { $scalars: true },
+        },
+        posts: {
+          selection: {
+            $scalars: true,
+            tags: {
+              selection: { $scalars: true },
+            },
+          },
+        },
+      },
+    })
+  })
+
+  it('handles update with complex nested operations', () => {
+    const query = {
+      arguments: {
+        where: { id: 1 },
+        data: {
+          email: 'updated@example.com',
+          profile: {
+            update: {
+              bio: 'Updated bio',
+            },
+          },
+          posts: {
+            create: { title: 'New Post' },
+            update: {
+              where: { id: 100 },
+              data: { title: 'Updated Title' },
+            },
+            deleteMany: {
+              where: { published: false },
+            },
+          },
+          tags: {
+            set: [{ id: 1 }, { id: 2 }],
+            disconnect: [{ id: 3 }],
+          },
+        },
+      },
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: { id: PARAM_PLACEHOLDER },
+        data: {
+          email: PARAM_PLACEHOLDER,
+          profile: {
+            update: {
+              bio: PARAM_PLACEHOLDER,
+            },
+          },
+          posts: {
+            create: { title: PARAM_PLACEHOLDER },
+            update: {
+              where: { id: PARAM_PLACEHOLDER },
+              data: { title: PARAM_PLACEHOLDER },
+            },
+            deleteMany: {
+              where: { published: PARAM_PLACEHOLDER },
+            },
+          },
+          tags: {
+            set: [{ id: PARAM_PLACEHOLDER }, { id: PARAM_PLACEHOLDER }],
+            disconnect: [{ id: PARAM_PLACEHOLDER }],
+          },
+        },
+      },
+      selection: { $scalars: true },
+    })
+  })
+
+  it('handles query with aggregations in selection', () => {
+    const query = {
+      arguments: {
+        where: { status: 'ACTIVE' },
+      },
+      selection: {
+        $scalars: true,
+        _count: {
+          selection: {
+            posts: true,
+            comments: true,
+          },
+        },
+        posts: {
+          arguments: {
+            where: { published: true },
+          },
+          selection: {
+            $scalars: true,
+            _count: {
+              selection: {
+                comments: true,
+                likes: true,
+              },
+            },
+          },
+        },
+      },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: { status: PARAM_PLACEHOLDER },
+      },
+      selection: {
+        $scalars: true,
+        _count: {
+          selection: {
+            posts: true,
+            comments: true,
+          },
+        },
+        posts: {
+          arguments: {
+            where: { published: PARAM_PLACEHOLDER },
+          },
+          selection: {
+            $scalars: true,
+            _count: {
+              selection: {
+                comments: true,
+                likes: true,
+              },
+            },
+          },
+        },
+      },
+    })
+  })
+
+  it('handles upsert with complex where and data', () => {
+    const query = {
+      arguments: {
+        where: {
+          email_tenantId: {
+            email: 'user@example.com',
+            tenantId: 'tenant-123',
+          },
+        },
+        create: {
+          email: 'user@example.com',
+          tenantId: 'tenant-123',
+          name: 'New User',
+          profile: {
+            create: { bio: 'New profile' },
+          },
+        },
+        update: {
+          name: 'Updated User',
+          profile: {
+            upsert: {
+              create: { bio: 'Created profile' },
+              update: { bio: 'Updated profile' },
+            },
+          },
+        },
+      },
+      selection: {
+        $scalars: true,
+        profile: {
+          selection: { $scalars: true },
+        },
+      },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: {
+          email_tenantId: {
+            email: PARAM_PLACEHOLDER,
+            tenantId: PARAM_PLACEHOLDER,
+          },
+        },
+        create: {
+          email: PARAM_PLACEHOLDER,
+          tenantId: PARAM_PLACEHOLDER,
+          name: PARAM_PLACEHOLDER,
+          profile: {
+            create: { bio: PARAM_PLACEHOLDER },
+          },
+        },
+        update: {
+          name: PARAM_PLACEHOLDER,
+          profile: {
+            upsert: {
+              create: { bio: PARAM_PLACEHOLDER },
+              update: { bio: PARAM_PLACEHOLDER },
+            },
+          },
+        },
+      },
+      selection: {
+        $scalars: true,
+        profile: {
+          selection: { $scalars: true },
+        },
+      },
+    })
+  })
+
+  it('handles complex filter with multiple relation traversals', () => {
+    const query = {
+      arguments: {
+        where: {
+          AND: [
+            {
+              author: {
+                profile: {
+                  is: {
+                    verified: true,
+                  },
+                },
+              },
+            },
+            {
+              categories: {
+                some: {
+                  parent: {
+                    name: 'Technology',
+                  },
+                },
+              },
+            },
+            {
+              NOT: {
+                tags: {
+                  none: {
+                    name: { in: ['spam', 'blocked'] },
+                  },
+                },
+              },
+            },
+          ],
+        },
+        orderBy: [{ createdAt: { sort: 'desc' } }, { title: { sort: 'asc' } }],
+        take: 20,
+        skip: 0,
+      },
+      selection: {
+        $scalars: true,
+        author: {
+          selection: {
+            $scalars: true,
+            profile: {
+              selection: { $scalars: true },
+            },
+          },
+        },
+        categories: {
+          selection: {
+            $scalars: true,
+            parent: {
+              selection: { $scalars: true },
+            },
+          },
+        },
+        tags: {
+          selection: { $scalars: true },
+        },
+      },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: {
+          AND: [
+            {
+              author: {
+                profile: {
+                  is: {
+                    verified: PARAM_PLACEHOLDER,
+                  },
+                },
+              },
+            },
+            {
+              categories: {
+                some: {
+                  parent: {
+                    name: PARAM_PLACEHOLDER,
+                  },
+                },
+              },
+            },
+            {
+              NOT: {
+                tags: {
+                  none: {
+                    name: { in: [PARAM_PLACEHOLDER, PARAM_PLACEHOLDER] },
+                  },
+                },
+              },
+            },
+          ],
+        },
+        orderBy: [{ createdAt: { sort: 'desc' } }, { title: { sort: 'asc' } }],
+        take: 20,
+        skip: 0,
+      },
+      selection: {
+        $scalars: true,
+        author: {
+          selection: {
+            $scalars: true,
+            profile: {
+              selection: { $scalars: true },
+            },
+          },
+        },
+        categories: {
+          selection: {
+            $scalars: true,
+            parent: {
+              selection: { $scalars: true },
+            },
+          },
+        },
+        tags: {
+          selection: { $scalars: true },
+        },
+      },
+    })
+  })
+})

--- a/packages/sqlcommenter-query-insights/src/parameterize/tests/data-context.test.ts
+++ b/packages/sqlcommenter-query-insights/src/parameterize/tests/data-context.test.ts
@@ -1,0 +1,713 @@
+import { describe, expect, it } from 'vitest'
+
+import { PARAM_PLACEHOLDER, parameterizeQuery } from '../parameterize'
+
+describe('parameterizeQuery - data context (create/update)', () => {
+  describe('basic data operations', () => {
+    it('parameterizes all values in data object', () => {
+      const query = {
+        arguments: {
+          data: {
+            email: 'new@example.com',
+            name: 'New User',
+            age: 25,
+            isActive: true,
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          data: {
+            email: PARAM_PLACEHOLDER,
+            name: PARAM_PLACEHOLDER,
+            age: PARAM_PLACEHOLDER,
+            isActive: PARAM_PLACEHOLDER,
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('preserves null in data object', () => {
+      const query = {
+        arguments: {
+          data: {
+            deletedAt: null,
+            name: 'Test',
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          data: {
+            deletedAt: null,
+            name: PARAM_PLACEHOLDER,
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+
+  describe('nested relation creates', () => {
+    it('handles create in data', () => {
+      const query = {
+        arguments: {
+          data: {
+            email: 'user@example.com',
+            posts: {
+              create: {
+                title: 'My Post',
+                content: 'Content here',
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          data: {
+            email: PARAM_PLACEHOLDER,
+            posts: {
+              create: {
+                title: PARAM_PLACEHOLDER,
+                content: PARAM_PLACEHOLDER,
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles create with array of records', () => {
+      const query = {
+        arguments: {
+          data: {
+            email: 'user@example.com',
+            posts: {
+              create: [
+                { title: 'Post 1', content: 'Content 1' },
+                { title: 'Post 2', content: 'Content 2' },
+              ],
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          data: {
+            email: PARAM_PLACEHOLDER,
+            posts: {
+              create: [
+                { title: PARAM_PLACEHOLDER, content: PARAM_PLACEHOLDER },
+                { title: PARAM_PLACEHOLDER, content: PARAM_PLACEHOLDER },
+              ],
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles createMany in data', () => {
+      const query = {
+        arguments: {
+          data: {
+            email: 'user@example.com',
+            posts: {
+              createMany: {
+                data: [
+                  { title: 'Post 1', content: 'Content 1' },
+                  { title: 'Post 2', content: 'Content 2' },
+                ],
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          data: {
+            email: PARAM_PLACEHOLDER,
+            posts: {
+              createMany: {
+                data: [
+                  { title: PARAM_PLACEHOLDER, content: PARAM_PLACEHOLDER },
+                  { title: PARAM_PLACEHOLDER, content: PARAM_PLACEHOLDER },
+                ],
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+
+  describe('connect operations', () => {
+    it('handles connect in data', () => {
+      const query = {
+        arguments: {
+          data: {
+            email: 'user@example.com',
+            profile: {
+              connect: {
+                id: 123,
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          data: {
+            email: PARAM_PLACEHOLDER,
+            profile: {
+              connect: {
+                id: PARAM_PLACEHOLDER,
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles connect with array', () => {
+      const query = {
+        arguments: {
+          data: {
+            tags: {
+              connect: [{ id: 1 }, { id: 2 }, { id: 3 }],
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          data: {
+            tags: {
+              connect: [{ id: PARAM_PLACEHOLDER }, { id: PARAM_PLACEHOLDER }, { id: PARAM_PLACEHOLDER }],
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles connectOrCreate in data', () => {
+      const query = {
+        arguments: {
+          data: {
+            email: 'user@example.com',
+            profile: {
+              connectOrCreate: {
+                where: { userId: 123 },
+                create: { bio: 'New bio' },
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          data: {
+            email: PARAM_PLACEHOLDER,
+            profile: {
+              connectOrCreate: {
+                where: { userId: PARAM_PLACEHOLDER },
+                create: { bio: PARAM_PLACEHOLDER },
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+
+  describe('disconnect operations', () => {
+    it('handles disconnect with array', () => {
+      const query = {
+        arguments: {
+          data: {
+            posts: {
+              disconnect: [{ id: 1 }, { id: 2 }],
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          data: {
+            posts: {
+              disconnect: [{ id: PARAM_PLACEHOLDER }, { id: PARAM_PLACEHOLDER }],
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles disconnect with boolean', () => {
+      const query = {
+        arguments: {
+          data: {
+            profile: {
+              disconnect: true,
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          data: {
+            profile: {
+              disconnect: PARAM_PLACEHOLDER,
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles disconnect with where clause', () => {
+      const query = {
+        arguments: {
+          data: {
+            tags: {
+              disconnect: { id: 123 },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          data: {
+            tags: {
+              disconnect: { id: PARAM_PLACEHOLDER },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+
+  describe('set operations', () => {
+    it('handles set with array of values', () => {
+      const query = {
+        arguments: {
+          data: {
+            tags: {
+              set: ['tag1', 'tag2'],
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          data: {
+            tags: {
+              set: [PARAM_PLACEHOLDER, PARAM_PLACEHOLDER],
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles set with array of objects', () => {
+      const query = {
+        arguments: {
+          data: {
+            categories: {
+              set: [{ id: 1 }, { id: 2 }],
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          data: {
+            categories: {
+              set: [{ id: PARAM_PLACEHOLDER }, { id: PARAM_PLACEHOLDER }],
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+
+  describe('update operations', () => {
+    it('handles update in nested data', () => {
+      const query = {
+        arguments: {
+          data: {
+            profile: {
+              update: {
+                bio: 'Updated bio',
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          data: {
+            profile: {
+              update: {
+                bio: PARAM_PLACEHOLDER,
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles update with where clause', () => {
+      const query = {
+        arguments: {
+          data: {
+            posts: {
+              update: {
+                where: { id: 123 },
+                data: { title: 'Updated title' },
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          data: {
+            posts: {
+              update: {
+                where: { id: PARAM_PLACEHOLDER },
+                data: { title: PARAM_PLACEHOLDER },
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles updateMany in nested data', () => {
+      const query = {
+        arguments: {
+          data: {
+            posts: {
+              updateMany: {
+                where: { published: false },
+                data: { draft: true },
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          data: {
+            posts: {
+              updateMany: {
+                where: { published: PARAM_PLACEHOLDER },
+                data: { draft: PARAM_PLACEHOLDER },
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+
+  describe('upsert operations', () => {
+    it('handles upsert in nested data', () => {
+      const query = {
+        arguments: {
+          data: {
+            profile: {
+              upsert: {
+                create: { bio: 'New bio' },
+                update: { bio: 'Updated bio' },
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          data: {
+            profile: {
+              upsert: {
+                create: { bio: PARAM_PLACEHOLDER },
+                update: { bio: PARAM_PLACEHOLDER },
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles upsert with where clause', () => {
+      const query = {
+        arguments: {
+          data: {
+            posts: {
+              upsert: {
+                where: { slug: 'my-post' },
+                create: { title: 'New Post', slug: 'my-post' },
+                update: { title: 'Updated Post' },
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          data: {
+            posts: {
+              upsert: {
+                where: { slug: PARAM_PLACEHOLDER },
+                create: { title: PARAM_PLACEHOLDER, slug: PARAM_PLACEHOLDER },
+                update: { title: PARAM_PLACEHOLDER },
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+
+  describe('delete operations', () => {
+    it('handles delete in nested data', () => {
+      const query = {
+        arguments: {
+          data: {
+            posts: {
+              delete: { id: 123 },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          data: {
+            posts: {
+              delete: { id: PARAM_PLACEHOLDER },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles delete with array', () => {
+      const query = {
+        arguments: {
+          data: {
+            posts: {
+              delete: [{ id: 1 }, { id: 2 }],
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          data: {
+            posts: {
+              delete: [{ id: PARAM_PLACEHOLDER }, { id: PARAM_PLACEHOLDER }],
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles delete with boolean', () => {
+      const query = {
+        arguments: {
+          data: {
+            profile: {
+              delete: true,
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          data: {
+            profile: {
+              delete: PARAM_PLACEHOLDER,
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles deleteMany in nested data', () => {
+      const query = {
+        arguments: {
+          data: {
+            posts: {
+              deleteMany: {
+                where: { published: false },
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          data: {
+            posts: {
+              deleteMany: {
+                where: { published: PARAM_PLACEHOLDER },
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+
+  describe('complex nested data operations', () => {
+    it('handles multiple nested operations together', () => {
+      const query = {
+        arguments: {
+          data: {
+            email: 'user@example.com',
+            profile: {
+              create: { bio: 'New user' },
+            },
+            posts: {
+              create: [{ title: 'Post 1' }],
+              connect: [{ id: 100 }],
+            },
+            tags: {
+              set: [{ id: 1 }, { id: 2 }],
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          data: {
+            email: PARAM_PLACEHOLDER,
+            profile: {
+              create: { bio: PARAM_PLACEHOLDER },
+            },
+            posts: {
+              create: [{ title: PARAM_PLACEHOLDER }],
+              connect: [{ id: PARAM_PLACEHOLDER }],
+            },
+            tags: {
+              set: [{ id: PARAM_PLACEHOLDER }, { id: PARAM_PLACEHOLDER }],
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles deeply nested relation creates', () => {
+      const query = {
+        arguments: {
+          data: {
+            email: 'user@example.com',
+            posts: {
+              create: {
+                title: 'My Post',
+                comments: {
+                  create: {
+                    content: 'First comment',
+                    author: {
+                      connect: { id: 456 },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          data: {
+            email: PARAM_PLACEHOLDER,
+            posts: {
+              create: {
+                title: PARAM_PLACEHOLDER,
+                comments: {
+                  create: {
+                    content: PARAM_PLACEHOLDER,
+                    author: {
+                      connect: { id: PARAM_PLACEHOLDER },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+})

--- a/packages/sqlcommenter-query-insights/src/parameterize/tests/edge-cases.test.ts
+++ b/packages/sqlcommenter-query-insights/src/parameterize/tests/edge-cases.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest'
+
+import { PARAM_PLACEHOLDER, parameterizeQuery } from '../parameterize'
+
+describe('parameterizeQuery - edge cases', () => {
+  it('handles empty objects', () => {
+    const query = {
+      arguments: {
+        where: {},
+      },
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: {},
+      },
+      selection: { $scalars: true },
+    })
+  })
+
+  it('handles empty arrays', () => {
+    const query = {
+      arguments: {
+        where: {
+          id: { in: [] },
+        },
+      },
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: {
+          id: { in: [] },
+        },
+      },
+      selection: { $scalars: true },
+    })
+  })
+
+  it('handles deeply nested empty structures', () => {
+    const query = {
+      arguments: {
+        where: {
+          AND: [{ OR: [] }, {}],
+        },
+      },
+      selection: {},
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: {
+          AND: [{ OR: [] }, {}],
+        },
+      },
+      selection: {},
+    })
+  })
+
+  it('handles query with no arguments', () => {
+    const query = {
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      selection: { $scalars: true },
+    })
+  })
+
+  it('handles query with empty arguments', () => {
+    const query = {
+      arguments: {},
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {},
+      selection: { $scalars: true },
+    })
+  })
+
+  it('handles null at top level', () => {
+    expect(parameterizeQuery(null)).toEqual(null)
+  })
+
+  it('handles undefined at top level', () => {
+    expect(parameterizeQuery(undefined)).toEqual(undefined)
+  })
+
+  it('handles primitive at top level', () => {
+    expect(parameterizeQuery('string')).toEqual(PARAM_PLACEHOLDER)
+    expect(parameterizeQuery(123)).toEqual(PARAM_PLACEHOLDER)
+    expect(parameterizeQuery(true)).toEqual(PARAM_PLACEHOLDER)
+  })
+
+  it('handles array at top level', () => {
+    expect(parameterizeQuery(['a', 'b', 'c'])).toEqual([PARAM_PLACEHOLDER, PARAM_PLACEHOLDER, PARAM_PLACEHOLDER])
+  })
+
+  it('handles mixed array with objects and primitives', () => {
+    const query = {
+      arguments: {
+        where: {
+          OR: [{ status: 'ACTIVE' }, 'literal', 123],
+        },
+      },
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: {
+          OR: [{ status: PARAM_PLACEHOLDER }, PARAM_PLACEHOLDER, PARAM_PLACEHOLDER],
+        },
+      },
+      selection: { $scalars: true },
+    })
+  })
+
+  it('handles very deeply nested structures', () => {
+    const query = {
+      arguments: {
+        where: {
+          AND: [
+            {
+              OR: [
+                {
+                  NOT: {
+                    AND: [{ field: 'value' }],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: {
+          AND: [
+            {
+              OR: [
+                {
+                  NOT: {
+                    AND: [{ field: PARAM_PLACEHOLDER }],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+      selection: { $scalars: true },
+    })
+  })
+})

--- a/packages/sqlcommenter-query-insights/src/parameterize/tests/filter-operators.test.ts
+++ b/packages/sqlcommenter-query-insights/src/parameterize/tests/filter-operators.test.ts
@@ -1,0 +1,569 @@
+import { describe, expect, it } from 'vitest'
+
+import { PARAM_PLACEHOLDER, parameterizeQuery } from '../parameterize'
+
+describe('parameterizeQuery - filter operators', () => {
+  describe('equality operators', () => {
+    it('parameterizes equals operator value', () => {
+      const query = {
+        arguments: {
+          where: {
+            email: { equals: 'user@example.com' },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            email: { equals: PARAM_PLACEHOLDER },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('parameterizes not operator with value', () => {
+      const query = {
+        arguments: {
+          where: {
+            email: { not: 'admin@example.com' },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            email: { not: PARAM_PLACEHOLDER },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('parameterizes not operator with nested object', () => {
+      const query = {
+        arguments: {
+          where: {
+            email: { not: { equals: 'admin@example.com' } },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            email: { not: { equals: PARAM_PLACEHOLDER } },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+
+  describe('list operators', () => {
+    it('parameterizes in operator array', () => {
+      const query = {
+        arguments: {
+          where: {
+            status: { in: ['ACTIVE', 'PENDING'] },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            status: { in: [PARAM_PLACEHOLDER, PARAM_PLACEHOLDER] },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('parameterizes notIn operator array', () => {
+      const query = {
+        arguments: {
+          where: {
+            status: { notIn: ['DELETED', 'ARCHIVED'] },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            status: { notIn: [PARAM_PLACEHOLDER, PARAM_PLACEHOLDER] },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+
+  describe('comparison operators', () => {
+    it('parameterizes lt operator', () => {
+      const query = {
+        arguments: {
+          where: {
+            age: { lt: 18 },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            age: { lt: PARAM_PLACEHOLDER },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('parameterizes lte operator', () => {
+      const query = {
+        arguments: {
+          where: {
+            age: { lte: 17 },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            age: { lte: PARAM_PLACEHOLDER },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('parameterizes gt operator', () => {
+      const query = {
+        arguments: {
+          where: {
+            age: { gt: 65 },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            age: { gt: PARAM_PLACEHOLDER },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('parameterizes gte operator', () => {
+      const query = {
+        arguments: {
+          where: {
+            age: { gte: 66 },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            age: { gte: PARAM_PLACEHOLDER },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('parameterizes multiple comparison operators together', () => {
+      const query = {
+        arguments: {
+          where: {
+            age: { lt: 18, lte: 17, gt: 65, gte: 66 },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            age: {
+              lt: PARAM_PLACEHOLDER,
+              lte: PARAM_PLACEHOLDER,
+              gt: PARAM_PLACEHOLDER,
+              gte: PARAM_PLACEHOLDER,
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+
+  describe('string operators', () => {
+    it('parameterizes contains operator', () => {
+      const query = {
+        arguments: {
+          where: {
+            name: { contains: 'John' },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            name: { contains: PARAM_PLACEHOLDER },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('parameterizes startsWith operator', () => {
+      const query = {
+        arguments: {
+          where: {
+            name: { startsWith: 'J' },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            name: { startsWith: PARAM_PLACEHOLDER },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('parameterizes endsWith operator', () => {
+      const query = {
+        arguments: {
+          where: {
+            name: { endsWith: 'n' },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            name: { endsWith: PARAM_PLACEHOLDER },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('parameterizes all string operators together', () => {
+      const query = {
+        arguments: {
+          where: {
+            name: { contains: 'John', startsWith: 'J', endsWith: 'n' },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            name: {
+              contains: PARAM_PLACEHOLDER,
+              startsWith: PARAM_PLACEHOLDER,
+              endsWith: PARAM_PLACEHOLDER,
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('parameterizes search operator (full-text search)', () => {
+      const query = {
+        arguments: {
+          where: {
+            content: { search: 'prisma database' },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            content: { search: PARAM_PLACEHOLDER },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('preserves mode operator (structural enum)', () => {
+      const query = {
+        arguments: {
+          where: {
+            name: { contains: 'john', mode: 'insensitive' },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            name: { contains: PARAM_PLACEHOLDER, mode: 'insensitive' },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+
+  describe('array field operators', () => {
+    it('parameterizes has operator', () => {
+      const query = {
+        arguments: {
+          where: {
+            tags: { has: 'typescript' },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            tags: { has: PARAM_PLACEHOLDER },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('parameterizes hasEvery operator', () => {
+      const query = {
+        arguments: {
+          where: {
+            tags: { hasEvery: ['typescript', 'prisma'] },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            tags: { hasEvery: [PARAM_PLACEHOLDER, PARAM_PLACEHOLDER] },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('parameterizes hasSome operator', () => {
+      const query = {
+        arguments: {
+          where: {
+            tags: { hasSome: ['typescript', 'javascript'] },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            tags: { hasSome: [PARAM_PLACEHOLDER, PARAM_PLACEHOLDER] },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('parameterizes isEmpty operator', () => {
+      const query = {
+        arguments: {
+          where: {
+            tags: { isEmpty: true },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            tags: { isEmpty: PARAM_PLACEHOLDER },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+
+  describe('JSON operators', () => {
+    it('parameterizes path operator', () => {
+      const query = {
+        arguments: {
+          where: {
+            metadata: { path: ['nested', 'field'], equals: 'value' },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            metadata: {
+              path: [PARAM_PLACEHOLDER, PARAM_PLACEHOLDER],
+              equals: PARAM_PLACEHOLDER,
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('parameterizes string_contains operator', () => {
+      const query = {
+        arguments: {
+          where: {
+            metadata: { string_contains: 'search term' },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            metadata: { string_contains: PARAM_PLACEHOLDER },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('parameterizes string_starts_with operator', () => {
+      const query = {
+        arguments: {
+          where: {
+            metadata: { string_starts_with: 'prefix' },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            metadata: { string_starts_with: PARAM_PLACEHOLDER },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('parameterizes string_ends_with operator', () => {
+      const query = {
+        arguments: {
+          where: {
+            metadata: { string_ends_with: 'suffix' },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            metadata: { string_ends_with: PARAM_PLACEHOLDER },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('parameterizes array_contains operator', () => {
+      const query = {
+        arguments: {
+          where: {
+            metadata: { array_contains: 'element' },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            metadata: { array_contains: PARAM_PLACEHOLDER },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('parameterizes array_starts_with operator', () => {
+      const query = {
+        arguments: {
+          where: {
+            metadata: { array_starts_with: 'first' },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            metadata: { array_starts_with: PARAM_PLACEHOLDER },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('parameterizes array_ends_with operator', () => {
+      const query = {
+        arguments: {
+          where: {
+            metadata: { array_ends_with: 'last' },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            metadata: { array_ends_with: PARAM_PLACEHOLDER },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+})

--- a/packages/sqlcommenter-query-insights/src/parameterize/tests/logical-operators.test.ts
+++ b/packages/sqlcommenter-query-insights/src/parameterize/tests/logical-operators.test.ts
@@ -1,0 +1,373 @@
+import { describe, expect, it } from 'vitest'
+
+import { PARAM_PLACEHOLDER, parameterizeQuery } from '../parameterize'
+
+describe('parameterizeQuery - logical operators', () => {
+  describe('AND operator', () => {
+    it('handles AND operator with array', () => {
+      const query = {
+        arguments: {
+          where: {
+            AND: [{ email: 'a@example.com' }, { name: 'Test' }],
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            AND: [{ email: PARAM_PLACEHOLDER }, { name: PARAM_PLACEHOLDER }],
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles AND operator with single object', () => {
+      const query = {
+        arguments: {
+          where: {
+            AND: { email: 'a@example.com', name: 'Test' },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            AND: { email: PARAM_PLACEHOLDER, name: PARAM_PLACEHOLDER },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles nested AND operators', () => {
+      const query = {
+        arguments: {
+          where: {
+            AND: [{ AND: [{ field1: 'value1' }, { field2: 'value2' }] }, { field3: 'value3' }],
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            AND: [
+              { AND: [{ field1: PARAM_PLACEHOLDER }, { field2: PARAM_PLACEHOLDER }] },
+              { field3: PARAM_PLACEHOLDER },
+            ],
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+
+  describe('OR operator', () => {
+    it('handles OR operator with array', () => {
+      const query = {
+        arguments: {
+          where: {
+            OR: [{ status: 'ACTIVE' }, { status: 'PENDING' }],
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            OR: [{ status: PARAM_PLACEHOLDER }, { status: PARAM_PLACEHOLDER }],
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles OR operator with complex conditions', () => {
+      const query = {
+        arguments: {
+          where: {
+            OR: [{ email: { contains: '@company.com' } }, { role: 'ADMIN' }],
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            OR: [{ email: { contains: PARAM_PLACEHOLDER } }, { role: PARAM_PLACEHOLDER }],
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+
+  describe('NOT operator', () => {
+    it('handles NOT operator with single object', () => {
+      const query = {
+        arguments: {
+          where: {
+            NOT: { email: 'admin@example.com' },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            NOT: { email: PARAM_PLACEHOLDER },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles NOT operator as array', () => {
+      const query = {
+        arguments: {
+          where: {
+            NOT: [{ email: 'admin@example.com' }, { role: 'SYSTEM' }],
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            NOT: [{ email: PARAM_PLACEHOLDER }, { role: PARAM_PLACEHOLDER }],
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles NOT operator with nested conditions', () => {
+      const query = {
+        arguments: {
+          where: {
+            NOT: {
+              OR: [{ status: 'DELETED' }, { status: 'ARCHIVED' }],
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            NOT: {
+              OR: [{ status: PARAM_PLACEHOLDER }, { status: PARAM_PLACEHOLDER }],
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+
+  describe('is/isNot operators (nullable relations)', () => {
+    it('handles is operator with null', () => {
+      const query = {
+        arguments: {
+          where: {
+            profile: { is: null },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            profile: { is: null },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles is operator with nested conditions', () => {
+      const query = {
+        arguments: {
+          where: {
+            profile: { is: { bio: 'Developer' } },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            profile: { is: { bio: PARAM_PLACEHOLDER } },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles isNot operator with null', () => {
+      const query = {
+        arguments: {
+          where: {
+            profile: { isNot: null },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            profile: { isNot: null },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles isNot operator with nested conditions', () => {
+      const query = {
+        arguments: {
+          where: {
+            profile: { isNot: { verified: false } },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            profile: { isNot: { verified: PARAM_PLACEHOLDER } },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+
+  describe('combined logical operators', () => {
+    it('handles AND with OR', () => {
+      const query = {
+        arguments: {
+          where: {
+            AND: [
+              { email: { contains: '@company.com' } },
+              {
+                OR: [{ role: 'ADMIN' }, { role: 'MODERATOR' }],
+              },
+            ],
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            AND: [
+              { email: { contains: PARAM_PLACEHOLDER } },
+              {
+                OR: [{ role: PARAM_PLACEHOLDER }, { role: PARAM_PLACEHOLDER }],
+              },
+            ],
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles AND with NOT', () => {
+      const query = {
+        arguments: {
+          where: {
+            AND: [{ isActive: true }, { NOT: { role: 'BANNED' } }],
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            AND: [{ isActive: PARAM_PLACEHOLDER }, { NOT: { role: PARAM_PLACEHOLDER } }],
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles OR with NOT', () => {
+      const query = {
+        arguments: {
+          where: {
+            OR: [{ status: 'ACTIVE' }, { NOT: { deletedAt: null } }],
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            OR: [{ status: PARAM_PLACEHOLDER }, { NOT: { deletedAt: null } }],
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles complex nested logical operators', () => {
+      const query = {
+        arguments: {
+          where: {
+            AND: [
+              {
+                OR: [{ email: { endsWith: '@company.com' } }, { AND: [{ role: 'ADMIN' }, { verified: true }] }],
+              },
+              {
+                NOT: {
+                  OR: [{ status: 'BANNED' }, { status: 'SUSPENDED' }],
+                },
+              },
+            ],
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            AND: [
+              {
+                OR: [
+                  { email: { endsWith: PARAM_PLACEHOLDER } },
+                  { AND: [{ role: PARAM_PLACEHOLDER }, { verified: PARAM_PLACEHOLDER }] },
+                ],
+              },
+              {
+                NOT: {
+                  OR: [{ status: PARAM_PLACEHOLDER }, { status: PARAM_PLACEHOLDER }],
+                },
+              },
+            ],
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+})

--- a/packages/sqlcommenter-query-insights/src/parameterize/tests/order-by-and-pagination.test.ts
+++ b/packages/sqlcommenter-query-insights/src/parameterize/tests/order-by-and-pagination.test.ts
@@ -1,0 +1,449 @@
+import { describe, expect, it } from 'vitest'
+
+import { PARAM_PLACEHOLDER, parameterizeQuery } from '../parameterize'
+
+describe('parameterizeQuery - orderBy', () => {
+  describe('simple orderBy', () => {
+    it('preserves sort direction strings', () => {
+      const query = {
+        arguments: {
+          orderBy: {
+            createdAt: { sort: 'desc', nulls: 'last' },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          orderBy: {
+            createdAt: { sort: 'desc', nulls: 'last' },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('preserves simple sort direction string (shorthand format)', () => {
+      const query = {
+        arguments: {
+          orderBy: {
+            name: 'asc',
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      // Shorthand orderBy format should preserve sort direction
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          orderBy: {
+            name: 'asc',
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('preserves desc sort direction in shorthand format', () => {
+      const query = {
+        arguments: {
+          orderBy: {
+            createdAt: 'desc',
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          orderBy: {
+            createdAt: 'desc',
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('preserves sort with nulls handling', () => {
+      const query = {
+        arguments: {
+          orderBy: {
+            updatedAt: { sort: 'asc', nulls: 'first' },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          orderBy: {
+            updatedAt: { sort: 'asc', nulls: 'first' },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+
+  describe('orderBy as array', () => {
+    it('handles orderBy with multiple fields', () => {
+      const query = {
+        arguments: {
+          orderBy: [{ lastName: { sort: 'asc' } }, { firstName: { sort: 'asc' } }],
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          orderBy: [{ lastName: { sort: 'asc' } }, { firstName: { sort: 'asc' } }],
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles mixed orderBy array formats', () => {
+      const query = {
+        arguments: {
+          orderBy: [{ createdAt: { sort: 'desc' } }, { name: 'asc' }],
+        },
+        selection: { $scalars: true },
+      }
+
+      // Both long format and shorthand format should be preserved
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          orderBy: [{ createdAt: { sort: 'desc' } }, { name: 'asc' }],
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+
+  describe('nested relation orderBy', () => {
+    it('handles orderBy on nested relation', () => {
+      const query = {
+        arguments: {
+          orderBy: {
+            author: {
+              name: { sort: 'asc' },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          orderBy: {
+            author: {
+              name: { sort: 'asc' },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles orderBy in nested selection', () => {
+      const query = {
+        selection: {
+          $scalars: true,
+          posts: {
+            arguments: {
+              orderBy: { createdAt: { sort: 'desc' } },
+            },
+            selection: { $scalars: true },
+          },
+        },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        selection: {
+          $scalars: true,
+          posts: {
+            arguments: {
+              orderBy: { createdAt: { sort: 'desc' } },
+            },
+            selection: { $scalars: true },
+          },
+        },
+      })
+    })
+  })
+
+  describe('orderBy with aggregates', () => {
+    it('handles orderBy with _count', () => {
+      const query = {
+        arguments: {
+          orderBy: {
+            posts: {
+              _count: { sort: 'desc' },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          orderBy: {
+            posts: {
+              _count: { sort: 'desc' },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+})
+
+describe('parameterizeQuery - pagination', () => {
+  describe('take', () => {
+    it('preserves take value', () => {
+      const query = {
+        arguments: {
+          take: 10,
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          take: 10,
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('preserves negative take value (for reverse pagination)', () => {
+      const query = {
+        arguments: {
+          take: -10,
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          take: -10,
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+
+  describe('skip', () => {
+    it('preserves skip value', () => {
+      const query = {
+        arguments: {
+          skip: 20,
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          skip: 20,
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('preserves skip value of zero', () => {
+      const query = {
+        arguments: {
+          skip: 0,
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          skip: 0,
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+
+  describe('cursor', () => {
+    it('parameterizes cursor values', () => {
+      const query = {
+        arguments: {
+          cursor: {
+            id: 123,
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          cursor: {
+            id: PARAM_PLACEHOLDER,
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('parameterizes cursor with compound key', () => {
+      const query = {
+        arguments: {
+          cursor: {
+            tenantId_id: {
+              tenantId: 'tenant-123',
+              id: 456,
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          cursor: {
+            tenantId_id: {
+              tenantId: PARAM_PLACEHOLDER,
+              id: PARAM_PLACEHOLDER,
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+
+  describe('combined pagination', () => {
+    it('handles take, skip, and cursor together', () => {
+      const query = {
+        arguments: {
+          take: 10,
+          skip: 1,
+          cursor: {
+            id: 100,
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          take: 10,
+          skip: 1,
+          cursor: {
+            id: PARAM_PLACEHOLDER,
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles pagination with orderBy', () => {
+      const query = {
+        arguments: {
+          take: 20,
+          skip: 0,
+          orderBy: { createdAt: { sort: 'desc' } },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          take: 20,
+          skip: 0,
+          orderBy: { createdAt: { sort: 'desc' } },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles pagination with where clause', () => {
+      const query = {
+        arguments: {
+          where: { status: 'ACTIVE' },
+          take: 10,
+          skip: 5,
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: { status: PARAM_PLACEHOLDER },
+          take: 10,
+          skip: 5,
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+
+  describe('pagination in nested selections', () => {
+    it('preserves pagination in nested relation', () => {
+      const query = {
+        selection: {
+          $scalars: true,
+          posts: {
+            arguments: {
+              take: 5,
+              skip: 0,
+            },
+            selection: { $scalars: true },
+          },
+        },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        selection: {
+          $scalars: true,
+          posts: {
+            arguments: {
+              take: 5,
+              skip: 0,
+            },
+            selection: { $scalars: true },
+          },
+        },
+      })
+    })
+  })
+})
+
+describe('parameterizeQuery - distinct', () => {
+  it('preserves distinct field names', () => {
+    const query = {
+      arguments: {
+        distinct: ['email'],
+      },
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        distinct: ['email'],
+      },
+      selection: { $scalars: true },
+    })
+  })
+
+  it('preserves distinct with multiple fields', () => {
+    const query = {
+      arguments: {
+        distinct: ['email', 'name'],
+      },
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        distinct: ['email', 'name'],
+      },
+      selection: { $scalars: true },
+    })
+  })
+})

--- a/packages/sqlcommenter-query-insights/src/parameterize/tests/properties.test.ts
+++ b/packages/sqlcommenter-query-insights/src/parameterize/tests/properties.test.ts
@@ -1,0 +1,567 @@
+import * as fc from 'fast-check'
+import { describe, expect, it } from 'vitest'
+
+import { parameterizeQuery } from '../parameterize'
+
+/**
+ * Property-based tests for parameterizeQuery.
+ *
+ * The key property we want to verify is simple:
+ * **User data values should never appear in the parameterized output.**
+ *
+ * We generate arbitrary query shapes containing "canary" values and verify
+ * those values don't appear in the JSON-serialized output.
+ */
+
+/** A unique marker we can search for in serialized output */
+const CANARY_PREFIX = '___CANARY_'
+
+/** Generate a unique canary string */
+function canary(id: number): string {
+  return `${CANARY_PREFIX}${id}___`
+}
+
+/** Check if output contains any canary values */
+function containsCanary(output: unknown): boolean {
+  const serialized = JSON.stringify(output)
+  return serialized.includes(CANARY_PREFIX)
+}
+
+/**
+ * Create an arbitrary that generates canary-tagged user values.
+ * Each value contains a unique canary string that we can search for.
+ */
+function canaryValueArb(idArb: fc.Arbitrary<number>): fc.Arbitrary<unknown> {
+  return fc.oneof(
+    // Plain canary string
+    idArb.map((id) => canary(id)),
+    // Tagged DateTime
+    idArb.map((id) => ({ $type: 'DateTime', value: canary(id) })),
+    // Tagged Decimal
+    idArb.map((id) => ({ $type: 'Decimal', value: canary(id) })),
+    // Tagged BigInt
+    idArb.map((id) => ({ $type: 'BigInt', value: canary(id) })),
+    // Tagged Bytes
+    idArb.map((id) => ({ $type: 'Bytes', value: canary(id) })),
+    // Tagged Json
+    idArb.map((id) => ({ $type: 'Json', value: canary(id) })),
+    // Tagged Enum
+    idArb.map((id) => ({ $type: 'Enum', value: canary(id) })),
+  )
+}
+
+/**
+ * Create an arbitrary for filter operator objects containing canary values
+ */
+function filterOperatorArb(idArb: fc.Arbitrary<number>): fc.Arbitrary<Record<string, unknown>> {
+  const valueArb = canaryValueArb(idArb)
+
+  return fc.oneof(
+    fc.record({ equals: valueArb }),
+    fc.record({ not: valueArb }),
+    fc.record({ in: fc.array(valueArb, { minLength: 1, maxLength: 3 }) }),
+    fc.record({ notIn: fc.array(valueArb, { minLength: 1, maxLength: 3 }) }),
+    fc.record({ lt: valueArb }),
+    fc.record({ lte: valueArb }),
+    fc.record({ gt: valueArb }),
+    fc.record({ gte: valueArb }),
+    fc.record({ contains: idArb.map((id) => canary(id)) }),
+    fc.record({ startsWith: idArb.map((id) => canary(id)) }),
+    fc.record({ endsWith: idArb.map((id) => canary(id)) }),
+    fc.record({ contains: idArb.map((id) => canary(id)), mode: fc.constant('insensitive') }),
+    fc.record({ search: idArb.map((id) => canary(id)) }),
+    // Array field operators
+    fc.record({ has: valueArb }),
+    fc.record({ hasEvery: fc.array(valueArb, { minLength: 1, maxLength: 3 }) }),
+    fc.record({ hasSome: fc.array(valueArb, { minLength: 1, maxLength: 3 }) }),
+    // JSON operators
+    fc.record({
+      path: fc.array(
+        idArb.map((id) => canary(id)),
+        { minLength: 1, maxLength: 3 },
+      ),
+      equals: valueArb,
+    }),
+    fc.record({ string_contains: idArb.map((id) => canary(id)) }),
+    fc.record({ string_starts_with: idArb.map((id) => canary(id)) }),
+    fc.record({ string_ends_with: idArb.map((id) => canary(id)) }),
+    fc.record({ array_contains: valueArb }),
+  )
+}
+
+/**
+ * Create an arbitrary for where clause field values (either direct value or filter operator)
+ */
+function whereFieldValueArb(idArb: fc.Arbitrary<number>): fc.Arbitrary<unknown> {
+  return fc.oneof(canaryValueArb(idArb), filterOperatorArb(idArb))
+}
+
+/**
+ * Create an arbitrary for simple where clauses (field -> value mappings)
+ */
+function simpleWhereArb(idArb: fc.Arbitrary<number>): fc.Arbitrary<Record<string, unknown>> {
+  return fc.dictionary(
+    fc.constantFrom('id', 'email', 'name', 'status', 'age', 'isActive', 'createdAt', 'content', 'title'),
+    whereFieldValueArb(idArb),
+    { minKeys: 1, maxKeys: 4 },
+  )
+}
+
+/**
+ * Create an arbitrary for relation filter operators (some, every, none)
+ */
+function relationFilterArb(
+  whereArb: fc.Arbitrary<Record<string, unknown>>,
+): fc.Arbitrary<Record<string, Record<string, unknown>>> {
+  return fc.oneof(
+    fc.record({ posts: fc.record({ some: whereArb }) }),
+    fc.record({ posts: fc.record({ every: whereArb }) }),
+    fc.record({ posts: fc.record({ none: whereArb }) }),
+    fc.record({ comments: fc.record({ some: whereArb }) }),
+    fc.record({ author: fc.record({ is: whereArb }) }),
+    fc.record({ profile: fc.record({ isNot: whereArb }) }),
+  )
+}
+
+/**
+ * Create an arbitrary for where clauses with logical operators and nesting
+ */
+function whereClauseArb(idArb: fc.Arbitrary<number>, maxDepth: number = 3): fc.Arbitrary<Record<string, unknown>> {
+  const simpleWhere = simpleWhereArb(idArb)
+
+  if (maxDepth <= 1) {
+    return simpleWhere
+  }
+
+  const recurse = whereClauseArb(idArb, maxDepth - 1)
+
+  return fc.oneof(
+    { weight: 3, arbitrary: simpleWhere },
+    { weight: 1, arbitrary: fc.record({ AND: fc.array(recurse, { minLength: 1, maxLength: 3 }) }) },
+    { weight: 1, arbitrary: fc.record({ OR: fc.array(recurse, { minLength: 1, maxLength: 3 }) }) },
+    { weight: 1, arbitrary: fc.record({ NOT: recurse }) },
+    { weight: 1, arbitrary: relationFilterArb(simpleWhere) },
+    // Combined: simple fields + logical operator
+    {
+      weight: 1,
+      arbitrary: fc.record({
+        field1: whereFieldValueArb(idArb),
+        AND: fc.array(recurse, { minLength: 1, maxLength: 2 }),
+      }),
+    },
+  )
+}
+
+/**
+ * Create an arbitrary for data objects (for create/update operations)
+ */
+function dataObjectArb(idArb: fc.Arbitrary<number>): fc.Arbitrary<Record<string, unknown>> {
+  return fc.dictionary(
+    fc.constantFrom('email', 'name', 'title', 'content', 'status', 'age', 'isActive', 'bio'),
+    canaryValueArb(idArb),
+    { minKeys: 1, maxKeys: 5 },
+  )
+}
+
+/**
+ * Create an arbitrary for nested relation operations in data context
+ */
+function nestedDataOperationArb(idArb: fc.Arbitrary<number>): fc.Arbitrary<Record<string, unknown>> {
+  const simpleData = dataObjectArb(idArb)
+
+  return fc.oneof(
+    // create
+    fc.record({ posts: fc.record({ create: simpleData }) }),
+    fc.record({ posts: fc.record({ create: fc.array(simpleData, { minLength: 1, maxLength: 2 }) }) }),
+    // createMany
+    fc.record({
+      posts: fc.record({ createMany: fc.record({ data: fc.array(simpleData, { minLength: 1, maxLength: 2 }) }) }),
+    }),
+    // connect
+    fc.record({ profile: fc.record({ connect: fc.record({ id: idArb.map((id) => canary(id)) }) }) }),
+    fc.record({
+      tags: fc.record({
+        connect: fc.array(fc.record({ id: idArb.map((id) => canary(id)) }), { minLength: 1, maxLength: 3 }),
+      }),
+    }),
+    // connectOrCreate
+    fc.record({
+      profile: fc.record({
+        connectOrCreate: fc.record({
+          where: fc.record({ id: idArb.map((id) => canary(id)) }),
+          create: simpleData,
+        }),
+      }),
+    }),
+    // update
+    fc.record({ profile: fc.record({ update: simpleData }) }),
+    // upsert
+    fc.record({
+      profile: fc.record({
+        upsert: fc.record({
+          create: simpleData,
+          update: simpleData,
+        }),
+      }),
+    }),
+    // disconnect
+    fc.record({
+      tags: fc.record({
+        disconnect: fc.array(fc.record({ id: idArb.map((id) => canary(id)) }), { minLength: 1, maxLength: 2 }),
+      }),
+    }),
+    // set
+    fc.record({
+      tags: fc.record({
+        set: fc.array(fc.record({ id: idArb.map((id) => canary(id)) }), { minLength: 1, maxLength: 3 }),
+      }),
+    }),
+    // delete
+    fc.record({ posts: fc.record({ delete: fc.record({ id: idArb.map((id) => canary(id)) }) }) }),
+    // deleteMany
+    fc.record({ posts: fc.record({ deleteMany: fc.record({ where: simpleWhereArb(idArb) }) }) }),
+    // updateMany
+    fc.record({
+      posts: fc.record({
+        updateMany: fc.record({
+          where: simpleWhereArb(idArb),
+          data: simpleData,
+        }),
+      }),
+    }),
+  )
+}
+
+/**
+ * Create an arbitrary for the full data clause (simple fields + optional nested operations)
+ */
+function fullDataArb(idArb: fc.Arbitrary<number>): fc.Arbitrary<Record<string, unknown>> {
+  return fc.oneof(
+    dataObjectArb(idArb),
+    // Data with nested relation operation
+    fc.tuple(dataObjectArb(idArb), nestedDataOperationArb(idArb)).map(([simple, nested]) => ({ ...simple, ...nested })),
+  )
+}
+
+/**
+ * Create an arbitrary for selection objects
+ */
+function selectionArb(maxDepth: number = 2): fc.Arbitrary<Record<string, unknown>> {
+  const simpleSelection = fc.record({
+    $scalars: fc.constant(true as const),
+  })
+
+  if (maxDepth <= 1) {
+    return simpleSelection
+  }
+
+  const nestedSelection = selectionArb(maxDepth - 1)
+
+  return fc.oneof(
+    simpleSelection,
+    fc.record({
+      $scalars: fc.constant(true as const),
+      $composites: fc.boolean(),
+    }),
+    // With nested relation selection
+    fc.record({
+      $scalars: fc.constant(true as const),
+      posts: fc.record({
+        selection: nestedSelection,
+      }),
+    }),
+    fc.record({
+      $scalars: fc.constant(true as const),
+      author: fc.record({
+        selection: nestedSelection,
+      }),
+    }),
+    // With nested relation selection + arguments
+    fc.record({
+      $scalars: fc.constant(true as const),
+      posts: fc.record({
+        arguments: fc.record({
+          take: fc.integer({ min: 1, max: 100 }),
+          skip: fc.integer({ min: 0, max: 100 }),
+        }),
+        selection: nestedSelection,
+      }),
+    }),
+  )
+}
+
+/**
+ * Create an arbitrary for orderBy clauses
+ */
+function orderByArb(): fc.Arbitrary<Record<string, unknown> | Record<string, unknown>[]> {
+  const simpleOrderBy: fc.Arbitrary<Record<string, unknown>> = fc
+    .constantFrom('createdAt', 'updatedAt', 'name', 'id')
+    .chain((field) =>
+      fc.record({
+        [field]: fc.record({
+          sort: fc.constantFrom('asc', 'desc'),
+          nulls: fc.constantFrom('first', 'last'),
+        }),
+      }),
+    )
+
+  return fc.oneof(simpleOrderBy, fc.array(simpleOrderBy, { minLength: 1, maxLength: 3 }))
+}
+
+/**
+ * Create an arbitrary for cursor objects
+ */
+function cursorArb(idArb: fc.Arbitrary<number>): fc.Arbitrary<Record<string, unknown>> {
+  return fc.oneof(
+    fc.record({ id: idArb.map((id) => canary(id)) }),
+    fc.record({
+      email_tenantId: fc.record({
+        email: idArb.map((id) => canary(id)),
+        tenantId: idArb.map((id) => canary(id)),
+      }),
+    }),
+  )
+}
+
+/**
+ * Create an arbitrary for complete query-like objects
+ */
+function queryArb(idArb: fc.Arbitrary<number>): fc.Arbitrary<Record<string, unknown>> {
+  return fc.record(
+    {
+      arguments: fc.record(
+        {
+          where: whereClauseArb(idArb),
+          data: fullDataArb(idArb),
+          take: fc.integer({ min: 1, max: 100 }),
+          skip: fc.integer({ min: 0, max: 100 }),
+          orderBy: orderByArb(),
+          cursor: cursorArb(idArb),
+          distinct: fc.array(fc.constantFrom('email', 'name', 'id', 'createdAt'), { minLength: 1, maxLength: 3 }),
+        },
+        { requiredKeys: [] },
+      ),
+      selection: selectionArb(),
+    },
+    { requiredKeys: ['selection'] },
+  )
+}
+
+/**
+ * Create an arbitrary for queries focused on where clauses
+ */
+function whereQueryArb(idArb: fc.Arbitrary<number>): fc.Arbitrary<Record<string, unknown>> {
+  return fc.record({
+    arguments: fc.record({
+      where: whereClauseArb(idArb, 4),
+    }),
+    selection: fc.record({ $scalars: fc.constant(true as const) }),
+  })
+}
+
+/**
+ * Create an arbitrary for queries focused on data operations
+ */
+function dataQueryArb(idArb: fc.Arbitrary<number>): fc.Arbitrary<Record<string, unknown>> {
+  return fc.record({
+    arguments: fc.record({
+      data: fullDataArb(idArb),
+    }),
+    selection: fc.record({ $scalars: fc.constant(true as const) }),
+  })
+}
+
+/**
+ * Create an arbitrary for queries with deeply nested selections
+ */
+function nestedSelectionQueryArb(idArb: fc.Arbitrary<number>): fc.Arbitrary<Record<string, unknown>> {
+  return fc.record({
+    arguments: fc.record({
+      where: simpleWhereArb(idArb),
+      take: fc.integer({ min: 1, max: 50 }),
+    }),
+    selection: selectionArb(4),
+  })
+}
+
+describe('parameterizeQuery - property-based tests', () => {
+  // Use a mapped arbitrary to generate unique IDs for each test run
+  const idArb = fc.integer({ min: 0, max: 100000 })
+
+  describe('no user data leakage', () => {
+    it('does not leak canary values from arbitrary where clauses', () => {
+      fc.assert(
+        fc.property(whereQueryArb(idArb), (query) => {
+          const result = parameterizeQuery(query)
+          expect(containsCanary(result)).toBe(false)
+        }),
+        { numRuns: 500 },
+      )
+    })
+
+    it('does not leak canary values from arbitrary data operations', () => {
+      fc.assert(
+        fc.property(dataQueryArb(idArb), (query) => {
+          const result = parameterizeQuery(query)
+          expect(containsCanary(result)).toBe(false)
+        }),
+        { numRuns: 500 },
+      )
+    })
+
+    it('does not leak canary values from arbitrary complete queries', () => {
+      fc.assert(
+        fc.property(queryArb(idArb), (query) => {
+          const result = parameterizeQuery(query)
+          expect(containsCanary(result)).toBe(false)
+        }),
+        { numRuns: 500 },
+      )
+    })
+
+    it('does not leak canary values from queries with nested selections', () => {
+      fc.assert(
+        fc.property(nestedSelectionQueryArb(idArb), (query) => {
+          const result = parameterizeQuery(query)
+          expect(containsCanary(result)).toBe(false)
+        }),
+        { numRuns: 300 },
+      )
+    })
+
+    it('does not leak canary values from deeply nested logical operators', () => {
+      // Generate extra-deep nesting specifically
+      fc.assert(
+        fc.property(idArb, (baseId) => {
+          // Manually construct a deeply nested structure
+          let where: Record<string, unknown> = { field: canary(baseId) }
+          for (let i = 0; i < 6; i++) {
+            const op = ['AND', 'OR', 'NOT'][i % 3]
+            if (op === 'NOT') {
+              where = { NOT: where }
+            } else {
+              where = { [op]: [where, { anotherField: canary(baseId + i + 1) }] }
+            }
+          }
+
+          const query = {
+            arguments: { where },
+            selection: { $scalars: true },
+          }
+
+          const result = parameterizeQuery(query)
+          expect(containsCanary(result)).toBe(false)
+        }),
+        { numRuns: 200 },
+      )
+    })
+  })
+
+  describe('structural guarantees', () => {
+    it('is deterministic: same input always produces same output', () => {
+      fc.assert(
+        fc.property(queryArb(idArb), (query) => {
+          const result1 = JSON.stringify(parameterizeQuery(query))
+          const result2 = JSON.stringify(parameterizeQuery(query))
+          expect(result1).toBe(result2)
+        }),
+        { numRuns: 200 },
+      )
+    })
+
+    it('is idempotent: parameterizing twice yields same result', () => {
+      fc.assert(
+        fc.property(queryArb(idArb), (query) => {
+          const once = parameterizeQuery(query)
+          const twice = parameterizeQuery(once)
+          expect(JSON.stringify(once)).toBe(JSON.stringify(twice))
+        }),
+        { numRuns: 200 },
+      )
+    })
+
+    it('always produces JSON-serializable output', () => {
+      fc.assert(
+        fc.property(queryArb(idArb), (query) => {
+          const result = parameterizeQuery(query)
+          // Should not throw
+          const serialized = JSON.stringify(result)
+          expect(typeof serialized).toBe('string')
+          // Should be parseable
+          expect(() => JSON.parse(serialized)).not.toThrow()
+        }),
+        { numRuns: 200 },
+      )
+    })
+
+    it('preserves null values in where clauses', () => {
+      fc.assert(
+        fc.property(idArb, (id) => {
+          const query = {
+            arguments: {
+              where: { deletedAt: null, name: canary(id) },
+            },
+            selection: { $scalars: true },
+          }
+
+          const result = parameterizeQuery(query) as { arguments: { where: { deletedAt: unknown } } }
+          expect(result.arguments.where.deletedAt).toBe(null)
+        }),
+        { numRuns: 100 },
+      )
+    })
+
+    it('preserves take and skip at top level', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 1, max: 1000 }), fc.integer({ min: 0, max: 1000 }), (take, skip) => {
+          const query = {
+            arguments: { take, skip },
+            selection: { $scalars: true },
+          }
+
+          const result = parameterizeQuery(query) as { arguments: { take: number; skip: number } }
+          expect(result.arguments.take).toBe(take)
+          expect(result.arguments.skip).toBe(skip)
+        }),
+        { numRuns: 100 },
+      )
+    })
+
+    it('preserves sort directions in orderBy', () => {
+      fc.assert(
+        fc.property(fc.constantFrom('asc', 'desc'), fc.constantFrom('first', 'last'), (sort, nulls) => {
+          const query = {
+            arguments: {
+              orderBy: { createdAt: { sort, nulls } },
+            },
+            selection: { $scalars: true },
+          }
+
+          const result = parameterizeQuery(query) as {
+            arguments: { orderBy: { createdAt: { sort: string; nulls: string } } }
+          }
+          expect(result.arguments.orderBy.createdAt.sort).toBe(sort)
+          expect(result.arguments.orderBy.createdAt.nulls).toBe(nulls)
+        }),
+        { numRuns: 50 },
+      )
+    })
+
+    it('preserves selection markers', () => {
+      fc.assert(
+        fc.property(fc.boolean(), fc.boolean(), (scalars, composites) => {
+          const query = {
+            selection: { $scalars: scalars, $composites: composites },
+          }
+
+          const result = parameterizeQuery(query) as {
+            selection: { $scalars: boolean; $composites: boolean }
+          }
+          expect(result.selection.$scalars).toBe(scalars)
+          expect(result.selection.$composites).toBe(composites)
+        }),
+        { numRuns: 50 },
+      )
+    })
+  })
+})

--- a/packages/sqlcommenter-query-insights/src/parameterize/tests/relation-filters.test.ts
+++ b/packages/sqlcommenter-query-insights/src/parameterize/tests/relation-filters.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it } from 'vitest'
+
+import { PARAM_PLACEHOLDER, parameterizeQuery } from '../parameterize'
+
+describe('parameterizeQuery - relation filters', () => {
+  describe('some operator', () => {
+    it('handles some relation filter', () => {
+      const query = {
+        arguments: {
+          where: {
+            posts: { some: { title: 'Test' } },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            posts: { some: { title: PARAM_PLACEHOLDER } },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles some with complex nested conditions', () => {
+      const query = {
+        arguments: {
+          where: {
+            posts: {
+              some: {
+                AND: [{ title: { contains: 'Prisma' } }, { published: true }],
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            posts: {
+              some: {
+                AND: [{ title: { contains: PARAM_PLACEHOLDER } }, { published: PARAM_PLACEHOLDER }],
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+
+  describe('every operator', () => {
+    it('handles every relation filter', () => {
+      const query = {
+        arguments: {
+          where: {
+            posts: { every: { published: true } },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            posts: { every: { published: PARAM_PLACEHOLDER } },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles every with multiple conditions', () => {
+      const query = {
+        arguments: {
+          where: {
+            comments: {
+              every: {
+                approved: true,
+                spam: false,
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            comments: {
+              every: {
+                approved: PARAM_PLACEHOLDER,
+                spam: PARAM_PLACEHOLDER,
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+
+  describe('none operator', () => {
+    it('handles none relation filter', () => {
+      const query = {
+        arguments: {
+          where: {
+            posts: { none: { deleted: true } },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            posts: { none: { deleted: PARAM_PLACEHOLDER } },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles none with filter operators', () => {
+      const query = {
+        arguments: {
+          where: {
+            users: {
+              none: {
+                email: { endsWith: '@blocked.com' },
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            users: {
+              none: {
+                email: { endsWith: PARAM_PLACEHOLDER },
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+
+  describe('nested relation filters', () => {
+    it('handles deeply nested relation filters', () => {
+      const query = {
+        arguments: {
+          where: {
+            author: {
+              posts: {
+                some: {
+                  comments: {
+                    every: {
+                      approved: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            author: {
+              posts: {
+                some: {
+                  comments: {
+                    every: {
+                      approved: PARAM_PLACEHOLDER,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles multiple relation filters at same level', () => {
+      const query = {
+        arguments: {
+          where: {
+            posts: { some: { published: true } },
+            comments: { none: { spam: true } },
+            followers: { every: { active: true } },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            posts: { some: { published: PARAM_PLACEHOLDER } },
+            comments: { none: { spam: PARAM_PLACEHOLDER } },
+            followers: { every: { active: PARAM_PLACEHOLDER } },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles relation filters combined with field filters', () => {
+      const query = {
+        arguments: {
+          where: {
+            email: { contains: '@company.com' },
+            posts: {
+              some: {
+                title: { startsWith: 'Announcement' },
+                views: { gt: 100 },
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            email: { contains: PARAM_PLACEHOLDER },
+            posts: {
+              some: {
+                title: { startsWith: PARAM_PLACEHOLDER },
+                views: { gt: PARAM_PLACEHOLDER },
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+
+    it('handles relation filters inside logical operators', () => {
+      const query = {
+        arguments: {
+          where: {
+            OR: [{ posts: { some: { featured: true } } }, { role: 'ADMIN' }],
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      expect(parameterizeQuery(query)).toEqual({
+        arguments: {
+          where: {
+            OR: [{ posts: { some: { featured: PARAM_PLACEHOLDER } } }, { role: PARAM_PLACEHOLDER }],
+          },
+        },
+        selection: { $scalars: true },
+      })
+    })
+  })
+})

--- a/packages/sqlcommenter-query-insights/src/parameterize/tests/security.test.ts
+++ b/packages/sqlcommenter-query-insights/src/parameterize/tests/security.test.ts
@@ -1,0 +1,571 @@
+import { describe, expect, it } from 'vitest'
+
+import { parameterizeQuery } from '../parameterize'
+
+describe('parameterizeQuery - security: no user data leakage', () => {
+  const sensitiveValues = [
+    'password123',
+    'secret-api-key',
+    'user@private.email',
+    'SSN-123-45-6789',
+    'credit-card-1234-5678',
+    '{"sensitive":"data"}',
+  ]
+
+  describe('where clauses', () => {
+    it('does not leak string values in where clauses', () => {
+      for (const sensitive of sensitiveValues) {
+        const query = {
+          arguments: { where: { field: sensitive } },
+          selection: { $scalars: true },
+        }
+
+        const result = parameterizeQuery(query)
+        const resultStr = JSON.stringify(result)
+        expect(resultStr).not.toContain(sensitive)
+      }
+    })
+
+    it('does not leak numeric values that could be IDs', () => {
+      const sensitiveId = 98765432
+
+      const query = {
+        arguments: { where: { id: sensitiveId } },
+        selection: { $scalars: true },
+      }
+
+      const result = parameterizeQuery(query)
+      const resultStr = JSON.stringify(result)
+      expect(resultStr).not.toContain(String(sensitiveId))
+    })
+
+    it('does not leak values in nested where conditions', () => {
+      const sensitive = 'secret-nested-value'
+
+      const query = {
+        arguments: {
+          where: {
+            user: {
+              profile: {
+                bio: sensitive,
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      const result = parameterizeQuery(query)
+      const resultStr = JSON.stringify(result)
+      expect(resultStr).not.toContain(sensitive)
+    })
+  })
+
+  describe('data clauses', () => {
+    it('does not leak string values in data clauses', () => {
+      for (const sensitive of sensitiveValues) {
+        const query = {
+          arguments: { data: { field: sensitive } },
+          selection: { $scalars: true },
+        }
+
+        const result = parameterizeQuery(query)
+        const resultStr = JSON.stringify(result)
+        expect(resultStr).not.toContain(sensitive)
+      }
+    })
+
+    it('does not leak values in nested data operations', () => {
+      const sensitiveEmail = 'private@secret.email'
+      const sensitiveContent = 'confidential content here'
+
+      const query = {
+        arguments: {
+          data: {
+            email: sensitiveEmail,
+            posts: {
+              create: {
+                content: sensitiveContent,
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      const result = parameterizeQuery(query)
+      const resultStr = JSON.stringify(result)
+      expect(resultStr).not.toContain(sensitiveEmail)
+      expect(resultStr).not.toContain(sensitiveContent)
+    })
+  })
+
+  describe('filter operators', () => {
+    it('does not leak values in filter operators', () => {
+      const operators = ['equals', 'contains', 'startsWith', 'endsWith', 'in', 'notIn', 'lt', 'gt', 'lte', 'gte']
+
+      for (const op of operators) {
+        for (const sensitive of sensitiveValues) {
+          const query = {
+            arguments: {
+              where: {
+                field: { [op]: op === 'in' || op === 'notIn' ? [sensitive] : sensitive },
+              },
+            },
+            selection: { $scalars: true },
+          }
+
+          const result = parameterizeQuery(query)
+          const resultStr = JSON.stringify(result)
+          expect(resultStr).not.toContain(sensitive)
+        }
+      }
+    })
+
+    it('does not leak values in search operator', () => {
+      const sensitive = 'secret search term'
+
+      const query = {
+        arguments: {
+          where: {
+            content: { search: sensitive },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      const result = parameterizeQuery(query)
+      const resultStr = JSON.stringify(result)
+      expect(resultStr).not.toContain(sensitive)
+    })
+
+    it('does not leak values in array operators', () => {
+      const sensitiveTag = 'secret-tag'
+
+      const operators = ['has', 'hasEvery', 'hasSome']
+      for (const op of operators) {
+        const query = {
+          arguments: {
+            where: {
+              tags: { [op]: op === 'has' ? sensitiveTag : [sensitiveTag] },
+            },
+          },
+          selection: { $scalars: true },
+        }
+
+        const result = parameterizeQuery(query)
+        const resultStr = JSON.stringify(result)
+        expect(resultStr).not.toContain(sensitiveTag)
+      }
+    })
+  })
+
+  describe('nested relations', () => {
+    it('does not leak values in nested relations', () => {
+      const sensitive = 'super-secret-value'
+
+      const query = {
+        arguments: {
+          where: {
+            posts: {
+              some: {
+                content: { contains: sensitive },
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      const result = parameterizeQuery(query)
+      const resultStr = JSON.stringify(result)
+      expect(resultStr).not.toContain(sensitive)
+    })
+
+    it('does not leak values in deeply nested relation filters', () => {
+      const sensitive1 = 'secret-author-name'
+      const sensitive2 = 'secret-comment-content'
+
+      const query = {
+        arguments: {
+          where: {
+            posts: {
+              some: {
+                author: {
+                  name: sensitive1,
+                },
+                comments: {
+                  every: {
+                    content: { contains: sensitive2 },
+                  },
+                },
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      const result = parameterizeQuery(query)
+      const resultStr = JSON.stringify(result)
+      expect(resultStr).not.toContain(sensitive1)
+      expect(resultStr).not.toContain(sensitive2)
+    })
+  })
+
+  describe('tagged values', () => {
+    it('does not leak tagged DateTime values', () => {
+      const dateValue = '2024-12-25T10:30:00.000Z'
+
+      const query = {
+        arguments: {
+          where: {
+            scheduledAt: { $type: 'DateTime', value: dateValue },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      const result = parameterizeQuery(query)
+      const resultStr = JSON.stringify(result)
+      expect(resultStr).not.toContain(dateValue)
+    })
+
+    it('does not leak tagged Decimal values', () => {
+      const decimalValue = '99999.99'
+
+      const query = {
+        arguments: {
+          where: {
+            salary: { $type: 'Decimal', value: decimalValue },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      const result = parameterizeQuery(query)
+      const resultStr = JSON.stringify(result)
+      expect(resultStr).not.toContain(decimalValue)
+    })
+
+    it('does not leak tagged BigInt values', () => {
+      const bigIntValue = '9007199254740993'
+
+      const query = {
+        arguments: {
+          where: {
+            bigNumber: { $type: 'BigInt', value: bigIntValue },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      const result = parameterizeQuery(query)
+      const resultStr = JSON.stringify(result)
+      expect(resultStr).not.toContain(bigIntValue)
+    })
+
+    it('does not leak tagged Bytes values', () => {
+      const bytesValue = 'U2VjcmV0RGF0YQ=='
+
+      const query = {
+        arguments: {
+          where: {
+            fileData: { $type: 'Bytes', value: bytesValue },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      const result = parameterizeQuery(query)
+      const resultStr = JSON.stringify(result)
+      expect(resultStr).not.toContain(bytesValue)
+    })
+
+    it('does not leak tagged Json values', () => {
+      const jsonValue = '{"secret":"dummy-api-key-NOTREAL"}'
+
+      const query = {
+        arguments: {
+          where: {
+            metadata: { $type: 'Json', value: jsonValue },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      const result = parameterizeQuery(query)
+      const resultStr = JSON.stringify(result)
+      expect(resultStr).not.toContain(jsonValue)
+      expect(resultStr).not.toContain('dummy-api-key-NOTREAL')
+    })
+
+    it('does not leak tagged Enum values', () => {
+      const enumValue = 'SECRET_STATUS'
+
+      const query = {
+        arguments: {
+          where: {
+            status: { $type: 'Enum', value: enumValue },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      const result = parameterizeQuery(query)
+      const resultStr = JSON.stringify(result)
+      expect(resultStr).not.toContain(enumValue)
+    })
+  })
+
+  describe('logical operators', () => {
+    it('does not leak values in deeply nested AND/OR conditions', () => {
+      const sensitiveEmail = 'private@secret.com'
+      const sensitivePassword = 'p@ssw0rd!'
+      const sensitiveRecoveryCode = 'backup-123'
+
+      const query = {
+        arguments: {
+          where: {
+            AND: [
+              { email: sensitiveEmail },
+              {
+                OR: [{ password: sensitivePassword }, { recoveryCode: sensitiveRecoveryCode }],
+              },
+            ],
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      const result = parameterizeQuery(query)
+      const resultStr = JSON.stringify(result)
+      expect(resultStr).not.toContain(sensitiveEmail)
+      expect(resultStr).not.toContain(sensitivePassword)
+      expect(resultStr).not.toContain(sensitiveRecoveryCode)
+    })
+
+    it('does not leak values in NOT conditions', () => {
+      const sensitive = 'excluded-secret'
+
+      const query = {
+        arguments: {
+          where: {
+            NOT: {
+              secretField: sensitive,
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      const result = parameterizeQuery(query)
+      const resultStr = JSON.stringify(result)
+      expect(resultStr).not.toContain(sensitive)
+    })
+  })
+
+  describe('cursor pagination', () => {
+    it('does not leak cursor ID values', () => {
+      const sensitiveId = 'user_abc123xyz'
+
+      const query = {
+        arguments: {
+          cursor: { id: sensitiveId },
+          take: 10,
+        },
+        selection: { $scalars: true },
+      }
+
+      const result = parameterizeQuery(query)
+      const resultStr = JSON.stringify(result)
+      expect(resultStr).not.toContain(sensitiveId)
+    })
+
+    it('does not leak compound cursor values', () => {
+      const sensitiveEmail = 'cursor@secret.com'
+      const sensitiveTenant = 'tenant-secret-123'
+
+      const query = {
+        arguments: {
+          cursor: {
+            email_tenantId: {
+              email: sensitiveEmail,
+              tenantId: sensitiveTenant,
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      const result = parameterizeQuery(query)
+      const resultStr = JSON.stringify(result)
+      expect(resultStr).not.toContain(sensitiveEmail)
+      expect(resultStr).not.toContain(sensitiveTenant)
+    })
+  })
+
+  describe('JSON operators', () => {
+    it('does not leak values in JSON path queries', () => {
+      const sensitivePath1 = 'secretField'
+      const sensitivePath2 = 'nestedSecret'
+      const sensitiveValue = 'secret-json-value'
+
+      const query = {
+        arguments: {
+          where: {
+            metadata: {
+              path: [sensitivePath1, sensitivePath2],
+              equals: sensitiveValue,
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      const result = parameterizeQuery(query)
+      const resultStr = JSON.stringify(result)
+      expect(resultStr).not.toContain(sensitivePath1)
+      expect(resultStr).not.toContain(sensitivePath2)
+      expect(resultStr).not.toContain(sensitiveValue)
+    })
+
+    it('does not leak values in JSON string operators', () => {
+      const sensitiveSearch = 'confidential-content'
+
+      const operators = ['string_contains', 'string_starts_with', 'string_ends_with']
+      for (const op of operators) {
+        const query = {
+          arguments: {
+            where: {
+              jsonField: { [op]: sensitiveSearch },
+            },
+          },
+          selection: { $scalars: true },
+        }
+
+        const result = parameterizeQuery(query)
+        const resultStr = JSON.stringify(result)
+        expect(resultStr).not.toContain(sensitiveSearch)
+      }
+    })
+
+    it('does not leak values in JSON array operators', () => {
+      const sensitiveElement = 'secret-array-element'
+
+      const operators = ['array_contains', 'array_starts_with', 'array_ends_with']
+      for (const op of operators) {
+        const query = {
+          arguments: {
+            where: {
+              jsonField: { [op]: sensitiveElement },
+            },
+          },
+          selection: { $scalars: true },
+        }
+
+        const result = parameterizeQuery(query)
+        const resultStr = JSON.stringify(result)
+        expect(resultStr).not.toContain(sensitiveElement)
+      }
+    })
+  })
+
+  describe('connect/disconnect operations', () => {
+    it('does not leak IDs in connect operations', () => {
+      const sensitiveId1 = 'secret-id-111'
+      const sensitiveId2 = 'secret-id-222'
+
+      const query = {
+        arguments: {
+          data: {
+            tags: {
+              connect: [{ id: sensitiveId1 }, { id: sensitiveId2 }],
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      const result = parameterizeQuery(query)
+      const resultStr = JSON.stringify(result)
+      expect(resultStr).not.toContain(sensitiveId1)
+      expect(resultStr).not.toContain(sensitiveId2)
+    })
+
+    it('does not leak IDs in connectOrCreate operations', () => {
+      const sensitiveId = 'secret-connect-or-create-id'
+      const sensitiveEmail = 'connectorcreate@secret.com'
+
+      const query = {
+        arguments: {
+          data: {
+            profile: {
+              connectOrCreate: {
+                where: { id: sensitiveId },
+                create: { email: sensitiveEmail },
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      const result = parameterizeQuery(query)
+      const resultStr = JSON.stringify(result)
+      expect(resultStr).not.toContain(sensitiveId)
+      expect(resultStr).not.toContain(sensitiveEmail)
+    })
+  })
+
+  describe('combined sensitive data', () => {
+    it('does not leak any values in a complex real-world query', () => {
+      const sensitiveData = {
+        email: 'john.doe@privatecompany.com',
+        password: 'SuperSecret123!',
+        ssn: '123-45-6789',
+        creditCard: '4111-1111-1111-1111',
+        apiKey: 'placeholder_api_key_NOTREAL',
+        internalId: 'usr_2024_confidential',
+        salary: '150000.00',
+        birthDate: '1990-05-15T00:00:00Z',
+      }
+
+      const query = {
+        arguments: {
+          where: {
+            OR: [{ email: sensitiveData.email }, { ssn: sensitiveData.ssn }],
+            AND: [
+              { apiKey: { equals: sensitiveData.apiKey } },
+              {
+                payments: {
+                  some: {
+                    cardNumber: { contains: sensitiveData.creditCard },
+                  },
+                },
+              },
+            ],
+          },
+          data: {
+            password: sensitiveData.password,
+            salary: { $type: 'Decimal', value: sensitiveData.salary },
+            birthDate: { $type: 'DateTime', value: sensitiveData.birthDate },
+            profile: {
+              update: {
+                internalId: sensitiveData.internalId,
+              },
+            },
+          },
+        },
+        selection: { $scalars: true },
+      }
+
+      const result = parameterizeQuery(query)
+      const resultStr = JSON.stringify(result)
+
+      for (const [key, value] of Object.entries(sensitiveData)) {
+        expect(resultStr, `should not contain ${key}`).not.toContain(value)
+      }
+    })
+  })
+})

--- a/packages/sqlcommenter-query-insights/src/parameterize/tests/selection-markers.test.ts
+++ b/packages/sqlcommenter-query-insights/src/parameterize/tests/selection-markers.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+
+import { parameterizeQuery } from '../parameterize'
+
+describe('parameterizeQuery - selection markers', () => {
+  it('preserves $scalars marker', () => {
+    const query = {
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      selection: { $scalars: true },
+    })
+  })
+
+  it('preserves $composites marker', () => {
+    const query = {
+      selection: { $composites: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      selection: { $composites: true },
+    })
+  })
+
+  it('preserves both markers together', () => {
+    const query = {
+      selection: { $scalars: true, $composites: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      selection: { $scalars: true, $composites: true },
+    })
+  })
+
+  it('preserves false values for selection markers', () => {
+    const query = {
+      selection: { $scalars: false, $composites: false },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      selection: { $scalars: false, $composites: false },
+    })
+  })
+
+  it('preserves selection markers in nested selections', () => {
+    const query = {
+      selection: {
+        $scalars: true,
+        posts: {
+          selection: {
+            $scalars: true,
+            $composites: true,
+          },
+        },
+      },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      selection: {
+        $scalars: true,
+        posts: {
+          selection: {
+            $scalars: true,
+            $composites: true,
+          },
+        },
+      },
+    })
+  })
+
+  it('preserves boolean field selections alongside markers', () => {
+    const query = {
+      selection: {
+        $scalars: true,
+        id: true,
+        name: true,
+        email: false,
+      },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      selection: {
+        $scalars: true,
+        id: true,
+        name: true,
+        email: false,
+      },
+    })
+  })
+
+  it('preserves nested relation selections with markers', () => {
+    const query = {
+      selection: {
+        $scalars: true,
+        author: {
+          selection: {
+            $scalars: true,
+          },
+        },
+        comments: {
+          selection: {
+            $composites: true,
+            author: {
+              selection: {
+                $scalars: true,
+              },
+            },
+          },
+        },
+      },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      selection: {
+        $scalars: true,
+        author: {
+          selection: {
+            $scalars: true,
+          },
+        },
+        comments: {
+          selection: {
+            $composites: true,
+            author: {
+              selection: {
+                $scalars: true,
+              },
+            },
+          },
+        },
+      },
+    })
+  })
+})

--- a/packages/sqlcommenter-query-insights/src/parameterize/tests/tagged-values.test.ts
+++ b/packages/sqlcommenter-query-insights/src/parameterize/tests/tagged-values.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from 'vitest'
+
+import { PARAM_PLACEHOLDER, parameterizeQuery } from '../parameterize'
+
+describe('parameterizeQuery - tagged values', () => {
+  it('parameterizes DateTime tagged values', () => {
+    const query = {
+      arguments: {
+        where: {
+          createdAt: { $type: 'DateTime', value: '2024-01-01T00:00:00Z' },
+        },
+      },
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: {
+          createdAt: PARAM_PLACEHOLDER,
+        },
+      },
+      selection: { $scalars: true },
+    })
+  })
+
+  it('parameterizes Decimal tagged values', () => {
+    const query = {
+      arguments: {
+        where: {
+          price: { $type: 'Decimal', value: '99.99' },
+        },
+      },
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: {
+          price: PARAM_PLACEHOLDER,
+        },
+      },
+      selection: { $scalars: true },
+    })
+  })
+
+  it('parameterizes BigInt tagged values', () => {
+    const query = {
+      arguments: {
+        where: {
+          bigNum: { $type: 'BigInt', value: '9007199254740993' },
+        },
+      },
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: {
+          bigNum: PARAM_PLACEHOLDER,
+        },
+      },
+      selection: { $scalars: true },
+    })
+  })
+
+  it('parameterizes Bytes tagged values', () => {
+    const query = {
+      arguments: {
+        where: {
+          data: { $type: 'Bytes', value: 'SGVsbG8gV29ybGQ=' },
+        },
+      },
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: {
+          data: PARAM_PLACEHOLDER,
+        },
+      },
+      selection: { $scalars: true },
+    })
+  })
+
+  it('parameterizes Json tagged values', () => {
+    const query = {
+      arguments: {
+        where: {
+          metadata: { $type: 'Json', value: '{"key":"value"}' },
+        },
+      },
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: {
+          metadata: PARAM_PLACEHOLDER,
+        },
+      },
+      selection: { $scalars: true },
+    })
+  })
+
+  it('parameterizes Enum tagged values', () => {
+    const query = {
+      arguments: {
+        where: {
+          status: { $type: 'Enum', value: 'ACTIVE' },
+        },
+      },
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: {
+          status: PARAM_PLACEHOLDER,
+        },
+      },
+      selection: { $scalars: true },
+    })
+  })
+
+  it('parameterizes Raw tagged values', () => {
+    const query = {
+      arguments: {
+        where: {
+          field: { $type: 'Raw', value: 'some raw value' },
+        },
+      },
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: {
+          field: PARAM_PLACEHOLDER,
+        },
+      },
+      selection: { $scalars: true },
+    })
+  })
+
+  it('preserves FieldRef tagged values (structural)', () => {
+    const fieldRef = { $type: 'FieldRef', value: { _ref: 'otherField', _container: 'Model' } }
+    const query = {
+      arguments: {
+        where: {
+          field: { equals: fieldRef },
+        },
+      },
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: {
+          field: { equals: fieldRef },
+        },
+      },
+      selection: { $scalars: true },
+    })
+  })
+
+  it('parameterizes tagged values in data context', () => {
+    const query = {
+      arguments: {
+        data: {
+          createdAt: { $type: 'DateTime', value: '2024-01-01T00:00:00Z' },
+          price: { $type: 'Decimal', value: '99.99' },
+          metadata: { $type: 'Json', value: '{"key":"value"}' },
+        },
+      },
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        data: {
+          createdAt: PARAM_PLACEHOLDER,
+          price: PARAM_PLACEHOLDER,
+          metadata: PARAM_PLACEHOLDER,
+        },
+      },
+      selection: { $scalars: true },
+    })
+  })
+
+  it('parameterizes tagged values in nested filter operators', () => {
+    const query = {
+      arguments: {
+        where: {
+          createdAt: {
+            gte: { $type: 'DateTime', value: '2024-01-01T00:00:00Z' },
+            lt: { $type: 'DateTime', value: '2024-12-31T23:59:59Z' },
+          },
+        },
+      },
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: {
+          createdAt: {
+            gte: PARAM_PLACEHOLDER,
+            lt: PARAM_PLACEHOLDER,
+          },
+        },
+      },
+      selection: { $scalars: true },
+    })
+  })
+
+  it('parameterizes tagged values in arrays', () => {
+    const query = {
+      arguments: {
+        where: {
+          status: {
+            in: [
+              { $type: 'Enum', value: 'ACTIVE' },
+              { $type: 'Enum', value: 'PENDING' },
+            ],
+          },
+        },
+      },
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: {
+          status: {
+            in: [PARAM_PLACEHOLDER, PARAM_PLACEHOLDER],
+          },
+        },
+      },
+      selection: { $scalars: true },
+    })
+  })
+})

--- a/packages/sqlcommenter-query-insights/src/shape/shape.ts
+++ b/packages/sqlcommenter-query-insights/src/shape/shape.ts
@@ -1,0 +1,81 @@
+/**
+ * Query shaping logic for Prisma query insights.
+ *
+ * Transforms JSON protocol query representations into Prisma-like format:
+ * - Move `arguments` contents one level up
+ * - Convert `selection` to `select`/`include`:
+ *   - If `$scalars: true`, use `include` for relations
+ *   - If no `$scalars`, use `select` for both scalars and relations
+ * - Simplify relation selections to `true` when possible
+ */
+
+type Obj = Record<string, unknown>
+
+function isObject(value: unknown): value is Obj {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isEmpty(obj: Obj | undefined): boolean {
+  return !obj || Object.keys(obj).length === 0
+}
+
+/**
+ * Checks if a selection can be simplified to `true` (only $scalars/$composites, no other fields)
+ */
+function isSimpleSelection(selection: Obj | undefined): boolean {
+  if (!selection || selection.$scalars !== true) return false
+  return Object.keys(selection).every((k) => k === '$scalars' || k === '$composites')
+}
+
+/**
+ * Shapes a value that could be a nested query, a simple selection, or a boolean.
+ */
+function shapeValue(value: unknown): unknown {
+  if (value === true || !isObject(value)) return value
+
+  // Check if it's a nested query (has arguments or selection keys)
+  if ('arguments' in value || 'selection' in value) {
+    const args = value.arguments as Obj | undefined
+    const selection = value.selection as Obj | undefined
+
+    // Can simplify to true if args empty and selection is simple
+    if (isEmpty(args) && isSimpleSelection(selection)) {
+      return true
+    }
+
+    return shapeQuery(value)
+  }
+
+  // It's a simple selection object (e.g., { $scalars: true })
+  return isSimpleSelection(value) ? true : shapeQuery({ selection: value })
+}
+
+/**
+ * Shapes a query object from JSON protocol format to Prisma-like format.
+ */
+export function shapeQuery(query: unknown): unknown {
+  if (!isObject(query)) return query
+
+  const args = query.arguments as Obj | undefined
+  const selection = query.selection as Obj | undefined
+  const result: Obj = args ? { ...args } : {}
+
+  if (!selection) return result
+
+  const hasScalars = selection.$scalars === true
+  const fields: Obj = {}
+
+  for (const [key, value] of Object.entries(selection)) {
+    // Skip markers and boolean fields when $scalars is present (they're redundant)
+    if (key === '$scalars' || key === '$composites') continue
+    if (hasScalars && typeof value === 'boolean') continue
+
+    fields[key] = typeof value === 'boolean' ? value : shapeValue(value)
+  }
+
+  if (Object.keys(fields).length > 0) {
+    result[hasScalars ? 'include' : 'select'] = fields
+  }
+
+  return result
+}

--- a/packages/sqlcommenter-query-insights/src/shape/tests/basic-shaping.test.ts
+++ b/packages/sqlcommenter-query-insights/src/shape/tests/basic-shaping.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest'
+
+import { shapeQuery } from '../shape'
+
+describe('shapeQuery - basic transformations', () => {
+  describe('example 1: scalars only, no relations', () => {
+    it('returns just the arguments when selection is only $scalars and $composites', () => {
+      const before = {
+        arguments: { where: { id: 1 } },
+        selection: {
+          $scalars: true,
+          $composites: true,
+        },
+      }
+
+      const after = {
+        where: { id: 1 },
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+
+    it('handles empty arguments', () => {
+      const before = {
+        arguments: {},
+        selection: {
+          $scalars: true,
+          $composites: true,
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual({})
+    })
+
+    it('handles missing arguments', () => {
+      const before = {
+        selection: {
+          $scalars: true,
+          $composites: true,
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual({})
+    })
+  })
+
+  describe('example 2: scalars with simple relation', () => {
+    it('uses include with true for relation when parent has $scalars', () => {
+      const before = {
+        arguments: { where: { id: 1 } },
+        selection: {
+          $scalars: true,
+          $composites: true,
+          posts: {
+            $scalars: true,
+            $composites: true,
+          },
+        },
+      }
+
+      const after = {
+        where: { id: 1 },
+        include: {
+          posts: true,
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+
+    it('handles multiple simple relations', () => {
+      const before = {
+        arguments: { take: 10 },
+        selection: {
+          $scalars: true,
+          $composites: true,
+          posts: {
+            $scalars: true,
+            $composites: true,
+          },
+          profile: {
+            $scalars: true,
+            $composites: true,
+          },
+        },
+      }
+
+      const after = {
+        take: 10,
+        include: {
+          posts: true,
+          profile: true,
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+  })
+
+  describe('example 3: scalars with relation having explicit field selection', () => {
+    it('uses include with select for relation when relation selects specific fields', () => {
+      const before = {
+        arguments: { where: { id: 1 } },
+        selection: {
+          $scalars: true,
+          $composites: true,
+          posts: {
+            arguments: {},
+            selection: {
+              title: true,
+            },
+          },
+        },
+      }
+
+      const after = {
+        where: { id: 1 },
+        include: {
+          posts: {
+            select: {
+              title: true,
+            },
+          },
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+  })
+
+  describe('example 4: explicit field selection without $scalars', () => {
+    it('uses select for both fields and relations when no $scalars', () => {
+      const before = {
+        arguments: { where: { active: true } },
+        selection: {
+          name: true,
+          posts: {
+            arguments: {},
+            selection: {
+              title: true,
+            },
+          },
+        },
+      }
+
+      const after = {
+        where: { active: true },
+        select: {
+          name: true,
+          posts: {
+            select: {
+              title: true,
+            },
+          },
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+  })
+
+  describe('example 5: explicit selection with boolean relation', () => {
+    it('keeps boolean relation as true in select', () => {
+      const before = {
+        arguments: { skip: 5 },
+        selection: {
+          name: true,
+          posts: true,
+        },
+      }
+
+      const after = {
+        skip: 5,
+        select: {
+          name: true,
+          posts: true,
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+  })
+
+  describe('preserving false in selections', () => {
+    it('preserves false values in field selection', () => {
+      const before = {
+        arguments: {},
+        selection: {
+          name: true,
+          email: false,
+          password: false,
+        },
+      }
+
+      const after = {
+        select: {
+          name: true,
+          email: false,
+          password: false,
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+  })
+})

--- a/packages/sqlcommenter-query-insights/src/shape/tests/edge-cases.test.ts
+++ b/packages/sqlcommenter-query-insights/src/shape/tests/edge-cases.test.ts
@@ -1,0 +1,420 @@
+import { describe, expect, it } from 'vitest'
+
+import { shapeQuery } from '../shape'
+
+describe('shapeQuery - edge cases', () => {
+  describe('null and undefined handling', () => {
+    it('returns null for null input', () => {
+      expect(shapeQuery(null)).toBeNull()
+    })
+
+    it('returns undefined for undefined input', () => {
+      expect(shapeQuery(undefined)).toBeUndefined()
+    })
+
+    it('returns primitives as-is', () => {
+      expect(shapeQuery('string')).toBe('string')
+      expect(shapeQuery(123)).toBe(123)
+      expect(shapeQuery(true)).toBe(true)
+    })
+  })
+
+  describe('empty objects', () => {
+    it('handles completely empty query', () => {
+      expect(shapeQuery({})).toEqual({})
+    })
+
+    it('handles query with only empty arguments', () => {
+      const before = {
+        arguments: {},
+      }
+
+      expect(shapeQuery(before)).toEqual({})
+    })
+
+    it('handles query with only empty selection', () => {
+      const before = {
+        selection: {},
+      }
+
+      expect(shapeQuery(before)).toEqual({})
+    })
+
+    it('handles empty selection with only $composites (no $scalars)', () => {
+      const before = {
+        arguments: { where: { id: 1 } },
+        selection: {
+          $composites: true,
+        },
+      }
+
+      // No $scalars means no fields selected, should result in just arguments
+      expect(shapeQuery(before)).toEqual({ where: { id: 1 } })
+    })
+  })
+
+  describe('$scalars without $composites', () => {
+    it('handles $scalars: true without $composites', () => {
+      const before = {
+        arguments: { take: 5 },
+        selection: {
+          $scalars: true,
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual({ take: 5 })
+    })
+
+    it('handles $scalars: false', () => {
+      const before = {
+        arguments: { where: { id: 1 } },
+        selection: {
+          $scalars: false,
+          $composites: true,
+        },
+      }
+
+      // $scalars: false is not true, so no special handling
+      expect(shapeQuery(before)).toEqual({ where: { id: 1 } })
+    })
+  })
+
+  describe('only $composites ignored', () => {
+    it('ignores $composites in selection processing', () => {
+      const before = {
+        arguments: { where: { id: 1 } },
+        selection: {
+          $scalars: true,
+          $composites: true,
+          posts: {
+            $scalars: true,
+            $composites: true,
+          },
+        },
+      }
+
+      // $composites should not affect output
+      const after = {
+        where: { id: 1 },
+        include: {
+          posts: true,
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+  })
+
+  describe('selection with only relations', () => {
+    it('handles selection with only object relations (no booleans, no $scalars)', () => {
+      const before = {
+        arguments: { where: { id: 1 } },
+        selection: {
+          posts: {
+            arguments: {},
+            selection: {
+              $scalars: true,
+              $composites: true,
+            },
+          },
+        },
+      }
+
+      // No $scalars at top level, so use select
+      const after = {
+        where: { id: 1 },
+        select: {
+          posts: true,
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+  })
+
+  describe('complex argument structures', () => {
+    it('preserves nested argument structures', () => {
+      const before = {
+        arguments: {
+          where: {
+            AND: [{ email: { contains: 'test' } }, { age: { gte: 18 } }],
+          },
+          orderBy: [{ createdAt: 'desc' }, { name: 'asc' }],
+          take: 10,
+          skip: 5,
+        },
+        selection: {
+          $scalars: true,
+          $composites: true,
+        },
+      }
+
+      const after = {
+        where: {
+          AND: [{ email: { contains: 'test' } }, { age: { gte: 18 } }],
+        },
+        orderBy: [{ createdAt: 'desc' }, { name: 'asc' }],
+        take: 10,
+        skip: 5,
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+
+    it('preserves deeply nested data in arguments', () => {
+      const before = {
+        arguments: {
+          data: {
+            user: {
+              create: {
+                profile: {
+                  create: {
+                    bio: 'Hello',
+                  },
+                },
+              },
+            },
+          },
+        },
+        selection: {
+          $scalars: true,
+          $composites: true,
+        },
+      }
+
+      const after = {
+        data: {
+          user: {
+            create: {
+              profile: {
+                create: {
+                  bio: 'Hello',
+                },
+              },
+            },
+          },
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+  })
+
+  describe('relation with arguments but no selection', () => {
+    it('handles relation with only arguments', () => {
+      const before = {
+        arguments: { where: { id: 1 } },
+        selection: {
+          $scalars: true,
+          $composites: true,
+          posts: {
+            arguments: { take: 10 },
+          },
+        },
+      }
+
+      const after = {
+        where: { id: 1 },
+        include: {
+          posts: {
+            take: 10,
+          },
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+  })
+
+  describe('relation with only selection', () => {
+    it('handles relation with only selection (no arguments key)', () => {
+      const before = {
+        arguments: { where: { active: true } },
+        selection: {
+          $scalars: true,
+          $composites: true,
+          posts: {
+            selection: {
+              $scalars: true,
+              $composites: true,
+            },
+          },
+        },
+      }
+
+      // No arguments means it can be simplified to true
+      const after = {
+        where: { active: true },
+        include: {
+          posts: true,
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+  })
+
+  describe('mixed boolean and object fields without $scalars', () => {
+    it('combines boolean fields and shaped relations in select', () => {
+      const before = {
+        arguments: {},
+        selection: {
+          id: true,
+          name: true,
+          email: false,
+          posts: {
+            arguments: { take: 5 },
+            selection: {
+              title: true,
+              body: true,
+            },
+          },
+          profile: true,
+        },
+      }
+
+      const after = {
+        select: {
+          id: true,
+          name: true,
+          email: false,
+          posts: {
+            take: 5,
+            select: {
+              title: true,
+              body: true,
+            },
+          },
+          profile: true,
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+  })
+
+  describe('selection markers alongside explicit fields', () => {
+    it('$scalars overrides the explicit fields', () => {
+      const before = {
+        arguments: {},
+        selection: {
+          $scalars: true,
+          name: true,
+          email: true,
+        },
+      }
+
+      const after = {}
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+  })
+
+  describe('arrays as field values', () => {
+    it('preserves arrays in arguments', () => {
+      const before = {
+        arguments: {
+          where: {
+            id: { in: [1, 2, 3] },
+          },
+        },
+        selection: {
+          $scalars: true,
+          $composites: true,
+        },
+      }
+
+      const after = {
+        where: {
+          id: { in: [1, 2, 3] },
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+  })
+
+  describe('special characters in keys', () => {
+    it('handles field names with underscores', () => {
+      const before = {
+        arguments: {},
+        selection: {
+          first_name: true,
+          last_name: true,
+          _count: true,
+        },
+      }
+
+      const after = {
+        select: {
+          first_name: true,
+          last_name: true,
+          _count: true,
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+  })
+
+  describe('relation simplification edge cases', () => {
+    it('does not simplify when selection has extra fields beyond $scalars/$composites', () => {
+      const before = {
+        arguments: {},
+        selection: {
+          $scalars: true,
+          $composites: true,
+          posts: {
+            arguments: {},
+            selection: {
+              $scalars: true,
+              $composites: true,
+              comments: {
+                $scalars: true,
+                $composites: true,
+              },
+            },
+          },
+        },
+      }
+
+      // posts has nested comments, so it can't simplify to true
+      const after = {
+        include: {
+          posts: {
+            include: {
+              comments: true,
+            },
+          },
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+
+    it('simplifies relation when only $scalars is present (no $composites)', () => {
+      const before = {
+        arguments: { where: { id: 1 } },
+        selection: {
+          $scalars: true,
+          $composites: true,
+          posts: {
+            arguments: {},
+            selection: {
+              $scalars: true,
+            },
+          },
+        },
+      }
+
+      const after = {
+        where: { id: 1 },
+        include: {
+          posts: true,
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+  })
+})

--- a/packages/sqlcommenter-query-insights/src/shape/tests/nested-relations.test.ts
+++ b/packages/sqlcommenter-query-insights/src/shape/tests/nested-relations.test.ts
@@ -1,0 +1,409 @@
+import { describe, expect, it } from 'vitest'
+
+import { shapeQuery } from '../shape'
+
+describe('shapeQuery - nested relations', () => {
+  describe('example 6: mixed select with nested include', () => {
+    it('uses select at top level, include for nested relations with $scalars', () => {
+      const ARGS1 = { where: { active: true } }
+      const ARGS2 = { take: 10 }
+      const ARGS3 = { orderBy: { createdAt: 'desc' } }
+
+      const before = {
+        arguments: ARGS1,
+        selection: {
+          name: true,
+          posts: {
+            arguments: ARGS2,
+            selection: {
+              $scalars: true,
+              $composites: true,
+              comments: {
+                arguments: ARGS3,
+                selection: {
+                  $scalars: true,
+                  $composites: true,
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const after = {
+        ...ARGS1,
+        select: {
+          name: true,
+          posts: {
+            ...ARGS2,
+            include: {
+              comments: {
+                ...ARGS3,
+              },
+            },
+          },
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+  })
+
+  describe('example 7: nested relation simplified to true with empty arguments', () => {
+    it('simplifies deepest relation to true when arguments are empty', () => {
+      const ARGS1 = { where: { id: 1 } }
+      const ARGS2 = { skip: 5 }
+
+      const before = {
+        arguments: ARGS1,
+        selection: {
+          name: true,
+          posts: {
+            arguments: ARGS2,
+            selection: {
+              $scalars: true,
+              $composites: true,
+              comments: {
+                arguments: {},
+                selection: {
+                  $scalars: true,
+                  $composites: true,
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const after = {
+        ...ARGS1,
+        select: {
+          name: true,
+          posts: {
+            ...ARGS2,
+            include: {
+              comments: true,
+            },
+          },
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+
+    it('simplifies to true when arguments are missing entirely', () => {
+      const ARGS1 = { where: { id: 1 } }
+      const ARGS2 = { take: 20 }
+
+      const before = {
+        arguments: ARGS1,
+        selection: {
+          name: true,
+          posts: {
+            arguments: ARGS2,
+            selection: {
+              $scalars: true,
+              $composites: true,
+              comments: {
+                selection: {
+                  $scalars: true,
+                  $composites: true,
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const after = {
+        ...ARGS1,
+        select: {
+          name: true,
+          posts: {
+            ...ARGS2,
+            include: {
+              comments: true,
+            },
+          },
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+  })
+
+  describe('example 8: all include chain with simplification', () => {
+    it('uses include at all levels when all have $scalars', () => {
+      const ARGS1 = { where: { email: 'test@example.com' } }
+      const ARGS2 = { orderBy: { title: 'asc' } }
+
+      const before = {
+        arguments: ARGS1,
+        selection: {
+          $scalars: true,
+          $composites: true,
+          posts: {
+            arguments: ARGS2,
+            selection: {
+              $scalars: true,
+              $composites: true,
+              comments: {
+                arguments: {},
+                selection: {
+                  $scalars: true,
+                  $composites: true,
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const after = {
+        ...ARGS1,
+        include: {
+          posts: {
+            ...ARGS2,
+            include: {
+              comments: true,
+            },
+          },
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+  })
+
+  describe('example 9: include with nested select', () => {
+    it('uses include at top, select for relation without $scalars', () => {
+      const ARGS1 = { where: { id: 1 } }
+      const ARGS2 = { take: 5 }
+
+      const before = {
+        arguments: ARGS1,
+        selection: {
+          $scalars: true,
+          $composites: true,
+          posts: {
+            arguments: ARGS2,
+            selection: {
+              title: true,
+              comments: {
+                arguments: {},
+                selection: {
+                  $scalars: true,
+                  $composites: true,
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const after = {
+        ...ARGS1,
+        include: {
+          posts: {
+            ...ARGS2,
+            select: {
+              title: true,
+              comments: true,
+            },
+          },
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+  })
+
+  describe('deeply nested chains', () => {
+    it('handles 4 levels of nesting with mixed select/include', () => {
+      const before = {
+        arguments: { where: { id: 1 } },
+        selection: {
+          name: true,
+          posts: {
+            arguments: { take: 10 },
+            selection: {
+              $scalars: true,
+              $composites: true,
+              comments: {
+                arguments: { orderBy: { id: 'desc' } },
+                selection: {
+                  text: true,
+                  author: {
+                    arguments: {},
+                    selection: {
+                      $scalars: true,
+                      $composites: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const after = {
+        where: { id: 1 },
+        select: {
+          name: true,
+          posts: {
+            take: 10,
+            include: {
+              comments: {
+                orderBy: { id: 'desc' },
+                select: {
+                  text: true,
+                  author: true,
+                },
+              },
+            },
+          },
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+
+    it('handles all include chain with non-empty arguments at each level', () => {
+      const before = {
+        arguments: { where: { active: true } },
+        selection: {
+          $scalars: true,
+          $composites: true,
+          posts: {
+            arguments: { take: 5 },
+            selection: {
+              $scalars: true,
+              $composites: true,
+              comments: {
+                arguments: { skip: 2 },
+                selection: {
+                  $scalars: true,
+                  $composites: true,
+                  author: {
+                    arguments: { select: { name: true } },
+                    selection: {
+                      $scalars: true,
+                      $composites: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const after = {
+        where: { active: true },
+        include: {
+          posts: {
+            take: 5,
+            include: {
+              comments: {
+                skip: 2,
+                include: {
+                  author: {
+                    select: { name: true },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+  })
+
+  describe('multiple relations at the same level', () => {
+    it('handles multiple nested relations with different structures', () => {
+      const before = {
+        arguments: { where: { id: 1 } },
+        selection: {
+          $scalars: true,
+          $composites: true,
+          posts: {
+            arguments: { take: 10 },
+            selection: {
+              $scalars: true,
+              $composites: true,
+            },
+          },
+          profile: {
+            arguments: {},
+            selection: {
+              $scalars: true,
+              $composites: true,
+            },
+          },
+          comments: {
+            arguments: {},
+            selection: {
+              text: true,
+            },
+          },
+        },
+      }
+
+      const after = {
+        where: { id: 1 },
+        include: {
+          posts: {
+            take: 10,
+          },
+          profile: true,
+          comments: {
+            select: {
+              text: true,
+            },
+          },
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+
+    it('handles sibling relations in select mode', () => {
+      const before = {
+        arguments: {},
+        selection: {
+          name: true,
+          posts: {
+            arguments: {},
+            selection: {
+              title: true,
+            },
+          },
+          comments: {
+            arguments: {},
+            selection: {
+              $scalars: true,
+              $composites: true,
+            },
+          },
+        },
+      }
+
+      const after = {
+        select: {
+          name: true,
+          posts: {
+            select: {
+              title: true,
+            },
+          },
+          comments: true,
+        },
+      }
+
+      expect(shapeQuery(before)).toEqual(after)
+    })
+  })
+})

--- a/packages/sqlcommenter-query-insights/tsconfig.build.json
+++ b/packages/sqlcommenter-query-insights/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.regular.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/sqlcommenter-query-insights/tsconfig.json
+++ b/packages/sqlcommenter-query-insights/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./**/*"]
+}

--- a/packages/sqlcommenter/README.md
+++ b/packages/sqlcommenter/README.md
@@ -55,6 +55,7 @@ const prisma = new PrismaClient({
 
 - [`@prisma/sqlcommenter-query-tags`](https://www.npmjs.com/package/@prisma/sqlcommenter-query-tags): appends arbitrary tags to all queries within an async context.
 - [`@prisma/sqlcommenter-trace-context`](https://www.npmjs.com/package/@prisma/sqlcommenter-trace-context): appends `traceparent` comments to SQL queries for distributed tracing.
+- [`@prisma/sqlcommenter-query-insights`](https://www.npmjs.com/package/@prisma/sqlcommenter-query-insights): enables query insights for [Prisma Postgres](https://www.prisma.io/postgres).
 
 ### Query Context
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1859,6 +1859,15 @@ importers:
         specifier: workspace:*
         version: link:../json-protocol
 
+  packages/sqlcommenter-query-insights:
+    devDependencies:
+      '@prisma/sqlcommenter':
+        specifier: workspace:*
+        version: link:../sqlcommenter
+      fast-check:
+        specifier: 4.3.0
+        version: 4.3.0
+
   packages/sqlcommenter-query-tags:
     devDependencies:
       '@prisma/sqlcommenter':
@@ -5340,6 +5349,10 @@ packages:
     resolution: {integrity: sha512-Zu6tZ4g0T4H9Tiz3tdNPEHrSbuICj7yhdOM9RCZKNMkpjZ9avDV3ORklXaEmh4zvkX24/bGZ9DxKKqWfXttUqw==}
     engines: {node: '>=8.0.0'}
 
+  fast-check@4.3.0:
+    resolution: {integrity: sha512-JVw/DJSxVKl8uhCb7GrwanT9VWsCIdBkK3WpP37B/Au4pyaspriSjtrY2ApbSFwTg3ViPfniT13n75PhzE7VEQ==}
+    engines: {node: '>=12.17.0'}
+
   fast-content-type-parse@2.0.1:
     resolution: {integrity: sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==}
 
@@ -7214,6 +7227,9 @@ packages:
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  pure-rand@7.0.1:
+    resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
 
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
@@ -12168,6 +12184,10 @@ snapshots:
     dependencies:
       pure-rand: 5.0.3
 
+  fast-check@4.3.0:
+    dependencies:
+      pure-rand: 7.0.1
+
   fast-content-type-parse@2.0.1: {}
 
   fast-deep-equal@3.1.3: {}
@@ -14266,6 +14286,8 @@ snapshots:
   pure-rand@5.0.3: {}
 
   pure-rand@6.1.0: {}
+
+  pure-rand@7.0.1: {}
 
   qs@6.14.0:
     dependencies:

--- a/tsconfig.build.bundle.json
+++ b/tsconfig.build.bundle.json
@@ -34,6 +34,7 @@
       "@prisma/adapter-planetscale": ["./packages/adapter-planetscale/src"],
       "@prisma/query-plan-executor": ["./packages/query-plan-executor/src"],
       "@prisma/sqlcommenter": ["./packages/sqlcommenter/src"],
+      "@prisma/sqlcommenter-query-insights": ["./packages/sqlcommenter-query-insights/src"],
       "@prisma/sqlcommenter-query-tags": ["./packages/sqlcommenter-query-tags/src"],
       "@prisma/sqlcommenter-trace-context": ["./packages/sqlcommenter-trace-context/src"],
       "@prisma/ts-builders": ["./packages/ts-builders/src"]


### PR DESCRIPTION
Implement `@prisma/sqlcommenter-query-insights` plugin. The documentation is currently very generic and doesn't talk about Prisma Postgres because the corresponding functionality isn't yet available in Console. Once it is, the README will be rewritten to be Prisma Postgres centric (although third-party observability providers like Datadog, Sentry etc can also make use of this to provide new cool features for Prisma users).

In the future parameterization will happen in core using the query schema aka DMMF, which is also necessary for query plan caching. For now the plugin temporarily implements its own best-effort parameterization logic, which preserves the hardcoded list of values which are explicitly allowed in certain contexts, and errs on the side of parameterizing everything else.

Closes: https://linear.app/prisma-company/issue/TML-1645/build-ppg-query-insights-plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sqlcommenter plugin that emits parameterized, shape-preserving query insights in SQL comments (supports raw and batched formats).

* **Documentation**
  * Added plugin README and an embedder guide documenting formats, decoding, security considerations, and integration notes.

* **Tests**
  * Added extensive unit, property-based, and end-to-end test suites covering formatting, parameterization, shaping, security, edge cases, and batching.

* **Chores**
  * CI workflow updated to run the new tests and new package metadata added.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->