### PR TITLE
fix(adapter-mariadb): support IPv6 addresses in connection strings

### DIFF
--- a/packages/adapter-mariadb/src/credentials.test.ts
+++ b/packages/adapter-mariadb/src/credentials.test.ts
@@ -5,17 +5,13 @@ import { PrismaMariaDbAdapterFactory } from './mariadb'
 describe('credential sanitization', () => {
   test('connection string parse error should not expose password', async () => {
     const secretPassword = 'super_secret_password_12345'
-    // IPv6 address in brackets - causes parse error in mariadb driver
-    const connectionString = `mariadb://user:${secretPassword}@[64:ff9b::23be:d64c]/db`
+    // A connection string with a port but no host, which the mariadb driver rejects while
+    // echoing the whole string, including the password, back in its error message.
+    const connectionString = `mariadb://user:${secretPassword}@:3306/db`
 
     const factory = new PrismaMariaDbAdapterFactory(connectionString)
 
-    try {
-      await factory.connect()
-      expect.fail('Expected connection to fail')
-    } catch (error) {
-      const errorMessage = String(error)
-      expect(errorMessage).not.toContain(secretPassword)
-    }
+    await expect(factory.connect()).rejects.toThrow()
+    await expect(factory.connect()).rejects.not.toThrow(secretPassword)
   })
 })

--- a/packages/adapter-mariadb/src/ipv6.test.ts
+++ b/packages/adapter-mariadb/src/ipv6.test.ts
@@ -1,0 +1,56 @@
+import net from 'node:net'
+
+import * as mariadb from 'mariadb'
+import { describe, expect, test } from 'vitest'
+
+import { PrismaMariaDbAdapterFactory, rewriteConnectionString } from './mariadb'
+
+describe('IPv6 connection strings', () => {
+  test('are rejected by the driver verbatim, but accepted once rewritten', () => {
+    const connectionString = 'mariadb://user:pass@[2001:db8::1]:3306/db'
+
+    // `createPool` does not connect, but it does parse the connection string eagerly, so it
+    // fails on a host the driver's grammar rejects.
+    expect(() => mariadb.createPool(connectionString)).toThrow(/error parsing connection string/)
+    expect(() => mariadb.createPool(rewriteConnectionString(new URL(connectionString)).toString())).not.toThrow()
+  })
+
+  test('reach a server listening on ::1', async () => {
+    const server = net.createServer()
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject)
+        server.listen(0, '::1', resolve)
+      })
+    } catch (error) {
+      server.close()
+      // Environments without an IPv6 loopback have nothing meaningful to assert here.
+      if ((error as NodeJS.ErrnoException).code === 'EADDRNOTAVAIL') return
+      throw error
+    }
+
+    const remoteAddress = new Promise<string | undefined>((resolve) => {
+      server.once('connection', (socket) => {
+        resolve(socket.remoteAddress)
+        socket.destroy()
+      })
+    })
+
+    const { port } = server.address() as net.AddressInfo
+    const factory = new PrismaMariaDbAdapterFactory(
+      `mariadb://user:pass@[::1]:${port}/db?connectTimeout=500&initializationTimeout=500&acquireTimeout=500`,
+    )
+
+    // The listener is not a MariaDB server, so the handshake never completes. That the driver
+    // reaches it over IPv6 at all is what this asserts.
+    const connecting = factory.connect().catch(() => undefined)
+
+    try {
+      await expect(remoteAddress).resolves.toBe('::1')
+    } finally {
+      server.close()
+      await connecting.then((adapter) => adapter?.dispose().catch(() => {}))
+    }
+  })
+})

--- a/packages/adapter-mariadb/src/ipv6.test.ts
+++ b/packages/adapter-mariadb/src/ipv6.test.ts
@@ -44,13 +44,26 @@ describe('IPv6 connection strings', () => {
 
     // The listener is not a MariaDB server, so the handshake never completes. That the driver
     // reaches it over IPv6 at all is what this asserts.
-    const connecting = factory.connect().catch(() => undefined)
+    const connecting = factory.connect()
+
+    // `connect()` swallows connection failures in its capabilities probe, so it rejects only
+    // when the driver refused the connection string outright, and resolves without the server
+    // ever seeing a socket if it dialled somewhere else. Racing both against the socket reports
+    // whichever happened instead of waiting for a connection that is never coming and failing
+    // with a bare timeout.
+    const connectedElsewhere = connecting.then(
+      () => 'connect() finished without the server seeing a connection',
+      (error: unknown) => Promise.reject(error),
+    )
 
     try {
-      await expect(remoteAddress).resolves.toBe('::1')
+      await expect(Promise.race([remoteAddress, connectedElsewhere])).resolves.toBe('::1')
     } finally {
       server.close()
-      await connecting.then((adapter) => adapter?.dispose().catch(() => {}))
+      await connecting.then(
+        (adapter) => adapter.dispose().catch(() => {}),
+        () => undefined,
+      )
     }
   })
 })

