### PR TITLE
feat(adapter-mariadb): Improve MariaDB adapter error reporting by surfacing underlying error causes

### DIFF
--- a/packages/adapter-mariadb/src/errors.test.ts
+++ b/packages/adapter-mariadb/src/errors.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'vitest'
+
+import { convertDriverError } from './errors'
+
+describe('MariaDB adapter error handling', () => {
+  test('mysql error mapping includes nested driver cause when available', () => {
+    const nestedCause = {
+      errno: 45044,
+      sqlMessage:
+        'RSA public key is not available client side. Either set option `cachingRsaPublicKey` to indicate public key path, or allow public key retrieval with option `allowPublicKeyRetrieval`',
+      sqlState: '08S01',
+      message:
+        'RSA public key is not available client side. Either set option `cachingRsaPublicKey` to indicate public key path, or allow public key retrieval with option `allowPublicKeyRetrieval`',
+    }
+
+    const err = {
+      errno: 45028,
+      sqlMessage:
+        'pool timeout: failed to retrieve a connection from pool after 10005ms\n    (pool connections: active=0 idle=0 limit=5)',
+      sqlState: 'HY000',
+      cause: nestedCause,
+    }
+
+    const mapped = convertDriverError(err)
+
+    expect(mapped).toMatchObject({
+      kind: 'mysql',
+      code: 45028,
+      state: 'HY000',
+      message:
+        'pool timeout: failed to retrieve a connection from pool after 10005ms\n    (pool connections: active=0 idle=0 limit=5)',
+      cause:
+        'RSA public key is not available client side. Either set option `cachingRsaPublicKey` to indicate public key path, or allow public key retrieval with option `allowPublicKeyRetrieval`',
+      originalCode: '45028',
+      originalMessage:
+        'pool timeout: failed to retrieve a connection from pool after 10005ms\n    (pool connections: active=0 idle=0 limit=5)',
+    })
+  })
+
+  test('mysql error mapping omits cause when not available', () => {
+    const err = {
+      errno: 45028,
+      sqlMessage: 'An error occurred',
+      sqlState: 'HY000',
+    }
+
+    const mapped = convertDriverError(err)
+
+    expect(mapped).toMatchObject({
+      kind: 'mysql',
+      code: 45028,
+      state: 'HY000',
+      message: 'An error occurred',
+    })
+    // important: we want `cause` to be truly absent/undefined to keep payload minimal/stable
+    expect((mapped as any).cause).toBeUndefined()
+  })
+})

--- a/packages/adapter-mariadb/src/errors.ts
+++ b/packages/adapter-mariadb/src/errors.ts
@@ -1,4 +1,5 @@
 import { Error as DriverAdapterErrorObject, MappedError } from '@prisma/driver-adapter-utils'
+import type { SqlError } from 'mariadb/types/share'
 
 export function convertDriverError(error: unknown): DriverAdapterErrorObject {
   if (isDriverError(error)) {
@@ -136,6 +137,7 @@ export function mapDriverError(error: DriverError): MappedError {
         code: error.errno,
         message: error.sqlMessage ?? 'N/A',
         state: error.sqlState ?? 'N/A',
+        // eslint-disable-next-line @typescript-eslint/no-base-to-string
         cause: error.cause && 'toString' in error.cause ? error.cause.toString() : undefined,
       }
   }
@@ -145,7 +147,7 @@ type DriverError = {
   errno: number
   sqlMessage: string | null
   sqlState: string | null
-  cause?: any
+  cause?: SqlError
 }
 
 function isDriverError(error: any): error is DriverError {

--- a/packages/adapter-mariadb/src/errors.ts
+++ b/packages/adapter-mariadb/src/errors.ts
@@ -1,5 +1,5 @@
 import { Error as DriverAdapterErrorObject, MappedError } from '@prisma/driver-adapter-utils'
-import type { SqlError } from 'mariadb/types/share'
+import type { SqlError } from 'mariadb'
 
 export function convertDriverError(error: unknown): DriverAdapterErrorObject {
   if (isDriverError(error)) {

--- a/packages/adapter-mariadb/src/errors.ts
+++ b/packages/adapter-mariadb/src/errors.ts
@@ -137,8 +137,7 @@ export function mapDriverError(error: DriverError): MappedError {
         code: error.errno,
         message: error.sqlMessage ?? 'N/A',
         state: error.sqlState ?? 'N/A',
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string
-        cause: error.cause && 'toString' in error.cause ? error.cause.toString() : undefined,
+        cause: error.cause?.message ?? undefined,
       }
   }
 }

--- a/packages/adapter-mariadb/src/errors.ts
+++ b/packages/adapter-mariadb/src/errors.ts
@@ -136,6 +136,7 @@ export function mapDriverError(error: DriverError): MappedError {
         code: error.errno,
         message: error.sqlMessage ?? 'N/A',
         state: error.sqlState ?? 'N/A',
+        cause: error.cause && 'toString' in error.cause ? error.cause.toString() : undefined,
       }
   }
 }
