### PR TITLE
fix(adapter-mariadb): URL-encode username and password to handle special characters like @

### DIFF
--- a/packages/adapter-mariadb/src/mariadb.test.ts
+++ b/packages/adapter-mariadb/src/mariadb.test.ts
@@ -53,6 +53,12 @@ describe('rewriteConnectionString', () => {
     expect(rewriteConnectionString(input)).toBe(expected)
   })
 
+  test('should not double-encode already percent-encoded credentials', () => {
+    const input = 'mariadb://user%40domain:p%40ss%3Aword@localhost:3306/db'
+    const expected = 'mariadb://user%40domain:p%40ss%3Aword@localhost:3306/db'
+    expect(rewriteConnectionString(input)).toBe(expected)
+  })
+
   test('should handle mysql:// with @ in username', () => {
     const input = 'mysql://user@example.com:password@localhost:3306/db'
     const expected = 'mariadb://user%40example.com:password@localhost:3306/db'

--- a/packages/adapter-mariadb/src/mariadb.test.ts
+++ b/packages/adapter-mariadb/src/mariadb.test.ts
@@ -34,6 +34,30 @@ describe('rewriteConnectionString', () => {
     }
     expect(rewriteConnectionString(config)).toBe(config)
   })
+
+  test('should encode username with @ symbol', () => {
+    const input = 'mariadb://user@example.com:password@localhost:3306/db'
+    const expected = 'mariadb://user%40example.com:password@localhost:3306/db'
+    expect(rewriteConnectionString(input)).toBe(expected)
+  })
+
+  test('should encode password with special characters', () => {
+    const input = 'mariadb://user:p@ss:word@localhost:3306/db'
+    const expected = 'mariadb://user:p%40ss%3Aword@localhost:3306/db'
+    expect(rewriteConnectionString(input)).toBe(expected)
+  })
+
+  test('should encode both username and password with special characters', () => {
+    const input = 'mariadb://user@domain:p@ss:word@localhost:3306/db'
+    const expected = 'mariadb://user%40domain:p%40ss%3Aword@localhost:3306/db'
+    expect(rewriteConnectionString(input)).toBe(expected)
+  })
+
+  test('should handle mysql:// with @ in username', () => {
+    const input = 'mysql://user@example.com:password@localhost:3306/db'
+    const expected = 'mariadb://user%40example.com:password@localhost:3306/db'
+    expect(rewriteConnectionString(input)).toBe(expected)
+  })
 })
 
 describe('credential sanitization', () => {

--- a/packages/adapter-mariadb/src/mariadb.ts
+++ b/packages/adapter-mariadb/src/mariadb.ts
@@ -270,11 +270,9 @@ export function rewriteConnectionString(config: mariadb.PoolConfig | string): ma
     return connectionString
   }
 
-  // Parse the connection string to encode username and password
   try {
     const url = new URL(connectionString)
 
-    // Encode username and password if they contain special characters
     if (url.username) {
       url.username = encodeURIComponent(decodeURIComponent(url.username))
     }

--- a/packages/adapter-mariadb/src/mariadb.ts
+++ b/packages/adapter-mariadb/src/mariadb.ts
@@ -251,7 +251,8 @@ export function inferCapabilities(version: unknown): Capabilities {
 /**
  * Rewrites mysql:// connection strings to mariadb:// format.
  * This allows users to use mysql:// connection strings with the MariaDB adapter.
- * Also encodes special characters in username and password.
+ * Decodes and re-assigns username/password to normalize encoding.
+ * The WHATWG URL setter automatically percent-encodes characters in the userinfo set (@ : etc.).
  */
 export function rewriteConnectionString(config: mariadb.PoolConfig | string): mariadb.PoolConfig | string {
   if (typeof config !== 'string') {
@@ -274,10 +275,10 @@ export function rewriteConnectionString(config: mariadb.PoolConfig | string): ma
     const url = new URL(connectionString)
 
     if (url.username) {
-      url.username = encodeURIComponent(decodeURIComponent(url.username))
+      url.username = decodeURIComponent(url.username)
     }
     if (url.password) {
-      url.password = encodeURIComponent(decodeURIComponent(url.password))
+      url.password = decodeURIComponent(url.password)
     }
 
     return url.toString()

--- a/packages/adapter-mariadb/src/mariadb.ts
+++ b/packages/adapter-mariadb/src/mariadb.ts
@@ -261,12 +261,12 @@ export function rewriteConnectionString(config: mariadb.PoolConfig | string): ma
 
   let connectionString = config
 
-  // Rewrite mysql:// to mariadb://
+  // The mariadb driver only accepts mariadb:// scheme
   if (connectionString.startsWith('mysql://')) {
     connectionString = connectionString.replace(/^mysql:\/\//, 'mariadb://')
   }
 
-  // Only process mariadb:// connection strings
+  // Non-mariadb schemes should be returned as-is to avoid mangling unrelated config
   if (!connectionString.startsWith('mariadb://')) {
     return connectionString
   }
@@ -283,8 +283,8 @@ export function rewriteConnectionString(config: mariadb.PoolConfig | string): ma
 
     return url.toString()
   } catch (error) {
-    // If URL parsing fails, return the original string
-    // The mariadb driver will handle the error
+    // If URL parsing fails, return the connection string without credential normalization.
+    // The mariadb driver will surface its own parsing error.
     return connectionString
   }
 }


### PR DESCRIPTION
## Description

Fixes #29097

The MariaDB adapter now properly URL-encodes the username and password in connection strings before passing them to the mariadb driver. This prevents connection failures when usernames or passwords contain special characters that are used as delimiters in URLs (like @ and :).

## Changes

- Modified `rewriteConnectionString()` function to:
  - Parse the connection string using URL API
  - URL-encode username and password components
  - Reconstruct the connection string with encoded credentials
- Added comprehensive test cases covering:
  - Username with @ symbol
  - Password with @ and : symbols  
  - Both username and password with special characters
  - mysql:// connection strings with @ in username

## Testing

All existing tests pass, plus 4 new test cases added to verify the fix works correctly.

```bash
pnpm --filter @prisma/adapter-mariadb test
```

## Example

Before:
```typescript
// This would fail with parse error
const adapter = new PrismaMariaDb('mariadb://user@example.com:password@localhost:3306/db')
```

After:
```typescript
// Now works correctly - credentials are URL-encoded automatically
const adapter = new PrismaMariaDb('mariadb://user@example.com:password@localhost:3306/db')
// Internally converted to: mariadb://user%40example.com:password@localhost:3306/db
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Connection strings now normalize and percent-encode special characters in usernames and passwords (including '@' and ':'), avoid double-encoding, correctly handle MySQL-style URLs mapped to MariaDB format, and gracefully fall back for malformed strings.

* **Tests**
  * Added tests covering credential encoding, double-encoding avoidance, MySQL→MariaDB URL handling, and malformed-string fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->