### PR TITLE
fix: isolate sqlcommenter plugins from each other

### DIFF
--- a/packages/client-engine-runtime/package.json
+++ b/packages/client-engine-runtime/package.json
@@ -31,6 +31,7 @@
     "@prisma/debug": "workspace:*",
     "@prisma/driver-adapter-utils": "workspace:*",
     "@prisma/sqlcommenter": "workspace:*",
+    "klona": "2.0.6",
     "nanoid": "5.1.5",
     "ulid": "3.0.0",
     "uuid": "11.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -953,6 +953,9 @@ importers:
       '@prisma/sqlcommenter':
         specifier: workspace:*
         version: link:../sqlcommenter
+      klona:
+        specifier: 2.0.6
+        version: 2.0.6
       nanoid:
         specifier: 5.1.5
         version: 5.1.5


### PR DESCRIPTION
Make sure one sqcommenter plugin can't poison the context passed to all subsequent ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests validating SQL commenter context isolation and immutability across top-level, deeply nested properties, and arrays for both single and compacted queries.

* **Bug Fixes**
  * Ensure each plugin receives an isolated copy of the SQL commenter context so mutations in one plugin do not affect others or shared state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->