### PR TITLE
fix: remove pool param for studio ppg connections

### DIFF
--- a/packages/cli/src/Studio.ts
+++ b/packages/cli/src/Studio.ts
@@ -73,6 +73,7 @@ const PRISMA_ORM_SPECIFIC_QUERY_PARAMETERS = [
   'pool_timeout',
   'sslidentity',
   'sslaccept',
+  'pool', // Using connection pooling with `postgres` package is unable to connect to PPG. Disabling it for now by removing the param. See https://linear.app/prisma-company/issue/TML-1670.
   'socket_timeout',
   'pgbouncer',
   'statement_cache_size',


### PR DESCRIPTION
In Studio CLI the issue is that when using the pool query parameter the underlying postgres npm package is not able to connect to ppg. Even when using the plain postgres package with a ppg url I get the error of:

```
PostgresError: Failed to connect to upstream database. Please contact Prisma support if the problem persists.
```

This PR works around this issue by ensuring an unpooled connection string to ppg.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Postgres database connection stability by refining connection parameter configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->