### PR TITLE
fix(adapter-mssql): convert timeout parameters from seconds to milliseconds

### DIFF
--- a/packages/adapter-mssql/src/connection-string.test.ts
+++ b/packages/adapter-mssql/src/connection-string.test.ts
@@ -164,12 +164,12 @@ describe('parseConnectionString', () => {
 
     it('should convert timeout values from seconds to milliseconds as documented', () => {
       // Regression test for issue #29029: timeouts should be interpreted as seconds, not milliseconds
-      const connectionString = 'sqlserver://localhost;database=testdb;connectTimeout=1;socketTimeout=1;loginTimeout=1'
+      const connectionString = 'sqlserver://localhost;database=testdb;connectTimeout=2;socketTimeout=3;loginTimeout=5'
       const config = parseConnectionString(connectionString)
 
-      // All timeout values should be converted from 1 second to 1000 milliseconds
-      expect(config.connectionTimeout).toBe(1000) // 1 second = 1000ms
-      expect(config.requestTimeout).toBe(1000) // 1 second = 1000ms
+      // loginTimeout (5s) overwrites connectTimeout (2s) on config.connectionTimeout
+      expect(config.connectionTimeout).toBe(5000) // 5 seconds = 5000ms
+      expect(config.requestTimeout).toBe(3000) // 3 seconds = 3000ms
     })
   })
 

--- a/packages/adapter-mssql/src/connection-string.test.ts
+++ b/packages/adapter-mssql/src/connection-string.test.ts
@@ -129,37 +129,47 @@ describe('parseConnectionString', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;connectTimeout=30'
       const config = parseConnectionString(connectionString)
 
-      expect(config.connectionTimeout).toBe(30)
+      expect(config.connectionTimeout).toBe(30000) // 30 seconds in milliseconds
     })
 
     it('should parse connectionTimeout parameter correctly', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;connectionTimeout=30'
       const config = parseConnectionString(connectionString)
 
-      expect(config.connectionTimeout).toBe(30)
+      expect(config.connectionTimeout).toBe(30000) // 30 seconds in milliseconds
     })
 
     it('should parse loginTimeout parameter correctly', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;loginTimeout=45'
       const config = parseConnectionString(connectionString)
 
-      expect(config.connectionTimeout).toBe(45)
+      expect(config.connectionTimeout).toBe(45000) // 45 seconds in milliseconds
     })
 
     it('should parse socketTimeout parameter correctly', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;socketTimeout=60'
       const config = parseConnectionString(connectionString)
 
-      expect(config.requestTimeout).toBe(60)
+      expect(config.requestTimeout).toBe(60000) // 60 seconds in milliseconds
     })
 
     it('should handle multiple timeout parameters', () => {
       const connectionString = 'sqlserver://localhost;database=testdb;connectTimeout=30;socketTimeout=60;poolTimeout=10'
       const config = parseConnectionString(connectionString)
 
-      expect(config.connectionTimeout).toBe(30)
-      expect(config.requestTimeout).toBe(60)
-      expect(config.pool?.acquireTimeoutMillis).toBe(10000)
+      expect(config.connectionTimeout).toBe(30000) // 30 seconds in milliseconds
+      expect(config.requestTimeout).toBe(60000) // 60 seconds in milliseconds
+      expect(config.pool?.acquireTimeoutMillis).toBe(10000) // 10 seconds in milliseconds
+    })
+
+    it('should convert timeout values from seconds to milliseconds as documented', () => {
+      // Regression test for issue #29029: timeouts should be interpreted as seconds, not milliseconds
+      const connectionString = 'sqlserver://localhost;database=testdb;connectTimeout=1;socketTimeout=1;loginTimeout=1'
+      const config = parseConnectionString(connectionString)
+
+      // All timeout values should be converted from 1 second to 1000 milliseconds
+      expect(config.connectionTimeout).toBe(1000) // 1 second = 1000ms
+      expect(config.requestTimeout).toBe(1000) // 1 second = 1000ms
     })
   })
 

--- a/packages/adapter-mssql/src/connection-string.ts
+++ b/packages/adapter-mssql/src/connection-string.ts
@@ -140,7 +140,7 @@ export function parseConnectionString(connectionString: string): sql.config {
     if (isNaN(timeout)) {
       throw new Error(`Invalid connection timeout: ${connectionTimeout}`)
     }
-    config.connectionTimeout = timeout
+    config.connectionTimeout = timeout * 1000
   }
 
   const loginTimeout = firstKey(parameters, 'loginTimeout')
@@ -149,7 +149,7 @@ export function parseConnectionString(connectionString: string): sql.config {
     if (isNaN(timeout)) {
       throw new Error(`Invalid login timeout: ${loginTimeout}`)
     }
-    config.connectionTimeout = timeout
+    config.connectionTimeout = timeout * 1000
   }
 
   const socketTimeout = firstKey(parameters, 'socketTimeout')
@@ -158,7 +158,7 @@ export function parseConnectionString(connectionString: string): sql.config {
     if (isNaN(timeout)) {
       throw new Error(`Invalid socket timeout: ${socketTimeout}`)
     }
-    config.requestTimeout = timeout
+    config.requestTimeout = timeout * 1000
   }
 
   const poolTimeout = firstKey(parameters, 'poolTimeout')


### PR DESCRIPTION
## Problem

Fixes #29029

When using the SQL Server adapter with timeout parameters (connectionTimeout, loginTimeout, socketTimeout), values are passed directly to the underlying mssql driver in milliseconds, but the Prisma documentation states they should be in seconds. This causes confusion where setting  results in a 1ms timeout instead of 1 second.

## Root Cause

The connection string parser was passing timeout values directly to the mssql/tedious driver without conversion:
- `connectionTimeout`, `loginTimeout`, and `socketTimeout` were passed as-is
- The underlying driver expects milliseconds
- Only `poolTimeout` was correctly converting from seconds to milliseconds
- This created an inconsistency between parameters and made the API unintuitive

## Fix

Convert all timeout parameters from seconds to milliseconds by multiplying by 1000:
- `connectionTimeout` → `config.connectionTimeout = timeout * 1000`
- `loginTimeout` → `config.connectionTimeout = timeout * 1000`  
- `socketTimeout` → `config.requestTimeout = timeout * 1000`

This makes all timeout parameters consistent with:
1. The Prisma documentation (which states values are in seconds)
2. The `poolTimeout` parameter (which already does this conversion)
3. User expectations (seconds are more intuitive than milliseconds)

## Tests

- Updated all existing timeout tests to expect millisecond values
- Added regression test specifically for issue #29029 that validates 1 second = 1000ms conversion
- All 73 tests pass, including 6 new/updated timeout tests

## Breaking Change

**This is a breaking change** for users who worked around the bug by passing millisecond values. For example:
- Before: `connectTimeout=30000` (30 seconds workaround)
- After: `connectTimeout=30` (30 seconds as documented)

Users currently using millisecond workarounds will need to divide their values by 1000.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MSSQL adapter now correctly converts timeout values expressed in seconds into milliseconds, ensuring connectionTimeout, loginTimeout and requestTimeout behave as intended; pool acquire timeout behavior unchanged. Login timeout precedence over connect timeout is preserved.

* **Tests**
  * Expanded timeout tests, including a regression test verifying seconds-to-milliseconds conversion and correct timeout precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->