--- a/packages/adapter-mariadb/src/mariadb.test.ts
+++ b/packages/adapter-mariadb/src/mariadb.test.ts
@@ -81,6 +81,18 @@ describe('rewriteConnectionString', () => {
     const input = 'mariadb://user:pass@localhost:3306/db'
     expect(rewriteConnectionString(new URL(input)).toString()).toBe(input)
   })
+
+  test.each([
+    ['mariadb://user:pass@[::1]:3306/db', 'mariadb://user:pass@%3A%3A1:3306/db'],
+    ['mariadb://user:pass@[::1]/db', 'mariadb://user:pass@%3A%3A1/db'],
+    ['mysql://user:pass@[::1]:3306/db', 'mariadb://user:pass@%3A%3A1:3306/db'],
+    [
+      'mariadb://user:pass@[2001:db8::1]:3306/db?connectionLimit=10&ssl=true',
+      'mariadb://user:pass@2001%3Adb8%3A%3A1:3306/db?connectionLimit=10&ssl=true',
+    ],
+  ])('should percent-encode the IPv6 host of %s', (input, expected) => {
+    expect(rewriteConnectionString(new URL(input)).toString()).toBe(expected)
+  })
 })
 
 describe('useTextProtocol option', () => {

--- a/packages/adapter-mariadb/src/mariadb.ts
+++ b/packages/adapter-mariadb/src/mariadb.ts
@@ -306,13 +306,24 @@ export function inferCapabilities(version: unknown): Capabilities {
 }
 
 /**
- * Rewrites mysql:// connection strings to mariadb:// format.
- * This allows users to use mysql:// connection strings with the MariaDB adapter.
+ * Rewrites a connection string into the form the mariadb driver's own parser accepts:
+ *
+ * - `mysql://` is rewritten to `mariadb://`, so that users can point the MariaDB adapter
+ *   at a `mysql://` connection string.
+ * - The colons of a bracketed IPv6 host are percent-encoded. The driver's connection
+ *   string grammar forbids colons in the host, so `[::1]` never matches and the whole
+ *   string is rejected; it does run the host through `decodeURIComponent`, so an encoded
+ *   host round-trips to the correct address.
  */
 export function rewriteConnectionString(url: URL): URL {
   if (url.protocol === 'mysql:') {
     url.protocol = 'mariadb:'
   }
+
+  if (url.hostname.startsWith('[') && url.hostname.endsWith(']')) {
+    url.hostname = encodeURIComponent(url.hostname.slice(1, -1))
+  }
+
   return url
 }
 


### PR DESCRIPTION
The MariaDB adapter rejects every connection string whose host is an IPv6 literal, so `mariadb://user:pass@[::1]:3306/db` fails before a connection is ever attempted. This makes the adapter unusable on IPv6-only hosts and in environments that resolve the database to a literal address.

The cause is in the driver rather than in our code: `mariadb`'s connection string grammar matches the host as `[^/:]+`, which cannot match a bracketed IPv6 literal, so the string fails to parse outright. The same regex is present in the latest release (3.5.3), so upgrading the driver does not help.

## Changes

- **Connection string rewriting** (`packages/adapter-mariadb/src/mariadb.ts`): `rewriteConnectionString` now percent-encodes the colons of a bracketed IPv6 host and drops the brackets, so `[::1]` becomes `%3A%3A1`. The driver runs the captured host through `decodeURIComponent`, so the address round-trips to `::1` intact. This slots into the existing `URL`-based rewriting the constructor already performs alongside the `mysql://` → `mariadb://` and `prepareCacheLength` handling; non-IPv6 connection strings are untouched.

- **Tests** (`packages/adapter-mariadb/src/ipv6.test.ts`): two levels of coverage. One test asserts the contract with the driver directly — `createPool` rejects the bracketed form and accepts the rewritten one — since `createPool` parses eagerly without connecting. The other opens a TCP listener on `::1` and asserts the adapter actually dials it, which is what distinguishes a correct rewrite from one that merely parses. Unit assertions on the rewritten strings themselves live alongside the existing `rewriteConnectionString` cases in `mariadb.test.ts`.

- **Credential sanitization test** (`packages/adapter-mariadb/src/credentials.test.ts`): this test used a bracketed IPv6 address as its way of provoking a parse error, which this change makes parse successfully. Left alone it would attempt a real network connection to a routable address and then pass vacuously, because `getCapabilities` swallows connection errors and the `expect.fail` call was itself caught by the surrounding `catch`. It now uses a host-less connection string, which the driver still rejects while echoing the password back, and asserts rejection and non-disclosure separately.

## Why

Rewriting the host rather than translating the connection string into a `PoolConfig` object keeps all option parsing in the driver's hands. The two paths are not equivalent: the driver applies `parseOptionDataType` — boolean coercion, numeric coercion, JSON parsing for `connectAttributes` and `sessionVariables` — only to strings, and coerces object properties individually and differently. Building a config object therefore means reimplementing that table and keeping it in step with the driver across upgrades, whereas encoding the host leaves a single well-understood transformation in our code.

IPv6 zone identifiers (`fe80::1%eth0`) remain unsupported. Node's `URL` parser rejects them outright, so such strings never reach this code; they fall through the constructor's existing `catch` and surface as the driver's own error, unchanged by this PR.
