### PR TITLE
ci: backport release CI changes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,7 +7,7 @@ on:
       - '*.*.x'
     paths-ignore:
       # Any update here needs to be done for `pull_request` (see below) and all files
-      # (test.yml, benchmark.yml, release-ci.yml, bundle-size.yml, ci-aux-files.yml)
+      # (test.yml, benchmark.yml, release.yml, bundle-size.yml, ci-aux-files.yml)
       - '*.md'
       # - '*.bench.ts' -> should not be ignored in this workflow
       - 'LICENSE'
@@ -23,7 +23,7 @@ on:
   pull_request:
     paths-ignore:
       # Any update here needs to be done for `branches` (see above) and all files
-      # (test.yml, benchmark.yml, release-ci.yml, bundle-size.yml, ci-aux-files.yml)
+      # (test.yml, benchmark.yml, release.yml, bundle-size.yml, ci-aux-files.yml)
       - '*.md'
       # - '*.bench.ts' -> should not be ignored in this workflow
       - 'LICENSE'

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths-ignore:
       # Any update here needs to be done for all files
-      # (test.yml, benchmark.yml, release-ci.yml, bundle-size.yml, ci-aux-files.yml)
+      # (test.yml, benchmark.yml, release.yml, bundle-size.yml, ci-aux-files.yml)
       - '*.md'
       - '*.bench.ts'
       - 'LICENSE'

--- a/.github/workflows/ci-aux-files.yml
+++ b/.github/workflows/ci-aux-files.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       # Any update here needs to be done for all files
-      # (test.yml, benchmark.yml, release-ci.yml, bundle-size.yml, ci-aux-files.yml)
+      # (test.yml, benchmark.yml, release.yml, bundle-size.yml, ci-aux-files.yml)
       - '*.md'
       - '*.bench.ts'
       - 'LICENSE'

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -9,7 +9,7 @@ on:
       - '*.*.x'
     paths-ignore:
       # Any update here needs to be done for all files
-      # (test.yml, benchmark.yml, release-ci.yml, bundle-size.yml, ci-aux-files.yml)
+      # (test.yml, benchmark.yml, release.yml, bundle-size.yml, ci-aux-files.yml)
       - '*.md'
       - '*.bench.ts'
       - 'LICENSE'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,51 +1,88 @@
-name: npm - release to latest
-run-name: npm - release ${{ github.event.inputs.targetVersion }} from ${{ github.ref_name }} on latest tag
+name: npm - release
 
 on:
