### PR TITLE
fix(client): fix tracing tests failing with QPE

### DIFF
--- a/packages/client/src/runtime/core/engines/client/RemoteExecutor.ts
+++ b/packages/client/src/runtime/core/engines/client/RemoteExecutor.ts
@@ -219,7 +219,7 @@ export class RemoteExecutor implements Executor {
         this.#emitLogEvent(log)
       }
     }
-    if (extensions.traces) {
+    if (extensions.spans) {
       // FIXME: log events should be emitted in the context of the corresponding
       // spans to be consistent with the normal `ClientEngine` behavior. Our
       // current `TracingHelper` interface makes it challenging to do so.
@@ -227,7 +227,7 @@ export class RemoteExecutor implements Executor {
       // not use `dispatchEngineSpans` here at all and emit the spans directly.
       // The second option is probably better long term so we can get rid of
       // `dispatchEngineSpans` entirely when QC is in GA and the QE is gone.
-      this.#tracingHelper.dispatchEngineSpans(extensions.traces)
+      this.#tracingHelper.dispatchEngineSpans(extensions.spans)
     }
   }
 

--- a/packages/client/src/runtime/core/engines/common/types/QueryEngine.ts
+++ b/packages/client/src/runtime/core/engines/common/types/QueryEngine.ts
@@ -69,7 +69,7 @@ export type QueryEngineBatchResult<T> = WithErrorsAndResultExtensions<{
 
 export type QueryEngineResultExtensions = {
   logs?: EngineTraceEvent[]
-  traces?: EngineSpan[]
+  spans?: EngineSpan[]
 }
 
 export type QueryEngineBatchRequest = QueryEngineBatchGraphQLRequest | JsonBatchQuery

--- a/packages/client/tests/functional/_utils/qpe-worker-entry.cjs
+++ b/packages/client/tests/functional/_utils/qpe-worker-entry.cjs
@@ -1,0 +1,9 @@
+// CommonJS wrapper to load qpe-worker.ts via tsx.
+// This is needed because Node.js 20 doesn't recognize .ts/.mts extensions when spawning workers,
+// even with --import tsx in execArgv. Using a .cjs entry point with tsx registration
+// works reliably across Node.js versions.
+
+'use strict'
+
+require('tsx')
+require('./qpe-worker.ts')

--- a/packages/client/tests/functional/_utils/qpe-worker.ts
+++ b/packages/client/tests/functional/_utils/qpe-worker.ts
@@ -1,4 +1,5 @@
 import events from 'node:events'
+import { promisify } from 'node:util'
 import { type MessagePort, parentPort } from 'node:worker_threads'
 
 import { serve, type ServerType } from '@hono/node-server'
@@ -118,8 +119,8 @@ async function handleStart(message: QpeWorkerStartMessage): Promise<QpeWorkerRea
 
 async function handleShutdown(): Promise<QpeWorkerShutdownResponse> {
   if (server) {
-    server.net.close()
-    await server.qpe.shutdown()
+    const closeNetServer = promisify(server.net.close.bind(server.net))
+    await Promise.all([closeNetServer(), server.qpe.shutdown()])
     server = undefined
   }
 

--- a/packages/client/tests/functional/_utils/qpe-worker.ts
+++ b/packages/client/tests/functional/_utils/qpe-worker.ts
@@ -1,0 +1,127 @@
+import events from 'node:events'
+import { type MessagePort, parentPort } from 'node:worker_threads'
+
+import { serve, type ServerType } from '@hono/node-server'
+import { context, trace } from '@opentelemetry/api'
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks'
+import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base'
+import type { Server } from '@prisma/query-plan-executor'
+
+context.setGlobalContextManager(new AsyncLocalStorageContextManager())
+trace.setGlobalTracerProvider(new BasicTracerProvider())
+
+export interface QpeWorkerStartMessage {
+  type: 'start'
+  databaseUrl: string
+}
+
+export interface QpeWorkerShutdownMessage {
+  type: 'shutdown'
+}
+
+export type QpeWorkerMessage = QpeWorkerStartMessage | QpeWorkerShutdownMessage
+
+export interface QpeWorkerReadyResponse {
+  type: 'ready'
+  hostname: string
+  port: number
+}
+
+export interface QpeWorkerShutdownResponse {
+  type: 'shutdown-complete'
+}
+
+export interface QpeWorkerErrorResponse {
+  type: 'error'
+  message: string
+}
+
+export type QpeWorkerResponse = QpeWorkerReadyResponse | QpeWorkerShutdownResponse | QpeWorkerErrorResponse
+
+if (!parentPort) {
+  throw new Error('This script must be run as a worker thread')
+}
+
+parentPort.on('message', (message: QpeWorkerMessage) => void handleMessage(parentPort!, message))
+
+let server: { qpe: Server; net: ServerType } | undefined
+
+async function handleMessage(port: MessagePort, message: QpeWorkerMessage): Promise<void> {
+  try {
+    let response: QpeWorkerResponse
+
+    switch (message.type) {
+      case 'start':
+        response = await handleStart(message)
+        break
+
+      case 'shutdown':
+        response = await handleShutdown()
+        break
+
+      default:
+        response = {
+          type: 'error',
+          message: `Unknown message type: ${(message satisfies never as { type: string }).type}`,
+        }
+        break
+    }
+
+    port.postMessage(response)
+  } catch (error) {
+    port.postMessage({
+      type: 'error',
+      message: error instanceof Error ? error.message : String(error),
+    } satisfies QpeWorkerErrorResponse)
+  }
+}
+
+async function handleStart(message: QpeWorkerStartMessage): Promise<QpeWorkerReadyResponse> {
+  // It should only be imported after initializing OpenTelemetry
+  const { Server, parseSize, parseDuration } = await import('@prisma/query-plan-executor')
+
+  const qpe = await Server.create({
+    databaseUrl: message.databaseUrl,
+    maxResponseSize: parseSize('128 MiB'),
+    queryTimeout: parseDuration('PT30S'),
+    maxTransactionTimeout: parseDuration('PT1M'),
+    maxTransactionWaitTime: parseDuration('PT1M'),
+    perRequestLogContext: {
+      logFormat: 'text',
+      logLevel: 'warn',
+    },
+  })
+
+  const hostname = '127.0.0.1'
+
+  const net = serve({
+    fetch: qpe.fetch,
+    hostname,
+    port: 0,
+  })
+
+  await events.once(net, 'listening')
+  const address = net.address()
+
+  if (address === null) {
+    throw new Error('query plan executor server did not start')
+  }
+
+  if (typeof address === 'string') {
+    throw new Error('query plan executor must be listening on TCP and not Unix socket')
+  }
+
+  server = { qpe, net }
+
+  return { type: 'ready', hostname, port: address.port }
+}
+
+async function handleShutdown(): Promise<QpeWorkerShutdownResponse> {
+  if (server) {
+    server.net.close()
+    await server.qpe.shutdown()
+    server = undefined
+  }
+
+  return { type: 'shutdown-complete' }
+}

--- a/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
@@ -136,10 +136,15 @@ function setupTestSuiteMatrix(
 
             qpeWorker!.once('message', (response: QpeWorkerResponse) => {
               clearTimeout(timeoutId)
-              if (response.type === 'ready') {
-                resolve(response)
-              } else if (response.type === 'error') {
-                reject(new Error(response.message))
+              switch (response.type) {
+                case 'ready':
+                  resolve(response)
+                  break
+                case 'error':
+                  reject(new Error(response.message))
+                  break
+                default:
+                  reject(new Error(`Unexpected response type: ${response.type}`))
               }
             })
 
@@ -255,10 +260,15 @@ function setupTestSuiteMatrix(
 
               new Promise<void>((resolve, reject) => {
                 qpeWorker!.once('message', (response: QpeWorkerResponse) => {
-                  if (response.type === 'shutdown-complete') {
-                    resolve()
-                  } else if (response.type === 'error') {
-                    reject(new Error(response.message))
+                  switch (response.type) {
+                    case 'shutdown-complete':
+                      resolve()
+                      break
+                    case 'error':
+                      reject(new Error(response.message))
+                      break
+                    default:
+                      reject(new Error(`Unexpected response type: ${response.type}`))
                   }
                 })
 

--- a/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
@@ -128,8 +128,10 @@ function setupTestSuiteMatrix(
           const qpeStartupTimeoutMs = 10_000
 
           const { hostname, port } = await new Promise<QpeWorkerReadyResponse>((resolve, reject) => {
-            const timeoutId = setTimeout(async () => {
-              await qpeWorker!.terminate()
+            const timeoutId = setTimeout(() => {
+              void qpeWorker!
+                .terminate()
+                .catch((err) => console.error('Error terminating QPE worker due to startup timeout:', err))
               qpeWorker = undefined
               reject(new Error(`QPE worker startup timed out after ${qpeStartupTimeoutMs}ms`))
             }, qpeStartupTimeoutMs).unref()

--- a/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
+++ b/packages/client/tests/functional/_utils/setupTestSuiteMatrix.ts
@@ -125,7 +125,7 @@ function setupTestSuiteMatrix(
         if (clientMeta.clientEngineExecutor === 'remote') {
           qpeWorker = new Worker(path.join(__dirname, 'qpe-worker-entry.cjs'))
 
-          const qpeStartupTimeoutMs = 10_000
+          const qpeStartupTimeoutMs = 60_000
 
           const { hostname, port } = await new Promise<QpeWorkerReadyResponse>((resolve, reject) => {
             const timeoutId = setTimeout(() => {
@@ -258,7 +258,7 @@ function setupTestSuiteMatrix(
         if (qpeWorker) {
           try {
             await Promise.race([
-              timers.setTimeout(3000, undefined, { ref: false }),
+              timers.setTimeout(5000, undefined, { ref: false }),
 
               new Promise<void>((resolve, reject) => {
                 qpeWorker!.once('message', (response: QpeWorkerResponse) => {

--- a/packages/client/tests/functional/tracing-filtered-spans/tests.ts
+++ b/packages/client/tests/functional/tracing-filtered-spans/tests.ts
@@ -36,10 +36,10 @@ beforeAll(() => {
     instrumentations: [
       new PrismaInstrumentation({
         ignoreSpanTypes: [
-          'prisma:engine:connection',
           /prisma:client:operat.*/,
           'prisma:client:compile',
           'prisma:client:db_query',
+          'prisma:accelerate:db_query',
         ],
       }),
     ],

--- a/packages/query-plan-executor/src/logic/app.ts
+++ b/packages/query-plan-executor/src/logic/app.ts
@@ -132,15 +132,15 @@ export class App {
   /**
    * Commits a transaction.
    */
-  async commitTransaction(transactionId: string): Promise<void> {
-    return await this.#transactionManager.commitTransaction(transactionId)
+  commitTransaction(transactionId: string): Promise<void> {
+    return this.#transactionManager.commitTransaction(transactionId)
   }
 
   /**
    * Rolls back a transaction.
    */
-  async rollbackTransaction(transactionId: string): Promise<void> {
-    return await this.#transactionManager.rollbackTransaction(transactionId)
+  rollbackTransaction(transactionId: string): Promise<void> {
+    return this.#transactionManager.rollbackTransaction(transactionId)
   }
 
   /**

--- a/packages/query-plan-executor/src/tracing/handler.test.ts
+++ b/packages/query-plan-executor/src/tracing/handler.test.ts
@@ -31,7 +31,7 @@ describe('TracingHandler', () => {
 
     // Verify a span was collected
     expect(collector.spans.length).toEqual(1)
-    expect(collector.spans[0].name).toEqual('prisma:engine:test-operation')
+    expect(collector.spans[0].name).toEqual('prisma:accelerate:test-operation')
   })
 
   test('runInChildSpan with options object', () => {
@@ -59,7 +59,7 @@ describe('TracingHandler', () => {
     // Verify a span was collected with the expected attributes
     expect(collector.spans.length).toEqual(1)
     const collectedSpan = collector.spans[0]
-    expect(collectedSpan.name).toEqual('prisma:engine:test-operation')
+    expect(collectedSpan.name).toEqual('prisma:accelerate:test-operation')
     expect(collectedSpan.attributes).toBeDefined()
     expect(collectedSpan.attributes!['test.key']).toEqual('test.value')
     expect(collectedSpan.attributes!['another.key']).toEqual('another.value')
@@ -81,7 +81,7 @@ describe('TracingHandler', () => {
 
     // Verify a span was collected
     expect(collector.spans.length).toEqual(1)
-    expect(collector.spans[0].name).toEqual('prisma:engine:async-operation')
+    expect(collector.spans[0].name).toEqual('prisma:accelerate:async-operation')
   })
 
   test('runs without active collector', () => {
@@ -117,7 +117,7 @@ describe('TracingHandler', () => {
 
     // Verify a span was collected despite the error
     expect(collector.spans.length).toEqual(1)
-    expect(collector.spans[0].name).toEqual('prisma:engine:error-operation')
+    expect(collector.spans[0].name).toEqual('prisma:accelerate:error-operation')
   })
 
   test('handles errors in async functions', async () => {
@@ -142,7 +142,7 @@ describe('TracingHandler', () => {
 
     // Verify a span was collected despite the error
     expect(collector.spans.length).toEqual(1)
-    expect(collector.spans[0].name).toEqual('prisma:engine:async-error-operation')
+    expect(collector.spans[0].name).toEqual('prisma:accelerate:async-error-operation')
   })
 
   test('nested spans create parent-child relationship', () => {
@@ -170,8 +170,8 @@ describe('TracingHandler', () => {
 
     // Verify the child has the parent ID
     expect(spans[0].parentId).toEqual(parentId)
-    expect(spans[0].name).toEqual('prisma:engine:child-operation')
-    expect(spans[1].name).toEqual('prisma:engine:parent-operation')
+    expect(spans[0].name).toEqual('prisma:accelerate:child-operation')
+    expect(spans[1].name).toEqual('prisma:accelerate:parent-operation')
   })
 
   test('root option creates spans without parent', () => {
@@ -198,7 +198,7 @@ describe('TracingHandler', () => {
     expect(collector.spans.length).toEqual(2)
 
     // Find the root span
-    const rootSpan = collector.spans.find((span) => span.name === 'prisma:engine:root-operation')
+    const rootSpan = collector.spans.find((span) => span.name === 'prisma:accelerate:root-operation')
 
     // Verify it has no parent
     expect(rootSpan).toBeDefined()
@@ -217,7 +217,7 @@ describe('TracingHandler', () => {
 
       expect(collector.spans.length).toEqual(1)
 
-      const rootSpan = collector.spans.find((span) => span.name === 'prisma:engine:root-operation')
+      const rootSpan = collector.spans.find((span) => span.name === 'prisma:accelerate:root-operation')
 
       expect(rootSpan).toBeDefined()
       expect(rootSpan!.parentId).toEqual(null)

--- a/packages/query-plan-executor/src/tracing/integration.test.ts
+++ b/packages/query-plan-executor/src/tracing/integration.test.ts
@@ -56,9 +56,9 @@ test('full flow with nested spans and context', async () => {
   expect(collector.spans.length).toEqual(3)
 
   // Find each span by name
-  const processSpan = collector.spans.find((s) => s.name === 'prisma:engine:process-data')
-  const parseSpan = collector.spans.find((s) => s.name === 'prisma:engine:parse-data')
-  const transformSpan = collector.spans.find((s) => s.name === 'prisma:engine:transform-data')
+  const processSpan = collector.spans.find((s) => s.name === 'prisma:accelerate:process-data')
+  const parseSpan = collector.spans.find((s) => s.name === 'prisma:accelerate:parse-data')
+  const transformSpan = collector.spans.find((s) => s.name === 'prisma:accelerate:transform-data')
 
   // Verify all spans exist
   expect(processSpan).toBeDefined()
@@ -223,9 +223,9 @@ test('handles errors correctly', async () => {
   expect(collector.spans.length).toEqual(3)
 
   // All spans should be recorded despite the error
-  expect(collector.spans.find((s) => s.name === 'prisma:engine:process-broken-data')).toBeDefined()
-  expect(collector.spans.find((s) => s.name === 'prisma:engine:first-step')).toBeDefined()
-  expect(collector.spans.find((s) => s.name === 'prisma:engine:error-step')).toBeDefined()
+  expect(collector.spans.find((s) => s.name === 'prisma:accelerate:process-broken-data')).toBeDefined()
+  expect(collector.spans.find((s) => s.name === 'prisma:accelerate:first-step')).toBeDefined()
+  expect(collector.spans.find((s) => s.name === 'prisma:accelerate:error-step')).toBeDefined()
 
   // ----- VERIFY OPENTELEMETRY SPANS -----
 

--- a/packages/query-plan-executor/src/tracing/span.test.ts
+++ b/packages/query-plan-executor/src/tracing/span.test.ts
@@ -109,7 +109,7 @@ describe('SpanProxy', () => {
     const exported = proxy.endAndExport(endTime)
 
     // Verify the exported span
-    expect(exported.name).toEqual(`prisma:engine:${TEST_NAME}`)
+    expect(exported.name).toEqual(`prisma:accelerate:${TEST_NAME}`)
     expect(exported.kind).toEqual('client')
     expect(exported.id).toBeDefined()
     expect(exported.parentId).toBeDefined()
@@ -143,7 +143,7 @@ describe('SpanProxy', () => {
     const exported = proxy.endAndExport(now)
 
     // Verify the exported span
-    expect(exported.name).toEqual(`prisma:engine:${TEST_NAME}`)
+    expect(exported.name).toEqual(`prisma:accelerate:${TEST_NAME}`)
     expect(exported.kind).toEqual('internal') // Default value
     expect(exported.id).toBeDefined()
     expect(exported.parentId).toEqual(null)

--- a/packages/query-plan-executor/src/tracing/span.ts
+++ b/packages/query-plan-executor/src/tracing/span.ts
@@ -142,7 +142,7 @@ export class SpanProxy implements Span {
       parentId,
       attributes,
       links,
-      name: `prisma:engine:${this.#name}`,
+      name: `prisma:accelerate:${this.#name}`,
       kind: serializeSpanKind(this.#kind),
       startTime: this.#startTime,
       endTime: instantToHrTime(endTime),


### PR DESCRIPTION
This PR fixes tracing tests broken with QPE for three reasons:

1. The mismatch between the expected and actual field names (`traces` vs `spans`) in the result extensions. `RemoteExecutor` used the outdated name previously used by QE, not the new one used by QPE.
2. Functional tests started the QPE server in the same Node.js process, which led to internal (non-exported) QPE spans being picked up by the `SpanProcessor` set up in tests. This PR isolates the QPE server in a worker thread.
3. QPE had unnecessary extra spans created at the top level in `app.ts`, although they are already created by `QueryInterpreter` and `Transactionmanager`, which led to duplicate spans (i.e. `db_query` within `db_query`, `start_transaction` within `span_transaction` etc).

Additionally, this change renames the QPE span to have `prisma:accelerate:` prefix instead of `prisma:engine:`.

Closes https://linear.app/prisma-company/issue/TML-1395/fix-missing-spans-in-tracing-tests-with-qcaccelerate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test infrastructure now runs the query-plan executor in a worker for improved isolation and Node 20 compatibility.

* **Tests**
  * Standardized telemetry span names to the new accelerate prefix.
  * Span filtering updated so different spans are now captured or suppressed, affecting which spans appear in traces.

* **Refactor**
  * Removed redundant tracing wrappers around core executor methods.
  * Engine events are now dispatched as spans instead of traces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->