### PR TITLE
fix: Handle Prisma Postgres local dev URLs in adapter-pg

### DIFF
--- a/packages/adapter-pg/README.md
+++ b/packages/adapter-pg/README.md
@@ -32,6 +32,16 @@ const adapter = new PrismaPg({ connectionString })
 const prisma = new PrismaClient({ adapter })
 ```
 
+## Prisma Postgres Support
+
+This adapter supports both standard PostgreSQL databases and **Prisma Postgres** instances:
+
+- **Standard PostgreSQL**: Use connection strings starting with `postgres://` or `postgresql://`
+- **Prisma Postgres (local dev)**: Use connection strings from `npx prisma dev` (format: `prisma+postgres://localhost:...`)
+- **Prisma Postgres (serverless)**: For remote Prisma Postgres instances, use [`@prisma/adapter-ppg`](https://www.npmjs.com/package/@prisma/adapter-ppg) instead
+
+When using a local Prisma Postgres development instance (`prisma dev`), this adapter automatically extracts the actual database URL from the connection string, so you can use it directly without any manual conversion.
+
 ## Feedback
 
 We encourage you to create an issue if you find something missing or run into a bug.

--- a/packages/adapter-pg/src/__tests__/issue-29191.test.ts
+++ b/packages/adapter-pg/src/__tests__/issue-29191.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Integration test for issue #29191: Prisma postgres local instance connection error
+ * https://github.com/prisma/prisma/issues/29191
+ *
+ * This test verifies that the adapter correctly handles Prisma Postgres local dev URLs
+ * by extracting the actual database URL from the encoded api_key parameter.
+ */
+
+import pg from 'pg'
+import { describe, expect, it } from 'vitest'
+
+import { PrismaPgAdapterFactory } from '../pg'
+
+describe('Issue #29191 - Prisma Postgres local dev URL handling', () => {
+  it('should correctly parse and use the database URL from a Prisma Postgres local dev connection string', () => {
+    const apiKey = Buffer.from(
+      JSON.stringify({
+        databaseUrl:
+          'postgres://postgres:postgres@localhost:51214/template1?sslmode=disable&connection_limit=1&connect_timeout=0&max_idle_connection_lifetime=0&pool_timeout=0&single_use_connections=true&socket_timeout=0',
+        name: 'default',
+        shadowDatabaseUrl:
+          'postgres://postgres:postgres@localhost:51215/template1?sslmode=disable&connection_limit=1&connect_timeout=0&max_idle_connection_lifetime=0&pool_timeout=0&single_use_connections=true&socket_timeout=0',
+      }),
+    ).toString('base64')
+
+    const connectionString = `prisma+postgres://localhost:51216/?api_key=${apiKey}`
+
+    const config: pg.PoolConfig = { connectionString }
+    const factory = new PrismaPgAdapterFactory(config)
+
+    expect(factory['config'].connectionString).toBe(
+      'postgres://postgres:postgres@localhost:51214/template1?sslmode=disable&connection_limit=1&connect_timeout=0&max_idle_connection_lifetime=0&pool_timeout=0&single_use_connections=true&socket_timeout=0',
+    )
+  })
+
+  it('should work with the exact URL format from issue #29191', () => {
+    const apiKey = Buffer.from(
+      JSON.stringify({
+        databaseUrl: 'postgres://postgres:postgres@localhost:51214/template1?sslmode=disable',
+        name: 'apollo_db',
+        shadowDatabaseUrl: 'postgres://postgres:postgres@localhost:51215/template1?sslmode=disable',
+      }),
+    ).toString('base64')
+
+    const connectionString = `prisma+postgres://localhost:51216/?api_key=${apiKey}`
+
+    const adapter = new PrismaPgAdapterFactory({ connectionString })
+
+    expect(adapter['config'].connectionString).toBe(
+      'postgres://postgres:postgres@localhost:51214/template1?sslmode=disable',
+    )
+  })
+
+  it('should work with the exact URL format from issue #28773', () => {
+    const apiKey =
+      'eyJkYXRhYmFzZVVybCI6InBvc3RncmVzOi8vcG9zdGdyZXM6cG9zdGdyZXNAbG9jYWxob3N0OjUxMjE0L3RlbXBsYXRlMT9zc2xtb2RlPWRpc2FibGUmY29ubmVjdGlvbl9saW1pdD0xJmNvbm5lY3RfdGltZW91dD0wJm1heF9pZGxlX2Nvbm5lY3Rpb25fbGlmZXRpbWU9MCZwb29sX3RpbWVvdXQ9MCZzaW5nbGVfdXNlX2Nvbm5lY3Rpb25zPXRydWUmc29ja2V0X3RpbWVvdXQ9MCIsIm5hbWUiOiJkZWZhdWx0Iiwic2hhZG93RGF0YWJhc2VVcmwiOiJwb3N0Z3JlczovL3Bvc3RncmVzOnBvc3RncmVzQGxvY2FsaG9zdDo1MTIxNS90ZW1wbGF0ZTE_c3NsbW9kZT1kaXNhYmxlJmNvbm5lY3Rpb25fbGltaXQ9MSZjb25uZWN0X3RpbWVvdXQ9MCZtYXhfaWRsZV9jb25uZWN0aW9uX2xpZmV0aW1lPTAmcG9vbF90aW1lb3V0PTAmc2luZ2xlX3VzZV9jb25uZWN0aW9ucz10cnVlJnNvY2tldF90aW1lb3V0PTAifQ=='
+
+    const connectionString = `prisma+postgres://localhost:51213/?api_key=${apiKey}`
+
+    const adapter = new PrismaPgAdapterFactory({ connectionString })
+
+    expect(adapter['config'].connectionString).toContain('postgres://postgres:postgres@localhost:51214/template1')
+    expect(adapter['config'].connectionString).toContain('sslmode=disable')
+  })
+})

--- a/packages/adapter-pg/src/__tests__/pg.test.ts
+++ b/packages/adapter-pg/src/__tests__/pg.test.ts
@@ -98,4 +98,34 @@ describe('PrismaPgAdapterFactory', () => {
 
     await adapter.dispose()
   })
+
+  it('should handle Prisma Postgres local dev URLs', () => {
+    const apiKey = Buffer.from(
+      JSON.stringify({
+        databaseUrl: 'postgres://postgres:postgres@localhost:51214/template1?sslmode=disable',
+        name: 'default',
+        shadowDatabaseUrl: 'postgres://postgres:postgres@localhost:51215/template1?sslmode=disable',
+      }),
+    ).toString('base64')
+
+    const config: pg.PoolConfig = {
+      connectionString: `prisma+postgres://localhost:51213/?api_key=${apiKey}`,
+    }
+
+    const factory = new PrismaPgAdapterFactory(config)
+
+    expect(factory['config'].connectionString).toBe(
+      'postgres://postgres:postgres@localhost:51214/template1?sslmode=disable',
+    )
+  })
+
+  it('should pass through regular postgres URLs unchanged', () => {
+    const config: pg.PoolConfig = {
+      connectionString: 'postgres://localhost:5432/mydb',
+    }
+
+    const factory = new PrismaPgAdapterFactory(config)
+
+    expect(factory['config'].connectionString).toBe('postgres://localhost:5432/mydb')
+  })
 })

