### PR TITLE
feat(client-engine-runtime): remove outdated comment

### DIFF
--- a/packages/client-engine-runtime/src/interpreter/render-query.ts
+++ b/packages/client-engine-runtime/src/interpreter/render-query.ts
@@ -30,8 +30,6 @@ export function renderQuery(
       const chunks = dbQuery.chunkable ? chunkParams(dbQuery.fragments, args, maxChunkSize) : [args]
       return chunks.map((params) => {
         if (maxChunkSize !== undefined && params.length > maxChunkSize) {
-          // TODO: this should probably say something along the lines of `Query parameter limit exceeded error`, like in
-          // https://github.com/prisma/prisma-engines/blob/9c30299f5a0ea26a96790e13f796dc6094db3173/libs/user-facing-errors/src/query_engine/mod.rs#L276.
           throw new UserFacingError('The query parameter limit supported by your database is exceeded.', 'P2029')
         }
 


### PR DESCRIPTION
This PR closes [TML-1572](https://linear.app/prisma-company/issue/TML-1572/timebox-2h-normalize-error-message-in-functionalchunking-queryteststs), which is no longer relevant.

The old query engine used to have a generic `Query parameter limit exceeded error: {message}.` error, which a few possible instances of said dynamic `{message}`.

`The query parameter limit supported by your database is exceeded.` is the appropriate message for `js_pg` and `js_cockroachdb` in [this test](https://github.com/prisma/prisma/blob/b45b2f7345f7158d51f9efe91eb8e732a2f2ec4d/packages/client/tests/functional/chunking-query/tests.ts#L180-L183), and can be found in [`prisma-engines`](https://github.com/search?q=repo%3Aprisma%2Fprisma-engines%20QueryParameterLimitExceeded&type=code) too. This means that we no longer need to "normalize" this error message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal documentation comment with no impact to functionality or user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->