### PR TITLE
fix(cli): normalize line endings in prisma format output

### DIFF
--- a/packages/cli/src/Format.ts
+++ b/packages/cli/src/Format.ts
@@ -93,7 +93,10 @@ Or specify a Prisma schema path
           return new HelpError(`${bold(red(`!`))} The schema ${underline(filename)} is not found in the schema list.`)
         }
         const [, originalSchema] = originalSchemaTuple
-        if (originalSchema !== formattedSchema) {
+        // Normalize line endings before comparing to handle cross-platform differences
+        const normalizedOriginal = originalSchema.replace(/\r\n/g, '\n')
+        const normalizedFormatted = formattedSchema.replace(/\r\n/g, '\n')
+        if (normalizedOriginal !== normalizedFormatted) {
           return new HelpError(
             `${bold(red(`!`))} There are unformatted files. Run ${underline('prisma format')} to format them.`,
           )
@@ -103,7 +106,9 @@ Or specify a Prisma schema path
     }
 
     for (const [filename, data] of formattedDatamodel) {
-      await fs.writeFile(filename, data)
+      // Normalize line endings to LF to ensure consistent formatting across platforms
+      const normalizedData = data.replace(/\r\n/g, '\n')
+      await fs.writeFile(filename, normalizedData)
     }
 
     const after = Math.round(performance.now())


### PR DESCRIPTION
## Summary
Normalizes line endings to LF before writing formatted schema files to ensure consistent output across platforms.

## Problem
On Windows, `prisma format` produces files with mixed line endings: LF for most lines but CRLF for the last line. This causes:
- Inconsistent diffs between platforms in CI
- Files being reformatted on Linux after being formatted on Windows

## Solution
- Normalize line endings to LF before writing the formatted schema file
- Also normalize in `--check` mode to avoid false positives when comparing files with different line ending styles

## Changes
- `packages/cli/src/Format.ts`: Added line ending normalization using `.replace(/\r\n/g, '\n')`

Fixes #8548

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed cross-platform line ending inconsistencies to ensure consistent format checking and file output across Windows, macOS, and Linux environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->