### PR TITLE
perf(client): query plan caching PoC

### DIFF
--- a/packages/client/src/__tests__/benchmarks/query-performance/caching.bench.ts
+++ b/packages/client/src/__tests__/benchmarks/query-performance/caching.bench.ts
@@ -1,0 +1,187 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { withCodSpeed } from '@codspeed/benchmark.js-plugin'
+import { QueryCompiler, QueryCompilerConstructor } from '@prisma/client-common'
+import { JsonQuery } from '@prisma/json-protocol'
+import Benchmark from 'benchmark'
+
+import { parameterizeQuery } from '../../../runtime/core/engines/client/parameterize'
+import { loadQueryCompiler } from './qc-loader'
+
+let QueryCompilerClass: QueryCompilerConstructor
+let queryCompiler: QueryCompiler
+
+const BENCHMARK_DATAMODEL = fs.readFileSync(path.join(__dirname, 'schema.prisma'), 'utf-8')
+
+type Param = { $type: 'Param'; value: string }
+type Parameterizable<T> = T | Param
+
+function createFindUniqueQuery(id: Parameterizable<number>): JsonQuery {
+  return {
+    modelName: 'User',
+    action: 'findUnique',
+    query: {
+      arguments: { where: { id } },
+      selection: {
+        $scalars: true,
+      },
+    },
+  }
+}
+
+function createFindManyQuery(): JsonQuery {
+  return {
+    modelName: 'User',
+    action: 'findMany',
+    query: {
+      arguments: {
+        where: { isActive: true, role: 'user' },
+        orderBy: [{ createdAt: 'desc' }],
+        take: 20,
+      },
+      selection: {
+        $scalars: true,
+      },
+    },
+  }
+}
+
+function createBlogPostPageQuery(id: Parameterizable<number>): JsonQuery {
+  return {
+    modelName: 'Post',
+    action: 'findUnique',
+    query: {
+      arguments: { where: { id } },
+      selection: {
+        $scalars: true,
+        author: {
+          selection: {
+            id: true,
+            name: true,
+            avatar: true,
+          },
+        },
+        category: {
+          selection: {
+            $scalars: true,
+          },
+        },
+        tags: {
+          selection: {
+            tag: {
+              selection: {
+                $scalars: true,
+              },
+            },
+          },
+        },
+        comments: {
+          arguments: {
+            take: 10,
+            orderBy: [{ createdAt: 'desc' }],
+          },
+          selection: {
+            $scalars: true,
+            author: {
+              selection: {
+                id: true,
+                name: true,
+                avatar: true,
+              },
+            },
+          },
+        },
+        _count: {
+          selection: {
+            likes: true,
+            comments: true,
+          },
+        },
+      },
+    },
+  }
+}
+
+async function setup(): Promise<void> {
+  const provider = 'sqlite'
+
+  QueryCompilerClass = await loadQueryCompiler(provider)
+
+  queryCompiler = new QueryCompilerClass({
+    provider,
+    connectionInfo: {
+      supportsRelationJoins: false,
+    },
+    datamodel: BENCHMARK_DATAMODEL,
+  })
+}
+
+function syncBench(fn: () => void): Benchmark.Options {
+  return { fn }
+}
+
+async function runBenchmarks(): Promise<void> {
+  await setup()
+
+  const suite = withCodSpeed(new Benchmark.Suite('query-caching'))
+
+  suite.add(
+    'compile findUnique (uncached baseline)',
+    syncBench(() => {
+      queryCompiler.compile(JSON.stringify(createFindUniqueQuery(1)))
+    }),
+  )
+
+  suite.add(
+    'compile findMany filtered (uncached baseline)',
+    syncBench(() => {
+      queryCompiler.compile(JSON.stringify(createFindManyQuery()))
+    }),
+  )
+
+  suite.add(
+    'compile blog post page (uncached baseline)',
+    syncBench(() => {
+      queryCompiler.compile(JSON.stringify(createBlogPostPageQuery(1)))
+    }),
+  )
+
+  suite.add(
+    'parameterize findUnique',
+    syncBench(() => {
+      parameterizeQuery(createFindUniqueQuery(1))
+    }),
+  )
+
+  suite.add(
+    'parameterize findMany',
+    syncBench(() => {
+      parameterizeQuery(createFindManyQuery())
+    }),
+  )
+
+  suite.add(
+    'parameterize blog post page query',
+    syncBench(() => {
+      parameterizeQuery(createBlogPostPageQuery(1))
+    }),
+  )
+
+  await new Promise<void>((resolve) => {
+    void suite
+      .on('cycle', (event: Benchmark.Event) => {
+        console.log(String(event.target))
+      })
+      .on('complete', () => {
+        console.log('Query caching benchmarks complete.')
+        resolve()
+      })
+      .on('error', (event: Benchmark.Event) => {
+        console.error('Benchmark error:', event.target)
+      })
+      .run({ async: true })
+  })
+}
+
+void runBenchmarks()

