### PR TITLE
fix: case-insensitive in filter for string IN queries

### DIFF
--- a/packages/client-engine-runtime/src/interpreter/render-query.test.ts
+++ b/packages/client-engine-runtime/src/interpreter/render-query.test.ts
@@ -97,6 +97,45 @@ test('transforms IN template', () => {
   ])
 })
 
+test('lowercases string params for case-insensitive IN', () => {
+  expect(
+    renderQuery(
+      {
+        type: 'templateSql',
+        fragments: [
+          {
+            type: 'stringChunk',
+            chunk: 'SELECT * FROM t WHERE LOWER("col") IN ',
+          },
+          { type: 'parameterTuple' },
+          { type: 'stringChunk', chunk: ' OFFSET ' },
+          { type: 'parameter' },
+        ],
+        placeholderFormat: { prefix: '$', hasNumbering: true } satisfies PlaceholderFormat,
+        args: [['AbC.jpg', 'DEF.txt', 'gHi.png'], 0],
+        argTypes: [
+          { arity: 'scalar', scalarType: 'string' },
+          { arity: 'scalar', scalarType: 'int' },
+        ],
+        chunkable: true,
+      } satisfies QueryPlanDbQuery,
+      {} as ScopeBindings,
+      {},
+    ),
+  ).toEqual([
+    {
+      sql: 'SELECT * FROM t WHERE LOWER("col") IN ($1,$2,$3) OFFSET $4',
+      args: ['abc.jpg', 'def.txt', 'ghi.png', 0],
+      argTypes: [
+        { arity: 'scalar', scalarType: 'string' },
+        { arity: 'scalar', scalarType: 'string' },
+        { arity: 'scalar', scalarType: 'string' },
+        { arity: 'scalar', scalarType: 'int' },
+      ],
+    },
+  ])
+})
+
 test('transforms IN template with empty list', () => {
   expect(
     renderQuery(

--- a/packages/client/tests/functional/string-filters/tests.ts
+++ b/packages/client/tests/functional/string-filters/tests.ts
@@ -194,6 +194,18 @@ testMatrix.setupTestSuite(({ provider }) => {
 
         expect(results.map((r) => r.value).sort()).toEqual(['FOO BAR BAZ', 'baz', 'foo bar baz'])
       })
+
+      test('in case-insensitive', async () => {
+        const results = await prisma.testModel.findMany({
+          // @ts-test-if: provider === Providers.POSTGRESQL || provider === Providers.COCKROACHDB
+          where: {
+            value: { in: ['foo', 'BAR', 'baz'], mode: 'insensitive' },
+          },
+          orderBy: { value: 'asc' },
+        })
+
+        expect(results.map((r) => r.value)).toEqual(['bar', 'baz', 'foo', 'FOO BAR BAZ', 'Foo'])
+      })
     },
   )
 })


### PR DESCRIPTION
fix : #29215

### Summary

- in: [...] with mode: 'insensitive' stopped working in 7.4.0.

### Problem

- 7.3.0: LOWER(col) IN (LOWER($1), LOWER($2), ...)
- 7.4.0: LOWER(col) IN ($1, $2, ...) — params not lowercased

### Solution

- Lowercase string params when the SQL matches LOWER(...) IN.

### Changes

- render-query.ts — Lowercase params for that pattern
- render-query.test.ts — Unit test
- string-filters/tests.ts — Functional test

### Testing
- pnpm --filter @prisma/client-engine-runtime test -- render-query passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed case-insensitive string filtering with the IN operator. When using `mode: 'insensitive'` with IN filters, string values are now properly normalized for case-insensitive matching across PostgreSQL and CockroachDB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->