### PR TITLE
fix(adapter-mariadb,adapter-planetscale): return strings for text columns with binary collation in raw queries

### DIFF
--- a/packages/adapter-planetscale/src/planetscale.ts
+++ b/packages/adapter-planetscale/src/planetscale.ts
@@ -18,7 +18,7 @@ import { Debug, DriverAdapterError } from '@prisma/driver-adapter-utils'
 import { Mutex } from 'async-mutex'
 
 import { name as packageName } from '../package.json'
-import { cast, fieldToColumnType, mapArg, type PlanetScaleColumnType } from './conversion'
+import { cast, fieldToColumnType, mapArg } from './conversion'
 import { createDeferred, Deferred } from './deferred'
 import { convertDriverError } from './errors'
 
@@ -54,7 +54,7 @@ class PlanetScaleQueryable<ClientT extends planetScale.Client | planetScale.Tran
     const columns = fields.map((field) => field.name)
     return {
       columnNames: columns,
-      columnTypes: fields.map((field) => fieldToColumnType(field.type as PlanetScaleColumnType)),
+      columnTypes: fields.map((field) => fieldToColumnType(field)),
       rows: rows as SqlResultSet['rows'],
       lastInsertId,
     }

--- a/packages/client/tests/functional/raw-queries/mysql-column-type/_matrix.ts
+++ b/packages/client/tests/functional/raw-queries/mysql-column-type/_matrix.ts
@@ -1,4 +1,4 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
 import { Providers } from '../../_utils/providers'
 
-export default defineMatrix(() => [[{ provider: Providers.MYSQL, driverAdapter: 'js_mariadb' }]])
+export default defineMatrix(() => [[{ provider: Providers.MYSQL }]])

--- a/packages/client/tests/functional/raw-queries/mysql-column-type/_matrix.ts
+++ b/packages/client/tests/functional/raw-queries/mysql-column-type/_matrix.ts
@@ -1,0 +1,4 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+import { Providers } from '../../_utils/providers'
+
+export default defineMatrix(() => [[{ provider: Providers.MYSQL, driverAdapter: 'js_mariadb' }]])

--- a/packages/client/tests/functional/raw-queries/mysql-column-type/prisma/_schema.ts
+++ b/packages/client/tests/functional/raw-queries/mysql-column-type/prisma/_schema.ts
@@ -14,8 +14,9 @@ export default testMatrix.setupSchema(({ provider }) => {
       
       model User {
         id ${idForProvider(provider)}
-        str String
-        str_bin_collation String
+        char_bin_collation String @db.Char(191)
+        varchar_bin_collation String @db.VarChar(191)
+        text_bin_collation String @db.Text
       }
       `
 })

--- a/packages/client/tests/functional/raw-queries/mysql-column-type/prisma/_schema.ts
+++ b/packages/client/tests/functional/raw-queries/mysql-column-type/prisma/_schema.ts
@@ -1,0 +1,21 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+      generator client {
+        provider = "prisma-client-js"
+        output   = "../generated/prisma/client"
+      }
+      
+      datasource db {
+        provider = "${provider}"
+      }
+      
+      model User {
+        id ${idForProvider(provider)}
+        str String
+        str_bin_collation String
+      }
+      `
+})

