### PR TITLE
feat: compile raw queries in the client engine

### DIFF
--- a/packages/client/src/__tests__/deserializeRawParameters.test.ts
+++ b/packages/client/src/__tests__/deserializeRawParameters.test.ts
@@ -115,4 +115,21 @@ describe('deserializeRawParameters', () => {
     expect(result.args).toEqual(expectedArgs)
     expect(result.argTypes).toEqual(expectedTypes)
   })
+
+  test('throws error for invalid JSON', () => {
+    expect(() => deserializeRawParameters('not valid json')).toThrow()
+  })
+
+  test('throws error for non-array input', () => {
+    expect(() => deserializeRawParameters('{"key": "value"}')).toThrow(
+      'Received invalid serialized parameters: expected an array',
+    )
+  })
+
+  test('throws error for prisma__value without prisma__type', () => {
+    const serialized = JSON.stringify([{ prisma__value: '123' }])
+    expect(() => deserializeRawParameters(serialized)).toThrow(
+      'Invalid serialized parameter, prisma__type should not be present when prisma__value is present',
+    )
+  })
 })

--- a/packages/client/src/__tests__/deserializeRawParameters.test.ts
+++ b/packages/client/src/__tests__/deserializeRawParameters.test.ts
@@ -82,6 +82,18 @@ describe('deserializeRawParameters', () => {
       expectedArgs: [['hello', 'world', 'test']],
       expectedTypes: [{ scalarType: 'string', arity: 'list' }],
     },
+    {
+      name: 'JSON object',
+      input: [
+        { name: 'John', age: 30, active: true },
+        { items: ['a', 'b', 'c'], count: 3 },
+      ],
+      expectedArgs: ['{"name":"John","age":30,"active":true}', '{"items":["a","b","c"],"count":3}'],
+      expectedTypes: [
+        { scalarType: 'unknown', arity: 'scalar' },
+        { scalarType: 'unknown', arity: 'scalar' },
+      ],
+    },
   ])('fast serialization mode: $name', ({ input, expectedArgs, expectedTypes }) => {
     test('round-trip', () => {
       const result = roundTrip(input)

--- a/packages/client/src/__tests__/deserializeRawParameters.test.ts
+++ b/packages/client/src/__tests__/deserializeRawParameters.test.ts
@@ -129,7 +129,7 @@ describe('deserializeRawParameters', () => {
   test('throws error for prisma__value without prisma__type', () => {
     const serialized = JSON.stringify([{ prisma__value: '123' }])
     expect(() => deserializeRawParameters(serialized)).toThrow(
-      'Invalid serialized parameter, prisma__type should not be present when prisma__value is present',
+      'Invalid serialized parameter, prisma__type should be present when prisma__value is present',
     )
   })
 })

--- a/packages/client/src/__tests__/deserializeRawParameters.test.ts
+++ b/packages/client/src/__tests__/deserializeRawParameters.test.ts
@@ -13,7 +13,7 @@ describe('deserializeRawParameters', () => {
     expect(result).toEqual({ args: [], argTypes: [] })
   })
 
-  describe.each([
+  test.each([
     {
       name: 'primitives',
       input: [0, 1, true, false, '', 'hi', null, undefined],
@@ -94,15 +94,13 @@ describe('deserializeRawParameters', () => {
         { scalarType: 'unknown', arity: 'scalar' },
       ],
     },
-  ])('fast serialization mode: $name', ({ input, expectedArgs, expectedTypes }) => {
-    test('round-trip', () => {
-      const result = roundTrip(input)
-      expect(result.args).toEqual(expectedArgs)
-      expect(result.argTypes).toEqual(expectedTypes)
-    })
+  ])('$name - fast serialization roundtrip', ({ input, expectedArgs, expectedTypes }) => {
+    const result = roundTrip(input)
+    expect(result.args).toEqual(expectedArgs)
+    expect(result.argTypes).toEqual(expectedTypes)
   })
 
-  describe.each([
+  test.each([
     {
       name: 'BigInt',
       input: [BigInt('999'), [BigInt('123'), 'text']],
@@ -112,11 +110,9 @@ describe('deserializeRawParameters', () => {
         { scalarType: 'bigint', arity: 'list' },
       ],
     },
-  ])('slow serialization mode: $name', ({ input, expectedArgs, expectedTypes }) => {
-    test('round-trip', () => {
-      const result = roundTrip(input)
-      expect(result.args).toEqual(expectedArgs)
-      expect(result.argTypes).toEqual(expectedTypes)
-    })
+  ])('$name - slow serialization roundtrip', ({ input, expectedArgs, expectedTypes }) => {
+    const result = roundTrip(input)
+    expect(result.args).toEqual(expectedArgs)
+    expect(result.argTypes).toEqual(expectedTypes)
   })
 })

--- a/packages/client/src/__tests__/deserializeRawParameters.test.ts
+++ b/packages/client/src/__tests__/deserializeRawParameters.test.ts
@@ -1,0 +1,110 @@
+import { Decimal } from '@prisma/client-runtime-utils'
+
+import { deserializeRawParameters } from '../runtime/utils/deserializeRawParameters'
+import { serializeRawParameters } from '../runtime/utils/serializeRawParameters'
+
+function roundTrip(data: any[]) {
+  return deserializeRawParameters(serializeRawParameters(data))
+}
+
+describe('deserializeRawParameters', () => {
+  test('empty array', () => {
+    const result = deserializeRawParameters('[]')
+    expect(result).toEqual({ args: [], argTypes: [] })
+  })
+
+  describe.each([
+    {
+      name: 'primitives',
+      input: [0, 1, true, false, '', 'hi', null, undefined],
+      expectedArgs: [0, 1, true, false, '', 'hi', null, null],
+      expectedTypes: [
+        { scalarType: 'decimal', arity: 'scalar' },
+        { scalarType: 'decimal', arity: 'scalar' },
+        { scalarType: 'unknown', arity: 'scalar' },
+        { scalarType: 'unknown', arity: 'scalar' },
+        { scalarType: 'string', arity: 'scalar' },
+        { scalarType: 'string', arity: 'scalar' },
+        { scalarType: 'unknown', arity: 'scalar' },
+        { scalarType: 'unknown', arity: 'scalar' },
+      ],
+    },
+    {
+      name: 'BigInt',
+      input: [BigInt('321804719213721')],
+      expectedArgs: ['321804719213721'],
+      expectedTypes: [{ scalarType: 'bigint', arity: 'scalar' }],
+    },
+    {
+      name: 'Date',
+      input: [new Date('2020-06-22T17:07:16.348Z')],
+      expectedArgs: ['2020-06-22T17:07:16.348Z'],
+      expectedTypes: [{ scalarType: 'datetime', arity: 'scalar' }],
+    },
+    {
+      name: 'Decimal',
+      input: [new Decimal('1.1')],
+      expectedArgs: ['1.1'],
+      expectedTypes: [{ scalarType: 'decimal', arity: 'scalar' }],
+    },
+    {
+      name: 'Buffer',
+      input: [Buffer.from('hello')],
+      expectedArgs: ['aGVsbG8='],
+      expectedTypes: [{ scalarType: 'bytes', arity: 'scalar' }],
+    },
+    {
+      name: 'Uint8Array',
+      input: [Uint8Array.of(0x75, 0x69, 0x6e, 0x74, 0x38)],
+      expectedArgs: ['dWludDg='],
+      expectedTypes: [{ scalarType: 'bytes', arity: 'scalar' }],
+    },
+    {
+      name: 'ArrayBuffer',
+      input: (() => {
+        const arrayBuffer = new ArrayBuffer(6)
+        const array = new Uint8Array(arrayBuffer)
+        array.set([0x62, 0x75, 0x66, 0x66, 0x65, 0x72])
+        return [arrayBuffer]
+      })(),
+      expectedArgs: ['YnVmZmVy'],
+      expectedTypes: [{ scalarType: 'bytes', arity: 'scalar' }],
+    },
+    {
+      name: 'homogeneous BigInt array',
+      input: [[BigInt('123'), BigInt('456'), BigInt('789')]],
+      expectedArgs: [['123', '456', '789']],
+      expectedTypes: [{ scalarType: 'bigint', arity: 'list' }],
+    },
+    {
+      name: 'homogeneous string array',
+      input: [['hello', 'world', 'test']],
+      expectedArgs: [['hello', 'world', 'test']],
+      expectedTypes: [{ scalarType: 'string', arity: 'list' }],
+    },
+  ])('fast serialization mode: $name', ({ input, expectedArgs, expectedTypes }) => {
+    test('round-trip', () => {
+      const result = roundTrip(input)
+      expect(result.args).toEqual(expectedArgs)
+      expect(result.argTypes).toEqual(expectedTypes)
+    })
+  })
+
+  describe.each([
+    {
+      name: 'BigInt',
+      input: [BigInt('999'), [BigInt('123'), 'text']],
+      expectedArgs: ['999', ['123', 'text']],
+      expectedTypes: [
+        { scalarType: 'bigint', arity: 'scalar' },
+        { scalarType: 'bigint', arity: 'list' },
+      ],
+    },
+  ])('slow serialization mode: $name', ({ input, expectedArgs, expectedTypes }) => {
+    test('round-trip', () => {
+      const result = roundTrip(input)
+      expect(result.args).toEqual(expectedArgs)
+      expect(result.argTypes).toEqual(expectedTypes)
+    })
+  })
+})

--- a/packages/client/src/runtime/core/engines/common/utils/getBatchRequestPayload.ts
+++ b/packages/client/src/runtime/core/engines/common/utils/getBatchRequestPayload.ts
@@ -1,12 +1,8 @@
-import type { JsonQuery } from '@prisma/json-protocol'
+import type { JsonBatchQuery, JsonQuery } from '@prisma/json-protocol'
 
 import { TransactionOptions } from '../Engine'
-import { QueryEngineBatchRequest } from '../types/QueryEngine'
 
-export function getBatchRequestPayload(
-  batch: JsonQuery[],
-  transaction?: TransactionOptions<unknown>,
-): QueryEngineBatchRequest {
+export function getBatchRequestPayload(batch: JsonQuery[], transaction?: TransactionOptions<unknown>): JsonBatchQuery {
   return {
     batch,
     transaction: transaction?.kind === 'batch' ? { isolationLevel: transaction.options.isolationLevel } : undefined,

--- a/packages/client/src/runtime/utils/deserializeRawParameters.ts
+++ b/packages/client/src/runtime/utils/deserializeRawParameters.ts
@@ -1,9 +1,16 @@
-import { PrismaValue } from '@prisma/client-engine-runtime'
-import { ArgScalarType, ArgType } from '@prisma/driver-adapter-utils'
+import type { PrismaValue } from '@prisma/client-engine-runtime'
+import type { ArgScalarType, ArgType } from '@prisma/driver-adapter-utils'
 
 type RawParameters = {
   args: PrismaValue[]
   argTypes: ArgType[]
+}
+
+const tagToArgScalarType: Record<string, ArgScalarType> = {
+  bigint: 'bigint',
+  date: 'datetime',
+  decimal: 'decimal',
+  bytes: 'bytes',
 }
 
 export function deserializeRawParameters(serializedParameters: string): RawParameters {
@@ -46,20 +53,14 @@ function getArgType(parameter: unknown): ArgType {
 }
 
 function getScalarType(parameter: unknown): ArgScalarType {
-  if (typeof parameter === 'object' && parameter !== null && 'prisma__type' in parameter) {
-    switch (parameter.prisma__type) {
-      case 'bigint':
-        return 'bigint'
-
-      case 'date':
-        return 'datetime'
-
-      case 'decimal':
-        return 'decimal'
-
-      case 'bytes':
-        return 'bytes'
-    }
+  if (
+    typeof parameter === 'object' &&
+    parameter !== null &&
+    'prisma__type' in parameter &&
+    typeof parameter.prisma__type === 'string' &&
+    parameter.prisma__type in tagToArgScalarType
+  ) {
+    return tagToArgScalarType[parameter.prisma__type]
   }
 
   if (typeof parameter === 'bigint') {

--- a/packages/client/src/runtime/utils/deserializeRawParameters.ts
+++ b/packages/client/src/runtime/utils/deserializeRawParameters.ts
@@ -63,20 +63,12 @@ function getScalarType(parameter: unknown): ArgScalarType {
     return tagToArgScalarType[parameter.prisma__type]
   }
 
-  if (typeof parameter === 'bigint') {
-    return 'bigint'
-  }
-
   if (typeof parameter === 'number') {
     return 'decimal'
   }
 
   if (typeof parameter === 'string') {
     return 'string'
-  }
-
-  if (parameter instanceof Date) {
-    return 'datetime'
   }
 
   return 'unknown'

--- a/packages/client/src/runtime/utils/deserializeRawParameters.ts
+++ b/packages/client/src/runtime/utils/deserializeRawParameters.ts
@@ -1,0 +1,82 @@
+import { PrismaValue } from '@prisma/client-engine-runtime'
+import { ArgScalarType, ArgType } from '@prisma/driver-adapter-utils'
+
+type RawParameters = {
+  args: PrismaValue[]
+  argTypes: ArgType[]
+}
+
+export function deserializeRawParameters(serializedParameters: string): RawParameters {
+  const parsed = JSON.parse(serializedParameters)
+  if (!Array.isArray(parsed)) {
+    throw new Error('Invalid serialized parameters')
+  }
+  const args = parsed.map((parameter: unknown) => decodeParameter(parameter))
+  const argTypes = parsed.map((parameter: unknown) => getArgType(parameter))
+  return { args, argTypes }
+}
+
+function decodeParameter(parameter: unknown): PrismaValue {
+  if (Array.isArray(parameter)) {
+    return parameter.map((item) => decodeParameter(item))
+  }
+
+  if (
+    typeof parameter === 'object' &&
+    parameter !== null &&
+    'prisma__type' in parameter &&
+    'prisma__value' in parameter
+  ) {
+    return `${parameter.prisma__value}`
+  }
+
+  if (typeof parameter === 'object' && parameter !== null) {
+    return JSON.stringify(parameter)
+  }
+
+  return parameter as PrismaValue
+}
+
+function getArgType(parameter: unknown): ArgType {
+  if (Array.isArray(parameter)) {
+    return { scalarType: parameter.length > 0 ? getScalarType(parameter[0]) : 'unknown', arity: 'list' }
+  }
+
+  return { scalarType: getScalarType(parameter), arity: 'scalar' }
+}
+
+function getScalarType(parameter: unknown): ArgScalarType {
+  if (typeof parameter === 'object' && parameter !== null && 'prisma__type' in parameter) {
+    switch (parameter.prisma__type) {
+      case 'bigint':
+        return 'bigint'
+
+      case 'date':
+        return 'datetime'
+
+      case 'decimal':
+        return 'decimal'
+
+      case 'bytes':
+        return 'bytes'
+    }
+  }
+
+  if (typeof parameter === 'bigint') {
+    return 'bigint'
+  }
+
+  if (typeof parameter === 'number') {
+    return 'decimal'
+  }
+
+  if (typeof parameter === 'string') {
+    return 'string'
+  }
+
+  if (parameter instanceof Date) {
+    return 'datetime'
+  }
+
+  return 'unknown'
+}

--- a/packages/client/src/runtime/utils/deserializeRawParameters.ts
+++ b/packages/client/src/runtime/utils/deserializeRawParameters.ts
@@ -18,7 +18,7 @@ export function deserializeRawParameters(serializedParameters: string): RawParam
   try {
     parsed = JSON.parse(serializedParameters)
   } catch (err) {
-    throw new Error(`Received invalid serialized parameters: ${err}`)
+    throw new Error(`Received invalid serialized parameters: ${err.message}`)
   }
   if (!Array.isArray(parsed)) {
     throw new Error('Received invalid serialized parameters: expected an array')
@@ -35,7 +35,7 @@ function decodeParameter(parameter: unknown): PrismaValue {
 
   if (typeof parameter === 'object' && parameter !== null && 'prisma__value' in parameter) {
     if (!('prisma__type' in parameter)) {
-      throw new Error('Invalid serialized parameter, prisma__type should not be present when prisma__value is present')
+      throw new Error('Invalid serialized parameter, prisma__type should be present when prisma__value is present')
     }
     return `${parameter.prisma__value}`
   }

--- a/packages/client/tests/functional/tracing/tests.ts
+++ b/packages/client/tests/functional/tracing/tests.ts
@@ -643,11 +643,7 @@ testMatrix.setupTestSuite(
         // @ts-test-if: provider !== Providers.MONGODB
         await prisma.$queryRaw`SELECT 1 + 1;`
         await waitForSpanTree(
-          operation(undefined, 'queryRaw', [
-            ...clientCompile('queryRaw'),
-            clientSerialize(),
-            ...engine([dbQuery('SELECT 1 + 1;')]),
-          ]),
+          operation(undefined, 'queryRaw', [clientSerialize(), ...engine([dbQuery('SELECT 1 + 1;')])]),
         )
       })
 
@@ -661,11 +657,7 @@ testMatrix.setupTestSuite(
         await prisma.$executeRaw`SELECT 1 + 1;`
 
         await waitForSpanTree(
-          operation(undefined, 'executeRaw', [
-            ...clientCompile('executeRaw'),
-            clientSerialize(),
-            ...engine([dbQuery('SELECT 1 + 1;')]),
-          ]),
+          operation(undefined, 'executeRaw', [clientSerialize(), ...engine([dbQuery('SELECT 1 + 1;')])]),
         )
       })
     })

--- a/packages/json-protocol/src/index.ts
+++ b/packages/json-protocol/src/index.ts
@@ -4,6 +4,16 @@ export type JsonQuery = {
   query: JsonFieldSelection
 }
 
+export type RawJsonQuery = JsonQuery & {
+  action: 'executeRaw' | 'queryRaw'
+  query: {
+    arguments: {
+      query: string
+      parameters: string
+    }
+  }
+}
+
 export type JsonBatchQuery = {
   batch: JsonQuery[]
   transaction?: { isolationLevel?: IsolationLevel }

--- a/packages/json-protocol/src/index.ts
+++ b/packages/json-protocol/src/index.ts
@@ -4,13 +4,14 @@ export type JsonQuery = {
   query: JsonFieldSelection
 }
 
-export type RawJsonQuery = JsonQuery & {
+export type RawJsonQuery = {
   action: 'executeRaw' | 'queryRaw'
   query: {
     arguments: {
       query: string
       parameters: string
     }
+    selection: JsonSelectionSet
   }
 }
 


### PR DESCRIPTION
[TML-1733](https://linear.app/prisma-company/issue/TML-1733/bypass-qc-and-query-interpreter-for-raw-queries)

Bypasses the query compiler for raw queries. Additionally needed to implement deserialization for raw query args, since we've only implemented it in the query compiler before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Changed raw SQL execution flow, altering compile-and-execute routing and batch handling.
  * Updated batch request payloads to use the expanded JSON protocol.

* **New Features**
  * Added a new raw-query protocol type for standardized raw query payloads.
  * Added runtime deserialization of raw query parameters so arguments retain correct types across transport.

* **Tests**
  * Added unit tests for parameter deserialization and updated tracing tests to reflect the revised span sequence.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->