### PR TITLE
fix: use safeJsonStringify for nested Uint8Array in Json fields

### DIFF
--- a/packages/client/src/runtime/core/engines/client/parameterization/parameterize.ts
+++ b/packages/client/src/runtime/core/engines/client/parameterization/parameterize.ts
@@ -6,7 +6,7 @@
  * both schema rules and runtime value types agree.
  */
 
-import { deserializeJsonObject } from '@prisma/client-engine-runtime'
+import { deserializeJsonObject, safeJsonStringify } from '@prisma/client-engine-runtime'
 import type {
   JsonArgumentValue,
   JsonBatchQuery,
@@ -273,7 +273,7 @@ class Parameterizer {
    */
   #handleArray(items: unknown[], originalValue: unknown, edge: InputEdge): unknown {
     if (hasFlag(edge, EdgeFlag.ParamScalar) && getScalarMask(edge) & ScalarMask.Json) {
-      const jsonValue = JSON.stringify(deserializeJsonObject(items))
+      const jsonValue = safeJsonStringify(deserializeJsonObject(items))
       const type: PlaceholderType = { type: 'Json' }
       return this.#getOrCreatePlaceholder(jsonValue, type)
     }
@@ -324,7 +324,7 @@ class Parameterizer {
 
     const mask = getScalarMask(edge)
     if (mask & ScalarMask.Json) {
-      const jsonValue = JSON.stringify(deserializeJsonObject(obj))
+      const jsonValue = safeJsonStringify(deserializeJsonObject(obj))
       const type: PlaceholderType = { type: 'Json' }
       return this.#getOrCreatePlaceholder(jsonValue, type)
     }

--- a/packages/client/tests/functional/issues/29267-uint8array-in-json/_matrix.ts
+++ b/packages/client/tests/functional/issues/29267-uint8array-in-json/_matrix.ts
@@ -1,0 +1,4 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+import { allProviders, Providers } from '../../_utils/providers'
+
+export default defineMatrix(() => [allProviders.filter(({ provider }) => provider !== Providers.SQLSERVER)])

--- a/packages/client/tests/functional/issues/29267-uint8array-in-json/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/29267-uint8array-in-json/prisma/_schema.ts
@@ -1,0 +1,19 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+    generator client {
+      provider = "prisma-client-js"
+    }
+
+    datasource db {
+      provider = "${provider}"
+    }
+
+    model TestRecord {
+      id ${idForProvider(provider)}
+      data Json
+    }
+  `
+})

--- a/packages/client/tests/functional/issues/29267-uint8array-in-json/tests.ts
+++ b/packages/client/tests/functional/issues/29267-uint8array-in-json/tests.ts
@@ -1,0 +1,68 @@
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(
+  () => {
+    test('serializes Uint8Array nested in object as base64', async () => {
+      const uint8 = new Uint8Array([72, 101, 108, 108, 111])
+
+      const record = await prisma.testRecord.create({
+        data: {
+          data: { payload: uint8, label: 'test' } as any,
+        },
+      })
+
+      expect(record.data).toEqual({
+        payload: 'SGVsbG8=',
+        label: 'test',
+      })
+    })
+
+    test('serializes Uint8Array nested in array as base64', async () => {
+      const uint8 = new Uint8Array([72, 101, 108, 108, 111])
+
+      const record = await prisma.testRecord.create({
+        data: {
+          data: [uint8, 'hello'] as any,
+        },
+      })
+
+      expect(record.data).toEqual(['SGVsbG8=', 'hello'])
+    })
+
+    test('serializes Uint8Array directly as base64', async () => {
+      const uint8 = new Uint8Array([72, 101, 108, 108, 111])
+
+      const record = await prisma.testRecord.create({
+        data: {
+          data: uint8 as any,
+        },
+      })
+
+      expect(record.data).toBe('SGVsbG8=')
+    })
+
+    test('serializes deeply nested Uint8Array as base64', async () => {
+      const uint8 = new Uint8Array([1, 2, 3])
+
+      const record = await prisma.testRecord.create({
+        data: {
+          data: { outer: { inner: uint8 } } as any,
+        },
+      })
+
+      expect(record.data).toEqual({
+        outer: { inner: 'AQID' },
+      })
+    })
+  },
+  {
+    optOut: {
+      from: ['sqlserver'],
+      reason: 'SQL Server does not support JSON fields',
+    },
+  },
+)


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma/issues/29267

## Problem

`Uint8Array` values nested inside objects or arrays are serialized as numeric-keyed objects (e.g. `{"0":72,"1":101,"2":108,"3":108,"4":111}`) instead of base64 strings when stored in a `Json` field. Top-level `Uint8Array` values are unaffected.

This was introduced in #29182, which added `deserializeJsonObject()` before `JSON.stringify()` in the parameterization step to fix Date handling in Json fields. `deserializeJsonObject` correctly converts `{ $type: 'Bytes', value: 'SGVsbG8=' }` back to a `Uint8Array`, but `JSON.stringify` cannot natively serialize `Uint8Array` and falls back to `{"0":72,...}`.

## Fix

Replace `JSON.stringify` with `safeJsonStringify` (already exported from `@prisma/client-engine-runtime`) in both the `#handleArray` and `#handleObject` methods of `Parameterizer`. `safeJsonStringify` uses a custom replacer that converts `ArrayBuffer.isView` values to base64 strings and `BigInt` to string representation.

## Tests

Added a functional regression test in `packages/client/tests/functional/issues/29267-uint8array-in-json/` covering:
- `Uint8Array` nested inside an object
- `Uint8Array` nested inside an array
- `Uint8Array` passed directly (already working, included for completeness)
- Deeply nested `Uint8Array`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved JSON serialization for parameter handling to properly convert Uint8Array values to base64 strings when stored in JSON fields, ensuring correct data handling across create operations.

* **Tests**
  * Added comprehensive test coverage for Uint8Array serialization in JSON fields, including scenarios with nested objects, arrays, and various nesting depths across multiple database providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->