--- a/packages/client/tests/functional/raw-queries/mysql-column-type/test.ts
+++ b/packages/client/tests/functional/raw-queries/mysql-column-type/test.ts
@@ -9,7 +9,9 @@ testMatrix.setupTestSuite(
   () => {
     beforeAll(async () => {
       // Prisma Schema does not support specifying column collation
-      await prisma.$executeRaw`ALTER TABLE \`User\` MODIFY \`str_bin_collation\` VARCHAR(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL`
+      await prisma.$executeRaw`ALTER TABLE \`User\` MODIFY \`char_bin_collation\` CHAR(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL`
+      await prisma.$executeRaw`ALTER TABLE \`User\` MODIFY \`varchar_bin_collation\` VARCHAR(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL`
+      await prisma.$executeRaw`ALTER TABLE \`User\` MODIFY \`text_bin_collation\` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL`
     })
 
     beforeEach(async () => {
@@ -19,19 +21,21 @@ testMatrix.setupTestSuite(
     test('columns with _bin collation return strings, not Uint8Array', async () => {
       await prisma.user.create({
         data: {
-          str: 'hello',
-          str_bin_collation: 'world',
+          char_bin_collation: 'hello',
+          varchar_bin_collation: 'hello',
+          text_bin_collation: 'hello',
         },
       })
 
       const result =
-        (await prisma.$queryRaw`SELECT \`str\`, \`str_bin_collation\` FROM \`User\` ORDER BY \`str\``) as Array<
+        (await prisma.$queryRaw`SELECT \`char_bin_collation\`, \`varchar_bin_collation\`, \`text_bin_collation\` FROM \`User\``) as Array<
           Record<string, unknown>
         >
 
       expect(result).toHaveLength(1)
-      expect(result[0].str).toBe('hello')
-      expect(result[0].str_bin_collation).toBe('world')
+      expect(result[0].char_bin_collation).toBe('hello')
+      expect(result[0].varchar_bin_collation).toBe('hello')
+      expect(result[0].text_bin_collation).toBe('hello')
     })
   },
   {

--- a/packages/client/tests/functional/raw-queries/mysql-column-type/test.ts
+++ b/packages/client/tests/functional/raw-queries/mysql-column-type/test.ts
@@ -1,0 +1,43 @@
+import { Providers } from '../../_utils/providers'
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(
+  () => {
+    beforeAll(async () => {
+      // Prisma Schema does not support specifying column collation
+      await prisma.$executeRaw`ALTER TABLE \`User\` MODIFY \`str_bin_collation\` VARCHAR(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL`
+    })
+
+    beforeEach(async () => {
+      await prisma.user.deleteMany()
+    })
+
+    test('columns with _bin collation return strings, not Uint8Array', async () => {
+      await prisma.user.create({
+        data: {
+          str: 'hello',
+          str_bin_collation: 'world',
+        },
+      })
+
+      const result =
+        (await prisma.$queryRaw`SELECT \`str\`, \`str_bin_collation\` FROM \`User\` ORDER BY \`str\``) as Array<
+          Record<string, unknown>
+        >
+
+      expect(result).toHaveLength(1)
+      expect(result[0].str).toBe('hello')
+      expect(result[0].str_bin_collation).toBe('world')
+    })
+  },
+  {
+    optOut: {
+      from: [Providers.POSTGRESQL, Providers.SQLITE, Providers.MONGODB, Providers.COCKROACHDB, Providers.SQLSERVER],
+      reason: 'This test is for MySQL-specific column type detection',
+    },
+  },
+)


### PR DESCRIPTION
Fixes #29237

## Summary

### adapter-mariadb
Replace the `BINARY_FLAG` check with a collation index check (`collation.index === 63`), matching the approach used by `mariadb-connector-nodejs`.
https://github.com/mariadb-corporation/mariadb-connector-nodejs/blob/3.5.1/lib/cmd/decoder/text-decoder.js#L44

### adapter-planetscale
Add a charset-based collation check (`field.charset !== 63`) in `fieldToColumnType` to distinguish text columns from true binary columns. Vitess converts CHAR/VARCHAR/TEXT columns with a binary collation to BINARY/VARBINARY/BLOB respectively, so the charset value is used to detect this conversion.
https://github.com/planetscale/database-js/blob/de78eebfaec8cd88c670b8c644fc5a3fd69e664c/src/cast.ts#L92

## Root cause

Because the `mapColumnType` function in `adapter-mariadb` returns `ColumnTypeEnum.Bytes` when a column has a Binary Collation,
https://github.com/prisma/prisma/blob/7.4.1/packages/adapter-mariadb/src/conversion.ts#L86

and the `fieldToColumnType` function in `adapter-planetscale` does not inspect the charset at all for BLOB/BINARY/VARBINARY types,
https://github.com/prisma/prisma/blob/7.4.1/packages/adapter-planetscale/src/conversion.ts#L85

the `deserializeValue` function unintentionally converts even string data into a `Uint8Array`, treating it as a base64 string.
https://github.com/prisma/prisma/blob/7.4.1/packages/client/src/runtime/utils/deserializeRawResults.ts#L20

Since a Binary Collation can also apply to string data types like `CHAR`, the type determination logic in both `adapter-mariadb` and `adapter-planetscale` needs to be updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved binary collation detection in MariaDB and PlanetScale database adapters. Columns with binary collation now correctly return as text data.

* **Tests**
  * Added MySQL column type tests to validate binary collation handling in query results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->