### PR TITLE
Make @types/pg a direct dependency of adapter-pg

### DIFF
--- a/packages/adapter-pg/package.json
+++ b/packages/adapter-pg/package.json
@@ -38,10 +38,10 @@
   "dependencies": {
     "@prisma/driver-adapter-utils": "workspace:*",
     "pg": "^8.16.3",
-    "postgres-array": "3.0.4"
+    "postgres-array": "3.0.4",
+    "@types/pg": "8.11.11"
   },
   "devDependencies": {
-    "@prisma/debug": "workspace:*",
-    "@types/pg": "8.11.11"
+    "@prisma/debug": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,6 +303,9 @@ importers:
       '@prisma/driver-adapter-utils':
         specifier: workspace:*
         version: link:../driver-adapter-utils
+      '@types/pg':
+        specifier: 8.11.11
+        version: 8.11.11
       pg:
         specifier: ^8.16.3
         version: 8.16.3
@@ -313,9 +316,6 @@ importers:
       '@prisma/debug':
         specifier: workspace:*
         version: link:../debug
-      '@types/pg':
-        specifier: 8.11.11
-        version: 8.11.11
 
   packages/adapter-planetscale:
     dependencies:


### PR DESCRIPTION
**What changed**

`@types/pg` was moved from a `devDependency` to a regular `dependency` in `adapter-pg`'s `package.json`, and the pnpm lockfile entries were updated accordingly.

**Why**

When using `adapter-pg`, the TypeScript types for `pg` are not automatically available — they live in `@types/pg`, which is a separate package that the adapter consumed only as a dev dependency. Because of this, consumers who install `adapter-pg` end up with a poor developer experience: the adapter's types fail to load correctly at the consumer's side, since TypeScript can't resolve the underlying `pg` types without `@types/pg` being present.

The problem is subtle and frustrating: the user has no reason to know that `adapter-pg` internally depends on `@types/pg`, and nothing tells them they need to install it manually. The fix is to make `@types/pg` a direct, non-dev dependency so it is automatically installed whenever `adapter-pg` is installed — both for the end user's type resolution and for the build itself.

**Impact**

No runtime behavior changes. This is a types-only fix that improves the out-of-the-box TypeScript experience for anyone using `adapter-pg`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL adapter dependencies: moved type definitions from development-only to runtime dependencies so they're available when the adapter is installed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->