### PR TITLE
fix(studio): normalize Prisma MySQL URL params before mysql2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,14 @@
   - Test files named `*.test.ts` are excluded from build output via esbuild config; place tests alongside source files.
   - **Update this file** (`AGENTS.md`) whenever you learn something new about the codebase that would be valuable for future tasks.
 
+## Git manners and releases
+
+- New features and bugfixes should be developed on a new branch.
+- When a feature or bugfix is complete, add it to a section at the top of `CHANGELOG.md` called `Upcoming`. If the section does not exist, add it.
+- To release a new version, pick a new version number and rename the `Upcoming` section to that version number.
+- Update the `version` field in `package.json` as part of the release.
+- Do the release ceremony in a single separate commit.
+
 - **Knowledge reminders**:
   - Your training data contains a lot of outdated information that doesn't apply to Prisma 7. Always analyze this codebase like you would analyze a project you are not familiar with, and prefer the learnings from this file and this codebase over your prior knowledge. In particular, remember:
     - **There's no such thing as "query engine" in Prisma**

--- a/packages/cli/src/Studio.ts
+++ b/packages/cli/src/Studio.ts
@@ -87,6 +87,14 @@ const PRISMA_ORM_SPECIFIC_QUERY_PARAMETERS = [
   'statement_cache_size',
 ] as const
 
+const PRISMA_ORM_SPECIFIC_MYSQL_QUERY_PARAMETERS = [
+  'connection_limit',
+  'pool_timeout',
+  'socket_timeout',
+  'sslaccept',
+  'sslidentity',
+] as const
+
 const POSTGRES_STUDIO_STUFF: StudioStuff = {
   async createExecutor(connectionString) {
     const postgresModule = await import('postgres')
@@ -231,7 +239,7 @@ Please use Node.js >=22.5, Deno >=2.2 or Bun >=1.0 or ensure you have the \`bett
     async createExecutor(connectionString) {
       const { createPool } = await import('mysql2/promise')
 
-      const pool = createPool(connectionString)
+      const pool = createPool(normalizeMySQLConnectionString(connectionString))
 
       process.once('SIGINT', () => pool.end())
       process.once('SIGTERM', () => pool.end())
@@ -476,6 +484,40 @@ function getUrlBasePath(url: string | undefined, configPath: string | null): str
   return url ? process.cwd() : configPath ? dirname(configPath) : process.cwd()
 }
 
+function normalizeMySQLConnectionString(connectionString: string): string {
+  const connectionURL = new URL(connectionString)
+
+  const connectionLimit = connectionURL.searchParams.get('connection_limit')
+
+  if (connectionLimit && !connectionURL.searchParams.has('connectionLimit')) {
+    connectionURL.searchParams.set('connectionLimit', connectionLimit)
+  }
+
+  const sslAccept = connectionURL.searchParams.get('sslaccept')
+
+  if (sslAccept && !connectionURL.searchParams.has('ssl')) {
+    connectionURL.searchParams.set('ssl', JSON.stringify(prismaSslAcceptToMySQL2Ssl(sslAccept)))
+  }
+
+  for (const queryParameter of PRISMA_ORM_SPECIFIC_MYSQL_QUERY_PARAMETERS) {
+    connectionURL.searchParams.delete(queryParameter)
+  }
+
+  return connectionURL.toString()
+}
+
+function prismaSslAcceptToMySQL2Ssl(sslAccept: string): { rejectUnauthorized: boolean } {
+  switch (sslAccept) {
+    case 'strict':
+      return { rejectUnauthorized: true }
+    case 'accept_invalid_certs':
+      return { rejectUnauthorized: false }
+    default:
+      throw new Error(
+        `Unknown Prisma MySQL sslaccept value "${sslAccept}". Supported values are "strict" and "accept_invalid_certs".`,
+      )
+  }
+}
 // prettier-ignore
 const INDEX_HTML =
 `<!doctype html>

--- a/packages/cli/src/__tests__/Studio.vitest.ts
+++ b/packages/cli/src/__tests__/Studio.vitest.ts
@@ -1,0 +1,122 @@
+import { defaultTestConfig } from '@prisma/config'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const createPoolMock = vi.fn(() => ({ end: vi.fn() }))
+
+vi.mock('mysql2/promise', () => {
+  return {
+    createPool: createPoolMock,
+  }
+})
+
+vi.mock('@hono/node-server', () => {
+  return {
+    serve: vi.fn(() => ({ close: vi.fn() })),
+  }
+})
+
+vi.mock('@prisma/studio-core/data/mysql2', () => {
+  return {
+    createMySQL2Executor: vi.fn(() => ({
+      execute: vi.fn(),
+    })),
+  }
+})
+
+vi.mock('@prisma/studio-core/data/bff', () => {
+  return {
+    serializeError: vi.fn(() => ({ message: 'mock-error' })),
+  }
+})
+
+vi.mock('@prisma/studio-core/data/node-sqlite', () => {
+  return {
+    createNodeSQLiteExecutor: vi.fn(() => ({
+      execute: vi.fn(),
+    })),
+  }
+})
+
+vi.mock('@prisma/studio-core/data/postgresjs', () => {
+  return {
+    createPostgresJSExecutor: vi.fn(() => ({
+      execute: vi.fn(),
+    })),
+  }
+})
+
+describe('Studio MySQL URL compatibility', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    createPoolMock.mockClear()
+  })
+
+  test('converts sslaccept=strict to mysql2 ssl JSON', async () => {
+    const { Studio } = await import('../Studio')
+
+    await Studio.new().parse(
+      [
+        '--browser',
+        'none',
+        '--port',
+        '5555',
+        '--url',
+        'mysql://user:password@aws.connect.psdb.cloud/db?sslaccept=strict',
+      ],
+      defaultTestConfig(),
+    )
+
+    expect(createPoolMock).toHaveBeenCalledTimes(1)
+
+    const passedUrl = new URL(createPoolMock.mock.calls[0][0])
+
+    expect(passedUrl.searchParams.get('sslaccept')).toBeNull()
+    expect(passedUrl.searchParams.get('ssl')).toBe('{"rejectUnauthorized":true}')
+  })
+
+  test('maps connection_limit to mysql2 connectionLimit', async () => {
+    const { Studio } = await import('../Studio')
+
+    await Studio.new().parse(
+      [
+        '--browser',
+        'none',
+        '--port',
+        '5555',
+        '--url',
+        'mysql://user:password@aws.connect.psdb.cloud/db?connection_limit=7',
+      ],
+      defaultTestConfig(),
+    )
+
+    expect(createPoolMock).toHaveBeenCalledTimes(1)
+
+    const passedUrl = new URL(createPoolMock.mock.calls[0][0])
+
+    expect(passedUrl.searchParams.get('connection_limit')).toBeNull()
+    expect(passedUrl.searchParams.get('connectionLimit')).toBe('7')
+  })
+
+  test('converts sslaccept=accept_invalid_certs to mysql2 ssl JSON', async () => {
+    const { Studio } = await import('../Studio')
+
+    await Studio.new().parse(
+      [
+        '--browser',
+        'none',
+        '--port',
+        '5555',
+        '--url',
+        'mysql://user:password@aws.connect.psdb.cloud/db?sslaccept=accept_invalid_certs',
+      ],
+      defaultTestConfig(),
+    )
+
+    expect(createPoolMock).toHaveBeenCalledTimes(1)
+
+    const passedUrl = new URL(createPoolMock.mock.calls[0][0])
+
+    expect(passedUrl.searchParams.get('sslaccept')).toBeNull()
+    expect(passedUrl.searchParams.get('ssl')).toBe('{"rejectUnauthorized":false}')
+  })
+})


