### PR TITLE
fix: fix byte upserts by removing legacy byte array representation

### DIFF
--- a/packages/adapter-better-sqlite3/src/conversion.ts
+++ b/packages/adapter-better-sqlite3/src/conversion.ts
@@ -150,11 +150,6 @@ export function mapRow(row: Row, columnTypes: ColumnType[]): ResultValue[] {
   for (let i = 0; i < row.length; i++) {
     const value = row[i]
 
-    if (value instanceof ArrayBuffer) {
-      result[i] = new Uint8Array(value)
-      continue
-    }
-
     // If an integer is required and the current number isn't one,
     // discard the fractional part.
     if (

--- a/packages/adapter-better-sqlite3/src/conversion.ts
+++ b/packages/adapter-better-sqlite3/src/conversion.ts
@@ -150,12 +150,8 @@ export function mapRow(row: Row, columnTypes: ColumnType[]): ResultValue[] {
   for (let i = 0; i < row.length; i++) {
     const value = row[i]
 
-    // Convert array buffers to arrays of bytes.
-    // Base64 would've been more efficient but would collide with the existing
-    // logic that treats string values of type Bytes as raw UTF-8 bytes that was
-    // implemented for other adapters.
-    if (value instanceof ArrayBuffer || value instanceof Buffer) {
-      result[i] = Array.from(new Uint8Array(value))
+    if (value instanceof ArrayBuffer) {
+      result[i] = Buffer.from(value)
       continue
     }
 
@@ -238,10 +234,6 @@ export function mapArg<A>(
 
   if (typeof arg === 'string' && argType.scalarType === 'bytes') {
     return Buffer.from(arg, 'base64')
-  }
-
-  if (Array.isArray(arg) && argType.scalarType === 'bytes') {
-    return Buffer.from(arg)
   }
 
   return arg

--- a/packages/adapter-better-sqlite3/src/conversion.ts
+++ b/packages/adapter-better-sqlite3/src/conversion.ts
@@ -4,7 +4,7 @@ import { PrismaBetterSqlite3Options } from './better-sqlite3'
 
 const debug = Debug('prisma:driver-adapter:better-sqlite3:conversion')
 
-type Value = null | string | number | bigint | ArrayBuffer | Buffer
+type Value = null | string | number | bigint | Buffer
 export type Row = {
   /** Number of columns in this row.
    *

--- a/packages/adapter-better-sqlite3/src/conversion.ts
+++ b/packages/adapter-better-sqlite3/src/conversion.ts
@@ -151,7 +151,7 @@ export function mapRow(row: Row, columnTypes: ColumnType[]): ResultValue[] {
     const value = row[i]
 
     if (value instanceof ArrayBuffer) {
-      result[i] = Buffer.from(value)
+      result[i] = new Uint8Array(value)
       continue
     }
 

--- a/packages/adapter-d1/src/conversion.ts
+++ b/packages/adapter-d1/src/conversion.ts
@@ -107,7 +107,7 @@ export function mapRow<A>(result: (A | ResultValue)[], columnTypes: ColumnType[]
     const value = result[i]
 
     if (value instanceof ArrayBuffer) {
-      result[i] = Buffer.from(value)
+      result[i] = new Uint8Array(value)
       continue
     }
 

--- a/packages/adapter-d1/src/conversion.ts
+++ b/packages/adapter-d1/src/conversion.ts
@@ -107,7 +107,7 @@ export function mapRow<A>(result: (A | ResultValue)[], columnTypes: ColumnType[]
     const value = result[i]
 
     if (value instanceof ArrayBuffer) {
-      result[i] = Array.from(new Uint8Array(value))
+      result[i] = Buffer.from(value)
       continue
     }
 

--- a/packages/adapter-libsql/src/conversion.ts
+++ b/packages/adapter-libsql/src/conversion.ts
@@ -139,7 +139,7 @@ export function mapRow(row: Row, columnTypes: ColumnType[]): ResultValue[] {
     // logic that treats string values of type Bytes as raw UTF-8 bytes that was
     // implemented for other adapters.
     if (value instanceof ArrayBuffer) {
-      result[i] = Array.from(new Uint8Array(value))
+      result[i] = Buffer.from(value)
       continue
     }
 
@@ -206,10 +206,6 @@ export function mapArg(arg: unknown, argType: ArgType, options?: PrismaLibSqlOpt
 
   if (typeof arg === 'string' && argType.scalarType === 'bytes') {
     return Buffer.from(arg, 'base64')
-  }
-
-  if (Array.isArray(arg) && argType.scalarType === 'bytes') {
-    return new Uint8Array(arg)
   }
 
   return arg as InValue

--- a/packages/adapter-libsql/src/conversion.ts
+++ b/packages/adapter-libsql/src/conversion.ts
@@ -134,6 +134,11 @@ export function mapRow(row: Row, columnTypes: ColumnType[]): ResultValue[] {
   for (let i = 0; i < row.length; i++) {
     const value = row[i]
 
+    if (value instanceof ArrayBuffer) {
+      result[i] = new Uint8Array(value)
+      continue
+    }
+
     // If an integer is required and the current number isn't one,
     // discard the fractional part.
     if (

--- a/packages/adapter-libsql/src/conversion.ts
+++ b/packages/adapter-libsql/src/conversion.ts
@@ -139,7 +139,7 @@ export function mapRow(row: Row, columnTypes: ColumnType[]): ResultValue[] {
     // logic that treats string values of type Bytes as raw UTF-8 bytes that was
     // implemented for other adapters.
     if (value instanceof ArrayBuffer) {
-      result[i] = Buffer.from(value)
+      result[i] = new Uint8Array(value)
       continue
     }
 

--- a/packages/adapter-libsql/src/conversion.ts
+++ b/packages/adapter-libsql/src/conversion.ts
@@ -134,11 +134,6 @@ export function mapRow(row: Row, columnTypes: ColumnType[]): ResultValue[] {
   for (let i = 0; i < row.length; i++) {
     const value = row[i]
 
-    if (value instanceof ArrayBuffer) {
-      result[i] = new Uint8Array(value)
-      continue
-    }
-
     // If an integer is required and the current number isn't one,
     // discard the fractional part.
     if (

--- a/packages/adapter-libsql/src/conversion.ts
+++ b/packages/adapter-libsql/src/conversion.ts
@@ -134,10 +134,6 @@ export function mapRow(row: Row, columnTypes: ColumnType[]): ResultValue[] {
   for (let i = 0; i < row.length; i++) {
     const value = row[i]
 
-    // Convert array buffers to arrays of bytes.
-    // Base64 would've been more efficient but would collide with the existing
-    // logic that treats string values of type Bytes as raw UTF-8 bytes that was
-    // implemented for other adapters.
     if (value instanceof ArrayBuffer) {
       result[i] = new Uint8Array(value)
       continue

--- a/packages/adapter-mariadb/src/conversion.ts
+++ b/packages/adapter-mariadb/src/conversion.ts
@@ -133,10 +133,6 @@ export function mapArg<A>(arg: A | Date, argType: ArgType): null | BigInt | stri
     return Buffer.from(arg, 'base64')
   }
 
-  if (Array.isArray(arg) && argType.scalarType === 'bytes') {
-    return Buffer.from(arg)
-  }
-
   if (ArrayBuffer.isView(arg)) {
     return Buffer.from(arg.buffer, arg.byteOffset, arg.byteLength)
   }
@@ -158,10 +154,6 @@ export function mapRow<A>(row: A[], fields?: mariadb.FieldInfo[]): (A | ResultVa
       case MariaDbColumnType.DATETIME:
       case MariaDbColumnType.DATETIME2:
         return new Date(`${value}Z`).toISOString().replace(/(\.000)?Z$/, '+00:00')
-    }
-
-    if (Buffer.isBuffer(value)) {
-      return Array.from(value)
     }
 
     if (typeof value === 'bigint') {

--- a/packages/adapter-mariadb/src/conversion.ts
+++ b/packages/adapter-mariadb/src/conversion.ts
@@ -134,7 +134,7 @@ export function mapArg<A>(arg: A | Date, argType: ArgType): null | BigInt | stri
   }
 
   if (ArrayBuffer.isView(arg)) {
-    return Buffer.from(arg.buffer, arg.byteOffset, arg.byteLength)
+    return new Uint8Array(arg.buffer, arg.byteOffset, arg.byteLength)
   }
 
   return arg

--- a/packages/adapter-mariadb/src/conversion.ts
+++ b/packages/adapter-mariadb/src/conversion.ts
@@ -103,7 +103,7 @@ export function mapColumnType(field: mariadb.FieldInfo): ColumnType {
   }
 }
 
-export function mapArg<A>(arg: A | Date, argType: ArgType): null | BigInt | string | Uint8Array | A {
+export function mapArg<A>(arg: A | Date, argType: ArgType): null | BigInt | string | Buffer | A {
   if (arg === null) {
     return null
   }
@@ -134,7 +134,7 @@ export function mapArg<A>(arg: A | Date, argType: ArgType): null | BigInt | stri
   }
 
   if (ArrayBuffer.isView(arg)) {
-    return new Uint8Array(arg.buffer, arg.byteOffset, arg.byteLength)
+    return Buffer.from(arg.buffer, arg.byteOffset, arg.byteLength)
   }
 
   return arg

--- a/packages/adapter-mssql/src/conversion.ts
+++ b/packages/adapter-mssql/src/conversion.ts
@@ -126,7 +126,7 @@ export function mapArg<A>(arg: A | BigInt | Date, argType: ArgType): null | numb
   }
 
   if (ArrayBuffer.isView(arg)) {
-    return Buffer.from(arg.buffer, arg.byteOffset, arg.byteLength)
+    return new Uint8Array(arg.buffer, arg.byteOffset, arg.byteLength)
   }
 
   return arg

--- a/packages/adapter-mssql/src/conversion.ts
+++ b/packages/adapter-mssql/src/conversion.ts
@@ -90,7 +90,7 @@ export function mapIsolationLevel(level: IsolationLevel): sql.IIsolationLevel {
   }
 }
 
-export function mapArg<A>(arg: A | BigInt | Date, argType: ArgType): null | number | BigInt | string | Uint8Array | A {
+export function mapArg<A>(arg: A | BigInt | Date, argType: ArgType): null | number | BigInt | string | Buffer | A {
   if (arg === null) {
     return null
   }
@@ -126,7 +126,7 @@ export function mapArg<A>(arg: A | BigInt | Date, argType: ArgType): null | numb
   }
 
   if (ArrayBuffer.isView(arg)) {
-    return new Uint8Array(arg.buffer, arg.byteOffset, arg.byteLength)
+    return Buffer.from(arg.buffer, arg.byteOffset, arg.byteLength)
   }
 
   return arg

--- a/packages/adapter-mssql/src/conversion.ts
+++ b/packages/adapter-mssql/src/conversion.ts
@@ -125,10 +125,6 @@ export function mapArg<A>(arg: A | BigInt | Date, argType: ArgType): null | numb
     return Buffer.from(arg, 'base64')
   }
 
-  if (Array.isArray(arg) && argType.scalarType === 'bytes') {
-    return Buffer.from(arg)
-  }
-
   if (ArrayBuffer.isView(arg)) {
     return Buffer.from(arg.buffer, arg.byteOffset, arg.byteLength)
   }
@@ -160,10 +156,6 @@ export function mapRow<A>(row: A[], columns?: sql.IColumn[]): (A | ResultValue)[
       }
       // If no suitable precision is found, return the value as is.
       return value
-    }
-
-    if (Buffer.isBuffer(value)) {
-      return Array.from(value)
     }
 
     // Using lower case to make it consistent with the driver in prisma-engines.

--- a/packages/adapter-neon/src/conversion.ts
+++ b/packages/adapter-neon/src/conversion.ts
@@ -362,11 +362,6 @@ function normalizeByteaArray(serializedBytesArray) {
   return parseBytesArray(serializedBytesArray)
 }
 
-/**
- * Convert bytes to a JSON-encodable representation since we can't
- * currently send a parsed Buffer or ArrayBuffer across JS to Rust
- * boundary.
- */
 function convertBytes(serializedBytes: string): Buffer {
   return parsePgBytes(serializedBytes)
 }

--- a/packages/adapter-neon/src/conversion.ts
+++ b/packages/adapter-neon/src/conversion.ts
@@ -428,7 +428,7 @@ export function mapArg<A>(arg: A | Date, argType: ArgType): null | unknown[] | s
 
   // https://github.com/brianc/node-postgres/pull/2930
   if (ArrayBuffer.isView(arg)) {
-    return Buffer.from(arg.buffer, arg.byteOffset, arg.byteLength)
+    return new Uint8Array(arg.buffer, arg.byteOffset, arg.byteLength)
   }
 
   return arg

--- a/packages/adapter-neon/src/conversion.ts
+++ b/packages/adapter-neon/src/conversion.ts
@@ -356,11 +356,7 @@ const parsePgBytes = getTypeParser(ScalarColumnType.BYTEA) as (_: string) => Buf
  * BYTEA_ARRAY - arrays of arbitrary raw binary strings
  */
 
-const parseBytesArray = getTypeParser(ArrayColumnType.BYTEA_ARRAY) as (_: string) => Buffer[]
-
-function normalizeByteaArray(serializedBytesArray) {
-  return parseBytesArray(serializedBytesArray)
-}
+const normalizeByteaArray = getTypeParser(ArrayColumnType.BYTEA_ARRAY) as (_: string) => Buffer[]
 
 function convertBytes(serializedBytes: string): Buffer {
   return parsePgBytes(serializedBytes)

--- a/packages/adapter-pg/src/conversion.ts
+++ b/packages/adapter-pg/src/conversion.ts
@@ -375,11 +375,6 @@ function normalizeByteaArray(serializedBytesArray) {
   return parseBytesArray(serializedBytesArray)
 }
 
-/**
- * Convert bytes to a JSON-encodable representation since we can't
- * currently send a parsed Buffer or ArrayBuffer across JS to Rust
- * boundary.
- */
 function convertBytes(serializedBytes: string): Buffer {
   return parsePgBytes(serializedBytes)
 }

--- a/packages/adapter-pg/src/conversion.ts
+++ b/packages/adapter-pg/src/conversion.ts
@@ -359,17 +359,6 @@ function toJson(json: string): string {
 /* Binary data handling */
 /************************/
 
-/**
- * TODO:
- * 1. Check if using base64 would be more efficient than this encoding.
- * 2. Consider the possibility of eliminating re-encoding altogether
- *    and passing bytea hex format to the engine if that can be aligned
- *    with other adapters of the same database provider.
- */
-function encodeBuffer(buffer: Buffer) {
-  return Array.from(new Uint8Array(buffer))
-}
-
 /*
  * BYTEA - arbitrary raw binary strings
  */
@@ -383,8 +372,7 @@ const parsePgBytes = getTypeParser(ScalarColumnType.BYTEA) as (_: string) => Buf
 const parseBytesArray = getTypeParser(ArrayColumnType.BYTEA_ARRAY) as (_: string) => Buffer[]
 
 function normalizeByteaArray(serializedBytesArray) {
-  const buffers = parseBytesArray(serializedBytesArray)
-  return buffers.map((buf) => (buf ? encodeBuffer(buf) : null))
+  return parseBytesArray(serializedBytesArray)
 }
 
 /**
@@ -392,9 +380,8 @@ function normalizeByteaArray(serializedBytesArray) {
  * currently send a parsed Buffer or ArrayBuffer across JS to Rust
  * boundary.
  */
-function convertBytes(serializedBytes: string): number[] {
-  const buffer = parsePgBytes(serializedBytes)
-  return encodeBuffer(buffer)
+function convertBytes(serializedBytes: string): Buffer {
+  return parsePgBytes(serializedBytes)
 }
 
 /* BIT_ARRAY, VARBIT_ARRAY */
@@ -455,10 +442,6 @@ export function mapArg<A>(arg: A | Date, argType: ArgType): null | unknown[] | s
 
   if (typeof arg === 'string' && argType.scalarType === 'bytes') {
     return Buffer.from(arg, 'base64')
-  }
-
-  if (Array.isArray(arg) && argType.scalarType === 'bytes') {
-    return Buffer.from(arg)
   }
 
   // https://github.com/brianc/node-postgres/pull/2930

--- a/packages/adapter-pg/src/conversion.ts
+++ b/packages/adapter-pg/src/conversion.ts
@@ -369,11 +369,7 @@ const parsePgBytes = getTypeParser(ScalarColumnType.BYTEA) as (_: string) => Buf
  * BYTEA_ARRAY - arrays of arbitrary raw binary strings
  */
 
-const parseBytesArray = getTypeParser(ArrayColumnType.BYTEA_ARRAY) as (_: string) => Buffer[]
-
-function normalizeByteaArray(serializedBytesArray) {
-  return parseBytesArray(serializedBytesArray)
-}
+const normalizeByteaArray = getTypeParser(ArrayColumnType.BYTEA_ARRAY) as (_: string) => Buffer[]
 
 function convertBytes(serializedBytes: string): Buffer {
   return parsePgBytes(serializedBytes)

--- a/packages/adapter-pg/src/conversion.ts
+++ b/packages/adapter-pg/src/conversion.ts
@@ -441,7 +441,7 @@ export function mapArg<A>(arg: A | Date, argType: ArgType): null | unknown[] | s
 
   // https://github.com/brianc/node-postgres/pull/2930
   if (ArrayBuffer.isView(arg)) {
-    return Buffer.from(arg.buffer, arg.byteOffset, arg.byteLength)
+    return new Uint8Array(arg.buffer, arg.byteOffset, arg.byteLength)
   }
 
   return arg

--- a/packages/adapter-planetscale/src/conversion.ts
+++ b/packages/adapter-planetscale/src/conversion.ts
@@ -104,13 +104,7 @@ export const cast: typeof defaultCast = (field, value) => {
     return typeof value === 'string' && value.length ? decodeUtf8(value) : value
   }
 
-  const defaultValue = defaultCast(field, value)
-
-  if (defaultValue instanceof Uint8Array) {
-    return Array.from(defaultValue)
-  }
-
-  return defaultValue
+  return defaultCast(field, value)
 }
 
 export function mapArg<A>(arg: A | Date, argType: ArgType): null | BigInt | string | Uint8Array | A {
@@ -141,10 +135,6 @@ export function mapArg<A>(arg: A | Date, argType: ArgType): null | BigInt | stri
 
   if (typeof arg === 'string' && argType.scalarType === 'bytes') {
     return Buffer.from(arg, 'base64')
-  }
-
-  if (Array.isArray(arg) && argType.scalarType === 'bytes') {
-    return Buffer.from(arg)
   }
 
   return arg

--- a/packages/adapter-ppg/src/conversion.ts
+++ b/packages/adapter-ppg/src/conversion.ts
@@ -405,12 +405,8 @@ const builtInByteParser = getTypeParser(ScalarColumnType.BYTEA) as (_: string) =
 /*
  * BYTEA_ARRAY - arrays of arbitrary raw binary strings
  */
-function parseBytesArray(x: string) {
+function normalizeByteaArray(x: string) {
   return parseArray(x).map(builtInByteParser)
-}
-
-function normalizeByteaArray(serializedBytesArray) {
-  return parseBytesArray(serializedBytesArray)
 }
 
 function convertBytes(serializedBytes: string): Buffer {

--- a/packages/adapter-ppg/src/conversion.ts
+++ b/packages/adapter-ppg/src/conversion.ts
@@ -393,17 +393,6 @@ function toJson(json: string): string {
 /* Binary data handling */
 /************************/
 
-/**
- * TODO:
- * 1. Check if using base64 would be more efficient than this encoding.
- * 2. Consider the possibility of eliminating re-encoding altogether
- *    and passing bytea hex format to the engine if that can be aligned
- *    with other adapters of the same database provider.
- */
-function encodeBuffer(buffer: Buffer) {
-  return Array.from(new Uint8Array(buffer))
-}
-
 /*
  * BYTEA - arbitrary raw binary strings
  * the PPG client uses base64 in this case. We do not convert the array of bytea, though (see below)
@@ -421,18 +410,11 @@ function parseBytesArray(x: string) {
 }
 
 function normalizeByteaArray(serializedBytesArray) {
-  const buffers = parseBytesArray(serializedBytesArray)
-  return buffers.map((buf) => (buf ? encodeBuffer(buf) : null))
+  return parseBytesArray(serializedBytesArray)
 }
 
-/**
- * Convert bytes to a JSON-encodable representation since we can't
- * currently send a parsed Buffer or ArrayBuffer across JS to Rust
- * boundary.
- */
-function convertBytes(serializedBytes: string): number[] {
-  const buffer = parsePgBytes(serializedBytes)
-  return encodeBuffer(buffer)
+function convertBytes(serializedBytes: string): Buffer {
+  return parsePgBytes(serializedBytes)
 }
 
 /* BIT_ARRAY, VARBIT_ARRAY */

--- a/packages/client-engine-runtime/src/interpreter/data-mapper.ts
+++ b/packages/client-engine-runtime/src/interpreter/data-mapper.ts
@@ -263,6 +263,9 @@ function mapValue(
           return { $type: 'Bytes', value: Buffer.from(value.slice(2), 'hex').toString('base64') }
 
         case 'array':
+          if (Array.isArray(value)) {
+            return { $type: 'Bytes', value: Buffer.from(value).toString('base64') }
+          }
           if (value instanceof Uint8Array) {
             return { $type: 'Bytes', value: Buffer.from(value).toString('base64') }
           }

--- a/packages/client-engine-runtime/src/interpreter/data-mapper.ts
+++ b/packages/client-engine-runtime/src/interpreter/data-mapper.ts
@@ -263,9 +263,6 @@ function mapValue(
           return { $type: 'Bytes', value: Buffer.from(value.slice(2), 'hex').toString('base64') }
 
         case 'array':
-          if (Array.isArray(value)) {
-            return { $type: 'Bytes', value: Buffer.from(value).toString('base64') }
-          }
           if (value instanceof Uint8Array) {
             return { $type: 'Bytes', value: Buffer.from(value).toString('base64') }
           }

--- a/packages/client-engine-runtime/src/interpreter/data-mapper.ts
+++ b/packages/client-engine-runtime/src/interpreter/data-mapper.ts
@@ -208,7 +208,7 @@ function mapValue(
           throw new DataMapperError(`Expected a boolean in column '${columnName}', got ${typeof value}: ${value}`)
         }
       }
-      if (Array.isArray(value)) {
+      if (Array.isArray(value) || value instanceof Uint8Array) {
         for (const byte of value) {
           if (byte !== 0) return true
         }

--- a/packages/client-engine-runtime/src/interpreter/serialize-sql.ts
+++ b/packages/client-engine-runtime/src/interpreter/serialize-sql.ts
@@ -73,19 +73,6 @@ function serializeRawValue(value: unknown, type: ColumnType): unknown {
       }
       return value.map((v) => serializeRawValue(v, ColumnTypeEnum.Json))
 
-    case ColumnTypeEnum.Bytes:
-      if (Array.isArray(value)) {
-        return new Uint8Array(value)
-      } else {
-        throw new Error(`Cannot serialize value of type ${typeof value} as Bytes`)
-      }
-
-    case ColumnTypeEnum.BytesArray:
-      if (!Array.isArray(value)) {
-        throw new Error(`Cannot serialize value of type ${typeof value} as BytesArray`)
-      }
-      return value.map((v) => serializeRawValue(v, ColumnTypeEnum.Bytes))
-
     case ColumnTypeEnum.Boolean:
       switch (typeof value) {
         case 'boolean':

--- a/packages/client/tests/functional/bytes-upsert/_matrix.ts
+++ b/packages/client/tests/functional/bytes-upsert/_matrix.ts
@@ -1,0 +1,4 @@
+import { defineMatrix } from '../_utils/defineMatrix'
+import { allProviders, Providers } from '../_utils/providers'
+
+export default defineMatrix(() => [allProviders.filter(({ provider }) => provider !== Providers.SQLSERVER)])

--- a/packages/client/tests/functional/bytes-upsert/prisma/_schema.ts
+++ b/packages/client/tests/functional/bytes-upsert/prisma/_schema.ts
@@ -1,0 +1,20 @@
+import { idForProvider } from '../../_utils/idForProvider'
+import { Providers } from '../../_utils/providers'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+
+  datasource db {
+    provider = "${provider}"
+  }
+
+  model TestByteId {
+    id ${idForProvider(provider, { includeDefault: true })}
+    bytes Bytes @unique${provider === Providers.MYSQL ? ' @db.VarBinary(16)' : ''}
+  }
+  `
+})

--- a/packages/client/tests/functional/bytes-upsert/tests.ts
+++ b/packages/client/tests/functional/bytes-upsert/tests.ts
@@ -1,0 +1,42 @@
+import { randomBytes } from 'crypto'
+
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(
+  () => {
+    test('bytes upsert should work correctly', async () => {
+      const byteId = new Uint8Array(randomBytes(16))
+      const upsertByteRow = () =>
+        prisma.testByteId.upsert({
+          create: {
+            bytes: byteId,
+          },
+          where: {
+            bytes: byteId,
+          },
+          update: {},
+        })
+
+      await upsertByteRow()
+      // This second call was failing in v7 with "No record was found for an upsert"
+      await upsertByteRow() // Should not throw
+
+      // Verify the record exists and has correct data
+      const result = await prisma.testByteId.findUnique({
+        where: { bytes: byteId },
+      })
+      expect(result).toBeTruthy()
+      expect(result?.bytes).toEqual(byteId)
+    })
+  },
+  {
+    optOut: {
+      from: ['sqlserver'],
+      reason: 'SQL Server does not support bytes IDs',
+    },
+  },
+)

--- a/packages/driver-adapter-utils/src/types.ts
+++ b/packages/driver-adapter-utils/src/types.ts
@@ -6,7 +6,7 @@ export type ColumnType = (typeof ColumnTypeEnum)[keyof typeof ColumnTypeEnum]
 /**
  * Represents a value that can be returned for a column from `queryRaw`.
  */
-export type ResultValue = number | string | boolean | null | ResultValue[]
+export type ResultValue = number | string | boolean | null | ResultValue[] | Uint8Array
 
 export interface SqlResultSet {
   /**


### PR DESCRIPTION
[TML-1683](https://linear.app/prisma-company/issue/TML-1683/fix-byte-array-upsert-issue)

Removes the legacy byte representation that used arrays. The old representation used arrays to make query arguments JSON serializable, which is something we no longer need. It was inefficient and it was also causing an edge case in the query renderer where it would interpret byte arrays as parameter lists.

Fixes https://github.com/prisma/prisma/issues/28824.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Binary values are preserved as native binary (Buffer/Uint8Array) across adapters; byte arrays are no longer auto-converted to number arrays or re-encoded.
  * Result value types now accept Uint8Array and runtime truthiness treats Uint8Array like arrays.
  * Bytes/BytesArray no longer receive special serialization/transformation and pass through raw binary.

* **Tests**
  * Added functional tests for upserting records using byte-array IDs (skipped on SQL Server).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->