### PR TITLE
feat(cli): add Prisma CLI path to version output

### DIFF
--- a/packages/cli/src/Version.ts
+++ b/packages/cli/src/Version.ts
@@ -17,7 +17,7 @@ import {
 } from '@prisma/internals'
 import { bold, dim, red } from 'kleur/colors'
 import os from 'os'
-import path from 'path'
+import path from 'node:path'
 
 import { getInstalledPrismaClientVersion } from './utils/getClientVersion'
 

--- a/packages/cli/src/Version.ts
+++ b/packages/cli/src/Version.ts
@@ -17,6 +17,7 @@ import {
 } from '@prisma/internals'
 import { bold, dim, red } from 'kleur/colors'
 import os from 'os'
+import path from 'path'
 
 import { getInstalledPrismaClientVersion } from './utils/getClientVersion'
 
@@ -79,6 +80,9 @@ export class Version implements Command {
     const prismaClientVersion = await getInstalledPrismaClientVersion()
     const typescriptVersion = await getTypescriptVersion()
 
+    // Get the Prisma CLI path from the current file location
+    const prismaCliPath = path.resolve(__dirname, '..')
+
     const rows = [
       [packageJson.name, packageJson.version],
       ['@prisma/client', prismaClientVersion ?? 'Not found'],
@@ -92,6 +96,7 @@ export class Version implements Command {
 
       ['Default Engines Hash', enginesVersion],
       ['Studio', packageJson.dependencies['@prisma/studio-core']],
+      ['Prisma CLI Path', prismaCliPath],
     ]
 
     /**

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -22,7 +22,8 @@ describe('version', () => {
       PSL                  : @prisma/prisma-schema-wasm CLI_VERSION.ENGINE_VERSION
       Schema Engine        : schema-engine-cli ENGINE_VERSION (at sanitized_path/schema-engine-TEST_PLATFORM)
       Default Engines Hash : ENGINE_VERSION
-      Studio               : STUDIO_VERSION"
+      Studio               : STUDIO_VERSION
+      Prisma CLI Path      : sanitized_path"
     `)
     expect(cleanSnapshot(data.stderr)).toMatchInlineSnapshot(`
       "Loaded Prisma config from prisma.config.ts.
@@ -72,6 +73,9 @@ function cleanSnapshot(str: string, versionOverride?: string): string {
 
   // sanitize windows specific engine names
   str = str.replace(/\.exe/g, '')
+
+  // sanitize Prisma CLI Path
+  str = str.replace(new RegExp('(Prisma CLI Path\\s+:( ).*)', 'g'), '$1sanitized_path')
 
   return str
 }

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -75,7 +75,7 @@ function cleanSnapshot(str: string, versionOverride?: string): string {
   str = str.replace(/\.exe/g, '')
 
   // sanitize Prisma CLI Path
-  str = str.replace(new RegExp('(Prisma CLI Path\\s+:( ).*)', 'g'), '$1sanitized_path')
+  str = str.replace(new RegExp('(Prisma CLI Path\s+:) .*', 'g'), '$1 sanitized_path')
 
   return str
 }


### PR DESCRIPTION
Adds the Prisma CLI installation path to the version command output to help debug which installation is being used.

Fixes #7771

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Version command now shows the Prisma CLI installation path in its output.

* **Tests**
  * Updated test snapshots and sanitization logic to include and verify the new CLI path field in version information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->