### PR TITLE
docs: improve JSDoc for addObjectProperties

### DIFF
--- a/packages/client/src/runtime/core/compositeProxy/addObjectProperties.ts
+++ b/packages/client/src/runtime/core/compositeProxy/addObjectProperties.ts
@@ -1,12 +1,18 @@
 import type { CompositeProxyLayer } from './createCompositeProxy'
 
 /**
- * Composite proxy layer that forwards all reads
- * to provided object
+ * Composite proxy layer that forwards all property reads
+ * to the provided object.
  *
- * @param object
- * @returns
+ * @param object The target object whose properties will be exposed through the proxy layer.
+ * @returns A composite proxy layer that reads values directly from the provided object.
+ *
+ * @example
+ * const layer = addObjectProperties({ name: 'Alice', age: 20 })
+ * layer.getPropertyValue('name') // 'Alice'
  */
+
+
 export function addObjectProperties(object: object): CompositeProxyLayer {
   return {
     getKeys() {


### PR DESCRIPTION
### What does this PR do?
Improves the JSDoc documentation for `addObjectProperties` by clarifying parameter and return descriptions and adding a simple usage example.

### Why is this change needed?
Clearer documentation helps developers understand how the composite proxy layer works and improves readability for contributors.

### Type of change
- Documentation improvement

### Checklist
- [x] No code logic changed
- [x] Documentation only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved internal documentation with enhanced parameter descriptions, return information, and usage examples for property forwarding functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->