--- a/packages/client/src/__tests__/benchmarks/query-performance/qc-loader.ts
+++ b/packages/client/src/__tests__/benchmarks/query-performance/qc-loader.ts
@@ -1,0 +1,38 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { QueryCompilerConstructor } from '@prisma/client-common'
+
+import { wasmQueryCompilerLoader } from '../../../runtime/core/engines/client/WasmQueryCompilerLoader'
+
+export function loadQueryCompiler(provider: string): Promise<QueryCompilerConstructor> {
+  const runtimeBase = path.join(__dirname, '..', '..', '..', '..', 'runtime')
+  return wasmQueryCompilerLoader.loadQueryCompiler({
+    activeProvider: provider,
+    clientVersion: '0.0.0',
+    compilerWasm: {
+      getRuntime: () => {
+        let runtimePath: string
+        if (process.env.LOCAL_QC_BUILD_DIRECTORY) {
+          runtimePath = path.join(process.env.LOCAL_QC_BUILD_DIRECTORY, provider, 'query_compiler_fast_bg.js')
+        } else {
+          runtimePath = path.join(runtimeBase, `query_compiler_fast_bg.${provider}.js`)
+        }
+        return Promise.resolve(require(runtimePath))
+      },
+      getQueryCompilerWasmModule: async () => {
+        let moduleBytes: BufferSource
+        if (process.env.LOCAL_QC_BUILD_DIRECTORY) {
+          const wasmPath = path.join(process.env.LOCAL_QC_BUILD_DIRECTORY, provider, 'query_compiler_fast_bg.wasm')
+          moduleBytes = await fs.promises.readFile(wasmPath)
+        } else {
+          const queryCompilerWasmFilePath = path.join(runtimeBase, `query_compiler_fast_bg.${provider}.wasm-base64.js`)
+          const wasmBase64: string = require(queryCompilerWasmFilePath).wasm
+          moduleBytes = Buffer.from(wasmBase64, 'base64')
+        }
+        return new WebAssembly.Module(moduleBytes)
+      },
+      importName: `./query_compiler_fast_bg.js`,
+    },
+  })
+}