+  push:
+    branches:
+      - main
+      - 'integration/*'
+      - '*.*.x'
+    paths-ignore:
+      # Any update here needs to be done for all files
+      # (test.yml, benchmark.yml, release.yml, bundle-size.yml, ci-aux-files.yml)
+      - '*.md'
+      - '*.bench.ts'
+      - 'LICENSE'
+      - '.dockerignore'
+      # - 'scripts/ci/publish.ts' -> should not be ignored in this workflow
+      - '.github/CODEOWNERS'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/DISCUSSION_TEMPLATE/**'
+      - '.devcontainer/**'
+      - '.vscode/**'
+      - 'graphs/**'
+      - 'sandbox/**'
+
   workflow_dispatch:
     inputs:
       targetVersion:
         description: 'Version to publish on latest tag (e.g. 5.0.0)'
         type: string
-        required: true
       skipEcosystemTestsChecks:
         description: 'Skip ecosystem tests checks'
         type: boolean
       skipPackages:
         description: 'Skip publishing some packages? (e.g. `@prisma/debug,@prisma/internals`)'
         type: string
-        required: false
       onlyPackages:
         description: 'Only publish some packages? (e.g. `@prisma/debug,@prisma/internals`)'
         type: string
-        required: false
       dryRun:
         description: 'Check to do a dry run (does not publish packages)'
         type: boolean
+      forceIntegrationRelease:
+        description: 'Check to force an integration release for any given branch name'
+        type: boolean
+      customDistTag:
+        description: 'Custom dist tag to publish to (e.g. `prev`)'
+        type: string
 
 env:
   # To hide "Update available 0.0.0 -> x.x.x"
   PRISMA_HIDE_UPDATE_MESSAGE: 'true'
+  # Environment variables based on trigger type and parameters
+  RELEASE_VERSION: ${{ github.event.inputs.targetVersion }}
+  SKIP_ECOSYSTEMTESTS_CHECK: ${{ github.event.inputs.skipEcosystemTestsChecks || 'false' }}
+  SKIP_PACKAGES: ${{ github.event.inputs.skipPackages }}
+  ONLY_PACKAGES: ${{ github.event.inputs.onlyPackages }}
+  DRY_RUN: ${{ github.event.inputs.dryRun || 'false' }}
+  FORCE_INTEGRATION_RELEASE: ${{ github.event.inputs.forceIntegrationRelease || 'false' }}
+  CUSTOM_DIST_TAG: ${{ github.event.inputs.customDistTag || '' }}
+
+  FAILURE_TITLE_TEMPLATE: >-
+    ${{
+      github.event.inputs.targetVersion &&
+      format('prisma/prisma Release {0} from {1} on latest tag failed :x:', github.event.inputs.targetVersion, github.ref_name) ||
+      'prisma/prisma Release failed :x:'
+    }}
 
 jobs:
   release:
-    timeout-minutes: 45
+    timeout-minutes: ${{ github.event.inputs.targetVersion && 45 || 75 }}
     runs-on: ubuntu-latest
 
     concurrency:
-      group: ${{ github.workflow }}
+      group: ${{ github.event.inputs.targetVersion && 'release-version' || 'release-push' }}
       cancel-in-progress: false
 
     permissions:
-      # required for publishing to npm with --provenance
-      # see https://docs.npmjs.com/generating-provenance-statements
-      id-token: write
+      id-token: write # required for OIDC / Trusted Publishers
 
     outputs:
       prismaVersion: ${{ steps.publish.outputs.prismaVersion }}
+      enginesCommitHash: ${{ steps.publish.outputs.enginesCommitHash }}
 
     steps:
-      - name: Print input
+      - name: Print inputs
         env:
           THE_INPUT: '${{ toJson(github.event.inputs) }}'
         run: |
@@ -53,25 +90,26 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: ./.github/actions/setup
+      - name: Install & build
+        uses: ./.github/actions/setup
         with:
-          node-version: 18
+          node-version: '20.19.0'
           skip-tsc: false
+
+      - name: Update npm to support Trusted Publishers
+        run: npm install -g npm@^11.5
 
       - name: Publish all packages to npm
         id: publish
         run: |
-          echo "RELEASE_VERSION $RELEASE_VERSION"
-          echo "SKIP_ECOSYSTEMTESTS_CHECK $SKIP_ECOSYSTEMTESTS_CHECK"
+          if [ -n "$RELEASE_VERSION" ]; then
+            echo "RELEASE_VERSION: $RELEASE_VERSION"
+          fi
+          if [ "$SKIP_ECOSYSTEMTESTS_CHECK" = "true" ]; then
+            echo "SKIP_ECOSYSTEMTESTS_CHECK: $SKIP_ECOSYSTEMTESTS_CHECK"
+          fi
           pnpm run publish-all
         env:
-          # Inputs
-          RELEASE_VERSION: ${{ github.event.inputs.targetVersion }}
-          SKIP_ECOSYSTEMTESTS_CHECK: ${{ github.event.inputs.skipEcosystemTestsChecks }}
-          ONLY_PACKAGES: ${{ github.event.inputs.onlyPackages }}
-          SKIP_PACKAGES: ${{ github.event.inputs.skipPackages }}
-          DRY_RUN: ${{ github.event.inputs.dryRun == 'true' && 'true' || '' }}
-          # Other
           GITHUB_CONTEXT: ${{ toJson(github) }}
           # https://docs.npmjs.com/generating-provenance-statements
           NPM_CONFIG_PROVENANCE: true
@@ -79,7 +117,6 @@ jobs:
           # Note: must use personal access token
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
           REDIS_URL: ${{ secrets.REDIS_URL }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           SLACK_RELEASE_FEED_WEBHOOK: ${{ secrets.SLACK_RELEASE_FEED_WEBHOOK }}
 
       - name: Print output
@@ -90,7 +127,9 @@ jobs:
 
       - name: Create a tag on prisma repository
         id: tag-prisma
-        if: ${{ steps.publish.outputs.prismaVersion != '' && github.event.inputs.dryRun != 'true' }}
+        if: >-
+          steps.publish.outputs.prismaVersion != '' &&
+          env.DRY_RUN != 'true'
         uses: ./.github/actions/create-git-tag
         with:
           token: ${{ secrets.BOT_TOKEN }}
@@ -100,13 +139,14 @@ jobs:
       - name: Create a tag on prisma-engines repository
         uses: ./.github/actions/create-git-tag
         id: tag-prisma-engines
-        if: ${{ steps.publish.outputs.prismaVersion != '' && github.event.inputs.dryRun != 'true' }}
+        if: >-
+          steps.publish.outputs.prismaVersion != '' &&
+          env.DRY_RUN != 'true'
         with:
           token: ${{ secrets.BOT_TOKEN }}
           repository: prisma/prisma-engines
           tag-name: ${{ steps.publish.outputs.prismaVersion }}
           commit-sha: ${{ steps.publish.outputs.enginesCommitHash }}
-          message: ${{ steps.publish.outputs.changelogSanitized }}
 
   # We also have `sendSlackMessage()` in publish.ts
   # It uses the #feed-prisma-releases channel and adds more information
@@ -131,7 +171,7 @@ jobs:
   failure:
     needs:
       - release
-    if: ${{ failure() }}
+    if: ${{ failure() && github.event.inputs.targetVersion }}
     name: Communicate failure
     runs-on: ubuntu-latest
     steps:
@@ -141,7 +181,7 @@ jobs:
       - name: Slack Notification on Failure
         uses: rtCamp/action-slack-notify@v2.3.2
         env:
-          SLACK_TITLE: 'prisma/prisma Release ${{ github.event.inputs.targetVersion }} from ${{ github.ref_name }} on latest tag failed :x:'
+          SLACK_TITLE: ${{ env.FAILURE_TITLE_TEMPLATE }}
           SLACK_COLOR: '#FF0000'
           SLACK_WEBHOOK: ${{ secrets.SLACK_RELEASE_FEED_WEBHOOK }}
           SLACK_CHANNEL: feed-prisma-publish-failures

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
       - '*.*.x'
     paths-ignore:
       # Any update here needs to be done for `pull_request` (see below) and all files
-      # (test.yml, benchmark.yml, release-ci.yml, bundle-size.yml, ci-aux-files.yml)
+      # (test.yml, benchmark.yml, release.yml, bundle-size.yml, ci-aux-files.yml)
       - '*.md'
       - '*.bench.ts'
       - 'LICENSE'
@@ -23,7 +23,7 @@ on:
   pull_request:
     paths-ignore:
       # Any update here needs to be done for `branches` (see above) and all files
-      # (test.yml, benchmark.yml, release-ci.yml, bundle-size.yml, ci-aux-files.yml)
+      # (test.yml, benchmark.yml, release.yml, bundle-size.yml, ci-aux-files.yml)
       - '*.md'
       - '*.bench.ts'
       - 'LICENSE'
@@ -100,7 +100,7 @@ jobs:
           )
         uses: benc-uk/workflow-dispatch@v1
         with:
-          workflow: release-ci.yml
+          workflow: release.yml
           token: ${{ secrets.BOT_TOKEN }}
           inputs: '{ "forceIntegrationRelease": "true" }'
           ref: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
Backports a number of changes from the `main` branch to the 6.19.x patch branch. We need these changes in order to use the new trusted publisher setup and the custom dist tag flag.

The files here are identical to the `main` branch.