### PR TITLE
test(client): push item/items to scalar list

### DIFF
--- a/packages/client/tests/functional/scalar-list-push/_matrix.ts
+++ b/packages/client/tests/functional/scalar-list-push/_matrix.ts
@@ -1,0 +1,10 @@
+import { defineMatrix } from '../_utils/defineMatrix'
+import { Providers } from '../_utils/providers'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: Providers.POSTGRESQL,
+    },
+  ],
+])

--- a/packages/client/tests/functional/scalar-list-push/prisma/_schema.ts
+++ b/packages/client/tests/functional/scalar-list-push/prisma/_schema.ts
@@ -1,0 +1,19 @@
+import { idForProvider } from '../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client"
+  }
+  
+  datasource db {
+    provider = "${provider}"
+  }
+  
+  model User {
+    id ${idForProvider(provider)}
+    content String[]
+  }
+  `
+})

--- a/packages/client/tests/functional/scalar-list-push/prisma/_schema.ts
+++ b/packages/client/tests/functional/scalar-list-push/prisma/_schema.ts
@@ -13,6 +13,7 @@ export default testMatrix.setupSchema(({ provider }) => {
   
   model User {
     id ${idForProvider(provider)}
+    email String @unique
     content String[]
   }
   `

--- a/packages/client/tests/functional/scalar-list-push/tests.ts
+++ b/packages/client/tests/functional/scalar-list-push/tests.ts
@@ -1,0 +1,46 @@
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(
+  () => {
+    beforeEach(async () => {
+      await prisma.user.deleteMany()
+      await prisma.user.create({ data: { content: ["prisma1", "prisma2"] } })
+    })
+
+    test('push with single element', async () => {
+      const result = await prisma.user.update({
+        where: { id: 1 },
+        data: {
+          content: {
+            push: "prisma3",
+          },
+        },
+      })
+
+      expect(result.content).toEqual(["prisma1", "prisma2", "prisma3"])
+    })
+
+    test('push with array value', async () => {
+      const result = await prisma.user.update({
+        where: { id: 1 },
+        data: {
+          content: {
+            push: ["prisma4", "prisma5"],
+          },
+        },
+      })
+
+      expect(result.content).toEqual(["prisma1", "prisma2", "prisma4", "prisma5"])
+    })
+  },
+  {
+    optOut: {
+      from: ['sqlite', 'mysql', 'sqlserver'],
+      reason: 'scalar lists are supported only on postgresql/cockroachdb/mongodb',
+    },
+  },
+)

--- a/packages/client/tests/functional/scalar-list-push/tests.ts
+++ b/packages/client/tests/functional/scalar-list-push/tests.ts
@@ -1,19 +1,22 @@
+import { faker } from '@faker-js/faker'
+
 import testMatrix from './_matrix'
 // @ts-ignore
 import type { PrismaClient } from './generated/prisma/client'
 
 declare let prisma: PrismaClient
+const email = faker.internet.email()
 
 testMatrix.setupTestSuite(
   () => {
     beforeEach(async () => {
       await prisma.user.deleteMany()
-      await prisma.user.create({ data: { content: ["prisma1", "prisma2"] } })
+      await prisma.user.create({ data: { email, content: ["prisma1", "prisma2"] } })
     })
 
     test('push with single element', async () => {
       const result = await prisma.user.update({
-        where: { id: 1 },
+        where: { email },
         data: {
           content: {
             push: "prisma3",
@@ -26,7 +29,7 @@ testMatrix.setupTestSuite(
 
     test('push with array value', async () => {
       const result = await prisma.user.update({
-        where: { id: 1 },
+        where: { email },
         data: {
           content: {
             push: ["prisma4", "prisma5"],


### PR DESCRIPTION
Related to issue #29200 and #29212

Same as json test but uses `TEXT[]` instead

Docs: https://www.prisma.io/docs/orm/prisma-client/special-fields-and-types/working-with-scalar-lists-arrays#adding-items-to-a-scalar-list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added functional tests validating scalar-list "push" behavior (single and multiple elements) with PostgreSQL, including opt-outs for unsupported databases.
  * Added a test matrix targeting PostgreSQL and dynamic test schema generation to support provider-specific test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->