### PR TITLE
fix(adapter-mssql): respect curly brace escaping in connection strings

### DIFF
--- a/packages/adapter-mssql/src/connection-string.test.ts
+++ b/packages/adapter-mssql/src/connection-string.test.ts
@@ -212,6 +212,13 @@ describe('parseConnectionString', () => {
       expect(config.password).toBe('pass=word')
     })
 
+    it('should handle equals signs inside braced values without affecting subsequent brace detection', () => {
+      const connectionString = 'sqlserver://localhost;password={my=pass{nested}};database=testdb'
+      const config = parseConnectionString(connectionString)
+      expect(config.password).toBe('my=pass{nested}')
+      expect(config.database).toBe('testdb')
+    })
+
     it('should handle password with both semicolon and equals when escaped', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;user=sa;password={pass;word=123}'
       const config = parseConnectionString(connectionString)

--- a/packages/adapter-mssql/src/connection-string.test.ts
+++ b/packages/adapter-mssql/src/connection-string.test.ts
@@ -212,11 +212,11 @@ describe('parseConnectionString', () => {
       expect(config.password).toBe('pass=word')
     })
 
-    it('should handle equals signs inside braced values without affecting subsequent brace detection', () => {
+    it('should throw error for nested braces inside braced values', () => {
       const connectionString = 'sqlserver://localhost;password={my=pass{nested}};database=testdb'
-      const config = parseConnectionString(connectionString)
-      expect(config.password).toBe('my=pass{nested}')
-      expect(config.database).toBe('testdb')
+      expect(() => parseConnectionString(connectionString)).toThrow(
+        "Malformed connection string: nested '{' braces are not supported",
+      )
     })
 
     it('should handle password with both semicolon and equals when escaped', () => {

--- a/packages/adapter-mssql/src/connection-string.test.ts
+++ b/packages/adapter-mssql/src/connection-string.test.ts
@@ -594,4 +594,41 @@ describe('extractSchemaFromConnectionString', () => {
 
     expect(schema).toBe('')
   })
+
+  describe('escaped schema values with curly braces', () => {
+    it('should extract schema with curly braces correctly', () => {
+      const connectionString = 'sqlserver://localhost;database=testdb;schema={custom}'
+      const schema = extractSchemaFromConnectionString(connectionString)
+
+      expect(schema).toBe('custom')
+    })
+
+    it('should handle schema with semicolon when escaped', () => {
+      const connectionString = 'sqlserver://localhost;database=testdb;schema={custom;schema}'
+      const schema = extractSchemaFromConnectionString(connectionString)
+
+      expect(schema).toBe('custom;schema')
+    })
+
+    it('should handle schema with equals sign when escaped', () => {
+      const connectionString = 'sqlserver://localhost;database=testdb;schema={custom=schema}'
+      const schema = extractSchemaFromConnectionString(connectionString)
+
+      expect(schema).toBe('custom=schema')
+    })
+
+    it('should handle schema with both semicolon and equals when escaped', () => {
+      const connectionString = 'sqlserver://localhost;database=testdb;schema={custom;schema=value}'
+      const schema = extractSchemaFromConnectionString(connectionString)
+
+      expect(schema).toBe('custom;schema=value')
+    })
+
+    it('should handle schema with escaped value and other parameters', () => {
+      const connectionString = 'sqlserver://localhost;database=testdb;user=sa;password={pass;word};schema={my;schema}'
+      const schema = extractSchemaFromConnectionString(connectionString)
+
+      expect(schema).toBe('my;schema')
+    })
+  })
 })

--- a/packages/adapter-mssql/src/connection-string.test.ts
+++ b/packages/adapter-mssql/src/connection-string.test.ts
@@ -190,6 +190,72 @@ describe('parseConnectionString', () => {
     })
   })
 
+  describe('escaped values with curly braces', () => {
+    it('should parse password with curly braces correctly', () => {
+      const connectionString = 'sqlserver://localhost;database=testdb;user=sa;password={mypassword}'
+      const config = parseConnectionString(connectionString)
+
+      expect(config.password).toBe('mypassword')
+    })
+
+    it('should handle password with semicolon when escaped', () => {
+      const connectionString = 'sqlserver://localhost;database=testdb;user=sa;password={pass;word}'
+      const config = parseConnectionString(connectionString)
+
+      expect(config.password).toBe('pass;word')
+    })
+
+    it('should handle password with equals sign when escaped', () => {
+      const connectionString = 'sqlserver://localhost;database=testdb;user=sa;password={pass=word}'
+      const config = parseConnectionString(connectionString)
+
+      expect(config.password).toBe('pass=word')
+    })
+
+    it('should handle password with both semicolon and equals when escaped', () => {
+      const connectionString = 'sqlserver://localhost;database=testdb;user=sa;password={pass;word=123}'
+      const config = parseConnectionString(connectionString)
+
+      expect(config.password).toBe('pass;word=123')
+    })
+
+    it('should handle escaped database name', () => {
+      const connectionString = 'sqlserver://localhost;database={test;db};user=sa;password=mypassword'
+      const config = parseConnectionString(connectionString)
+
+      expect(config.database).toBe('test;db')
+    })
+
+    it('should handle escaped user name', () => {
+      const connectionString = 'sqlserver://localhost;database=testdb;user={domain\\user;name};password=mypassword'
+      const config = parseConnectionString(connectionString)
+
+      expect(config.user).toBe('domain\\user;name')
+    })
+
+    it('should handle multiple escaped values', () => {
+      const connectionString = 'sqlserver://localhost;database={test;db};user={my;user};password={my;pass=word}'
+      const config = parseConnectionString(connectionString)
+
+      expect(config.database).toBe('test;db')
+      expect(config.user).toBe('my;user')
+      expect(config.password).toBe('my;pass=word')
+    })
+
+    it('should handle complex password with multiple special characters', () => {
+      const connectionString =
+        'sqlserver://localhost:1433;database=testdb;user=sa;password={P@ss;w=rd!123};encrypt=true'
+      const config = parseConnectionString(connectionString)
+
+      expect(config.server).toBe('localhost')
+      expect(config.port).toBe(1433)
+      expect(config.database).toBe('testdb')
+      expect(config.user).toBe('sa')
+      expect(config.password).toBe('P@ss;w=rd!123')
+      expect(config.options?.encrypt).toBe(true)
+    })
+  })
+
   describe('isolation level parameter', () => {
     it('should parse isolationLevel parameter correctly', () => {
       const testCases = [

--- a/packages/adapter-mssql/src/connection-string.test.ts
+++ b/packages/adapter-mssql/src/connection-string.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
-import { extractSchemaFromConnectionString, parseConnectionString } from './connection-string'
+import { parseConnectionString } from './connection-string'
 
 describe('parseConnectionString', () => {
   describe('basic connection parameters', () => {
     it('should parse a basic connection string correctly', () => {
       const connectionString = 'sqlserver://localhost:1433;database=testdb;user=sa;password=mypassword;encrypt=true'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.server).toBe('localhost')
       expect(config.port).toBe(1433)
@@ -18,7 +18,7 @@ describe('parseConnectionString', () => {
 
     it('should parse connection string without port', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;user=sa;password=mypassword'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.server).toBe('localhost')
       expect(config.port).toBeUndefined()
@@ -36,7 +36,7 @@ describe('parseConnectionString', () => {
       ]
 
       testCases.forEach((connectionString) => {
-        const config = parseConnectionString(connectionString)
+        const { config } = parseConnectionString(connectionString)
         expect(config.user).toBe('sa')
       })
     })
@@ -48,7 +48,7 @@ describe('parseConnectionString', () => {
       ]
 
       testCases.forEach((connectionString) => {
-        const config = parseConnectionString(connectionString)
+        const { config } = parseConnectionString(connectionString)
         expect(config.password).toBe('mypassword')
       })
     })
@@ -60,7 +60,7 @@ describe('parseConnectionString', () => {
       ]
 
       testCases.forEach((connectionString) => {
-        const config = parseConnectionString(connectionString)
+        const { config } = parseConnectionString(connectionString)
         expect(config.database).toBe('testdb')
       })
     })
@@ -74,7 +74,7 @@ describe('parseConnectionString', () => {
       ]
 
       testCases.forEach(({ input, expected }) => {
-        const config = parseConnectionString(input)
+        const { config } = parseConnectionString(input)
         expect(config.options?.encrypt).toBe(expected)
       })
     })
@@ -86,14 +86,14 @@ describe('parseConnectionString', () => {
       ]
 
       testCases.forEach(({ input, expected }) => {
-        const config = parseConnectionString(input)
+        const { config } = parseConnectionString(input)
         expect(config.options?.trustServerCertificate).toBe(expected)
       })
     })
 
     it('should handle both encryption parameters together', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;encrypt=true;trustServerCertificate=true'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.options?.encrypt).toBe(true)
       expect(config.options?.trustServerCertificate).toBe(true)
@@ -104,21 +104,21 @@ describe('parseConnectionString', () => {
     { input: 'sqlserver://localhost;database=testdb;multiSubnetFailover=true', expected: true },
     { input: 'sqlserver://localhost;database=testdb;multiSubnetFailover=false', expected: false },
   ])('should parse multiSubnetFailover parameter correctly for %o', ({ input, expected }) => {
-    const config = parseConnectionString(input)
+    const { config } = parseConnectionString(input)
     expect(config.options?.multiSubnetFailover).toBe(expected)
   })
 
   describe('connection pool parameters', () => {
     it('should parse connectionLimit parameter correctly', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;connectionLimit=10'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.pool?.max).toBe(10)
     })
 
     it('should parse poolTimeout parameter correctly', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;poolTimeout=15'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.pool?.acquireTimeoutMillis).toBe(15000) // 15 seconds in milliseconds
     })
@@ -127,35 +127,35 @@ describe('parseConnectionString', () => {
   describe('timeout parameters', () => {
     it('should parse connectTimeout parameter correctly', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;connectTimeout=30'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.connectionTimeout).toBe(30)
     })
 
     it('should parse connectionTimeout parameter correctly', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;connectionTimeout=30'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.connectionTimeout).toBe(30)
     })
 
     it('should parse loginTimeout parameter correctly', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;loginTimeout=45'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.connectionTimeout).toBe(45)
     })
 
     it('should parse socketTimeout parameter correctly', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;socketTimeout=60'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.requestTimeout).toBe(60)
     })
 
     it('should handle multiple timeout parameters', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;connectTimeout=30;socketTimeout=60;poolTimeout=10'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.connectionTimeout).toBe(30)
       expect(config.requestTimeout).toBe(60)
@@ -166,48 +166,60 @@ describe('parseConnectionString', () => {
   describe('application name parameter', () => {
     it('should parse applicationName parameter correctly', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;applicationName=MyApp'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.options?.appName).toBe('MyApp')
     })
 
     it('should parse application name parameter correctly', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;application name=MyApp'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.options?.appName).toBe('MyApp')
     })
   })
 
   describe('schema parameter', () => {
-    it('should ignore schema parameter', () => {
+    it('should ignore schema parameter in the config', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;schema=custom'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       // Schema should not be in the config, it's handled separately
       // The schema parameter is ignored during parsing
       expect(config.database).toBe('testdb')
+    })
+
+    it('should return schema parameter separately from config', () => {
+      const connectionString = 'sqlserver://localhost;database=testdb;schema=custom'
+      const { schema } = parseConnectionString(connectionString)
+      expect(schema).toBe('custom')
+    })
+
+    it('should return undefined for schema parameter if not provided', () => {
+      const connectionString = 'sqlserver://localhost;database=testdb'
+      const { schema } = parseConnectionString(connectionString)
+      expect(schema).toBeUndefined()
     })
   })
 
   describe('escaped values with curly braces', () => {
     it('should parse password with curly braces correctly', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;user=sa;password={mypassword}'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.password).toBe('mypassword')
     })
 
     it('should handle password with semicolon when escaped', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;user=sa;password={pass;word}'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.password).toBe('pass;word')
     })
 
     it('should handle password with equals sign when escaped', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;user=sa;password={pass=word}'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.password).toBe('pass=word')
     })
@@ -221,28 +233,28 @@ describe('parseConnectionString', () => {
 
     it('should handle password with both semicolon and equals when escaped', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;user=sa;password={pass;word=123}'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.password).toBe('pass;word=123')
     })
 
     it('should handle escaped database name', () => {
       const connectionString = 'sqlserver://localhost;database={test;db};user=sa;password=mypassword'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.database).toBe('test;db')
     })
 
     it('should handle escaped user name', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;user={domain\\user;name};password=mypassword'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.user).toBe('domain\\user;name')
     })
 
     it('should handle multiple escaped values', () => {
       const connectionString = 'sqlserver://localhost;database={test;db};user={my;user};password={my;pass=word}'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.database).toBe('test;db')
       expect(config.user).toBe('my;user')
@@ -252,7 +264,7 @@ describe('parseConnectionString', () => {
     it('should handle complex password with multiple special characters', () => {
       const connectionString =
         'sqlserver://localhost:1433;database=testdb;user=sa;password={P@ss;w=rd!123};encrypt=true'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.server).toBe('localhost')
       expect(config.port).toBe(1433)
@@ -264,14 +276,14 @@ describe('parseConnectionString', () => {
 
     it('should handle empty braces as empty string', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;user=sa;password={}'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.password).toBe('')
     })
 
     it('should not unescape braces that are not at value boundaries', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;user=sa;password=my{pass}word'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.password).toBe('my{pass}word')
     })
@@ -286,7 +298,7 @@ describe('parseConnectionString', () => {
 
     it('should not throw on unmatched closing brace (clamped)', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;user=sa;password=pass}word'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.password).toBe('pass}word')
     })
@@ -303,7 +315,7 @@ describe('parseConnectionString', () => {
       ]
 
       testCases.forEach(({ input, expected }) => {
-        const config = parseConnectionString(input)
+        const { config } = parseConnectionString(input)
         expect(config.options?.isolationLevel).toBe(expected)
       })
     })
@@ -318,7 +330,7 @@ describe('parseConnectionString', () => {
       ]
 
       testCases.forEach(({ input, expected }) => {
-        const config = parseConnectionString(input)
+        const { config } = parseConnectionString(input)
         expect(config.options?.isolationLevel).toBe(expected)
       })
     })
@@ -331,7 +343,7 @@ describe('parseConnectionString', () => {
       ]
 
       testCases.forEach(({ input, expected }) => {
-        const config = parseConnectionString(input)
+        const { config } = parseConnectionString(input)
         expect(config.options?.isolationLevel).toBe(expected)
       })
     })
@@ -340,7 +352,7 @@ describe('parseConnectionString', () => {
   describe('case sensitivity', () => {
     it('should handle case sensitive parameter names correctly', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;user=sa;password=mypassword;encrypt=true'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.database).toBe('testdb')
       expect(config.user).toBe('sa')
@@ -350,7 +362,7 @@ describe('parseConnectionString', () => {
 
     it('should handle case insensitive boolean values', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;encrypt=TRUE;trustServerCertificate=FALSE'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.options?.encrypt).toBe(true)
       expect(config.options?.trustServerCertificate).toBe(false)
@@ -360,7 +372,7 @@ describe('parseConnectionString', () => {
   describe('whitespace handling', () => {
     it('should handle whitespace around parameters', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;user=sa;password=mypassword'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.database).toBe('testdb')
       expect(config.user).toBe('sa')
@@ -369,7 +381,7 @@ describe('parseConnectionString', () => {
 
     it('should handle whitespace around values', () => {
       const connectionString = 'sqlserver://localhost;database= testdb ;user= sa ;password= mypassword '
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.database).toBe('testdb')
       expect(config.user).toBe('sa')
@@ -380,7 +392,7 @@ describe('parseConnectionString', () => {
   describe('unknown parameters', () => {
     it('should ignore unknown parameters without throwing', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;unknownParam=value;anotherUnknown=123'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.database).toBe('testdb')
       // Should not throw and should ignore unknown parameters
@@ -474,7 +486,7 @@ describe('parseConnectionString', () => {
       // Edge case from jacek-prisma: https://github.com/prisma/prisma/pull/29158#discussion_r1943210520
       // Tedious treats { as a quote character ONLY when it's the FIRST character of a value
       const connectionString = 'sqlserver://localhost;database=testdb;user=u{s;password=}password;'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       // According to tedious behavior:
       // user=u{s → user is "u{s" (the { is not the first char, so not treated as quote)
@@ -486,7 +498,7 @@ describe('parseConnectionString', () => {
 
     it('should handle braces in the middle of values correctly', () => {
       const connectionString = 'sqlserver://localhost;database=test{db}name;user=my{user}name;password=pass{word}'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       // Braces in the middle should be treated as literal characters
       expect(config.database).toBe('test{db}name')
@@ -496,7 +508,7 @@ describe('parseConnectionString', () => {
 
     it('should still escape when { is the first character', () => {
       const connectionString = 'sqlserver://localhost;database={test;db};user={my;user};password={my;pass=word}'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       // When { is first character, it should escape the content
       expect(config.database).toBe('test;db')
@@ -506,7 +518,7 @@ describe('parseConnectionString', () => {
 
     it('should handle mixed scenarios with braces', () => {
       const connectionString = 'sqlserver://localhost;database={db;1};user=prefix{middle};password={escaped;pwd}'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.database).toBe('db;1')
       expect(config.user).toBe('prefix{middle}')
@@ -515,7 +527,7 @@ describe('parseConnectionString', () => {
 
     it('should handle connection string with only server', () => {
       const connectionString = 'sqlserver://localhost'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.server).toBe('localhost')
       expect(config.database).toBeUndefined()
@@ -525,7 +537,7 @@ describe('parseConnectionString', () => {
 
     it('should handle connection string with empty values', () => {
       const connectionString = 'sqlserver://localhost;database=;user=;password='
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.server).toBe('localhost')
       expect(config.database).toBe('')
@@ -535,7 +547,7 @@ describe('parseConnectionString', () => {
 
     it('should handle connection string with malformed key-value pairs', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;=value;key=;='
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.server).toBe('localhost')
       expect(config.database).toBe('testdb')
@@ -549,7 +561,7 @@ describe('parseConnectionString', () => {
       'sqlserver://localhost:1433;database=testdb;authentication=ActiveDirectoryIntegrated',
       'sqlserver://localhost:1433;database=testdb;authentication=ActiveDirectoryInteractive',
     ])('should support authentication parameter for %s', (connectionString) => {
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
       expect(config.user).toBe(undefined)
       expect(config.password).toBe(undefined)
       expect(config.authentication?.type).toBe('azure-active-directory-default')
@@ -558,7 +570,7 @@ describe('parseConnectionString', () => {
     it('should support authentication password parameters', () => {
       const connectionString =
         'sqlserver://localhost:1433;database=testdb;authentication=ActiveDirectoryPassword;userName=user1;password=mypassword;clientId=my-client-id'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.authentication?.type).toBe('azure-active-directory-password')
       if (config.authentication?.type === 'azure-active-directory-password') {
@@ -575,7 +587,7 @@ describe('parseConnectionString', () => {
       'sqlserver://localhost:1433;database=testdb;authentication=ActiveDirectoryManagedIdentity;clientId=test-client;msiEndpoint=msi-endpoint-1;msiSecret=msi-secret-1',
       'sqlserver://localhost:1433;database=testdb;authentication=ActiveDirectoryMSI;clientId=test-client;msiEndpoint=msi-endpoint-1;msiSecret=msi-secret-1',
     ])('should support authentication managed identity parameters for %s', (connectionString) => {
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.user).toBe(undefined)
       expect(config.password).toBe(undefined)
@@ -594,7 +606,7 @@ describe('parseConnectionString', () => {
     it('should support authentication service principal parameters', () => {
       const connectionString =
         'sqlserver://localhost:1433;database=testdb;authentication=ActiveDirectoryServicePrincipal;userName=test-client-id;password=mysecret'
-      const config = parseConnectionString(connectionString)
+      const { config } = parseConnectionString(connectionString)
 
       expect(config.authentication?.type).toBe('azure-active-directory-service-principal-secret')
       if (config.authentication?.type === 'azure-active-directory-service-principal-secret') {
@@ -634,94 +646,6 @@ describe('parseConnectionString', () => {
           'Invalid authentication, ActiveDirectoryServicePrincipal requires userName (clientId), password (clientSecret)',
         )
       })
-    })
-  })
-})
-
-describe('extractSchemaFromConnectionString', () => {
-  it('should extract schema parameter correctly', () => {
-    const connectionString = 'sqlserver://localhost;database=testdb;schema=custom'
-    const schema = extractSchemaFromConnectionString(connectionString)
-
-    expect(schema).toBe('custom')
-  })
-
-  it('should extract schema parameter without database', () => {
-    const connectionString = 'sqlserver://localhost;schema=custom'
-    const schema = extractSchemaFromConnectionString(connectionString)
-
-    expect(schema).toBe('custom')
-  })
-
-  it('should return undefined when schema is not provided', () => {
-    const connectionString = 'sqlserver://localhost;database=testdb'
-    const schema = extractSchemaFromConnectionString(connectionString)
-
-    expect(schema).toBeUndefined()
-  })
-
-  it('should handle schema parameter with whitespace', () => {
-    const connectionString = 'sqlserver://localhost;database=testdb; schema = custom '
-    const schema = extractSchemaFromConnectionString(connectionString)
-
-    expect(schema).toBe('custom')
-  })
-
-  it('should handle empty schema value', () => {
-    const connectionString = 'sqlserver://localhost;database=testdb;schema='
-    const schema = extractSchemaFromConnectionString(connectionString)
-
-    expect(schema).toBe('')
-  })
-
-  describe('escaped schema values with curly braces', () => {
-    it('should extract schema with curly braces correctly', () => {
-      const connectionString = 'sqlserver://localhost;database=testdb;schema={custom}'
-      const schema = extractSchemaFromConnectionString(connectionString)
-
-      expect(schema).toBe('custom')
-    })
-
-    it('should handle schema with semicolon when escaped', () => {
-      const connectionString = 'sqlserver://localhost;database=testdb;schema={custom;schema}'
-      const schema = extractSchemaFromConnectionString(connectionString)
-
-      expect(schema).toBe('custom;schema')
-    })
-
-    it('should handle schema with equals sign when escaped', () => {
-      const connectionString = 'sqlserver://localhost;database=testdb;schema={custom=schema}'
-      const schema = extractSchemaFromConnectionString(connectionString)
-
-      expect(schema).toBe('custom=schema')
-    })
-
-    it('should handle schema with both semicolon and equals when escaped', () => {
-      const connectionString = 'sqlserver://localhost;database=testdb;schema={custom;schema=value}'
-      const schema = extractSchemaFromConnectionString(connectionString)
-
-      expect(schema).toBe('custom;schema=value')
-    })
-
-    it('should handle schema with escaped value and other parameters', () => {
-      const connectionString = 'sqlserver://localhost;database=testdb;user=sa;password={pass;word};schema={my;schema}'
-      const schema = extractSchemaFromConnectionString(connectionString)
-
-      expect(schema).toBe('my;schema')
-    })
-
-    it('should handle empty braces in schema as empty string', () => {
-      const connectionString = 'sqlserver://localhost;database=testdb;schema={}'
-      const schema = extractSchemaFromConnectionString(connectionString)
-
-      expect(schema).toBe('')
-    })
-
-    it('should not unescape braces that are not at schema value boundaries', () => {
-      const connectionString = 'sqlserver://localhost;database=testdb;schema=my{sche}ma'
-      const schema = extractSchemaFromConnectionString(connectionString)
-
-      expect(schema).toBe('my{sche}ma')
     })
   })
 })

--- a/packages/adapter-mssql/src/connection-string.ts
+++ b/packages/adapter-mssql/src/connection-string.ts
@@ -68,7 +68,6 @@ function splitRespectingBraces(str: string): string[] {
       }
       current += char
     } else if (char === ';' && braceDepth === 0) {
-      // Only split on semicolon if we're not inside curly braces
       parts.push(current)
       current = ''
     } else {
@@ -76,9 +75,12 @@ function splitRespectingBraces(str: string): string[] {
     }
   }
 
-  // Add the last part
   if (current) {
     parts.push(current)
+  }
+
+  if (braceDepth !== 0) {
+    throw new Error(`Malformed connection string: unclosed '{' brace (braceDepth=${braceDepth})`)
   }
 
   return parts
@@ -93,9 +95,7 @@ function splitRespectingBraces(str: string): string[] {
  */
 function unescapeValue(value: string): string {
   const trimmed = value.trim()
-  // Check if value is wrapped in curly braces
-  if (trimmed.startsWith('{') && trimmed.endsWith('}') && trimmed.length > 2) {
-    // Remove the outer braces
+  if (trimmed.startsWith('{') && trimmed.endsWith('}') && trimmed.length >= 2) {
     return trimmed.slice(1, -1)
   }
   return trimmed

--- a/packages/adapter-mssql/src/connection-string.ts
+++ b/packages/adapter-mssql/src/connection-string.ts
@@ -59,7 +59,6 @@ function splitRespectingBraces(str: string): string[] {
   const parts: string[] = []
   let current = ''
   let braceDepth = 0
-  let afterEquals = false
   let valueStartIndex = -1
 
   for (let i = 0; i < str.length; i++) {
@@ -67,30 +66,25 @@ function splitRespectingBraces(str: string): string[] {
 
     if (char === '=') {
       current += char
-      afterEquals = true
       valueStartIndex = i + 1
     } else if (char === '{') {
       // Only treat { as opening brace if it's the first character of a value
-      const isFirstCharOfValue = afterEquals && i === valueStartIndex
+      const isFirstCharOfValue = i === valueStartIndex
       if (isFirstCharOfValue) {
         braceDepth++
       }
       current += char
-      afterEquals = false
     } else if (char === '}') {
       if (braceDepth > 0) {
         braceDepth--
       }
       current += char
-      afterEquals = false
     } else if (char === ';' && braceDepth === 0) {
       parts.push(current)
       current = ''
-      afterEquals = false
       valueStartIndex = -1
     } else {
       current += char
-      afterEquals = false
     }
   }
 

--- a/packages/adapter-mssql/src/connection-string.ts
+++ b/packages/adapter-mssql/src/connection-string.ts
@@ -66,7 +66,9 @@ function splitRespectingBraces(str: string): string[] {
 
     if (char === '=') {
       current += char
-      valueStartIndex = i + 1
+      if (braceDepth === 0) {
+        valueStartIndex = i + 1
+      }
     } else if (char === '{') {
       // Only treat { as opening brace if it's the first character of a value
       const isFirstCharOfValue = i === valueStartIndex

--- a/packages/adapter-mssql/src/connection-string.ts
+++ b/packages/adapter-mssql/src/connection-string.ts
@@ -33,12 +33,12 @@ const debug = Debug('prisma:driver-adapter:mssql:connection-string')
  */
 export function extractSchemaFromConnectionString(connectionString: string): string | undefined {
   const withoutProtocol = connectionString.replace(/^sqlserver:\/\//, '')
-  const parts = withoutProtocol.split(';')
+  const parts = splitRespectingBraces(withoutProtocol)
 
   for (const part of parts) {
-    const [key, value] = part.split('=', 2)
+    const [key, ...valueParts] = part.split('=')
     if (key?.trim() === 'schema') {
-      return value?.trim()
+      return unescapeValue(valueParts.join('='))
     }
   }
   return undefined

--- a/packages/adapter-mssql/src/connection-string.ts
+++ b/packages/adapter-mssql/src/connection-string.ts
@@ -74,6 +74,8 @@ function splitRespectingBraces(str: string): string[] {
       const isFirstCharOfValue = i === valueStartIndex
       if (isFirstCharOfValue) {
         braceDepth++
+      } else if (braceDepth > 0) {
+        throw new Error(`Malformed connection string: nested '{' braces are not supported`)
       }
       current += char
     } else if (char === '}') {

--- a/packages/adapter-mssql/src/connection-string.ts
+++ b/packages/adapter-mssql/src/connection-string.ts
@@ -110,7 +110,6 @@ function unescapeValue(value: string): string {
 export function parseConnectionString(connectionString: string): sql.config {
   const withoutProtocol = connectionString.replace(/^sqlserver:\/\//, '')
 
-  // Split by semicolon while respecting curly brace escaping
   const parts = splitRespectingBraces(withoutProtocol)
   const [hostPart, ...paramParts] = parts
 
@@ -147,7 +146,6 @@ export function parseConnectionString(connectionString: string): sql.config {
     if (trimmedKey in parameters) {
       throw new Error(`Duplication configuration parameter: ${trimmedKey}`)
     }
-    // Join value parts back together (in case there were = signs in the value)
     const value = valueParts.join('=')
     parameters[trimmedKey] = unescapeValue(value)
     if (!handledParameters.includes(trimmedKey)) {

--- a/packages/adapter-mssql/src/connection-string.ts
+++ b/packages/adapter-mssql/src/connection-string.ts
@@ -63,7 +63,9 @@ function splitRespectingBraces(str: string): string[] {
       braceDepth++
       current += char
     } else if (char === '}') {
-      braceDepth--
+      if (braceDepth > 0) {
+        braceDepth--
+      }
       current += char
     } else if (char === ';' && braceDepth === 0) {
       // Only split on semicolon if we're not inside curly braces

--- a/packages/adapter-mssql/src/mssql.ts
+++ b/packages/adapter-mssql/src/mssql.ts
@@ -15,7 +15,7 @@ import { Mutex } from 'async-mutex'
 import sql from 'mssql'
 
 import { name as packageName } from '../package.json'
-import { extractSchemaFromConnectionString, parseConnectionString } from './connection-string'
+import { parseConnectionString } from './connection-string'
 import { mapArg, mapColumnType, mapIsolationLevel, mapRow } from './conversion'
 import { convertDriverError } from './errors'
 
@@ -185,12 +185,12 @@ export class PrismaMssqlAdapterFactory implements SqlDriverAdapterFactory {
 
   constructor(configOrString: sql.config | string, options?: PrismaMssqlOptions) {
     if (typeof configOrString === 'string') {
-      this.#config = parseConnectionString(configOrString)
+      const { config, schema } = parseConnectionString(configOrString)
+      this.#config = config
       // Extract schema from connection string and merge with provided options
-      const extractedSchema = extractSchemaFromConnectionString(configOrString)
       this.#options = {
         ...options,
-        schema: options?.schema ?? extractedSchema,
+        schema: options?.schema ?? schema,
       }
     } else {
       this.#config = configOrString


### PR DESCRIPTION
## Problem

Fixes #28932

Before migrating to v7 and using the PrismaMssql adapter, connection strings with escaped passwords (wrapped in curly braces) worked correctly. Since migrating, passwords with special characters like semicolons or equals signs fail to authenticate or cause parsing errors.

## Root Cause

The connection string parser in `packages/adapter-mssql/src/connection-string.ts` was splitting parameters by semicolons without respecting the MSSQL/JDBC curly brace escaping syntax. According to the spec, values wrapped in `{curly braces}` should be treated as literals where special characters like `;` and `=` do not act as delimiters.

The old code:
```typescript
const [hostPart, ...paramParts] = withoutProtocol.split(';')
```

This simple split didn't account for escaped values, causing passwords like `{pass;word}` to be incorrectly parsed.

## Fix

Implemented two new helper functions:

1. `splitRespectingBraces()` - Splits by semicolons while tracking curly brace depth, only splitting when outside of braces
2. `unescapeValue()` - Removes outer curly braces from escaped values while preserving the inner content

Also added proper validation for malformed connection strings (empty host).

## Tests

Added 8 new test cases covering:
- Password with curly braces (no special chars)
- Password with semicolon when escaped
- Password with equals sign when escaped  
- Password with both semicolon and equals when escaped
- Escaped database name
- Escaped user name
- Multiple escaped values in one connection string
- Complex password with multiple special characters

All existing tests continue to pass (80 total tests passing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Connection string parsing now respects curly-brace escaping: values wrapped in braces preserve internal semicolons/equals, are unwrapped on extraction, and malformed/unclosed braces produce a descriptive error. Server host validation now requires a non-empty host.

* **Tests**
  * Added extensive tests for brace-escaped passwords, users, schemas/databases, multiple escaped parameters, empty braces, ambiguity cases, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->