### PR TITLE
fix(adapter-mariadb): handle object-based rows returned from driver

### DIFF
--- a/packages/adapter-mariadb/src/conversion.test.ts
+++ b/packages/adapter-mariadb/src/conversion.test.ts
@@ -1,0 +1,38 @@
+import * as mariadb from 'mariadb'
+import { describe, expect, it } from 'vitest'
+
+import { mapRow } from './conversion'
+
+describe('mapRow', () => {
+  it('maps datetime columns from object rows to ISO strings', () => {
+    const row = { createdAt: '2024-01-02 03:04:05.000' }
+
+    const result = mapRow(row, [{ type: 'DATETIME' } as unknown as mariadb.FieldInfo])
+
+    expect(result).toEqual(['2024-01-02T03:04:05+00:00'])
+  })
+
+  it('maps bigint columns from object rows to strings', () => {
+    const row = { id: 123n }
+
+    const result = mapRow(row, [{ type: 'BIGINT' } as unknown as mariadb.FieldInfo])
+
+    expect(result).toEqual(['123'])
+  })
+
+  it('preserves property order for mixed object rows', () => {
+    const row = {
+      createdAt: '2024-01-02 03:04:05.123',
+      id: 5n,
+      note: null,
+    }
+
+    const result = mapRow(row, [
+      { type: 'DATETIME' } as unknown as mariadb.FieldInfo,
+      { type: 'BIGINT' } as unknown as mariadb.FieldInfo,
+      { type: 'VARCHAR' } as unknown as mariadb.FieldInfo,
+    ])
+
+    expect(result).toEqual(['2024-01-02T03:04:05.123+00:00', '5', null])
+  })
+})

--- a/packages/adapter-mariadb/src/conversion.ts
+++ b/packages/adapter-mariadb/src/conversion.ts
@@ -140,9 +140,11 @@ export function mapArg<A>(arg: A | Date, argType: ArgType): null | BigInt | stri
   return arg
 }
 
-export function mapRow<A>(row: A[], fields?: mariadb.FieldInfo[]): (A | ResultValue)[] {
-  return row.map((value, i) => {
-    const type = fields?.[i].type as unknown as MariaDbColumnType
+export function mapRow<A>(row: A[] | Record<string, A>, fields?: mariadb.FieldInfo[]): (A | ResultValue)[] {
+  const values = Array.isArray(row) ? row : Object.values(row)
+
+  return values.map((value, i) => {
+    const type = fields?.[i]?.type as unknown as MariaDbColumnType
 
     if (value === null) {
       return null


### PR DESCRIPTION
### Problem
The MariaDB adapter assumed rows returned from the driver were always arrays.
In some cases (e.g. stored procedures), the driver may return object-based rows,
leading to a runtime `row.map is not a function` error.

### Solution
Normalize the row input by converting object-based rows to arrays before mapping,
while preserving existing behavior for array-based rows.

### Verification
The issue was reproduced with a local MariaDB instance using
`$queryRawUnsafe('CALL …')`. The fix was verified by patching the adapter runtime.


<img width="819" height="454" alt="스크린샷 2026-01-25 오후 9 25 43" src="https://github.com/user-attachments/assets/1836e7a6-9c40-46e0-8d79-8f4aff8e8a14" />


Fixes #29068


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MariaDB adapter now accepts row data provided as either objects or arrays, improving input flexibility while remaining backward compatible.

* **Tests**
  * Added tests validating date/time formatting, large integer handling, and preservation of field order when mapping mixed rows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->