### PR TITLE
fix: add missing deserialization for JSON values

### DIFF
--- a/packages/client-engine-runtime/src/batch.ts
+++ b/packages/client-engine-runtime/src/batch.ts
@@ -1,4 +1,4 @@
-import { deserializeJsonResponse } from './json-protocol'
+import { deserializeJsonObject } from './json-protocol'
 import { QueryPlanNode } from './query-plan'
 import { UserFacingError } from './user-facing-error'
 import { doKeysMatch } from './utils'
@@ -77,7 +77,7 @@ export function convertCompactedRows(
   // a list of objects that contain the keys of every row
   const keysPerRow = rows.map((item) =>
     compiledBatch.keys.reduce((acc, key) => {
-      acc[key] = deserializeJsonResponse(item[key])
+      acc[key] = deserializeJsonObject(item[key])
       return acc
     }, {}),
   )

--- a/packages/client-engine-runtime/src/json-protocol.test.ts
+++ b/packages/client-engine-runtime/src/json-protocol.test.ts
@@ -1,46 +1,46 @@
 import { Decimal } from '@prisma/client-runtime-utils'
 
-import { deserializeJsonResponse } from './json-protocol'
+import { deserializeJsonObject } from './json-protocol'
 
-describe('deserializeJsonResponse', () => {
+describe('deserializeJsonObject', () => {
   test('primitives', () => {
-    expect(deserializeJsonResponse(1)).toBe(1)
-    expect(deserializeJsonResponse('foo')).toBe('foo')
-    expect(deserializeJsonResponse(null)).toBe(null)
-    expect(deserializeJsonResponse(false)).toBe(false)
+    expect(deserializeJsonObject(1)).toBe(1)
+    expect(deserializeJsonObject('foo')).toBe('foo')
+    expect(deserializeJsonObject(null)).toBe(null)
+    expect(deserializeJsonObject(false)).toBe(false)
   })
 
   test('Date', () => {
-    const value = deserializeJsonResponse({ $type: 'DateTime', value: '1980-01-02T00:00:00.000Z' })
+    const value = deserializeJsonObject({ $type: 'DateTime', value: '1980-01-02T00:00:00.000Z' })
     expect(value).toBeInstanceOf(Date)
     expect(value).toEqual(new Date('1980-01-02T00:00:00.000Z'))
   })
 
   test('BigInt', () => {
-    const value = deserializeJsonResponse({ $type: 'BigInt', value: '123' })
+    const value = deserializeJsonObject({ $type: 'BigInt', value: '123' })
     expect(value).toBe(123n)
   })
 
   test('Bytes', () => {
-    const value = deserializeJsonResponse({ $type: 'Bytes', value: 'aGVsbG8gd29ybGQ=' })
+    const value = deserializeJsonObject({ $type: 'Bytes', value: 'aGVsbG8gd29ybGQ=' })
     expect(value).toBeInstanceOf(Uint8Array)
     expect(value).toEqual(new Uint8Array(Buffer.from('hello world')))
   })
 
   test('Decimal', () => {
-    const value = deserializeJsonResponse({ $type: 'Decimal', value: '123.45' })
+    const value = deserializeJsonObject({ $type: 'Decimal', value: '123.45' })
     expect(value).toBeInstanceOf(Decimal)
     expect(value).toEqual(new Decimal('123.45'))
   })
 
   test('Json', () => {
-    const value = deserializeJsonResponse({ $type: 'Json', value: '{"foo":123}' })
+    const value = deserializeJsonObject({ $type: 'Json', value: '{"foo":123}' })
     expect(value).toEqual({ foo: 123 })
   })
 
   test('object', () => {
     expect(
-      deserializeJsonResponse({
+      deserializeJsonObject({
         name: 'John',
         height: 173.45,
         money: { $type: 'Decimal', value: '123.45' },
@@ -59,6 +59,6 @@ describe('deserializeJsonResponse', () => {
   })
 
   test('array', () => {
-    expect(deserializeJsonResponse(['foo', 123, { $type: 'BigInt', value: '123' }])).toEqual(['foo', 123, 123n])
+    expect(deserializeJsonObject(['foo', 123, { $type: 'BigInt', value: '123' }])).toEqual(['foo', 123, 123n])
   })
 })

--- a/packages/client-engine-runtime/src/json-protocol.ts
+++ b/packages/client-engine-runtime/src/json-protocol.ts
@@ -113,13 +113,13 @@ function mapObjectValues<K extends PropertyKey, T, U>(
   return result
 }
 
-export function deserializeJsonResponse(result: unknown): unknown {
+export function deserializeJsonObject(result: unknown): unknown {
   if (result === null) {
     return result
   }
 
   if (Array.isArray(result)) {
-    return result.map(deserializeJsonResponse)
+    return result.map(deserializeJsonObject)
   }
 
   if (typeof result === 'object') {
@@ -132,7 +132,7 @@ export function deserializeJsonResponse(result: unknown): unknown {
       return result
     }
 
-    return mapObjectValues(result, deserializeJsonResponse)
+    return mapObjectValues(result, deserializeJsonObject)
   }
 
   return result

--- a/packages/client-engine-runtime/src/json-protocol.ts
+++ b/packages/client-engine-runtime/src/json-protocol.ts
@@ -9,6 +9,7 @@ export type BigIntTaggedValue = { $type: 'BigInt'; value: string }
 export type FieldRefTaggedValue = { $type: 'FieldRef'; value: { _ref: string } }
 export type EnumTaggedValue = { $type: 'Enum'; value: string }
 export type JsonTaggedValue = { $type: 'Json'; value: string }
+export type RawTaggedValue = { $type: 'Raw'; value: unknown }
 
 export type JsonInputTaggedValue =
   | DateTaggedValue
@@ -18,6 +19,7 @@ export type JsonInputTaggedValue =
   | FieldRefTaggedValue
   | JsonTaggedValue
   | EnumTaggedValue
+  | RawTaggedValue
 
 export type JsonOutputTaggedValue =
   | DateTaggedValue
@@ -25,6 +27,7 @@ export type JsonOutputTaggedValue =
   | BytesTaggedValue
   | BigIntTaggedValue
   | JsonTaggedValue
+  | RawTaggedValue
 
 export type JsOutputValue =
   | null
@@ -95,6 +98,8 @@ function normalizeTaggedValue({ $type, value }: JsonOutputTaggedValue): JsonOutp
       return { $type, value: String(new Decimal(value)) }
     case 'Json':
       return { $type, value: JSON.stringify(JSON.parse(value)) }
+    case 'Raw':
+      return { $type, value }
     default:
       assertNever(value, 'Unknown tagged value')
   }
@@ -152,6 +157,8 @@ function deserializeTaggedValue({ $type, value }: JsonOutputTaggedValue): JsOutp
       return new Decimal(value)
     case 'Json':
       return JSON.parse(value)
+    case 'Raw':
+      return value as JsOutputValue
     default:
       assertNever(value, 'Unknown tagged value')
   }

--- a/packages/client/src/runtime/RequestHandler.ts
+++ b/packages/client/src/runtime/RequestHandler.ts
@@ -1,5 +1,5 @@
 import { Context } from '@opentelemetry/api'
-import { deserializeJsonResponse } from '@prisma/client-engine-runtime'
+import { deserializeJsonObject } from '@prisma/client-engine-runtime'
 import { hasBatchIndex } from '@prisma/client-runtime-utils'
 import { Debug } from '@prisma/debug'
 import { assertNever } from '@prisma/internals'
@@ -274,7 +274,7 @@ export class RequestHandler {
     const deserializedResponse =
       operation === 'queryRaw'
         ? deserializeRawResult(extractedResponse as RawResponse)
-        : (deserializeJsonResponse(extractedResponse) as unknown)
+        : (deserializeJsonObject(extractedResponse) as unknown)
 
     return unpacker ? unpacker(deserializedResponse) : deserializedResponse
   }

--- a/packages/client/src/runtime/core/engines/client/parameterization/parameterize.ts
+++ b/packages/client/src/runtime/core/engines/client/parameterization/parameterize.ts
@@ -6,6 +6,7 @@
  * both schema rules and runtime value types agree.
  */
 
+import { deserializeJsonObject } from '@prisma/client-engine-runtime'
 import type {
   JsonArgumentValue,
   JsonBatchQuery,
@@ -323,7 +324,7 @@ class Parameterizer {
 
     const mask = getScalarMask(edge)
     if (mask & ScalarMask.Json) {
-      const jsonValue = JSON.stringify(obj)
+      const jsonValue = JSON.stringify(deserializeJsonObject(obj))
       const type: PlaceholderType = { type: 'Json' }
       return this.#getOrCreatePlaceholder(jsonValue, type)
     }

--- a/packages/client/src/runtime/core/engines/client/parameterization/parameterize.ts
+++ b/packages/client/src/runtime/core/engines/client/parameterization/parameterize.ts
@@ -273,7 +273,7 @@ class Parameterizer {
    */
   #handleArray(items: unknown[], originalValue: unknown, edge: InputEdge): unknown {
     if (hasFlag(edge, EdgeFlag.ParamScalar) && getScalarMask(edge) & ScalarMask.Json) {
-      const jsonValue = JSON.stringify(items)
+      const jsonValue = JSON.stringify(deserializeJsonObject(items))
       const type: PlaceholderType = { type: 'Json' }
       return this.#getOrCreatePlaceholder(jsonValue, type)
     }

--- a/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.ts
+++ b/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.ts
@@ -500,7 +500,7 @@ class SerializeContext {
   }
 
   shouldWrapRawValues(): boolean {
-    return this.params.wrapRawValues ?? false
+    return this.params.wrapRawValues ?? true
   }
 
   getComputedFields() {

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -26,7 +26,7 @@ export {
   type Operation,
   type RuntimeDataModel,
 } from '@prisma/client-common'
-export { deserializeJsonResponse } from '@prisma/client-engine-runtime'
+export { deserializeJsonObject } from '@prisma/client-engine-runtime'
 export type { RawValue, Value } from '@prisma/client-runtime-utils'
 export type { AnyNullClass, DbNullClass, JsonNullClass } from '@prisma/client-runtime-utils'
 export {

--- a/packages/client/tests/functional/issues/29174-jsonb-parameter-regression/_matrix.ts
+++ b/packages/client/tests/functional/issues/29174-jsonb-parameter-regression/_matrix.ts
@@ -1,0 +1,4 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+import { allProviders } from '../../_utils/providers'
+
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/issues/29174-jsonb-parameter-regression/_matrix.ts
+++ b/packages/client/tests/functional/issues/29174-jsonb-parameter-regression/_matrix.ts
@@ -1,4 +1,4 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
-import { allProviders } from '../../_utils/providers'
+import { allProviders, Providers } from '../../_utils/providers'
 
-export default defineMatrix(() => [allProviders])
+export default defineMatrix(() => [allProviders.filter(({ provider }) => provider !== Providers.SQLSERVER)])

--- a/packages/client/tests/functional/issues/29174-jsonb-parameter-regression/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/29174-jsonb-parameter-regression/prisma/_schema.ts
@@ -1,0 +1,19 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+    generator client {
+      provider  = "prisma-client-js"
+    }
+
+    datasource db {
+      provider = "${provider}"
+    }
+
+    model User {
+      id ${idForProvider(provider)}
+      properties Json
+    }
+  `
+})

--- a/packages/client/tests/functional/issues/29174-jsonb-parameter-regression/tests.ts
+++ b/packages/client/tests/functional/issues/29174-jsonb-parameter-regression/tests.ts
@@ -4,57 +4,65 @@ import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
 
-testMatrix.setupTestSuite(() => {
-  test('correctly deserializes Date objects in JSON fields', async () => {
-    const user = await prisma.user.create({
-      data: {
-        properties: {
-          dateField: new Date(),
+testMatrix.setupTestSuite(
+  () => {
+    test('correctly deserializes Date objects in JSON fields', async () => {
+      const user = await prisma.user.create({
+        data: {
+          properties: {
+            dateField: new Date(),
+          },
         },
-      },
-    })
+      })
 
-    expect(user).toMatchObject({
-      properties: {
-        dateField: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
-      },
-    })
-  })
-
-  test('correctly deserializes Date array objects in JSON fields', async () => {
-    const user = await prisma.user.create({
-      data: {
+      expect(user).toMatchObject({
         properties: {
-          dateArrayField: [new Date(), new Date()],
+          dateField: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
         },
-      },
+      })
     })
 
-    expect(user).toMatchObject({
-      properties: {
-        dateArrayField: [
-          expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
-          expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
-        ],
-      },
-    })
-  })
+    test('correctly deserializes Date array objects in JSON fields', async () => {
+      const user = await prisma.user.create({
+        data: {
+          properties: {
+            dateArrayField: [new Date(), new Date()],
+          },
+        },
+      })
 
-  test('correctly deserializes Date objects in JSON fields with $type', async () => {
-    const user = await prisma.user.create({
-      data: {
+      expect(user).toMatchObject({
+        properties: {
+          dateArrayField: [
+            expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
+            expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
+          ],
+        },
+      })
+    })
+
+    test('correctly deserializes Date objects in JSON fields with $type', async () => {
+      const user = await prisma.user.create({
+        data: {
+          properties: {
+            $type: 'Json',
+            dateField: new Date(),
+          },
+        },
+      })
+
+      expect(user).toMatchObject({
         properties: {
           $type: 'Json',
-          dateField: new Date(),
+          dateField: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
         },
-      },
+      })
     })
-
-    expect(user).toMatchObject({
-      properties: {
-        $type: 'Json',
-        dateField: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
-      },
-    })
-  })
-})
+  },
+  {
+    optOut: {
+      from: ['sqlserver'],
+      reason: 'SQL server does not support JSON fields',
+    },
+  },
+)

--- a/packages/client/tests/functional/issues/29174-jsonb-parameter-regression/tests.ts
+++ b/packages/client/tests/functional/issues/29174-jsonb-parameter-regression/tests.ts
@@ -1,0 +1,41 @@
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(() => {
+  test('correctly deserializes Date objects in JSON fields', async () => {
+    const user = await prisma.user.create({
+      data: {
+        properties: {
+          dateField: new Date(),
+        },
+      },
+    })
+
+    expect(user).toMatchObject({
+      properties: {
+        dateField: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
+      },
+    })
+  })
+
+  test('correctly deserializes Date objects in JSON fields with $type', async () => {
+    const user = await prisma.user.create({
+      data: {
+        properties: {
+          $type: 'Json',
+          dateField: new Date(),
+        },
+      },
+    })
+
+    expect(user).toMatchObject({
+      properties: {
+        $type: 'Json',
+        dateField: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
+      },
+    })
+  })
+})

--- a/packages/client/tests/functional/issues/29174-jsonb-parameter-regression/tests.ts
+++ b/packages/client/tests/functional/issues/29174-jsonb-parameter-regression/tests.ts
@@ -21,6 +21,25 @@ testMatrix.setupTestSuite(() => {
     })
   })
 
+  test('correctly deserializes Date array objects in JSON fields', async () => {
+    const user = await prisma.user.create({
+      data: {
+        properties: {
+          dateArrayField: [new Date(), new Date()],
+        },
+      },
+    })
+
+    expect(user).toMatchObject({
+      properties: {
+        dateArrayField: [
+          expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
+          expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
+        ],
+      },
+    })
+  })
+
   test('correctly deserializes Date objects in JSON fields with $type', async () => {
     const user = await prisma.user.create({
       data: {


### PR DESCRIPTION
[TML-1901](https://linear.app/prisma-company/issue/TML-1901/investigate-and-fix-jsonb-regression-in-74)
Fixes https://github.com/prisma/prisma/issues/29174

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JSON date deserialization in JSONB parameter fields to preserve date formatting and custom type info.

* **Refactor**
  * Renamed exported deserialization function for clearer naming.
  * Raw JSON values are now preserved during deserialization.
  * Changed default behavior to wrap raw values during JSON serialization when option unspecified.

* **Tests**
  * Added functional tests covering JSON date deserialization and related scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->