--- a/packages/adapter-pg/src/__tests__/prisma-postgres-local.test.ts
+++ b/packages/adapter-pg/src/__tests__/prisma-postgres-local.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest'
+
+import { extractDatabaseUrl, isPrismaPostgresLocalDevUrl, toPostgresConnectionString } from '../prisma-postgres-local'
+
+describe('isPrismaPostgresLocalDevUrl', () => {
+  it('returns true for prisma+postgres://localhost URLs', () => {
+    expect(isPrismaPostgresLocalDevUrl('prisma+postgres://localhost:5432')).toBe(true)
+    expect(isPrismaPostgresLocalDevUrl('prisma+postgres://localhost:51213/?api_key=xxx')).toBe(true)
+  })
+
+  it('returns true for prisma+postgres://127.0.0.1 URLs', () => {
+    expect(isPrismaPostgresLocalDevUrl('prisma+postgres://127.0.0.1:5432')).toBe(true)
+  })
+
+  it('returns true for prisma+postgres://[::1] URLs', () => {
+    expect(isPrismaPostgresLocalDevUrl('prisma+postgres://[::1]:5432')).toBe(true)
+  })
+
+  it('returns true for prisma+postgres://[0:0:0:0:0:0:0:1] URLs (normalized to [::1])', () => {
+    // URL parser normalizes the expanded IPv6 form to compressed form
+    expect(isPrismaPostgresLocalDevUrl('prisma+postgres://[0:0:0:0:0:0:0:1]:5432')).toBe(true)
+  })
+
+  it('returns false for prisma+postgres:// URLs with non-localhost hosts', () => {
+    expect(isPrismaPostgresLocalDevUrl('prisma+postgres://accelerate.prisma-data.net')).toBe(false)
+    expect(isPrismaPostgresLocalDevUrl('prisma+postgres://example.com:5432')).toBe(false)
+  })
+
+  it('returns false for regular postgres:// URLs', () => {
+    expect(isPrismaPostgresLocalDevUrl('postgres://localhost:5432')).toBe(false)
+    expect(isPrismaPostgresLocalDevUrl('postgresql://localhost:5432')).toBe(false)
+  })
+
+  it('returns false for invalid URLs', () => {
+    expect(isPrismaPostgresLocalDevUrl('not a url')).toBe(false)
+    expect(isPrismaPostgresLocalDevUrl('http://localhost')).toBe(false)
+  })
+
+  it('accepts URL objects', () => {
+    expect(isPrismaPostgresLocalDevUrl(new URL('prisma+postgres://localhost:5432'))).toBe(true)
+    expect(isPrismaPostgresLocalDevUrl(new URL('postgres://localhost:5432'))).toBe(false)
+  })
+})
+
+describe('extractDatabaseUrl', () => {
+  it('extracts the database URL from a valid Prisma Postgres local dev URL', () => {
+    const apiKey = Buffer.from(
+      JSON.stringify({
+        databaseUrl: 'postgres://postgres:postgres@localhost:51214/template1?sslmode=disable',
+        name: 'default',
+        shadowDatabaseUrl: 'postgres://postgres:postgres@localhost:51215/template1?sslmode=disable',
+      }),
+    ).toString('base64')
+
+    const url = `prisma+postgres://localhost:51213/?api_key=${apiKey}`
+    const result = extractDatabaseUrl(url)
+
+    expect(result).toBe('postgres://postgres:postgres@localhost:51214/template1?sslmode=disable')
+  })
+
+  it('throws an error if the URL is not a Prisma Postgres local dev URL', () => {
+    expect(() => extractDatabaseUrl('postgres://localhost:5432')).toThrow('Invalid Prisma Postgres local dev URL')
+    expect(() => extractDatabaseUrl('prisma+postgres://example.com:5432')).toThrow(
+      'Invalid Prisma Postgres local dev URL',
+    )
+  })
+
+  it('throws an error if api_key parameter is missing', () => {
+    expect(() => extractDatabaseUrl('prisma+postgres://localhost:5432')).toThrow('Missing api_key parameter')
+  })
+
+  it('throws an error if api_key cannot be decoded', () => {
+    expect(() => extractDatabaseUrl('prisma+postgres://localhost:5432/?api_key=invalid-base64!!!')).toThrow(
+      'Invalid api_key format',
+    )
+  })
+
+  it('throws an error if decoded api_key does not contain databaseUrl', () => {
+    const apiKey = Buffer.from(JSON.stringify({ name: 'default' })).toString('base64')
+    expect(() => extractDatabaseUrl(`prisma+postgres://localhost:5432/?api_key=${apiKey}`)).toThrow(
+      'Invalid api_key structure',
+    )
+  })
+
+  it('accepts URL objects', () => {
+    const apiKey = Buffer.from(
+      JSON.stringify({
+        databaseUrl: 'postgres://localhost:5432/test',
+        name: 'default',
+        shadowDatabaseUrl: 'postgres://localhost:5433/test',
+      }),
+    ).toString('base64')
+
+    const url = new URL(`prisma+postgres://localhost:51213/?api_key=${apiKey}`)
+    const result = extractDatabaseUrl(url)
+
+    expect(result).toBe('postgres://localhost:5432/test')
+  })
+})
+
+describe('toPostgresConnectionString', () => {
+  it('extracts database URL from Prisma Postgres local dev URLs', () => {
+    const apiKey = Buffer.from(
+      JSON.stringify({
+        databaseUrl: 'postgres://postgres:postgres@localhost:51214/template1',
+        name: 'default',
+        shadowDatabaseUrl: 'postgres://postgres:postgres@localhost:51215/template1',
+      }),
+    ).toString('base64')
+
+    const url = `prisma+postgres://localhost:51213/?api_key=${apiKey}`
+    const result = toPostgresConnectionString(url)
+
+    expect(result).toBe('postgres://postgres:postgres@localhost:51214/template1')
+  })
+
+  it('returns regular postgres:// URLs as-is', () => {
+    const url = 'postgres://localhost:5432/mydb'
+    expect(toPostgresConnectionString(url)).toBe(url)
+  })
+
+  it('returns postgresql:// URLs as-is', () => {
+    const url = 'postgresql://user:pass@localhost:5432/mydb'
+    expect(toPostgresConnectionString(url)).toBe(url)
+  })
+
+  it('returns non-localhost prisma+postgres:// URLs as-is', () => {
+    const url = 'prisma+postgres://accelerate.prisma-data.net/?api_key=xxx'
+    expect(toPostgresConnectionString(url)).toBe(url)
+  })
+
+  it('accepts URL objects', () => {
+    const apiKey = Buffer.from(
+      JSON.stringify({
+        databaseUrl: 'postgres://localhost:5432/test',
+        name: 'default',
+        shadowDatabaseUrl: 'postgres://localhost:5433/test',
+      }),
+    ).toString('base64')
+
+    const url = new URL(`prisma+postgres://localhost:51213/?api_key=${apiKey}`)
+    const result = toPostgresConnectionString(url)
+
+    expect(result).toBe('postgres://localhost:5432/test')
+  })
+})

