### PR TITLE
fix: prevent mariadb credential leak

### DIFF
--- a/packages/adapter-mariadb/src/mariadb.test.ts
+++ b/packages/adapter-mariadb/src/mariadb.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 
-import { inferCapabilities, rewriteConnectionString } from './mariadb'
+import { inferCapabilities, PrismaMariaDbAdapterFactory, rewriteConnectionString } from './mariadb'
 
 describe.each([
   ['8.0.12', { supportsRelationJoins: false }],
@@ -33,5 +33,23 @@ describe('rewriteConnectionString', () => {
       database: 'db',
     }
     expect(rewriteConnectionString(config)).toBe(config)
+  })
+})
+
+describe('credential sanitization', () => {
+  test('connection string parse error should not expose password', async () => {
+    const secretPassword = 'super_secret_password_12345'
+    // IPv6 address in brackets - causes parse error in mariadb driver
+    const connectionString = `mariadb://user:${secretPassword}@[64:ff9b::23be:d64c]/db`
+
+    const factory = new PrismaMariaDbAdapterFactory(connectionString)
+
+    try {
+      await factory.connect()
+      expect.fail('Expected connection to fail')
+    } catch (error) {
+      const errorMessage = String(error)
+      expect(errorMessage).not.toContain(secretPassword)
+    }
   })
 })

--- a/packages/adapter-mariadb/src/mariadb.ts
+++ b/packages/adapter-mariadb/src/mariadb.ts
@@ -193,6 +193,10 @@ export class PrismaMariaDbAdapterFactory implements SqlDriverAdapterFactory {
     try {
       pool = mariadb.createPool(this.#config)
     } catch (error) {
+      // We match on an error which is known to leak the connection string and replace it with
+      // a custom error message.
+      // The error might change in a future version of the driver, but this is covered in a
+      // test, which checks for credential leakage regardless of the exact error message.
       if (error instanceof Error && error.message.startsWith('error parsing connection string')) {
         throw new Error(
           "error parsing connection string, format must be 'mariadb://[<user>[:<password>]@]<host>[:<port>]/[<db>[?<opt1>=<value1>[&<opt2>=<value2>]]]'",

--- a/packages/adapter-mariadb/src/mariadb.ts
+++ b/packages/adapter-mariadb/src/mariadb.ts
@@ -201,9 +201,8 @@ export class PrismaMariaDbAdapterFactory implements SqlDriverAdapterFactory {
         throw new Error(
           "error parsing connection string, format must be 'mariadb://[<user>[:<password>]@]<host>[:<port>]/[<db>[?<opt1>=<value1>[&<opt2>=<value2>]]]'",
         )
-      } else {
-        throw error
       }
+      throw error
     }
     if (this.#capabilities === undefined) {
       this.#capabilities = await getCapabilities(pool)

--- a/packages/adapter-mariadb/src/mariadb.ts
+++ b/packages/adapter-mariadb/src/mariadb.ts
@@ -189,7 +189,18 @@ export class PrismaMariaDbAdapterFactory implements SqlDriverAdapterFactory {
   }
 
   async connect(): Promise<PrismaMariaDbAdapter> {
-    const pool = mariadb.createPool(this.#config)
+    let pool: mariadb.Pool
+    try {
+      pool = mariadb.createPool(this.#config)
+    } catch (error) {
+      if (error instanceof Error && error.message.startsWith('error parsing connection string')) {
+        throw new Error(
+          "error parsing connection string, format must be 'mariadb://[<user>[:<password>]@]<host>[:<port>]/[<db>[?<opt1>=<value1>[&<opt2>=<value2>]]]'",
+        )
+      } else {
+        throw error
+      }
+    }
     if (this.#capabilities === undefined) {
       this.#capabilities = await getCapabilities(pool)
     }


### PR DESCRIPTION
[TML-1815](https://linear.app/prisma-company/issue/TML-1815/security-sanitize-logged-connection-strings-from-qpe)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for invalid MariaDB connection strings, providing clearer, user-friendly messages when connection parsing fails.
  * Prevented sensitive credentials from appearing in error output to avoid leaking passwords.

* **Tests**
  * Added credential-sanitization tests to verify connection errors do not expose passwords.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->