### PR TITLE
feat(client): Allow client extension to change query action

### DIFF
--- a/packages/client/src/runtime/core/extensions/applyQueryExtensions.ts
+++ b/packages/client/src/runtime/core/extensions/applyQueryExtensions.ts
@@ -37,7 +37,7 @@ function iterateAndCallQueryCallbacks(
       // @ts-expect-error because not part of public API
       __internalParams: params,
       query: (args, operation, __internalParams = params) => {
-        if (operation) params.action = operation
+        if (operation) __internalParams.action = operation
         // we need to keep track of the current customDataProxyFetch
         // this is to cascade customDataProxyFetch like a middleware
         const currCustomFetch = __internalParams.customDataProxyFetch

--- a/packages/client/src/runtime/core/extensions/applyQueryExtensions.ts
+++ b/packages/client/src/runtime/core/extensions/applyQueryExtensions.ts
@@ -36,7 +36,8 @@ function iterateAndCallQueryCallbacks(
       args: deepCloneArgs(params.args ?? {}),
       // @ts-expect-error because not part of public API
       __internalParams: params,
-      query: (args, __internalParams = params) => {
+      query: (args, operation, __internalParams = params) => {
+        if (operation) params.action = operation
         // we need to keep track of the current customDataProxyFetch
         // this is to cascade customDataProxyFetch like a middleware
         const currCustomFetch = __internalParams.customDataProxyFetch

--- a/packages/client/src/runtime/core/types/exported/ExtensionArgs.ts
+++ b/packages/client/src/runtime/core/types/exported/ExtensionArgs.ts
@@ -58,7 +58,7 @@ export type ModelQueryOptionsCbArgs = {
   query: (args: JsArgs, operation?: Action) => Promise<unknown>
 }
 
-export type QueryOptionsCb = (args: QueryOptionsCbArgs, operation?: Action) => Promise<any>
+export type QueryOptionsCb = (args: QueryOptionsCbArgs) => Promise<any>
 export type ModelQueryOptionsCb = (args: ModelQueryOptionsCbArgs) => Promise<any>
 
 export type QueryOptions = {

--- a/packages/client/src/runtime/core/types/exported/ExtensionArgs.ts
+++ b/packages/client/src/runtime/core/types/exported/ExtensionArgs.ts
@@ -1,4 +1,4 @@
-import { JsArgs } from './JsApi'
+import { Action, JsArgs } from './JsApi'
 import { RawQueryArgs } from './RawQueryArgs'
 import { Optional } from './Utils'
 
@@ -48,17 +48,17 @@ export type QueryOptionsCbArgs = {
   model?: string
   operation: string
   args: JsArgs | RawQueryArgs
-  query: (args: JsArgs | RawQueryArgs) => Promise<unknown>
+  query: (args: JsArgs | RawQueryArgs, operation?: Action) => Promise<unknown>
 }
 
 export type ModelQueryOptionsCbArgs = {
   model: string
   operation: string
   args: JsArgs
-  query: (args: JsArgs) => Promise<unknown>
+  query: (args: JsArgs, operation?: Action) => Promise<unknown>
 }
 
-export type QueryOptionsCb = (args: QueryOptionsCbArgs) => Promise<any>
+export type QueryOptionsCb = (args: QueryOptionsCbArgs, operation?: Action) => Promise<any>
 export type ModelQueryOptionsCb = (args: ModelQueryOptionsCbArgs) => Promise<any>
 
 export type QueryOptions = {

--- a/packages/client/src/runtime/core/types/exported/Extensions.ts
+++ b/packages/client/src/runtime/core/types/exported/Extensions.ts
@@ -3,6 +3,7 @@ import { Sql } from '@prisma/client-runtime-utils'
 
 import { RequiredExtensionArgs as UserArgs } from './ExtensionArgs'
 import { ITXClientDenyList } from './itxClientDenyList'
+import { Action } from './JsApi'
 import { InputJsonObject, JsonObject } from './Json'
 import { OperationPayload } from './Payload'
 import { PrismaPromise } from './Public'
@@ -91,7 +92,7 @@ export type DynamicQueryExtensionCb<
   _1 extends PropertyKey,
   _2 extends PropertyKey,
 > =
-  <A extends DynamicQueryExtensionCbArgs<TypeMap, _0, _1, _2>>(args: A) =>
+  <A extends DynamicQueryExtensionCbArgs<TypeMap, _0, _1, _2>>(args: A, operation?: Action) =>
     Promise<TypeMap[_0][_1][_2]['result']>
 
 // prettier-ignore
@@ -106,11 +107,11 @@ export type DynamicQueryExtensionCbArgs<
       args: DynamicQueryExtensionCbArgsArgs<TypeMap, _0, _1, _2>,
       model: _0 extends 0 ? undefined : _1,
       operation: _2,
-      query: <A extends DynamicQueryExtensionCbArgsArgs<TypeMap, _0, _1, _2>>(args: A) =>
+      query: <A extends DynamicQueryExtensionCbArgsArgs<TypeMap, _0, _1, _2>>(args: A, operation?: Action) =>
         PrismaPromise<TypeMap[_0][_1]['operations'][_2]['result']>
     } : never : never
   ) & { // but we don't distribute for query so that the input types stay union
-    query: (args: DynamicQueryExtensionCbArgsArgs<TypeMap, _0, _1, _2>) =>
+    query: (args: DynamicQueryExtensionCbArgsArgs<TypeMap, _0, _1, _2>, operation?: Action) =>
       PrismaPromise<TypeMap[_0][_1]['operations'][_2]['result']>
   }
 

--- a/packages/client/src/runtime/core/types/exported/Extensions.ts
+++ b/packages/client/src/runtime/core/types/exported/Extensions.ts
@@ -92,7 +92,7 @@ export type DynamicQueryExtensionCb<
   _1 extends PropertyKey,
   _2 extends PropertyKey,
 > =
-  <A extends DynamicQueryExtensionCbArgs<TypeMap, _0, _1, _2>>(args: A, operation?: Action) =>
+  <A extends DynamicQueryExtensionCbArgs<TypeMap, _0, _1, _2>>(args: A) =>
     Promise<TypeMap[_0][_1][_2]['result']>
 
 // prettier-ignore

--- a/packages/client/src/runtime/core/types/exported/Extensions.ts
+++ b/packages/client/src/runtime/core/types/exported/Extensions.ts
@@ -61,7 +61,7 @@ export type DynamicQueryExtensionArgs<
 > = {
   [K in keyof Q_]:
     K extends '$allOperations'
-    ? (args: { model?: string, operation: string, args: any, query: (args: any) => PrismaPromise<any> }) => Promise<any>
+    ? (args: { model?: string, operation: string, args: any, query: (args: any, operation?: Action) => PrismaPromise<any> }) => Promise<any>
     : K extends '$allModels'
       ? {
           [P in keyof Q_[K] | keyof TypeMap['model'][keyof TypeMap['model']]['operations'] | '$allOperations']?:
@@ -95,6 +95,27 @@ export type DynamicQueryExtensionCb<
   <A extends DynamicQueryExtensionCbArgs<TypeMap, _0, _1, _2>>(args: A) =>
     Promise<TypeMap[_0][_1][_2]['result']>
 
+type QueryOperation<
+  TypeMap extends TypeMapDef,
+  _0 extends PropertyKey,
+  _1 extends PropertyKey,
+> = keyof TypeMap[_0][_1]['operations']
+
+type QueryCb<TypeMap extends TypeMapDef, _0 extends PropertyKey, _1 extends PropertyKey, _2 extends PropertyKey> = <
+  _3 extends QueryOperation<TypeMap, _0, _1> | undefined = undefined,
+  A extends DynamicQueryExtensionCbArgsArgs<
+    TypeMap,
+    _0,
+    _1,
+    _3 extends QueryOperation<TypeMap, _0, _1> ? _3 : _2
+  > = DynamicQueryExtensionCbArgsArgs<TypeMap, _0, _1, _3 extends QueryOperation<TypeMap, _0, _1> ? _3 : _2>,
+>(
+  args: A,
+  operation?: _3,
+) => _3 extends QueryOperation<TypeMap, _0, _1>
+  ? PrismaPromise<TypeMap[_0][_1]['operations'][_3]['result']>
+  : PrismaPromise<TypeMap[_0][_1]['operations'][_2]['result']>
+
 // prettier-ignore
 export type DynamicQueryExtensionCbArgs<
   TypeMap extends TypeMapDef,
@@ -107,12 +128,10 @@ export type DynamicQueryExtensionCbArgs<
       args: DynamicQueryExtensionCbArgsArgs<TypeMap, _0, _1, _2>,
       model: _0 extends 0 ? undefined : _1,
       operation: _2,
-      query: <A extends DynamicQueryExtensionCbArgsArgs<TypeMap, _0, _1, _2>>(args: A, operation?: Action) =>
-        PrismaPromise<TypeMap[_0][_1]['operations'][_2]['result']>
+      query: QueryCb<TypeMap, _0, _1, _2>
     } : never : never
   ) & { // but we don't distribute for query so that the input types stay union
-    query: (args: DynamicQueryExtensionCbArgsArgs<TypeMap, _0, _1, _2>, operation?: Action) =>
-      PrismaPromise<TypeMap[_0][_1]['operations'][_2]['result']>
+    query: QueryCb<TypeMap, _0, _1, _2>
   }
 
 export type DynamicQueryExtensionCbArgsArgs<


### PR DESCRIPTION
Adds an optional argument to the query function available in [Client Extensions query](https://www.prisma.io/docs/orm/prisma-client/client-extensions/query) that if set changes the operation that is performed.

### Example:
Can for example be used to implement soft deletion by changing any delete operation to an update operation:
```ts
...
.$extends(
	Prisma.defineExtension({
		name: "Soft Delete Extension",
		query: {
			$allModels: {
				async delete({args, query, model, operation}) {
					return query({...args, data: { isDeleted: true }}, "update");
				}
			}
		}
	})
)
...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query extension callbacks and public typings now accept an optional operation/context parameter so callbacks can receive the operation when provided.

* **Breaking Changes**
  * Public callback and extension type signatures changed to include the optional operation parameter — update any custom extensions or handlers to the new signature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->