### PR TITLE
fix: correct mariadb relationJoins check

### DIFF
--- a/packages/adapter-mariadb/src/mariadb.test.ts
+++ b/packages/adapter-mariadb/src/mariadb.test.ts
@@ -5,6 +5,9 @@ import { inferCapabilities, PrismaMariaDbAdapterFactory, rewriteConnectionString
 describe.each([
   ['8.0.12', { supportsRelationJoins: false }],
   ['8.0.13', { supportsRelationJoins: true }],
+  ['8.1.0', { supportsRelationJoins: true }],
+  ['8.4.5', { supportsRelationJoins: true }],
+  ['8.4.13', { supportsRelationJoins: true }],
   ['11.4.7-MariaDB-ubu2404', { supportsRelationJoins: false }],
 ])('infer capabilities for %s', (version, capabilities) => {
   test(`inferCapabilities(${version})`, () => {

--- a/packages/adapter-mariadb/src/mariadb.ts
+++ b/packages/adapter-mariadb/src/mariadb.ts
@@ -255,8 +255,8 @@ export function inferCapabilities(version: unknown): Capabilities {
 
   // No relation-joins support for mysql < 8.0.13 or mariadb.
   const isMariaDB = suffix?.toLowerCase()?.includes('mariadb') ?? false
-  const supportsRelationJoins = !isMariaDB && (major > 8 || (major === 8 && minor >= 0 && patch >= 13))
-
+  const supportsRelationJoins =
+    !isMariaDB && (major > 8 || (major === 8 && (minor > 0 || (minor === 0 && patch >= 13))))
   return { supportsRelationJoins }
 }
 


### PR DESCRIPTION
[TML-1934](https://linear.app/prisma-company/issue/TML-1934/fix-broken-relationjoins-check-in-the-mariadb-adapter)

Fixes https://github.com/prisma/prisma/issues/29235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended test matrix with MariaDB versions 8.1.0, 8.4.5, and 8.4.13.

* **Bug Fixes**
  * Improved relation-joins compatibility detection for better MariaDB 8.x version support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->