### PR TITLE
fix(client-engine-runtime): make `DataMapperError` a `UserFacingError`

### DIFF
--- a/packages/client-engine-runtime/src/interpreter/data-mapper.ts
+++ b/packages/client-engine-runtime/src/interpreter/data-mapper.ts
@@ -9,7 +9,7 @@ export class DataMapperError extends UserFacingError {
   name = 'DataMapperError'
 
   constructor(message: string, options?: { cause?: unknown }) {
-    super(message, 'P2006', options)
+    super(message, 'P2023', options)
   }
 }
 

--- a/packages/client-engine-runtime/src/interpreter/data-mapper.ts
+++ b/packages/client-engine-runtime/src/interpreter/data-mapper.ts
@@ -1,11 +1,16 @@
 import { Decimal } from '@prisma/client-runtime-utils'
 
 import { FieldScalarType, FieldType, ResultNode } from '../query-plan'
+import { UserFacingError } from '../user-facing-error'
 import { assertNever, safeJsonStringify } from '../utils'
 import { PrismaObject, Value } from './scope'
 
-export class DataMapperError extends Error {
+export class DataMapperError extends UserFacingError {
   name = 'DataMapperError'
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, 'P2006', options)
+  }
 }
 
 export function applyDataMap(data: Value, structure: ResultNode, enums: Record<string, Record<string, string>>): Value {

--- a/packages/client/tests/functional/issues/TML-1664-unknown-enum-value-read-error/_matrix.ts
+++ b/packages/client/tests/functional/issues/TML-1664-unknown-enum-value-read-error/_matrix.ts
@@ -1,0 +1,10 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+import { Providers } from '../../_utils/providers'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: Providers.POSTGRESQL,
+    },
+  ],
+])

--- a/packages/client/tests/functional/issues/TML-1664-unknown-enum-value-read-error/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/TML-1664-unknown-enum-value-read-error/prisma/_schema.ts
@@ -1,0 +1,24 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+    generator client {
+      provider = "prisma-client-js"
+    }
+
+    datasource db {
+      provider = "${provider}"
+    }
+
+    model User {
+      id     ${idForProvider(provider)}
+      status Status
+    }
+
+    enum Status {
+      ACTIVE
+      INACTIVE
+    }
+  `
+})

--- a/packages/client/tests/functional/issues/TML-1664-unknown-enum-value-read-error/test.ts
+++ b/packages/client/tests/functional/issues/TML-1664-unknown-enum-value-read-error/test.ts
@@ -1,0 +1,42 @@
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
+
+declare let prisma: PrismaClient
+
+/**
+ * Regression test for DataMapperError when reading unknown enum values.
+ *
+ * When the database contains an enum value that Prisma doesn't know about
+ * (e.g., a value added directly to the database after schema generation),
+ * reading the data should return a proper user-facing error (P2023)
+ * rather than throwing an internal error.
+ *
+ * This test adds a new enum value to the database that Prisma schema
+ * doesn't define, inserts a row with that value, then attempts to read it.
+ */
+testMatrix.setupTestSuite(
+  () => {
+    beforeAll(async () => {
+      // Add a new enum value to the database that Prisma doesn't know about
+      await prisma.$executeRawUnsafe(`ALTER TYPE "Status" ADD VALUE 'UNKNOWN_TO_PRISMA'`)
+
+      // Insert a row with the unknown enum value
+      await prisma.$executeRawUnsafe(`INSERT INTO "User" ("id", "status") VALUES ('1', 'UNKNOWN_TO_PRISMA')`)
+    })
+
+    test('returns P2023 error when reading enum value unknown to Prisma', async () => {
+      const result = await prisma.user.findMany().catch((e) => e)
+
+      expect(result.name).toBe('PrismaClientKnownRequestError')
+      expect(result.code).toBe('P2023')
+      expect(result.message).toContain("Value 'UNKNOWN_TO_PRISMA' not found in enum 'Status'")
+    })
+  },
+  {
+    optOut: {
+      from: ['mysql', 'cockroachdb', 'mongodb', 'sqlite', 'sqlserver'],
+      reason: 'Test uses PostgreSQL-specific ALTER TYPE syntax for enum modification',
+    },
+  },
+)


### PR DESCRIPTION
Make `DataMapperError` a `UserFacingError` with code P2023 so that it's correctly caught and converted to `PrismaClientKnownRequestError` in Prisma Client, and so that it is properly handled by the query plan executor server and returned as HTTP 400 and not HTTP 500.

Ref: https://linear.app/prisma-company/issue/TML-1664/fix-incorrect-500-error-returned-from-qpe-instead-of-400

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Error handling for data-mapping now surfaces consistent, user-facing errors with a stable error code for unknown-enum read failures.
* **Tests**
  * Added a regression test plus supporting test matrix and schema to reproduce and verify the unknown-enum value read error (PostgreSQL-focused).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->