### PR TITLE
feat: add distinct field JSDoc to findMany operation

### DIFF
--- a/packages/client-generator-js/src/TSClient/jsdoc.ts
+++ b/packages/client-generator-js/src/TSClient/jsdoc.ts
@@ -236,6 +236,7 @@ ${onlySelect}
       skip: JSDocFields.skip,
       cursor: (singular, plural) => addLinkToDocs(`Sets the position for listing ${plural}.`, 'cursor'),
       take: JSDocFields.take,
+      distinct: JSDocFields.distinct,
     },
   },
   update: {

--- a/packages/client-generator-ts/src/TSClient/jsdoc.ts
+++ b/packages/client-generator-ts/src/TSClient/jsdoc.ts
@@ -236,6 +236,7 @@ ${onlySelect}
       skip: JSDocFields.skip,
       cursor: (singular, plural) => addLinkToDocs(`Sets the position for listing ${plural}.`, 'cursor'),
       take: JSDocFields.take,
+      distinct: JSDocFields.distinct,
     },
   },
   update: {


### PR DESCRIPTION
Fixes #5509

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced JSDoc documentation to include the `distinct` option for findMany operations in the JavaScript client generator
  * Added support for documenting the `distinct` option across findMany, findFirst, and findFirstOrThrow operations in the TypeScript client generator

<!-- end of auto-generated comment: release notes by coderabbit.ai -->