@@ -144,6 +145,7 @@ type DriverError = {
   errno: number
   sqlMessage: string | null
   sqlState: string | null
+  cause?: any
 }
 
 function isDriverError(error: any): error is DriverError {

--- a/packages/driver-adapter-utils/src/types.ts
+++ b/packages/driver-adapter-utils/src/types.ts
@@ -173,7 +173,7 @@ export type MappedError =
       code: number
       message: string
       state: string
-      cause: string | undefined
+      cause?: string
     }
   | {
       kind: 'sqlite'

--- a/packages/driver-adapter-utils/src/types.ts
+++ b/packages/driver-adapter-utils/src/types.ts
@@ -173,6 +173,7 @@ export type MappedError =
       code: number
       message: string
       state: string
+      cause: string | undefined
     }
   | {
       kind: 'sqlite'


### PR DESCRIPTION

**Summary**
The `mariadb` driver wraps connection‑level failures in a pool timeout error, but it also includes a nested `cause` with the real reason. This PR updates `@prisma/adapter-mariadb` error mapping so MySQL/MariaDB driver errors include the underlying driver cause (when present), instead of only surfacing the top-level pool timeout. Closes #28612

**Why**
[Users were hitting errors like “pool timeout”](https://github.com/prisma/prisma/issues/28612) where the real root cause was attached by the MariaDB driver as a nested cause (e.g. socket connect timeout, RSA public key retrieval). Prisma surfaced only the outer message, so people couldn’t diagnose what to fix.

**Behavior before vs after**


- **Before:**

  ```text
  DriverAdapterError: pool timeout: failed to retrieve a connection from pool after 10008ms
      (pool connections: active=0 idle=0 limit=5)
    cause: {
      originalCode: '45028',
      originalMessage: 'pool timeout: failed to retrieve a connection from pool after 10008ms (pool connections: ...)',
      kind: 'mysql',
      code: 45028,
      message: 'pool timeout: failed to retrieve a connection from pool after 10008ms (pool connections: ...)',
      state: 'HY000'
    }
  ```

  The underlying message about RSA public key retrieval or socket timeout was completely hidden.

- **After:**

  ```text
  DriverAdapterError: pool timeout: failed to retrieve a connection from pool after 10008ms
      (pool connections: active=0 idle=0 limit=5)
    cause: {
      originalCode: '45028',
      originalMessage: 'pool timeout: failed to retrieve a connection from pool after 10008ms (pool connections: ...)',
      kind: 'mysql',
      code: 45028,
      message: 'pool timeout: failed to retrieve a connection from pool after 10008ms (pool connections: ...)',
      state: 'HY000',
      cause: 'SqlError: (conn:44, no: 45044, SQLState: 08S01) RSA public key is not available client side. Either set option `cachingRsaPublicKey` to indicate public key path, or allow public key retrieval with option `allowPublicKeyRetrieval`'
    }
  ```

  Also applies to network issues like:

  ```text
    ...
    cause: 'SqlError: (conn:-1, no: 45012, SQLState: 08S01) Connection timeout: failed to create socket after 1003ms'
  }
  ```

Now users can immediately see whether the problem is TLS/SSL, authentication (RSA key retrieval), connectivity (socket timeout), etc., instead of only a generic pool timeout.

---

**Notes**

- This follows the existing convention in `driver-adapter-utils` of exposing additional detail in a `cause: string` field.
- It avoids concatenating multiple messages into `message`, keeping the top-level error text focused while still surfacing full context via `cause`.
- It is **backwards compatible**: It specifically fixes the diagnosability issues described in [#28612](https://github.com/prisma/prisma/issues/28612) without changing how errors are raised or handled elsewhere.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MariaDB/MySQL adapter error reporting to include an optional underlying-cause field and to propagate nested error messages, providing richer diagnostic context in logs and error payloads.
* **Tests**
  * Added tests validating error-mapping behavior with and without nested driver causes to ensure cause propagation and omission behave as expected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->