### PR TITLE
test: add missing restoreAllMocks

### DIFF
--- a/packages/debug/src/__tests__/debug.extended.test.ts
+++ b/packages/debug/src/__tests__/debug.extended.test.ts
@@ -20,6 +20,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.resetModules()
+  vi.restoreAllMocks()
 })
 
 test('with a namespace', async () => {


### PR DESCRIPTION
Adds a missing `restoreAllMocks` to fix [🧪 / Others [v20.19.0]](https://github.com/prisma/prisma/actions/runs/22404623961/job/64860796095?pr=29255#logs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup procedures to ensure proper restoration of mocked functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->