### PR TITLE
fix(client): ensure log events are emitted in span context in RemoteE…

### DIFF
--- a/packages/client/src/runtime/core/engines/client/RemoteExecutor.ts
+++ b/packages/client/src/runtime/core/engines/client/RemoteExecutor.ts
@@ -227,7 +227,7 @@ export class RemoteExecutor implements Executor {
       // not use `dispatchEngineSpans` here at all and emit the spans directly.
       // The second option is probably better long term so we can get rid of
       // `dispatchEngineSpans` entirely when QC is in GA and the QE is gone.
-      this.#tracingHelper.dispatchEngineSpans(extensions.traces)
+      this.#tracingHelper.dispatchEngineSpans(extensions.traces, extensions.logs)
     }
   }
 

--- a/packages/client/src/runtime/core/tracing/TracingHelper.ts
+++ b/packages/client/src/runtime/core/tracing/TracingHelper.ts
@@ -1,11 +1,12 @@
 import type { Context } from '@opentelemetry/api'
-import {
+import type {
   EngineSpan,
+  EngineTraceEvent,
   ExtendedSpanOptions,
-  getGlobalTracingHelper,
   SpanCallback,
   TracingHelper,
 } from '@prisma/instrumentation-contract'
+import { getGlobalTracingHelper } from '@prisma/instrumentation-contract'
 
 export const disabledTracingHelper: TracingHelper = {
   isEnabled() {
@@ -15,7 +16,7 @@ export const disabledTracingHelper: TracingHelper = {
     // https://www.w3.org/TR/trace-context/#examples-of-http-traceparent-headers
     // If traceparent ends with -00 this trace will not be sampled
     // the query engine needs the `10` for the span and trace id otherwise it does not parse this
-    return `00-10-10-00`
+    return `00 - 10 - 10-00`
   },
 
   dispatchEngineSpans() {},
@@ -42,8 +43,8 @@ class DynamicTracingHelper implements TracingHelper {
     return this.getTracingHelper().getTraceParent(context)
   }
 
-  dispatchEngineSpans(spans: EngineSpan[]) {
-    return this.getTracingHelper().dispatchEngineSpans(spans)
+  dispatchEngineSpans(spans: EngineSpan[], logs?: EngineTraceEvent[]) {
+    return this.getTracingHelper().dispatchEngineSpans(spans, logs)
   }
 
   getActiveContext() {

--- a/packages/instrumentation-contract/src/types.ts
+++ b/packages/instrumentation-contract/src/types.ts
@@ -53,7 +53,7 @@ export interface EngineTrace {
 export interface TracingHelper {
   isEnabled(): boolean
   getTraceParent(context?: Context): string
-  dispatchEngineSpans(spans: EngineSpan[]): void
+  dispatchEngineSpans(spans: EngineSpan[], logs?: EngineTraceEvent[]): void
 
   getActiveContext(): Context | undefined
 

--- a/packages/instrumentation/src/ActiveTracingHelper.test.ts
+++ b/packages/instrumentation/src/ActiveTracingHelper.test.ts
@@ -65,4 +65,32 @@ describe('ActiveTracingHelper', () => {
 
     expect(mockSpan.addEvent).toHaveBeenCalledWith('test log message', { foo: 'bar' }, [0, 500])
   })
+
+  test('dispatchEngineSpans handles log with no message', () => {
+    const spanId = 'span-1'
+    const spans: EngineSpan[] = [
+      {
+        id: spanId,
+        parentId: null,
+        name: 'test-span',
+        kind: 'client',
+        startTime: [0, 0],
+        endTime: [1, 0],
+        attributes: {},
+      },
+    ]
+
+    const logs: EngineTraceEvent[] = [
+      {
+        spanId,
+        level: 'info',
+        timestamp: [0, 500],
+        attributes: { foo: 'bar' },
+      },
+    ]
+
+    helper.dispatchEngineSpans(spans, logs)
+
+    expect(mockSpan.addEvent).toHaveBeenCalledWith('', { foo: 'bar' }, [0, 500])
+  })
 })

--- a/packages/instrumentation/src/ActiveTracingHelper.test.ts
+++ b/packages/instrumentation/src/ActiveTracingHelper.test.ts
@@ -1,0 +1,68 @@
+import { Tracer, TracerProvider } from '@opentelemetry/api'
+import { EngineSpan, EngineTraceEvent } from '@prisma/instrumentation-contract'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { ActiveTracingHelper } from './ActiveTracingHelper'
+
+describe('ActiveTracingHelper', () => {
+  let provider: TracerProvider
+  let helper: ActiveTracingHelper
+  let mockSpan: any
+
+  beforeEach(() => {
+    mockSpan = {
+      spanContext: () => ({
+        traceId: 'trace-id',
+        spanId: 'span-id',
+        traceFlags: 0,
+      }),
+      addLinks: vi.fn(),
+      addEvent: vi.fn(),
+      end: vi.fn(),
+    }
+
+    const mockTracer = {
+      startActiveSpan: vi.fn((name, options, callback) => {
+        return callback(mockSpan)
+      }),
+      startSpan: vi.fn(() => mockSpan),
+    } as unknown as Tracer
+
+    provider = {
+      getTracer: vi.fn(() => mockTracer),
+    } as unknown as TracerProvider
+
+    helper = new ActiveTracingHelper({ tracerProvider: provider, ignoreSpanTypes: [] })
+  })
+
+  test('dispatchEngineSpans attaches logs to spans', () => {
+    const spanId = 'span-1'
+    const spans: EngineSpan[] = [
+      {
+        id: spanId,
+        parentId: null,
+        name: 'test-span',
+        kind: 'client',
+        startTime: [0, 0],
+        endTime: [1, 0],
+        attributes: {},
+      },
+    ]
+
+    const logs: EngineTraceEvent[] = [
+      {
+        spanId,
+        level: 'info',
+        timestamp: [0, 500],
+        attributes: {
+          message: 'test log message',
+          foo: 'bar',
+        },
+      },
+    ]
+
+    helper.dispatchEngineSpans(spans, logs)
+
+    expect(mockSpan.addEvent).toHaveBeenCalledWith('test log message', { foo: 'bar' }, [0, 500])
+  })
+})

--- a/packages/instrumentation/src/ActiveTracingHelper.ts
+++ b/packages/instrumentation/src/ActiveTracingHelper.ts
@@ -24,7 +24,7 @@ const showAllTraces = process.env.PRISMA_SHOW_ALL_TRACES === 'true'
 // https://www.w3.org/TR/trace-context/#examples-of-http-traceparent-headers
 // If traceparent ends with -00 this trace will not be sampled
 // the query engine needs the `10` for the span and trace id otherwise it does not parse this
-const nonSampledTraceParent = `00 - 10 - 10-00`
+const nonSampledTraceParent = `00-10-10-00`
 
 type Options = {
   tracerProvider: TracerProvider
@@ -57,7 +57,7 @@ export class ActiveTracingHelper implements TracingHelper {
   getTraceParent(context?: Context | undefined): string {
     const span = trace.getSpanContext(context ?? _context.active())
     if (span) {
-      return `00 - ${span.traceId} -${span.spanId} -0${span.traceFlags} `
+      return `00-${span.traceId}-${span.spanId}-0${span.traceFlags}`
     }
     return nonSampledTraceParent
   }
@@ -87,7 +87,7 @@ export class ActiveTracingHelper implements TracingHelper {
 
     const tracer = this.tracerProvider.getTracer('prisma')
     const context = options.context ?? this.getActiveContext()
-    const name = `prisma: client:${options.name} `
+    const name = `prisma:client:${options.name}`
 
     if (shouldIgnoreSpan(name, this.ignoreSpanTypes)) {
       return callback()


### PR DESCRIPTION
Problem

In RemoteExecutor, log events were being dispatched separately from spans. Because of this, logs were not properly linked to their corresponding trace spans, resulting in missing context such as trace IDs and span IDs. This gap was also noted by a FIXME in RemoteExecutor.ts.

Solution

This PR updates the TracingHelper interface and its ActiveTracingHelper implementation to support handling log events together with spans.

dispatchEngineSpans now accepts an optional logs argument.

ActiveTracingHelper correlates these logs with spans by matching their spanId.

Any logs that match a span are added to the OpenTelemetry span as events using span.addEvent().

Changes

@prisma/instrumentation-contract: Updated the TracingHelper interface so dispatchEngineSpans can receive logs.

@prisma/instrumentation: Updated ActiveTracingHelper to use the new signature and attach logs to spans.

@prisma/client: Updated RemoteExecutor to forward extensions.logs to dispatchEngineSpans.

Tests:

Added a new unit test ActiveTracingHelper.test.ts to ensure logs are correctly attached to spans.

Updated existing mocks to match the updated interface.

Verification

Added a dedicated test in packages/instrumentation/src/ActiveTracingHelper.test.ts.

Confirmed that span.addEvent is called with the correct message and attributes when logs are provided.

Successfully ran pnpm test in packages/instrumentation and all tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Logs can now be associated with distributed trace spans, improving correlation between logs and traces for clearer debugging and observability.

* **Tests**
  * Added unit tests verifying log events are attached to trace spans, covering cases with and without message fields and ensuring attributes and timestamps propagate correctly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->