### PR DESCRIPTION
## Summary
- normalize MySQL connection strings passed to `prisma studio --url` before calling `mysql2.createPool`
- map Prisma `sslaccept` values to mysql2 `ssl` JSON (`strict` => `rejectUnauthorized: true`, `accept_invalid_certs` => `rejectUnauthorized: false`)
- map Prisma `connection_limit` to mysql2 `connectionLimit`
- remove Prisma-only MySQL params that mysql2 treats as invalid connection options (`connection_limit`, `pool_timeout`, `socket_timeout`, `sslaccept`, `sslidentity`)
- add focused Vitest coverage for these translations
- update `AGENTS.md` with a new **Git manners and releases** section and remove the temporary Studio note

## Test plan
- Added tests first in `packages/cli/src/__tests__/Studio.vitest.ts` and ran them before implementation (failing assertions on `sslaccept`/`connection_limit` passthrough)
- After implementation, re-ran:
  - `pnpm --filter prisma test src/__tests__/Studio.vitest.ts`

## Notes
- kept current `prisma+postgres` Studio support from `main` intact while applying the MySQL URL compatibility fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive guidance on Git branching, changelog management, and release versioning practices.

* **Bug Fixes**
  * Enhanced MySQL connection handling in Prisma Studio to properly normalize SSL and connection limit parameters.

* **Tests**
  * Added test suite for MySQL connection parameter compatibility with Prisma Studio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->