--- a/packages/adapter-pg/src/index.ts
+++ b/packages/adapter-pg/src/index.ts
@@ -1,1 +1,2 @@
 export { PrismaPgAdapterFactory as PrismaPg } from './pg'
+export { extractDatabaseUrl, isPrismaPostgresLocalDevUrl, toPostgresConnectionString } from './prisma-postgres-local'

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -275,11 +275,11 @@ export class PrismaPgAdapterFactory implements SqlMigrationAwareDriverAdapterFac
       this.config = poolOrConfig.options
     } else {
       this.externalPool = null
-      this.config = this.normalizeConfig(poolOrConfig)
+      this.config = this.#normalizeConfig(poolOrConfig)
     }
   }
 
-  private normalizeConfig(config: pg.PoolConfig): pg.PoolConfig {
+  #normalizeConfig(config: pg.PoolConfig): pg.PoolConfig {
     if (config.connectionString) {
       const normalized = toPostgresConnectionString(config.connectionString)
       if (normalized !== config.connectionString) {

--- a/packages/adapter-pg/src/prisma-postgres-local.ts
+++ b/packages/adapter-pg/src/prisma-postgres-local.ts
@@ -1,0 +1,120 @@
+/**
+ * Utilities for handling Prisma Postgres local dev instance URLs.
+ *
+ * Local Prisma Postgres instances (started via `prisma dev`) use URLs in the format:
+ * `prisma+postgres://localhost:PORT/?api_key=BASE64_JSON`
+ *
+ * The api_key parameter contains a base64-encoded JSON object with the actual
+ * PostgreSQL connection details that should be used with the pg driver.
+ *
+ * @remarks
+ * When to use which adapter for Prisma Postgres:
+ * - Local dev instances (`npx prisma dev`) → Use `@prisma/adapter-pg` (this package)
+ * - Remote serverless instances → Use `@prisma/adapter-ppg`
+ *
+ * This package automatically handles the URL conversion for local dev instances,
+ * so you can pass the connection string from `prisma dev` directly to the adapter.
+ */
+
+const PRISMA_POSTGRES_PROTOCOL = 'prisma+postgres:'
+
+interface PrismaPostgresDevApiKey {
+  databaseUrl: string
+  name: string
+  shadowDatabaseUrl: string
+}
+
+/**
+ * Type guard to validate that a decoded object matches PrismaPostgresDevApiKey structure.
+ */
+function isPrismaPostgresDevApiKey(obj: unknown): obj is PrismaPostgresDevApiKey {
+  if (typeof obj !== 'object' || obj === null) {
+    return false
+  }
+
+  const candidate = obj as Record<string, unknown>
+  return (
+    typeof candidate.databaseUrl === 'string' &&
+    typeof candidate.name === 'string' &&
+    typeof candidate.shadowDatabaseUrl === 'string'
+  )
+}
+
+/**
+ * Checks if a URL is a Prisma Postgres local dev instance URL.
+ */
+export function isPrismaPostgresLocalDevUrl(connectionString: string | URL): boolean {
+  try {
+    const url = typeof connectionString === 'string' ? new URL(connectionString) : connectionString
+    if (url.protocol !== PRISMA_POSTGRES_PROTOCOL) {
+      return false
+    }
+
+    const { hostname } = url
+    // Note: URL parser normalizes [0:0:0:0:0:0:0:1] to [::1], so we only need to check the normalized form
+    return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Extracts the actual PostgreSQL database URL from a Prisma Postgres local dev URL.
+ *
+ * @param connectionString The prisma+postgres://localhost URL
+ * @returns The actual postgres:// URL to use for connections
+ * @throws Error if the URL is invalid or the api_key cannot be decoded
+ */
+export function extractDatabaseUrl(connectionString: string | URL): string {
+  const url = typeof connectionString === 'string' ? new URL(connectionString) : connectionString
+
+  if (!isPrismaPostgresLocalDevUrl(url)) {
+    throw new Error(
+      `Invalid Prisma Postgres local dev URL. Expected prisma+postgres://localhost, got ${url.protocol}//${url.host}`,
+    )
+  }
+
+  const apiKey = url.searchParams.get('api_key')
+  if (!apiKey) {
+    throw new Error('Missing api_key parameter in Prisma Postgres local dev URL')
+  }
+
+  let decodedApiKey: unknown
+  try {
+    const jsonString = Buffer.from(apiKey, 'base64').toString('utf-8')
+    decodedApiKey = JSON.parse(jsonString)
+  } catch (error) {
+    // Buffer.from() doesn't throw on invalid base64, it silently produces garbage.
+    // Only JSON.parse() can throw here (always SyntaxError for invalid JSON).
+    throw new Error(
+      `Invalid api_key format: expected base64-encoded JSON, got ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+
+  if (!isPrismaPostgresDevApiKey(decodedApiKey)) {
+    throw new Error(
+      'Invalid api_key structure: expected object with databaseUrl, name, and shadowDatabaseUrl properties',
+    )
+  }
+
+  return decodedApiKey.databaseUrl
+}
+
+/**
+ * Converts a connection string to a format suitable for the pg driver.
+ *
+ * If the connection string is a Prisma Postgres local dev URL, extracts the
+ * actual database URL. Otherwise, returns the connection string as-is.
+ *
+ * @param connectionString The connection string (may be prisma+postgres:// or postgres://)
+ * @returns A standard PostgreSQL connection string
+ */
+export function toPostgresConnectionString(connectionString: string | URL): string {
+  const connStr = typeof connectionString === 'string' ? connectionString : connectionString.toString()
+
+  if (isPrismaPostgresLocalDevUrl(connStr)) {
+    return extractDatabaseUrl(connStr)
+  }
+
+  return connStr
+}


### PR DESCRIPTION
Fixes #29191, #28773

## Problem

`npx prisma dev` generates connection strings like:
```
prisma+postgres://localhost:51216/?api_key=BASE64_JSON
```

The `pg` driver doesn't understand this protocol → `Connection terminated unexpectedly`

## Solution

Automatically detect and decode these URLs to extract the actual `postgres://` connection string from the base64-encoded `api_key` parameter.

**Before:**
```typescript
// Fails with "Connection terminated unexpectedly"
const adapter = new PrismaPg({
  connectionString: 'prisma+postgres://localhost:51216/?api_key=...'
})
```

**After:**
```typescript
// Works automatically
const adapter = new PrismaPg({
  connectionString: 'prisma+postgres://localhost:51216/?api_key=...'
})
```

## Changes

- Add URL detection and extraction utilities (`prisma-postgres-local.ts`)
- Auto-convert URLs in `PrismaPgAdapterFactory` constructor
- 21 new tests (18 unit + 3 integration)
- Updated README with Prisma Postgres documentation

## Testing

- All 58 tests pass
- Tests use actual URLs from reported issues
- Backward compatible (regular `postgres://` URLs unchanged)
- Linter passes

## Documentation

README now clarifies adapter usage:
- Standard PostgreSQL → `@prisma/adapter-pg`
- Prisma Postgres local dev → `@prisma/adapter-pg`
- Prisma Postgres serverless → `@prisma/adapter-ppg`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prisma Postgres local development support: connection strings that wrap real database URLs are automatically detected and converted to standard PostgreSQL URLs for seamless use.

* **Documentation**
  * README expanded to describe supported connection modes (Standard PostgreSQL, Prisma Postgres local dev, Prisma Postgres serverless) and where to give feedback.

* **Tests**
  * Extensive tests added to validate parsing, extraction, and conversion of Prisma Postgres local dev URLs across scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->