--- a/packages/client/src/runtime/core/engines/client/QueryPlanCache.test.ts
+++ b/packages/client/src/runtime/core/engines/client/QueryPlanCache.test.ts
@@ -1,0 +1,225 @@
+import { QueryPlanCache } from './QueryPlanCache'
+
+describe('QueryPlanCache', () => {
+  describe('single cache', () => {
+    it('stores and retrieves entries', () => {
+      const cache = new QueryPlanCache()
+      const entry = {
+        plan: { type: 'value' as const, args: null },
+        placeholderPaths: ['query.arguments.where.id'],
+      }
+
+      cache.setSingle('key1', entry)
+      const retrieved = cache.getSingle('key1')
+
+      expect(retrieved).toBe(entry)
+    })
+
+    it('returns undefined for missing keys', () => {
+      const cache = new QueryPlanCache()
+
+      expect(cache.getSingle('nonexistent')).toBeUndefined()
+    })
+
+    it('updates existing entries', () => {
+      const cache = new QueryPlanCache()
+      const entry1 = {
+        plan: { type: 'value' as const, args: null },
+        placeholderPaths: ['path1'],
+      }
+      const entry2 = {
+        plan: { type: 'value' as const, args: { test: true } },
+        placeholderPaths: ['path2'],
+      }
+
+      cache.setSingle('key', entry1)
+      cache.setSingle('key', entry2)
+
+      expect(cache.getSingle('key')).toBe(entry2)
+      expect(cache.singleCacheSize).toBe(1)
+    })
+
+    it('evicts oldest entry when at capacity', () => {
+      const cache = new QueryPlanCache(2)
+      const entry1 = { plan: { type: 'value' as const, args: 1 }, placeholderPaths: [] }
+      const entry2 = { plan: { type: 'value' as const, args: 2 }, placeholderPaths: [] }
+      const entry3 = { plan: { type: 'value' as const, args: 3 }, placeholderPaths: [] }
+
+      cache.setSingle('key1', entry1)
+      cache.setSingle('key2', entry2)
+      cache.setSingle('key3', entry3)
+
+      expect(cache.getSingle('key1')).toBeUndefined()
+      expect(cache.getSingle('key2')).toBeDefined()
+      expect(cache.getSingle('key3')).toBeDefined()
+      expect(cache.singleCacheSize).toBe(2)
+    })
+
+    it('refreshes entry on get (LRU behavior)', () => {
+      const cache = new QueryPlanCache(2)
+      const entry1 = { plan: { type: 'value' as const, args: 1 }, placeholderPaths: [] }
+      const entry2 = { plan: { type: 'value' as const, args: 2 }, placeholderPaths: [] }
+      const entry3 = { plan: { type: 'value' as const, args: 3 }, placeholderPaths: [] }
+
+      cache.setSingle('key1', entry1)
+      cache.setSingle('key2', entry2)
+
+      // Access key1 to make it recently used
+      cache.getSingle('key1')
+
+      // Add key3, should evict key2 (oldest)
+      cache.setSingle('key3', entry3)
+
+      expect(cache.getSingle('key1')).toBeDefined()
+      expect(cache.getSingle('key2')).toBeUndefined()
+      expect(cache.getSingle('key3')).toBeDefined()
+    })
+  })
+
+  describe('batch cache', () => {
+    it('stores and retrieves batch entries', () => {
+      const cache = new QueryPlanCache()
+      const entry = {
+        response: {
+          type: 'multi' as const,
+          plans: [
+            { type: 'value' as const, args: null },
+            { type: 'value' as const, args: null },
+          ],
+        },
+        placeholderPaths: ['batch[0].query.arguments.where.id', 'batch[1].query.arguments.where.id'],
+      }
+
+      cache.setBatch('batchKey', entry)
+      const retrieved = cache.getBatch('batchKey')
+
+      expect(retrieved).toBe(entry)
+    })
+
+    it('returns undefined for missing batch keys', () => {
+      const cache = new QueryPlanCache()
+
+      expect(cache.getBatch('nonexistent')).toBeUndefined()
+    })
+
+    it('stores compacted batch responses', () => {
+      const cache = new QueryPlanCache()
+      const entry = {
+        response: {
+          type: 'compacted' as const,
+          plan: { type: 'value' as const, args: null },
+          arguments: [{ id: 1 }, { id: 2 }],
+          nestedSelection: ['name', 'email'],
+          keys: ['id'],
+          expectNonEmpty: true,
+        },
+        placeholderPaths: ['batch[0].query.arguments.where.id', 'batch[1].query.arguments.where.id'],
+      }
+
+      cache.setBatch('compactedKey', entry)
+      const retrieved = cache.getBatch('compactedKey')
+
+      expect(retrieved).toBe(entry)
+      expect(retrieved?.response.type).toBe('compacted')
+    })
+
+    it('updates existing batch entries', () => {
+      const cache = new QueryPlanCache()
+      const entry1 = {
+        response: { type: 'multi' as const, plans: [] },
+        placeholderPaths: [],
+      }
+      const entry2 = {
+        response: { type: 'multi' as const, plans: [{ type: 'value' as const, args: null }] },
+        placeholderPaths: ['updated'],
+      }
+
+      cache.setBatch('key', entry1)
+      cache.setBatch('key', entry2)
+
+      expect(cache.getBatch('key')).toBe(entry2)
+      expect(cache.batchCacheSize).toBe(1)
+    })
+
+    it('evicts oldest batch entry when at capacity', () => {
+      const cache = new QueryPlanCache(2)
+      const makeEntry = (id: number) => ({
+        response: { type: 'multi' as const, plans: [{ type: 'value' as const, args: id }] },
+        placeholderPaths: [],
+      })
+
+      cache.setBatch('key1', makeEntry(1))
+      cache.setBatch('key2', makeEntry(2))
+      cache.setBatch('key3', makeEntry(3))
+
+      expect(cache.getBatch('key1')).toBeUndefined()
+      expect(cache.getBatch('key2')).toBeDefined()
+      expect(cache.getBatch('key3')).toBeDefined()
+      expect(cache.batchCacheSize).toBe(2)
+    })
+
+    it('refreshes batch entry on get (LRU behavior)', () => {
+      const cache = new QueryPlanCache(2)
+      const makeEntry = (id: number) => ({
+        response: { type: 'multi' as const, plans: [{ type: 'value' as const, args: id }] },
+        placeholderPaths: [],
+      })
+
+      cache.setBatch('key1', makeEntry(1))
+      cache.setBatch('key2', makeEntry(2))
+
+      // Access key1 to make it recently used
+      cache.getBatch('key1')
+
+      // Add key3, should evict key2 (oldest)
+      cache.setBatch('key3', makeEntry(3))
+
+      expect(cache.getBatch('key1')).toBeDefined()
+      expect(cache.getBatch('key2')).toBeUndefined()
+      expect(cache.getBatch('key3')).toBeDefined()
+    })
+  })
+
+  describe('combined behavior', () => {
+    it('maintains separate caches for single and batch entries', () => {
+      const cache = new QueryPlanCache()
+
+      const singleEntry = { plan: { type: 'value' as const, args: 'single' }, placeholderPaths: [] }
+      const batchEntry = {
+        response: { type: 'multi' as const, plans: [{ type: 'value' as const, args: 'batch' }] },
+        placeholderPaths: [],
+      }
+
+      cache.setSingle('sharedKey', singleEntry)
+      cache.setBatch('sharedKey', batchEntry)
+
+      expect(cache.getSingle('sharedKey')).toBe(singleEntry)
+      expect(cache.getBatch('sharedKey')).toBe(batchEntry)
+    })
+
+    it('reports combined size', () => {
+      const cache = new QueryPlanCache()
+
+      cache.setSingle('single1', { plan: { type: 'value' as const, args: null }, placeholderPaths: [] })
+      cache.setSingle('single2', { plan: { type: 'value' as const, args: null }, placeholderPaths: [] })
+      cache.setBatch('batch1', { response: { type: 'multi' as const, plans: [] }, placeholderPaths: [] })
+
+      expect(cache.singleCacheSize).toBe(2)
+      expect(cache.batchCacheSize).toBe(1)
+      expect(cache.size).toBe(3)
+    })
+
+    it('clears both caches', () => {
+      const cache = new QueryPlanCache()
+
+      cache.setSingle('single', { plan: { type: 'value' as const, args: null }, placeholderPaths: [] })
+      cache.setBatch('batch', { response: { type: 'multi' as const, plans: [] }, placeholderPaths: [] })
+
+      cache.clear()
+
+      expect(cache.getSingle('single')).toBeUndefined()
+      expect(cache.getBatch('batch')).toBeUndefined()
+      expect(cache.size).toBe(0)
+    })
+  })
+})

--- a/packages/client/src/runtime/core/engines/client/QueryPlanCache.ts
+++ b/packages/client/src/runtime/core/engines/client/QueryPlanCache.ts
@@ -1,0 +1,53 @@
+import type { QueryPlanNode } from '@prisma/client-engine-runtime'
+
+interface CacheEntry {
+  plan: QueryPlanNode
+  placeholderPaths: string[]
+}
+
+export class QueryPlanCache {
+  readonly #cache: Map<string, CacheEntry>
+  readonly #maxSize: number
+
+  constructor(maxSize = 1000) {
+    this.#cache = new Map()
+    this.#maxSize = maxSize
+  }
+
+  get(key: string): CacheEntry | undefined {
+    const entry = this.#cache.get(key)
+    if (entry) {
+      // Move to end for LRU behavior
+      this.#cache.delete(key)
+      this.#cache.set(key, entry)
+    }
+    return entry
+  }
+
+  set(key: string, entry: CacheEntry): void {
+    if (this.#cache.has(key)) {
+      // Update existing entry (also moves to end for LRU)
+      this.#cache.delete(key)
+      this.#cache.set(key, entry)
+      return
+    }
+
+    // Evict oldest if at capacity
+    if (this.#cache.size >= this.#maxSize) {
+      const firstKey = this.#cache.keys().next().value
+      if (firstKey !== undefined) {
+        this.#cache.delete(firstKey)
+      }
+    }
+
+    this.#cache.set(key, entry)
+  }
+
+  clear(): void {
+    this.#cache.clear()
+  }
+
+  get size(): number {
+    return this.#cache.size
+  }
+}

