### PR TITLE
docs(migrate): Fix typo in MigrateDiff command help text

### DIFF
--- a/packages/migrate/src/commands/MigrateDiff.ts
+++ b/packages/migrate/src/commands/MigrateDiff.ts
@@ -88,7 +88,7 @@ ${bold('Examples')}
     --to-schema=next_datamodel.prisma \\
     --script
 
-  From a peisma datamodel to the configured database
+  From a Prisma datamodel to the configured database
     e.g. roll forward after a migration failed in the middle
   ${dim('$')} prisma migrate diff \\
     --from-schema=next_datamodel.prisma \\


### PR DESCRIPTION
Corrected a typo in the command description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a spelling error in the help documentation to improve clarity for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->