### PR TITLE
ci: allow publishing with custom NPM tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,9 @@ on:
       forceIntegrationRelease:
         description: 'Check to force an integration release for any given branch name'
         type: boolean
+      skipNpmTag:
+        description: 'If set, the NPM release will be published without a tag'
+        type: boolean
 
 env:
   # To hide "Update available 0.0.0 -> x.x.x"
@@ -53,6 +56,7 @@ env:
   ONLY_PACKAGES: ${{ github.event.inputs.onlyPackages }}
   DRY_RUN: ${{ github.event.inputs.dryRun || 'false' }}
   FORCE_INTEGRATION_RELEASE: ${{ github.event.inputs.forceIntegrationRelease || 'false' }}
+  SKIP_NPM_TAG: ${{ github.event.inputs.skipNpmTag || 'false' }}
 
   FAILURE_TITLE_TEMPLATE: >-
     ${{

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,9 +42,9 @@ on:
       forceIntegrationRelease:
         description: 'Check to force an integration release for any given branch name'
         type: boolean
-      skipNpmTag:
-        description: 'If set, the NPM release will be published without a tag'
-        type: boolean
+      customDistTag:
+        description: 'Custom dist tag to publish to (e.g. `prev`)'
+        type: string
 
 env:
   # To hide "Update available 0.0.0 -> x.x.x"
@@ -56,7 +56,7 @@ env:
   ONLY_PACKAGES: ${{ github.event.inputs.onlyPackages }}
   DRY_RUN: ${{ github.event.inputs.dryRun || 'false' }}
   FORCE_INTEGRATION_RELEASE: ${{ github.event.inputs.forceIntegrationRelease || 'false' }}
-  SKIP_NPM_TAG: ${{ github.event.inputs.skipNpmTag || 'false' }}
+  CUSTOM_DIST_TAG: ${{ github.event.inputs.customDistTag || '' }}
 
   FAILURE_TITLE_TEMPLATE: >-
     ${{

--- a/scripts/ci/publish.ts
+++ b/scripts/ci/publish.ts
@@ -462,7 +462,7 @@ async function publish() {
     '--dry-run': Boolean,
     '--release': String, // TODO What does that do? Can we remove this? probably
     '--test': Boolean,
-    '--skip-npm-tag': Boolean,
+    '--custom-dist-tag': String,
   })
 
   if (!process.env.GITHUB_REF_NAME) {
@@ -487,8 +487,8 @@ async function publish() {
     // and then replace the args['--release'] with it
   }
 
-  if (process.env.SKIP_NPM_TAG === 'true') {
-    args['--skip-npm-tag'] = true
+  if (process.env.CUSTOM_DIST_TAG) {
+    args['--custom-dist-tag'] = process.env.CUSTOM_DIST_TAG
   }
 
   if (!args['--test'] && !args['--publish'] && !dryRun) {
@@ -558,8 +558,9 @@ async function publish() {
     tag = 'dev'
   }
 
-  if (args['--skip-npm-tag']) {
-    tag = undefined
+  if (args['--custom-dist-tag']) {
+    console.log(`Using custom dist tag: ${args['--custom-dist-tag']}`)
+    tag = args['--custom-dist-tag']
   }
 
   console.log({
@@ -592,8 +593,8 @@ async function publish() {
       }
       const passing = await areEcosystemTestsPassing(tagForEcosystemTestsCheck)
       if (!passing && process.env.SKIP_ECOSYSTEMTESTS_CHECK !== 'true') {
-        throw new Error(`We can't release, as the ecosystem-tests are not passing for the ${tag ?? 'N/A'} npm tag!
-Check them out at https://github.com/prisma/ecosystem-tests/actions?query=workflow%3Atest`)
+        throw new Error(`We can't release, as the ecosystem-tests are not passing for the ${tag} npm tag!
+Check them out at https://github.com/prisma/ecosystem-tests/actions?query=workflow%3Atest+branch%3A${tag}`)
       }
     }
 
@@ -704,7 +705,7 @@ async function publishPackages(
   publishOrder: string[][],
   dryRun: boolean,
   prismaVersion: string,
-  tag?: string,
+  tag: string,
   releaseVersion?: string,
 ): Promise<void> {
   // we need to release a new `prisma` CLI in all cases.
@@ -769,7 +770,7 @@ async function publishPackages(
 
       const newVersion = prismaVersion
 
-      console.log(`\nPublishing ${magenta(`${pkgName}@${newVersion}`)}${tag ? dim(` on ${tag}`) : ''}`)
+      console.log(`\nPublishing ${magenta(`${pkgName}@${newVersion}`)} ${dim(`on ${tag}`)}`)
 
       // Why is this needed?
       // Was introduced in the first version of this script on Apr 14, 2020
@@ -812,7 +813,7 @@ async function publishPackages(
          *  - Your working directory is clean (there are no uncommitted changes).
          *  - The branch is up-to-date.
          */
-        await run(pkgDir, `pnpm publish --no-git-checks --access public${tag ? ` --tag ${tag}` : ''}`, dryRun)
+        await run(pkgDir, `pnpm publish --no-git-checks --access public --tag ${tag}`, dryRun)
       }
     }
   }


### PR DESCRIPTION
[TML-1637](https://linear.app/prisma-company/issue/TML-1637/modify-release-workflow-to-support-prisma-6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a custom distribution tag during release, allowing explicit control over the publish tag.

* **Chores**
  * Release workflow updated to accept and propagate a custom dist-tag input.
  * Publishing flow now reads the custom tag input and applies it to the publish step, with clearer logging of the chosen tag.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->