### PR TITLE
fix: fix citext test

### DIFF
--- a/packages/integration-tests/src/__tests__/integration/postgresql/__scenarios.ts
+++ b/packages/integration-tests/src/__tests__/integration/postgresql/__scenarios.ts
@@ -1381,28 +1381,25 @@ export const scenarios = [
       },
     ],
   },
-  // TODO: https://linear.app/prisma-company/issue/TML-1647/fix-broken-citext-integration-test
-  // {
-  //   name: 'findMany where - case insensitive field',
-  //   up: `
-  //     drop extension if exists citext cascade;
-  //     create extension citext;
-  //     create table users (
-  //       id serial primary key not null,
-  //       email citext not null unique
-  //     );
-  //     insert into users ("email") values ('max@prisma.io');
-  //   `,
-  //   do: (client) => {
-  //     return client.users.findMany({ where: { email: 'MAX@PRISMA.IO' } })
-  //   },
-  //   expect: [
-  //     {
-  //       email: 'max@prisma.io',
-  //       id: 1,
-  //     },
-  //   ],
-  // },
+  {
+    name: 'findMany where - case insensitive field',
+    up: `
+      drop extension if exists citext cascade;
+      create extension citext schema public;
+      create table users (
+        id serial primary key not null,
+        email public.citext unique not null
+      );
+      insert into users ("email") values ('max@prisma.io');
+    `,
+    do: (client) => client.users.findMany({ where: { email: 'MAX@PRISMA.IO' } }),
+    expect: [
+      {
+        email: 'max@prisma.io',
+        id: 1,
+      },
+    ],
+  },
   {
     name: 'findMany where decimal',
     up: `

--- a/packages/integration-tests/src/__tests__/integration/postgresql/__snapshots__/introspection.test.ts.snap
+++ b/packages/integration-tests/src/__tests__/integration/postgresql/__snapshots__/introspection.test.ts.snap
@@ -315,6 +315,25 @@ model posts {
 
 exports[`introspection: findMany orderBy desc: warnings 1`] = `null`;
 
+exports[`introspection: findMany where - case insensitive field: datamodel 1`] = `
+"generator client {
+  provider = "prisma-client-js"
+  output = "***"
+}
+
+datasource postgresql {
+  provider = "postgresql"
+}
+
+model users {
+  id    Int    @id @default(autoincrement())
+  email String @unique @postgresql.Citext
+}
+"
+`;
+
+exports[`introspection: findMany where - case insensitive field: warnings 1`] = `null`;
+
 exports[`introspection: findMany where OR[contains, contains] : datamodel 1`] = `
 "generator client {
   provider = "prisma-client-js"


### PR DESCRIPTION
[TML-1647](https://linear.app/prisma-company/issue/TML-1647/fix-broken-citext-integration-test)

The issue is that the CITEXT is not in the search path during the execution of the query. The query just returns an empty list of rows and the comparison fails silently.

The schema search path problem is linked to the known issue of adapter-pg not behaving like the Rust driver with regard to the schema parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Re-enabled case-insensitive field matching test for PostgreSQL with improved configuration, enhancing test coverage for the feature.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->