### PR TITLE
chore(cli): bump @prisma/studio-core to latest with proper licensing.

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -183,7 +183,7 @@
     "@prisma/config": "workspace:*",
     "@prisma/dev": "0.16.0",
     "@prisma/engines": "workspace:*",
-    "@prisma/studio-core": "0.8.2",
+    "@prisma/studio-core": "0.9.0",
     "mysql2": "3.15.3",
     "postgres": "3.4.7"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -430,8 +430,8 @@ importers:
         specifier: workspace:*
         version: link:../engines
       '@prisma/studio-core':
-        specifier: 0.8.2
-        version: 0.8.2
+        specifier: 0.9.0
+        version: 0.9.0
       mysql2:
         specifier: 3.15.3
         version: 3.15.3
@@ -3595,8 +3595,8 @@ packages:
   '@prisma/schema-engine-wasm@7.2.0-4.0c8ef2ce45c83248ab3df073180d5eda9e8be7a3':
     resolution: {integrity: sha512-Kdyw3LJXp1lbXow1de9WJEFwZdG0Apll4RV1uanatNZlz3cOfl9wuQzD8rh9T+pg6wGT201l+klpJV9sox/S3Q==}
 
-  '@prisma/studio-core@0.8.2':
-    resolution: {integrity: sha512-/iAEWEUpTja+7gVMu1LtR2pPlvDmveAwMHdTWbDeGlT7yiv0ZTCPpmeAGdq/Y9aJ9Zj1cEGBXGRbmmNPj022PQ==}
+  '@prisma/studio-core@0.9.0':
+    resolution: {integrity: sha512-xA2zoR/ADu/NCSQuriBKTh6Ps4XjU0bErkEcgMfnSGh346K1VI7iWKnoq1l2DoxUqiddPHIEWwtxJ6xCHG6W7g==}
     peerDependencies:
       '@types/react': ^18.0.0 || ^19.0.0
       react: ^18.0.0 || ^19.0.0
@@ -10152,7 +10152,7 @@ snapshots:
 
   '@prisma/schema-engine-wasm@7.2.0-4.0c8ef2ce45c83248ab3df073180d5eda9e8be7a3': {}
 
-  '@prisma/studio-core@0.8.2': {}
+  '@prisma/studio-core@0.9.0': {}
 
   '@redocly/ajv@8.17.1':
     dependencies:


### PR DESCRIPTION
Hey :wave:

closes TML-1685.
closes prisma/studio#1424.

This PR bumps `@prisma/studio-core` to latest version which is licensed correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to latest versions for improved stability and performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->