### PR TITLE
fix(client): preserve Prisma.skip through query extension args cloning

### DIFF
--- a/packages/client/src/runtime/utils/deepCloneArgs.test.ts
+++ b/packages/client/src/runtime/utils/deepCloneArgs.test.ts
@@ -1,0 +1,51 @@
+import { isSkip, skip } from '../core/types'
+import { deepCloneArgs } from './deepCloneArgs'
+
+describe('deepCloneArgs', () => {
+  test('preserves Skip instances through cloning', () => {
+    const args = {
+      data: {
+        name: skip,
+        email: 'test@example.com',
+      },
+    }
+
+    const cloned = deepCloneArgs(args) as Record<string, any>
+
+    expect(isSkip(cloned.data.name)).toBe(true)
+    expect(cloned.data.name).toBe(skip)
+    expect(cloned.data.email).toBe('test@example.com')
+  })
+
+  test('preserves Skip as a top-level value', () => {
+    const args = {
+      where: skip,
+      orderBy: { name: 'asc' },
+    }
+
+    const cloned = deepCloneArgs(args) as Record<string, any>
+
+    expect(isSkip(cloned.where)).toBe(true)
+    expect(cloned.where).toBe(skip)
+  })
+
+  test('preserves Skip in arrays', () => {
+    const args = {
+      data: [skip, 'value'],
+    }
+
+    const cloned = deepCloneArgs(args) as Record<string, any>
+
+    expect(isSkip(cloned.data[0])).toBe(true)
+  })
+
+  test('still deep clones regular objects', () => {
+    const inner = { foo: 'bar' }
+    const args = { data: inner }
+
+    const cloned = deepCloneArgs(args) as Record<string, any>
+
+    expect(cloned.data).toEqual(inner)
+    expect(cloned.data).not.toBe(inner)
+  })
+})

--- a/packages/client/src/runtime/utils/deepCloneArgs.ts
+++ b/packages/client/src/runtime/utils/deepCloneArgs.ts
@@ -2,6 +2,7 @@ import { Decimal, ObjectEnumValue, Sql } from '@prisma/client-runtime-utils'
 import { assertNever } from '@prisma/internals'
 
 import { isFieldRef } from '../core/model/FieldRef'
+import { isSkip } from '../core/types'
 import { isTypedSql, TypedSql, UnknownTypedSql } from '../core/types/exported'
 import { JsArgs, JsInputValue } from '../core/types/exported/JsApi'
 import { RawQueryArgs } from '../core/types/exported/RawQueryArgs'
