### PR TITLE
feat(client): expose ModelName to compute function in Result extensions

### DIFF
--- a/packages/client/src/runtime/core/extensions/applyResultExtensions.test.ts
+++ b/packages/client/src/runtime/core/extensions/applyResultExtensions.test.ts
@@ -560,3 +560,26 @@ test('allows to omit transitive dependency of a computed team', () => {
   expect(extended).not.toHaveProperty('firstName')
   expect(extended).toHaveProperty('screamingName', 'JOHN!!!')
 })
+
+test('model name is available in compute function', () => {
+  const result = {}
+
+  const extension = {
+    result: {
+      $allModels: {
+        modelName: {
+          compute: (_, modelName) => {
+            return modelName
+          },
+        },
+      },
+    },
+  }
+
+  const extended = applyResultExtensions({
+    result,
+    modelName: 'user',
+    extensions: MergedExtensionsList.single(extension),
+  })
+  expect(extended).toHaveProperty('modelName', 'user')
+})

--- a/packages/client/src/runtime/core/extensions/applyResultExtensions.ts
+++ b/packages/client/src/runtime/core/extensions/applyResultExtensions.ts
@@ -62,7 +62,7 @@ export function applyResultExtensions({ result, modelName, select, omit, extensi
 
     if (areNeedsMet(result, field.needs)) {
       computedPropertiesLayers.push(
-        computedPropertyLayer(field, createCompositeProxy(result, computedPropertiesLayers)),
+        computedPropertyLayer(field, createCompositeProxy(result, computedPropertiesLayers), modelName),
       )
     }
   }
@@ -77,6 +77,6 @@ function areNeedsMet(result: object, neededProperties: string[]) {
   return neededProperties.every((property) => hasOwnProperty(result, property))
 }
 
-function computedPropertyLayer(field: ComputedField, result: object): CompositeProxyLayer {
-  return cacheProperties(addProperty(field.name, () => field.compute(result)))
+function computedPropertyLayer(field: ComputedField, result: object, modelName: string): CompositeProxyLayer {
+  return cacheProperties(addProperty(field.name, () => field.compute(result, modelName)))
 }

--- a/packages/client/src/runtime/core/extensions/resultUtils.ts
+++ b/packages/client/src/runtime/core/extensions/resultUtils.ts
@@ -97,8 +97,8 @@ function composeCompute(
   if (!previousCompute) {
     return nextCompute
   }
-  return (model) => {
-    return nextCompute({ ...model, [fieldName]: previousCompute(model) })
+  return (model, modelName) => {
+    return nextCompute({ ...model, [fieldName]: previousCompute(model, modelName) }, modelName)
   }
 }
 

--- a/packages/client/src/runtime/core/types/exported/ExtensionArgs.ts
+++ b/packages/client/src/runtime/core/types/exported/ExtensionArgs.ts
@@ -15,7 +15,7 @@ export type ResultArgs = {
   }
 }
 
-export type ResultArgsFieldCompute = (model: any) => unknown
+export type ResultArgsFieldCompute = (model: any, modelName: string) => unknown
 
 export type ResultArg = {
   [FieldName in string]: ResultFieldDefinition

--- a/packages/client/src/runtime/core/types/exported/Extensions.ts
+++ b/packages/client/src/runtime/core/types/exported/Extensions.ts
@@ -129,7 +129,10 @@ export type DynamicResultExtensionArgs<R_, TypeMap extends TypeMapDef> = {
   [K in keyof R_]: {
     [P in keyof R_[K]]?: {
       needs?: DynamicResultExtensionNeeds<TypeMap, ModelKey<TypeMap, K>, R_[K][P]>
-      compute(data: DynamicResultExtensionData<TypeMap, ModelKey<TypeMap, K>, R_[K][P]>): any
+      compute(
+        data: DynamicResultExtensionData<TypeMap, ModelKey<TypeMap, K>, R_[K][P]>,
+        modelName: ModelKey<TypeMap, K>,
+      ): any
     }
   }
 }


### PR DESCRIPTION
Closes #19821

Pass an extra parameter named modelName to compute function in result extension.
It will allow to create condition based on model name in compute function for $allModels.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Extension compute functions now receive the model name as an additional parameter, enabling context-aware computations and allowing extensions to tailor results based on which model is being processed.

* **Tests**
  * Added unit test coverage verifying that the model name is available to extension compute functions at compute time, ensuring correct behavior and preventing regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->