### PR TITLE
docs(root): fix links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ npx create-db --interactive
 
 ### The Prisma data model
 
-On this page, the focus is on the data model. You can learn more about [Data sources](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-schema/data-sources) and [Generators](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-schema/generators) on the respective docs pages.
+On this page, the focus is on the data model. You can learn more about [Data sources](https://www.prisma.io/docs/orm/prisma-schema/overview/data-sources) and [Generators](https://www.prisma.io/docs/orm/prisma-schema/overview/generators) on the respective docs pages.
 
 #### Functions of Prisma models
 


### PR DESCRIPTION
Fixes #29195 

This PR fixes the broken links for "Data sources" and "Generators" on line 159 of README.md.

The links were returning 404 errors. Updated them to point to the correct documentation pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links in the README to point to the latest reference materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->