@@ -43,7 +44,7 @@ function cloneTypedSql(rawParam: UnknownTypedSql): UnknownTypedSql {
 
 // based on https://github.com/lukeed/klona/blob/v2.0.6/src/index.js
 function deepCloneValue(x: JsInputValue): JsInputValue {
-  if (typeof x !== 'object' || x == null || x instanceof ObjectEnumValue || isFieldRef(x)) {
+  if (typeof x !== 'object' || x == null || x instanceof ObjectEnumValue || isFieldRef(x) || isSkip(x)) {
     return x
   }
 

--- a/packages/client/tests/functional/skip/test.ts
+++ b/packages/client/tests/functional/skip/test.ts
@@ -169,7 +169,8 @@ testMatrix.setupTestSuite(() => {
       })
 
       expect(result).not.toHaveProperty('posts')
-      expectTypeOf(result).not.toHaveProperty('posts')
+      // TODO: Apparent issue with $extends + skip (TML-1913)
+      // expectTypeOf(result).not.toHaveProperty('posts')
     })
 
     test('skips relations in select', async () => {
@@ -181,7 +182,8 @@ testMatrix.setupTestSuite(() => {
       })
 
       expect(result).not.toHaveProperty('posts')
-      expectTypeOf(result).not.toHaveProperty('posts')
+      // TODO: Apparent issue with $extends + skip (TML-1913)
+      // expectTypeOf(result).not.toHaveProperty('posts')
     })
 
     test('skips fields in omit', async () => {
@@ -197,16 +199,17 @@ testMatrix.setupTestSuite(() => {
   })
 
   describe('after query extension', () => {
-    const extended = prisma.$extends({
-      query: {
-        $allModels: {
-          $allOperations: (params) => params.query(params.args),
+    const getExtendedClient = () =>
+      prisma.$extends({
+        query: {
+          $allModels: {
+            $allOperations: (params) => params.query(params.args),
+          },
         },
-      },
-    })
+      })
 
     test('skips fields in create with query extension', async () => {
-      const result = await extended.user.create({
+      const result = await getExtendedClient().user.create({
         data: {
           email: 'query-ext-test@example.com',
           name: Prisma.skip,
@@ -217,7 +220,7 @@ testMatrix.setupTestSuite(() => {
     })
 
     test('skips input fields in findMany with query extension', async () => {
-      const result = await extended.user.findMany({
+      const result = await getExtendedClient().user.findMany({
         where: {
           name: Prisma.skip,
         },
@@ -228,7 +231,7 @@ testMatrix.setupTestSuite(() => {
     })
 
     test('skips arguments in findMany with query extension', async () => {
-      const result = await extended.user.findMany({
+      const result = await getExtendedClient().user.findMany({
         where: Prisma.skip,
         orderBy: { name: 'asc' },
       })
@@ -237,7 +240,7 @@ testMatrix.setupTestSuite(() => {
     })
 
     test('skips relations in include with query extension', async () => {
-      const result = await extended.user.findFirstOrThrow({
+      const result = await getExtendedClient().user.findFirstOrThrow({
         include: {
           posts: Prisma.skip,
         },
@@ -247,7 +250,7 @@ testMatrix.setupTestSuite(() => {
     })
 
     test('skips relations in select with query extension', async () => {
-      const result = await extended.user.findFirstOrThrow({
+      const result = await getExtendedClient().user.findFirstOrThrow({
         select: {
           id: true,
           posts: Prisma.skip,

--- a/packages/client/tests/functional/skip/test.ts
+++ b/packages/client/tests/functional/skip/test.ts
@@ -197,15 +197,15 @@ testMatrix.setupTestSuite(() => {
   })
 
   describe('after query extension', () => {
-    test('skips fields in create with query extension', async () => {
-      const extended = prisma.$extends({
-        query: {
-          $allModels: {
-            $allOperations: (params) => params.query(params.args),
-          },
+    const extended = prisma.$extends({
+      query: {
+        $allModels: {
+          $allOperations: (params) => params.query(params.args),
         },
-      })
+      },
+    })
 
+    test('skips fields in create with query extension', async () => {
       const result = await extended.user.create({
         data: {
           email: 'query-ext-test@example.com',
@@ -217,14 +217,6 @@ testMatrix.setupTestSuite(() => {
     })
 
     test('skips input fields in findMany with query extension', async () => {
-      const extended = prisma.$extends({
-        query: {
-          $allModels: {
-            $allOperations: (params) => params.query(params.args),
-          },
-        },
-      })
-
       const result = await extended.user.findMany({
         where: {
           name: Prisma.skip,
@@ -236,14 +228,6 @@ testMatrix.setupTestSuite(() => {
     })
 
     test('skips arguments in findMany with query extension', async () => {
-      const extended = prisma.$extends({
-        query: {
-          $allModels: {
-            $allOperations: (params) => params.query(params.args),
-          },
-        },
-      })
-
       const result = await extended.user.findMany({
         where: Prisma.skip,
         orderBy: { name: 'asc' },
@@ -253,14 +237,6 @@ testMatrix.setupTestSuite(() => {
     })
 
     test('skips relations in include with query extension', async () => {
-      const extended = prisma.$extends({
-        query: {
-          $allModels: {
-            $allOperations: (params) => params.query(params.args),
-          },
-        },
-      })
-
       const result = await extended.user.findFirstOrThrow({
         include: {
           posts: Prisma.skip,
@@ -271,14 +247,6 @@ testMatrix.setupTestSuite(() => {
     })
 
     test('skips relations in select with query extension', async () => {
-      const extended = prisma.$extends({
-        query: {
-          $allModels: {
-            $allOperations: (params) => params.query(params.args),
-          },
-        },
-      })
-
       const result = await extended.user.findFirstOrThrow({
         select: {
           id: true,

--- a/packages/client/tests/functional/skip/test.ts
+++ b/packages/client/tests/functional/skip/test.ts
@@ -195,4 +195,98 @@ testMatrix.setupTestSuite(() => {
       expectTypeOf(result).toHaveProperty('email')
     })
   })
+
+  describe('after query extension', () => {
+    test('skips fields in create with query extension', async () => {
+      const extended = prisma.$extends({
+        query: {
+          $allModels: {
+            $allOperations: (params) => params.query(params.args),
+          },
+        },
+      })
+
+      const result = await extended.user.create({
+        data: {
+          email: 'query-ext-test@example.com',
+          name: Prisma.skip,
+        },
+      })
+
+      expect(result.name).toBe('Test User')
+    })
+
+    test('skips input fields in findMany with query extension', async () => {
+      const extended = prisma.$extends({
+        query: {
+          $allModels: {
+            $allOperations: (params) => params.query(params.args),
+          },
+        },
+      })
+
+      const result = await extended.user.findMany({
+        where: {
+          name: Prisma.skip,
+        },
+        orderBy: { name: 'asc' },
+      })
+
+      expect(result.length).toBeGreaterThanOrEqual(2)
+    })
+
+    test('skips arguments in findMany with query extension', async () => {
+      const extended = prisma.$extends({
+        query: {
+          $allModels: {
+            $allOperations: (params) => params.query(params.args),
+          },
+        },
+      })
+
+      const result = await extended.user.findMany({
+        where: Prisma.skip,
+        orderBy: { name: 'asc' },
+      })
+
+      expect(result.length).toBeGreaterThanOrEqual(2)
+    })
+
+    test('skips relations in include with query extension', async () => {
+      const extended = prisma.$extends({
+        query: {
+          $allModels: {
+            $allOperations: (params) => params.query(params.args),
+          },
+        },
+      })
+
+      const result = await extended.user.findFirstOrThrow({
+        include: {
+          posts: Prisma.skip,
+        },
+      })
+
+      expect(result).not.toHaveProperty('posts')
+    })
+
+    test('skips relations in select with query extension', async () => {
+      const extended = prisma.$extends({
+        query: {
+          $allModels: {
+            $allOperations: (params) => params.query(params.args),
+          },
+        },
+      })
+
+      const result = await extended.user.findFirstOrThrow({
+        select: {
+          id: true,
+          posts: Prisma.skip,
+        },
+      })
+
+      expect(result).not.toHaveProperty('posts')
+    })
+  })
 })

--- a/packages/client/tests/functional/skip/test.ts
+++ b/packages/client/tests/functional/skip/test.ts
@@ -169,8 +169,7 @@ testMatrix.setupTestSuite(() => {
       })
 
       expect(result).not.toHaveProperty('posts')
-      // TODO: Apparent issue with $extends + skip (TML-1913)
-      // expectTypeOf(result).not.toHaveProperty('posts')
+      expectTypeOf(result).not.toHaveProperty('posts')
     })
 
     test('skips relations in select', async () => {
@@ -182,8 +181,7 @@ testMatrix.setupTestSuite(() => {
       })
 
       expect(result).not.toHaveProperty('posts')
-      // TODO: Apparent issue with $extends + skip (TML-1913)
-      // expectTypeOf(result).not.toHaveProperty('posts')
+      expectTypeOf(result).not.toHaveProperty('posts')
     })
 
     test('skips fields in omit', async () => {


### PR DESCRIPTION
## Problem

When using `Prisma.skip` with query extensions (`$allModels.$allOperations`), the skip value gets silently converted to `{}` during argument cloning, causing runtime validation errors:

```
Argument `name`: Invalid value provided. Expected String or Null, provided Object.
```

This happens because `deepCloneArgs` treats the `Skip` instance as a regular object and clones it into a plain `{}`, which then fails the `instanceof Skip` check downstream in `serializeJsonQuery`.

## Fix

Added `isSkip(x)` to the early-return condition in `deepCloneValue`, so `Skip` instances pass through cloning untouched — the same pattern already used for `ObjectEnumValue` and `FieldRef`.

## Tests

- Added unit tests for `deepCloneArgs` verifying Skip preservation through cloning (top-level, nested, in arrays)
- Added functional tests for `Prisma.skip` used with `$allModels.$allOperations` query extensions covering create, findMany (input fields and top-level args), include, and select

Fixes #25845

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve "skip" markers when cloning or processing arguments so skip behavior remains consistent and immutable across operations, including when query extensions are used.

* **Tests**
  * Added tests validating skip preservation for top-level values, nested objects, arrays, and behavior across query extensions; also confirm regular values are deep-cloned (originals remain unchanged).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->