### PR TITLE
chore: make the interpreter reusable

### DIFF
--- a/packages/client-engine-runtime/bench/bench-utils.ts
+++ b/packages/client-engine-runtime/bench/bench-utils.ts
@@ -120,8 +120,6 @@ export function createConfiguredMockAdapter(): MockDriverAdapter {
 
 export function createInterpreterOptions(): QueryInterpreterOptions {
   return {
-    transactionManager: { enabled: false },
-    placeholderValues: {},
     tracingHelper: mockTracingHelper,
     serializer: serializeSql,
     provider: 'sqlite',

--- a/packages/client-engine-runtime/bench/interpreter.bench.ts
+++ b/packages/client-engine-runtime/bench/interpreter.bench.ts
@@ -14,6 +14,11 @@ import { DEEP_JOIN_PLAN, FIND_UNIQUE_PLAN, JOIN_PLAN, SEQUENCE_PLAN, SIMPLE_SELE
 async function runBenchmarks(): Promise<void> {
   const mockAdapter = createConfiguredMockAdapter()
   const interpreterOptions = createInterpreterOptions()
+  const runtimeOptions = {
+    queryable: mockAdapter,
+    scope: {},
+    transactionManager: { enabled: false },
+  } as const
 
   const suite = withCodSpeed(new Benchmark.Suite('query-interpreter'))
 
@@ -21,7 +26,7 @@ async function runBenchmarks(): Promise<void> {
     'interpreter: simple select',
     deferredBench(async () => {
       const interpreter = QueryInterpreter.forSql(interpreterOptions)
-      await interpreter.run(SIMPLE_SELECT_PLAN, mockAdapter)
+      await interpreter.run(SIMPLE_SELECT_PLAN, runtimeOptions)
     }),
   )
 
@@ -29,7 +34,7 @@ async function runBenchmarks(): Promise<void> {
     'interpreter: findUnique',
     deferredBench(async () => {
       const interpreter = QueryInterpreter.forSql(interpreterOptions)
-      await interpreter.run(FIND_UNIQUE_PLAN, mockAdapter)
+      await interpreter.run(FIND_UNIQUE_PLAN, runtimeOptions)
     }),
   )
 
@@ -37,7 +42,7 @@ async function runBenchmarks(): Promise<void> {
     'interpreter: join (1:N)',
     deferredBench(async () => {
       const interpreter = QueryInterpreter.forSql(interpreterOptions)
-      await interpreter.run(JOIN_PLAN, mockAdapter)
+      await interpreter.run(JOIN_PLAN, runtimeOptions)
     }),
   )
 
@@ -45,7 +50,7 @@ async function runBenchmarks(): Promise<void> {
     'interpreter: sequence',
     deferredBench(async () => {
       const interpreter = QueryInterpreter.forSql(interpreterOptions)
-      await interpreter.run(SEQUENCE_PLAN, mockAdapter)
+      await interpreter.run(SEQUENCE_PLAN, runtimeOptions)
     }),
   )
 
@@ -53,7 +58,7 @@ async function runBenchmarks(): Promise<void> {
     'interpreter: deep nested join',
     deferredBench(async () => {
       const interpreter = QueryInterpreter.forSql(interpreterOptions)
-      await interpreter.run(DEEP_JOIN_PLAN, mockAdapter)
+      await interpreter.run(DEEP_JOIN_PLAN, runtimeOptions)
     }),
   )
 


### PR DESCRIPTION
Came out of the `perf` branch work, the `forSql` calls are often visible on profiles generated in benchmarks. We can avoid them by separating construction-time and run-time options and reusing the interpreter instance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal runtime context flow for query interpreter to improve configuration management and reduce parameter passing overhead across interpretation operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->