--- a/packages/client/src/runtime/core/engines/client/QueryPlanCache.ts
+++ b/packages/client/src/runtime/core/engines/client/QueryPlanCache.ts
@@ -1,53 +1,98 @@
-import type { QueryPlanNode } from '@prisma/client-engine-runtime'
+import type { BatchResponse, QueryPlanNode } from '@prisma/client-engine-runtime'
 
-interface CacheEntry {
+interface SingleCacheEntry {
   plan: QueryPlanNode
   placeholderPaths: string[]
 }
 
+interface BatchCacheEntry {
+  response: BatchResponse
+  placeholderPaths: string[]
+}
+
 export class QueryPlanCache {
-  readonly #cache: Map<string, CacheEntry>
+  readonly #singleCache: Map<string, SingleCacheEntry>
+  readonly #batchCache: Map<string, BatchCacheEntry>
   readonly #maxSize: number
 
   constructor(maxSize = 1000) {
-    this.#cache = new Map()
+    this.#singleCache = new Map()
+    this.#batchCache = new Map()
     this.#maxSize = maxSize
   }
 
-  get(key: string): CacheEntry | undefined {
-    const entry = this.#cache.get(key)
+  getSingle(key: string): SingleCacheEntry | undefined {
+    const entry = this.#singleCache.get(key)
     if (entry) {
       // Move to end for LRU behavior
-      this.#cache.delete(key)
-      this.#cache.set(key, entry)
+      this.#singleCache.delete(key)
+      this.#singleCache.set(key, entry)
     }
     return entry
   }
 
-  set(key: string, entry: CacheEntry): void {
-    if (this.#cache.has(key)) {
+  setSingle(key: string, entry: SingleCacheEntry): void {
+    if (this.#singleCache.has(key)) {
       // Update existing entry (also moves to end for LRU)
-      this.#cache.delete(key)
-      this.#cache.set(key, entry)
+      this.#singleCache.delete(key)
+      this.#singleCache.set(key, entry)
       return
     }
 
     // Evict oldest if at capacity
-    if (this.#cache.size >= this.#maxSize) {
-      const firstKey = this.#cache.keys().next().value
+    if (this.#singleCache.size >= this.#maxSize) {
+      const firstKey = this.#singleCache.keys().next().value
       if (firstKey !== undefined) {
-        this.#cache.delete(firstKey)
+        this.#singleCache.delete(firstKey)
       }
     }
 
-    this.#cache.set(key, entry)
+    this.#singleCache.set(key, entry)
+  }
+
+  getBatch(key: string): BatchCacheEntry | undefined {
+    const entry = this.#batchCache.get(key)
+    if (entry) {
+      // Move to end for LRU behavior
+      this.#batchCache.delete(key)
+      this.#batchCache.set(key, entry)
+    }
+    return entry
+  }
+
+  setBatch(key: string, entry: BatchCacheEntry): void {
+    if (this.#batchCache.has(key)) {
+      // Update existing entry (also moves to end for LRU)
+      this.#batchCache.delete(key)
+      this.#batchCache.set(key, entry)
+      return
+    }
+
+    // Evict oldest if at capacity
+    if (this.#batchCache.size >= this.#maxSize) {
+      const firstKey = this.#batchCache.keys().next().value
+      if (firstKey !== undefined) {
+        this.#batchCache.delete(firstKey)
+      }
+    }
+
+    this.#batchCache.set(key, entry)
   }
 
   clear(): void {
-    this.#cache.clear()
+    this.#singleCache.clear()
+    this.#batchCache.clear()
   }
 
   get size(): number {
-    return this.#cache.size
+    return this.#singleCache.size + this.#batchCache.size
+  }
+
+  get singleCacheSize(): number {
+    return this.#singleCache.size
+  }
+
+  get batchCacheSize(): number {
+    return this.#batchCache.size
   }
 }

--- a/packages/client/src/runtime/core/engines/client/parameterize.test.ts
+++ b/packages/client/src/runtime/core/engines/client/parameterize.test.ts
@@ -1,0 +1,551 @@
+import { JsonQuery } from '@prisma/json-protocol'
+import { parameterizeQuery } from './parameterize'
+
+describe('parameterizeQuery', () => {
+  describe('top-level structural keys', () => {
+    it('preserves modelName and action', () => {
+      const query: JsonQuery = {
+        modelName: 'User',
+        action: 'findUnique',
+        query: {
+          arguments: { where: { id: 1 } },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result = parameterizeQuery(query)
+
+      expect(result.parameterizedQuery).toMatchObject({
+        modelName: 'User',
+        action: 'findUnique',
+      })
+      expect(result.placeholderValues).not.toHaveProperty('modelName')
+      expect(result.placeholderValues).not.toHaveProperty('action')
+    })
+  })
+
+  describe('scalar values', () => {
+    it('parameterizes string values', () => {
+      const query: JsonQuery = {
+        modelName: 'User',
+        action: 'findUnique',
+        query: {
+          arguments: { where: { email: 'test@example.com' } },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result = parameterizeQuery(query)
+
+      expect(result.parameterizedQuery).toMatchObject({
+        query: {
+          arguments: {
+            where: {
+              email: { $type: 'Param', value: expect.stringContaining('email') },
+            },
+          },
+        },
+      })
+      expect(Object.values(result.placeholderValues)).toContain('test@example.com')
+    })
+
+    it('parameterizes number values', () => {
+      const query: JsonQuery = {
+        modelName: 'User',
+        action: 'findUnique',
+        query: {
+          arguments: { where: { id: 42 } },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result = parameterizeQuery(query)
+
+      expect(Object.values(result.placeholderValues)).toContain(42)
+    })
+
+    it('preserves null values', () => {
+      const query: JsonQuery = {
+        modelName: 'User',
+        action: 'findMany',
+        query: {
+          arguments: { where: { deletedAt: null } },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result = parameterizeQuery(query)
+
+      expect(result.parameterizedQuery).toMatchObject({
+        query: {
+          arguments: {
+            where: {
+              deletedAt: null,
+            },
+          },
+        },
+      })
+    })
+
+    it('parameterizes boolean values in where clauses', () => {
+      const query: JsonQuery = {
+        modelName: 'User',
+        action: 'findMany',
+        query: {
+          arguments: { where: { isActive: true } },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result = parameterizeQuery(query)
+
+      expect(Object.values(result.placeholderValues)).toContain(true)
+    })
+  })
+
+  describe('filter operators', () => {
+    it('parameterizes equals filter', () => {
+      const query: JsonQuery = {
+        modelName: 'User',
+        action: 'findMany',
+        query: {
+          arguments: { where: { age: { equals: 25 } } },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result = parameterizeQuery(query)
+
+      expect(Object.values(result.placeholderValues)).toContain(25)
+    })
+
+    it('parameterizes in filter with array', () => {
+      const query: JsonQuery = {
+        modelName: 'User',
+        action: 'findMany',
+        query: {
+          arguments: { where: { id: { in: [1, 2, 3] } } },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result = parameterizeQuery(query)
+
+      expect(Object.values(result.placeholderValues)).toEqual(expect.arrayContaining([1, 2, 3]))
+      expect(result.placeholderPaths).toHaveLength(3)
+    })
+
+    it('parameterizes comparison operators (lt, lte, gt, gte)', () => {
+      const query: JsonQuery = {
+        modelName: 'User',
+        action: 'findMany',
+        query: {
+          arguments: {
+            where: {
+              age: { gte: 18, lte: 65 },
+              salary: { gt: 50000, lt: 200000 },
+            },
+          },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result = parameterizeQuery(query)
+
+      const values = Object.values(result.placeholderValues)
+      expect(values).toContain(18)
+      expect(values).toContain(65)
+      expect(values).toContain(50000)
+      expect(values).toContain(200000)
+    })
+
+    it('parameterizes string operators (contains, startsWith, endsWith)', () => {
+      const query: JsonQuery = {
+        modelName: 'User',
+        action: 'findMany',
+        query: {
+          arguments: {
+            where: {
+              name: { contains: 'john' },
+              email: { startsWith: 'admin', endsWith: '.com' },
+            },
+          },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result = parameterizeQuery(query)
+
+      const values = Object.values(result.placeholderValues)
+      expect(values).toContain('john')
+      expect(values).toContain('admin')
+      expect(values).toContain('.com')
+    })
+  })
+
+  describe('structural values', () => {
+    it('preserves selection booleans', () => {
+      const query: JsonQuery = {
+        modelName: 'User',
+        action: 'findUnique',
+        query: {
+          arguments: { where: { id: 1 } },
+          selection: {
+            id: true,
+            name: true,
+            email: false,
+          },
+        },
+      }
+
+      const result = parameterizeQuery(query)
+
+      expect(result.parameterizedQuery).toMatchObject({
+        query: {
+          selection: {
+            id: true,
+            name: true,
+            email: false,
+          },
+        },
+      })
+    })
+
+    it('preserves $scalars and $composites markers', () => {
+      const query: JsonQuery = {
+        modelName: 'User',
+        action: 'findUnique',
+        query: {
+          arguments: { where: { id: 1 } },
+          selection: {
+            $scalars: true,
+            $composites: true,
+          },
+        },
+      }
+
+      const result = parameterizeQuery(query)
+
+      expect(result.parameterizedQuery).toMatchObject({
+        query: {
+          selection: {
+            $scalars: true,
+            $composites: true,
+          },
+        },
+      })
+    })
+
+    it('preserves orderBy directions', () => {
+      const query: JsonQuery = {
+        modelName: 'User',
+        action: 'findMany',
+        query: {
+          arguments: {
+            orderBy: [{ name: 'asc' }, { createdAt: 'desc' }],
+          },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result = parameterizeQuery(query)
+
+      expect(result.parameterizedQuery).toMatchObject({
+        query: {
+          arguments: {
+            orderBy: [{ name: 'asc' }, { createdAt: 'desc' }],
+          },
+        },
+      })
+      expect(Object.keys(result.placeholderValues)).toHaveLength(0)
+    })
+
+    it('preserves take and skip values', () => {
+      const query: JsonQuery = {
+        modelName: 'User',
+        action: 'findMany',
+        query: {
+          arguments: {
+            take: 10,
+            skip: 20,
+          },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result = parameterizeQuery(query)
+
+      expect(result.parameterizedQuery).toMatchObject({
+        query: {
+          arguments: {
+            take: 10,
+            skip: 20,
+          },
+        },
+      })
+    })
+
+    it('preserves mode flag', () => {
+      const query: JsonQuery = {
+        modelName: 'User',
+        action: 'findMany',
+        query: {
+          arguments: {
+            where: {
+              name: { contains: 'test', mode: 'insensitive' },
+            },
+          },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result = parameterizeQuery(query)
+
+      expect(result.parameterizedQuery).toMatchObject({
+        query: {
+          arguments: {
+            where: {
+              name: { mode: 'insensitive' },
+            },
+          },
+        },
+      })
+      // 'test' should be parameterized but 'insensitive' should not
+      expect(Object.values(result.placeholderValues)).toContain('test')
+      expect(Object.values(result.placeholderValues)).not.toContain('insensitive')
+    })
+  })
+
+  describe('nested queries', () => {
+    it('parameterizes relation filter values', () => {
+      const query: JsonQuery = {
+        modelName: 'Post',
+        action: 'findMany',
+        query: {
+          arguments: {
+            where: {
+              author: {
+                name: { contains: 'john' },
+              },
+            },
+          },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result = parameterizeQuery(query)
+
+      expect(Object.values(result.placeholderValues)).toContain('john')
+    })
+
+    it('parameterizes nested data in create', () => {
+      const query: JsonQuery = {
+        modelName: 'User',
+        action: 'createOne',
+        query: {
+          arguments: {
+            data: {
+              name: 'Alice',
+              email: 'alice@example.com',
+              posts: {
+                create: {
+                  title: 'Hello World',
+                  content: 'Content here',
+                },
+              },
+            },
+          },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result = parameterizeQuery(query)
+
+      const values = Object.values(result.placeholderValues)
+      expect(values).toContain('Alice')
+      expect(values).toContain('alice@example.com')
+      expect(values).toContain('Hello World')
+      expect(values).toContain('Content here')
+    })
+  })
+
+  describe('tagged values', () => {
+    it('parameterizes DateTime tagged values', () => {
+      const dateValue = { $type: 'DateTime', value: '2023-01-01T00:00:00.000Z' }
+      const query: JsonQuery = {
+        modelName: 'User',
+        action: 'findMany',
+        query: {
+          arguments: {
+            where: { createdAt: dateValue },
+          },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result = parameterizeQuery(query)
+
+      // DateTime values are unwrapped when stored in placeholderValues
+      expect(Object.values(result.placeholderValues)).toContainEqual(dateValue.value)
+    })
+
+    it('preserves FieldRef tagged values', () => {
+      const fieldRef = { $type: 'FieldRef', value: { _ref: 'otherField', _container: 'User' } }
+      const query: JsonQuery = {
+        modelName: 'User',
+        action: 'findMany',
+        query: {
+          arguments: {
+            where: { balance: { gt: fieldRef } },
+          },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result = parameterizeQuery(query)
+
+      expect(result.parameterizedQuery).toMatchObject({
+        query: {
+          arguments: {
+            where: {
+              balance: { gt: fieldRef },
+            },
+          },
+        },
+      })
+      expect(Object.values(result.placeholderValues)).not.toContainEqual(fieldRef)
+    })
+  })
+
+  describe('placeholder naming', () => {
+    it('generates deterministic names for same structure', () => {
+      const query1: JsonQuery = {
+        modelName: 'User',
+        action: 'findUnique',
+        query: {
+          arguments: { where: { id: 1 } },
+          selection: { $scalars: true },
+        },
+      }
+
+      const query2: JsonQuery = {
+        modelName: 'User',
+        action: 'findUnique',
+        query: {
+          arguments: { where: { id: 2 } },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result1 = parameterizeQuery(query1)
+      const result2 = parameterizeQuery(query2)
+
+      // Same placeholder paths despite different values
+      expect(result1.placeholderPaths).toEqual(result2.placeholderPaths)
+    })
+
+    it('generates unique names for different values', () => {
+      const query: JsonQuery = {
+        modelName: 'User',
+        action: 'findMany',
+        query: {
+          arguments: {
+            where: {
+              id: { in: [1, 2, 3] },
+            },
+          },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result = parameterizeQuery(query)
+
+      // All paths should be unique
+      const uniquePaths = new Set(result.placeholderPaths)
+      expect(uniquePaths.size).toBe(result.placeholderPaths.length)
+    })
+
+    it('handles deeply nested paths', () => {
+      const query: JsonQuery = {
+        modelName: 'Post',
+        action: 'findMany',
+        query: {
+          arguments: {
+            where: {
+              author: {
+                profile: {
+                  bio: { contains: 'developer' },
+                },
+              },
+            },
+          },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result = parameterizeQuery(query)
+
+      expect(result.placeholderPaths[0]).toContain('author')
+      expect(result.placeholderPaths[0]).toContain('profile')
+      expect(result.placeholderPaths[0]).toContain('bio')
+    })
+  })
+
+  describe('cache key consistency', () => {
+    it('generates same cache key for same query structure', () => {
+      const query1: JsonQuery = {
+        modelName: 'User',
+        action: 'findUnique',
+        query: {
+          arguments: { where: { id: 1 } },
+          selection: { $scalars: true },
+        },
+      }
+
+      const query2: JsonQuery = {
+        modelName: 'User',
+        action: 'findUnique',
+        query: {
+          arguments: { where: { id: 2 } },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result1 = parameterizeQuery(query1)
+      const result2 = parameterizeQuery(query2)
+
+      const cacheKey1 = JSON.stringify(result1.parameterizedQuery)
+      const cacheKey2 = JSON.stringify(result2.parameterizedQuery)
+
+      expect(cacheKey1).toBe(cacheKey2)
+    })
+
+    it('generates different cache key for different query structure', () => {
+      const query1: JsonQuery = {
+        modelName: 'User',
+        action: 'findUnique',
+        query: {
+          arguments: { where: { id: 1 } },
+          selection: { $scalars: true },
+        },
+      }
+
+      const query2: JsonQuery = {
+        modelName: 'User',
+        action: 'findUnique',
+        query: {
+          arguments: { where: { email: 'test@example.com' } },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result1 = parameterizeQuery(query1)
+      const result2 = parameterizeQuery(query2)
+
+      const cacheKey1 = JSON.stringify(result1.parameterizedQuery)
+      const cacheKey2 = JSON.stringify(result2.parameterizedQuery)
+
+      expect(cacheKey1).not.toBe(cacheKey2)
+    })
+  })
+})

--- a/packages/client/src/runtime/core/engines/client/parameterize.ts
+++ b/packages/client/src/runtime/core/engines/client/parameterize.ts
@@ -1,0 +1,245 @@
+/**
+ * Query parameterization logic for query plan caching.
+ *
+ * This module handles the conversion of Prisma queries into parameterized shapes
+ * where user data values are replaced with placeholder markers, while extracting
+ * the actual values into a separate map.
+ */
+
+import { JsonQuery } from '@prisma/json-protocol'
+
+/**
+ * Placeholder object used to replace parameterized values in query shapes.
+ */
+const PARAM_PLACEHOLDER = { $type: 'Param' }
+
+/**
+ * Keys that represent nested relation operations within data contexts.
+ * These switch back from data context to default context.
+ */
+const RELATION_OPERATION_KEYS = new Set([
+  'connect',
+  'connectOrCreate',
+  'disconnect',
+  'set',
+  'create',
+  'createMany',
+  'update',
+  'updateMany',
+  'upsert',
+  'delete',
+  'deleteMany',
+])
+
+/**
+ * Keys that switch from data context back to default context.
+ */
+const STRUCTURAL_KEYS_IN_DATA = new Set([
+  'where',
+  'select',
+  'include',
+  'omit',
+  '_count',
+  '_sum',
+  '_avg',
+  '_min',
+  '_max',
+])
+
+/**
+ * Keys whose primitive values are structural (not user data).
+ */
+const STRUCTURAL_VALUE_KEYS = new Set([
+  'take',
+  'skip',
+  'sort',
+  'nulls',
+  'mode',
+  'relationLoadStrategy',
+  'distinct',
+  'by',
+])
+
+/**
+ * Top-level query keys that are structural and should not be parameterized.
+ */
+const TOP_LEVEL_STRUCTURAL_KEYS = new Set(['modelName', 'action'])
+
+type Context = 'default' | 'selection' | 'orderBy' | 'data'
+
+interface TaggedValue {
+  $type: string
+  value: unknown
+}
+
+function isTaggedValue(value: unknown): value is TaggedValue {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    '$type' in value &&
+    typeof (value as { $type: unknown }).$type === 'string'
+  )
+}
+
+function isSelectionMarker(key: string): boolean {
+  return key === '$scalars' || key === '$composites'
+}
+
+function isSortDirection(value: string): boolean {
+  return value === 'asc' || value === 'desc'
+}
+
+/**
+ * Get the context for a child key's value based on the key name and parent context.
+ */
+function getChildContext(key: string, parentContext: Context): Context {
+  // These keys always introduce their specific context
+  if (key === 'arguments') return 'default'
+  if (key === 'selection') return 'selection'
+  if (key === 'orderBy') return 'orderBy'
+  if (key === 'data') return 'data'
+
+  // In data context, certain keys escape back to default
+  if (parentContext === 'data') {
+    if (RELATION_OPERATION_KEYS.has(key) || STRUCTURAL_KEYS_IN_DATA.has(key)) {
+      return 'default'
+    }
+  }
+
+  // Otherwise inherit parent context
+  return parentContext
+}
+
+/**
+ * Recursively parameterize a value based on its context.
+ */
+function parameterize(
+  value: unknown,
+  context: Context,
+  path: string,
+  key: string | undefined,
+  placeholderValues: Record<string, unknown>,
+  placeholderPaths: string[],
+): unknown {
+  if (value === null || value === undefined) {
+    return value
+  }
+
+  if (isTaggedValue(value)) {
+    // FieldRef is structural, preserve it
+    if (value.$type === 'FieldRef') {
+      return value
+    }
+    // All other tagged values are user data
+    const placeholderName = path
+    placeholderValues[placeholderName] = decodeTaggedValue(value)
+    placeholderPaths.push(placeholderName)
+    return { ...PARAM_PLACEHOLDER, value: placeholderName }
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item, index) =>
+      parameterize(item, context, `${path}[${index}]`, key, placeholderValues, placeholderPaths),
+    )
+  }
+
+  if (typeof value === 'object') {
+    return parameterizeObject(value as Record<string, unknown>, context, path, placeholderValues, placeholderPaths)
+  }
+
+  if (key && STRUCTURAL_VALUE_KEYS.has(key)) {
+    return value
+  }
+
+  // In selection context, booleans indicate field selection
+  if (context === 'selection' && typeof value === 'boolean') {
+    return value
+  }
+
+  // In orderBy context, sort directions are structural
+  if (context === 'orderBy' && typeof value === 'string' && isSortDirection(value)) {
+    return value
+  }
+
+  // Otherwise, it's a user data value
+  const placeholderName = path
+  placeholderValues[placeholderName] = value
+  placeholderPaths.push(placeholderName)
+  return { ...PARAM_PLACEHOLDER, value: placeholderName }
+}
+
+function decodeTaggedValue({ $type, value }: TaggedValue): unknown {
+  switch ($type) {
+    case 'Bytes':
+      return Buffer.from(value as string, 'base64')
+    default:
+      return value
+  }
+}
+
+/**
+ * Parameterize an object by processing each key-value pair.
+ */
+function parameterizeObject(
+  obj: Record<string, unknown>,
+  context: Context,
+  path: string,
+  placeholderValues: Record<string, unknown>,
+  placeholderPaths: string[],
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+
+  // Sort keys for consistent cache keys
+  const keys = Object.keys(obj).sort()
+  for (const key of keys) {
+    const value = obj[key]
+    if (isSelectionMarker(key)) {
+      result[key] = value
+      continue
+    }
+
+    // Top-level structural keys should not be parameterized
+    if (path === '' && TOP_LEVEL_STRUCTURAL_KEYS.has(key)) {
+      result[key] = value
+      continue
+    }
+
+    const childContext = getChildContext(key, context)
+    const childPath = path ? `${path}.${key}` : key
+    result[key] = parameterize(value, childContext, childPath, key, placeholderValues, placeholderPaths)
+  }
+
+  return result
+}
+
+export interface ParameterizeResult {
+  parameterizedQuery: JsonQuery
+  placeholderValues: Record<string, unknown>
+  placeholderPaths: string[]
+}
+
+/**
+ * Parameterizes a query object, replacing all user data values with placeholders
+ * and extracting the actual values into a separate map.
+ *
+ * @param query - The query object to parameterize
+ * @returns An object containing the parameterized query, placeholder values map, and paths array
+ */
+export function parameterizeQuery(query: JsonQuery): ParameterizeResult {
+  const placeholderValues: Record<string, unknown> = {}
+  const placeholderPaths: string[] = []
+  const parameterizedQuery = parameterize(
+    query,
+    'default',
+    '',
+    undefined,
+    placeholderValues,
+    placeholderPaths,
+  ) as JsonQuery
+
+  return {
+    parameterizedQuery,
+    placeholderValues,
+    placeholderPaths,
+  }
+}

--- a/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.ts
+++ b/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.ts
@@ -309,6 +309,7 @@ function serializeArgumentsValue(
 
   if (ArrayBuffer.isView(jsValue)) {
     const { buffer, byteOffset, byteLength } = jsValue
+    // TODO(perf): get rid of this conversion
     return { $type: 'Bytes', value: Buffer.from(buffer, byteOffset, byteLength).toString('base64') }
   }
 

--- a/packages/sqlcommenter-query-insights/src/parameterize/parameterize.ts
+++ b/packages/sqlcommenter-query-insights/src/parameterize/parameterize.ts
@@ -100,7 +100,8 @@ function parameterize(value: unknown, context: Context, key?: string): unknown {
   }
 
   if (isTaggedValue(value)) {
-    return value.$type === 'FieldRef' ? value : PARAM_PLACEHOLDER
+    // Preserve structural tagged values: FieldRef (field comparisons) and Param (already parameterized)
+    return value.$type === 'FieldRef' || value.$type === 'Param' ? value : PARAM_PLACEHOLDER
   }
 
   if (Array.isArray(value)) {

--- a/packages/sqlcommenter-query-insights/src/parameterize/tests/tagged-values.test.ts
+++ b/packages/sqlcommenter-query-insights/src/parameterize/tests/tagged-values.test.ts
@@ -164,6 +164,70 @@ describe('parameterizeQuery - tagged values', () => {
     })
   })
 
+  it('preserves pre-existing Param tagged values', () => {
+    const query = {
+      arguments: {
+        where: {
+          email: { contains: PARAM_PLACEHOLDER },
+          age: { gte: PARAM_PLACEHOLDER },
+        },
+      },
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: {
+          email: { contains: PARAM_PLACEHOLDER },
+          age: { gte: PARAM_PLACEHOLDER },
+        },
+      },
+      selection: { $scalars: true },
+    })
+  })
+
+  it('preserves pre-existing Param tagged values in data context', () => {
+    const query = {
+      arguments: {
+        data: {
+          name: PARAM_PLACEHOLDER,
+          email: PARAM_PLACEHOLDER,
+        },
+      },
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        data: {
+          name: PARAM_PLACEHOLDER,
+          email: PARAM_PLACEHOLDER,
+        },
+      },
+      selection: { $scalars: true },
+    })
+  })
+
+  it('preserves pre-existing Param tagged values in arrays', () => {
+    const query = {
+      arguments: {
+        where: {
+          id: { in: [PARAM_PLACEHOLDER, PARAM_PLACEHOLDER] },
+        },
+      },
+      selection: { $scalars: true },
+    }
+
+    expect(parameterizeQuery(query)).toEqual({
+      arguments: {
+        where: {
+          id: { in: [PARAM_PLACEHOLDER, PARAM_PLACEHOLDER] },
+        },
+      },
+      selection: { $scalars: true },
+    })
+  })
+
   it('parameterizes tagged values in data context', () => {
     const query = {
       arguments: {


### PR DESCRIPTION
Implements a proof-of-concept for query plan caching that uses a strawman non production ready parameterization algorithm.

This proves that query plan caching provides significant performance improvements for repeated queries with different parameters and measures the concrete impact.

Next steps:
- Finish implementation of query plan caching for batch queries.
- Mark parameterizable places in the query schema (Rust) and DMMF.
- Embed the parameter metadata in the generated client for schema-aware parameterization.
- We will also probably need new kinds of parameters for things like lists so we can parameterize more queries and make shapes more generics, and move chunking completely to the client side.

Ref: https://linear.app/prisma-company/issue/TML-1725/query-plan-caching
