### PR TITLE
chore(cli): bump `@prisma/dev`, fix init usage following changes.

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -181,7 +181,7 @@
   },
   "dependencies": {
     "@prisma/config": "workspace:*",
-    "@prisma/dev": "0.16.1",
+    "@prisma/dev": "0.17.0",
     "@prisma/engines": "workspace:*",
     "@prisma/studio-core": "0.9.0",
     "mysql2": "3.15.3",

--- a/packages/cli/src/Init.ts
+++ b/packages/cli/src/Init.ts
@@ -122,7 +122,7 @@ export const defaultEnv = async (url: string | undefined, debug = false, comment
     let created = false
     const state =
       (await ServerState.fromServerDump({ debug })) ||
-      ((created = true), await ServerState.createExclusively({ persistenceMode: 'stateful', debug }))
+      ((created = true), await ServerState.createExclusively({ debug, persistenceMode: 'stateful' }))
 
     if (created) {
       await state.close()
@@ -131,6 +131,8 @@ export const defaultEnv = async (url: string | undefined, debug = false, comment
     const server = await startPrismaDevServer({
       databasePort: state.databasePort,
       dryRun: true,
+      name: state.name,
+      persistenceMode: 'stateful',
       port: state.port,
       shadowDatabasePort: state.shadowDatabasePort,
       debug,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -424,8 +424,8 @@ importers:
         specifier: workspace:*
         version: link:../config
       '@prisma/dev':
-        specifier: 0.16.1
-        version: 0.16.1(typescript@5.4.5)
+        specifier: 0.17.0
+        version: 0.17.0(typescript@5.4.5)
       '@prisma/engines':
         specifier: workspace:*
         version: link:../engines
@@ -3568,8 +3568,8 @@ packages:
   '@prisma/debug@6.8.2':
     resolution: {integrity: sha512-4muBSSUwJJ9BYth5N8tqts8JtiLT8QI/RSAzEogwEfpbYGFo9mYsInsVo8dqXdPO2+Rm5OG5q0qWDDE3nyUbVg==}
 
-  '@prisma/dev@0.16.1':
-    resolution: {integrity: sha512-wc5mwb5K9bJq9eD1GJhW28UTHFrV5vubMVuNoIwbLMykHn7TGDVwexlsGIHd7z+3rQHgPl4+Yz+PDsbg6p1gog==}
+  '@prisma/dev@0.17.0':
+    resolution: {integrity: sha512-6sGebe5jxX+FEsQTpjHLzvOGPn6ypFQprcs3jcuIWv1Xp/5v6P/rjfdvAwTkP2iF6pDx2tCd8vGLNWcsWzImTA==}
 
   '@prisma/engines-version@7.2.0-4.0c8ef2ce45c83248ab3df073180d5eda9e8be7a3':
     resolution: {integrity: sha512-KezsjCZDsbjNR7SzIiVlUsn9PnLePI7r5uxABlwL+xoerurZTfgQVbIjvjF2sVr3Uc0ZcsnREw3F84HvbggGdA==}
@@ -10105,7 +10105,7 @@ snapshots:
 
   '@prisma/debug@6.8.2': {}
 
-  '@prisma/dev@0.16.1(typescript@5.4.5)':
+  '@prisma/dev@0.17.0(typescript@5.4.5)':
     dependencies:
       '@electric-sql/pglite': 0.3.2
       '@electric-sql/pglite-socket': 0.0.6(@electric-sql/pglite@0.3.2)


### PR DESCRIPTION
Hey :wave:

closes TML-1695.

This PR bumps `@prisma/dev` and aligns the init command with the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to their latest versions.

* **Refactor**
  * Internal code reorganization to improve configuration handling and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->