### PR TITLE
chore: remove unused CLI commands

### DIFF
--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -154,13 +154,7 @@ async function main(): Promise<number> {
       format: Format.new(),
       telemetry: Telemetry.new(),
       debug: DebugInfo.new(),
-      // TODO: add rules subcommand to --help after EA
-      rules: new SubCommand('@prisma/cli-security-rules'),
       dev: new SubCommand('@prisma/cli-dev'),
-      // TODO: add deploy subcommand to --help after it works.
-      deploy: new SubCommand('@prisma/cli-deploy'),
-      // TODO: add login subcommand to --help after it works.
-      login: new SubCommand('@prisma/cli-login'),
       studio: Studio.new(),
     },
     ['version', 'init', 'migrate', 'db', 'generate', 'validate', 'format', 'telemetry'],


### PR DESCRIPTION
## Summary

Removes three unused CLI subcommand registrations from `packages/cli/src/bin.ts`:

- `rules` (`@prisma/cli-security-rules`)
- `deploy` (`@prisma/cli-deploy`)
- `login` (`@prisma/cli-login`)

These were registered as lazy `SubCommand` entries pointing to packages that don't exist in the repository. They were not exposed in `--help` output (guarded by TODO comments) and would fail at runtime if invoked. Removing them reduces dead code and avoids confusion.

The `dev` subcommand (`@prisma/cli-dev`) is intentionally kept as it remains in active use.

## Test plan

- No behavioral change — these commands were not functional or documented.
- Existing CLI tests continue to pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * The `rules`, `deploy`, and `login` CLI subcommands have been removed and are no longer available. These commands will not be recognized when executed from the command line. If you have automated workflows or scripts that rely on these commands, they will need to be updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->