### PR TITLE
fix(client): mapped enums

### DIFF
--- a/packages/client-generator-ts/src/TSClient/Enum.ts
+++ b/packages/client-generator-ts/src/TSClient/Enum.ts
@@ -22,7 +22,7 @@ export class Enum {
     const { type } = this
 
     const enumVariants = `{
-${indent(type.data.map((v) => `${v.key}: ${this.getValue(v.value)}`).join(',\n'), TAB_SIZE)}
+${indent(type.data.map((v) => `${v.key}: ${this.getValue(v.key)}`).join(',\n'), TAB_SIZE)}
 } as const`
     const enumBody = this.isStrictEnum() ? `runtime.makeStrictEnum(${enumVariants})` : enumVariants
 

--- a/packages/client-generator-ts/src/TSClient/Enum.ts
+++ b/packages/client-generator-ts/src/TSClient/Enum.ts
@@ -22,7 +22,7 @@ export class Enum {
     const { type } = this
 
     const enumVariants = `{
-${indent(type.data.map((v) => `${v.key}: ${this.getValue(v.key)}`).join(',\n'), TAB_SIZE)}
+${indent(type.data.map((v) => `${v.key}: ${this.getValue(v.value)}`).join(',\n'), TAB_SIZE)}
 } as const`
     const enumBody = this.isStrictEnum() ? `runtime.makeStrictEnum(${enumVariants})` : enumVariants
 

--- a/packages/client/tests/functional/issues/28591-mapped-enums/_matrix.ts
+++ b/packages/client/tests/functional/issues/28591-mapped-enums/_matrix.ts
@@ -1,0 +1,10 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+import { Providers } from '../../_utils/providers'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: Providers.POSTGRESQL,
+    },
+  ],
+])

--- a/packages/client/tests/functional/issues/28591-mapped-enums/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/28591-mapped-enums/prisma/_schema.ts
@@ -1,0 +1,30 @@
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+    generator client {
+      provider = "prisma-client-js"
+    }
+
+    datasource db {
+      provider = "${provider}"
+    }
+
+    enum SuggestionStatus {
+      PENDING  @map("pending")
+      ACCEPTED @map("accepted")
+      REJECTED @map("rejected")
+
+      @@map("SuggestionStatus")
+    }
+
+    model SuggestionModel {
+      id                 Int              @id @default(autoincrement())
+      suggestedContent   String           @map("suggested_content")
+      status             SuggestionStatus @default(PENDING)
+
+      @@index([status])
+      @@map("snippet_suggestions")
+    }
+  `
+})

--- a/packages/client/tests/functional/issues/28591-mapped-enums/test.ts
+++ b/packages/client/tests/functional/issues/28591-mapped-enums/test.ts
@@ -1,0 +1,26 @@
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(
+  () => {
+    test('create with mapped enum', async () => {
+      const enrichment = await prisma.suggestionModel.create({
+        data: {
+          suggestedContent: 'some content',
+          status: 'PENDING',
+        },
+      })
+
+      expect(enrichment.status).toBe('PENDING')
+    })
+  },
+  {
+    optOut: {
+      from: ['sqlite', 'mysql', 'mongodb', 'cockroachdb', 'sqlserver'],
+      reason: 'Issue reported for Postgres, keeping it focused.',
+    },
+  },
+)

--- a/packages/client/tests/functional/issues/28591-mapped-enums/test.ts
+++ b/packages/client/tests/functional/issues/28591-mapped-enums/test.ts
@@ -1,16 +1,52 @@
 import testMatrix from './_matrix'
 // @ts-ignore
-import type { PrismaClient } from './generated/prisma/client'
+import type * as imports from './generated/prisma/client'
 
-declare let prisma: PrismaClient
+declare let prisma: imports.PrismaClient
+declare let loaded: {
+  SuggestionStatus: typeof imports.SuggestionStatus
+}
 
 testMatrix.setupTestSuite(
   () => {
     test('create with mapped enum', async () => {
+      const { SuggestionStatus } = loaded
+
+      expect(SuggestionStatus.PENDING).toBe('pending')
+
+      /**
+      Currently, this fails with:
+
+      ```
+      PrismaClientValidationError: 
+      Invalid `prisma.suggestionModel.create()` invocation in
+      /Users/jkomyno/work/prisma/prisma/packages/client/tests/functional/issues/28591-mapped-enums/test.ts:17:55
+
+        14 
+        15 expect(SuggestionStatus.PENDING).toBe('pending')
+        16 
+      → 17 const enrichment = await prisma.suggestionModel.create({
+            data: {
+              suggestedContent: "some content",
+              status: "pending"
+                      ~~~~~~~~~
+            }
+          })
+
+      Invalid value for argument `status`. Expected SuggestionStatus.
+
+        44 |   })
+        45 |
+      > 46 |   throw new PrismaClientValidationError(messageWithContext, { clientVersion })
+          |         ^
+        47 | }
+        48 |
+      ```
+       */
       const enrichment = await prisma.suggestionModel.create({
         data: {
           suggestedContent: 'some content',
-          status: 'PENDING',
+          status: SuggestionStatus.PENDING, // evaluates to "pending" - causes runtime error
         },
       })
 


### PR DESCRIPTION
**draft**

This PR:
- closes https://github.com/prisma/prisma/issues/28591
- adds a new functional test, `issues/28591-mapped-enums`
  - before the commits that implemented the fix, the test would fail with:
    ```
      ● typescript › issues.28591-mapped-enums.test (provider=postgresql, js_pg)/test.ts
    
        assert.fail(received, expected)
    
        Message:
          Type '"PENDING"' is not assignable to type 'SuggestionStatus | undefined'. Did you mean '"pending"'? At: tests/functional/issues/28591-mapped-enums/.generated/issues.28591-mapped-enums.test (provider=postgresql, js_pg)/test.ts:13:11
    
          70 |     for (const checkPath of keys(suiteChecks)) {
          71 |       if (checkPath.includes(path.dirname(suiteFilePath))) {
        > 72 |         assert.fail(suiteChecks[checkPath])
             |                ^
          73 |       }
          74 |     }
          75 |   })
    
          at typescript/tests.ts:72:16
    ```

/integration