### PR TITLE
chore: migrate get-platform to vitest

### DIFF
--- a/packages/get-platform/jest.config.js
+++ b/packages/get-platform/jest.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  preset: '../../helpers/test/presets/default.js',
-  snapshotSerializers: ['./src/test-utils/jestSnapshotSerializer'],
-  prettierPath: '../../node_modules/prettier2',
-}

--- a/packages/get-platform/package.json
+++ b/packages/get-platform/package.json
@@ -15,16 +15,11 @@
   "bugs": "https://github.com/prisma/prisma/issues",
   "devDependencies": {
     "@codspeed/benchmark.js-plugin": "4.0.0",
-    "@swc/core": "1.11.5",
-    "@swc/jest": "0.2.37",
-    "@types/jest": "29.5.14",
     "@types/node": "~20.19.24",
     "benchmark": "2.1.4",
     "escape-string-regexp": "5.0.0",
     "execa": "8.0.1",
     "fs-jetpack": "5.1.0",
-    "jest": "29.7.0",
-    "jest-junit": "16.0.0",
     "kleur": "4.1.5",
     "tempy": "1.0.1",
     "terminal-link": "4.0.0",
@@ -37,7 +32,7 @@
   "scripts": {
     "dev": "DEV=true tsx helpers/build.ts",
     "build": "tsx helpers/build.ts",
-    "test": "jest",
+    "test": "vitest run",
     "prepublishOnly": "pnpm run build"
   },
   "files": [

--- a/packages/get-platform/src/__tests__/getPlatform.test.ts
+++ b/packages/get-platform/src/__tests__/getPlatform.test.ts
@@ -1,40 +1,22 @@
 import { stripVTControlCharacters } from 'node:util'
 
-import { describe, expect, type MockInstance, test, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { getBinaryTargetForCurrentPlatformInternal, getPlatformInfoMemoized } from '../getPlatform'
+import { vitestConsoleContext, vitestContext } from '../test-utils/vitestContext'
 
-const it = test.extend<{
-  consoleMock: {
-    log: MockInstance
-    warn: MockInstance
-    error: MockInstance
-  }
-}>({
-  // eslint-disable-next-line no-empty-pattern
-  consoleMock: async ({}, use) => {
-    const mocks = {
-      log: vi.spyOn(console, 'log').mockImplementation(() => {}),
-      warn: vi.spyOn(console, 'warn').mockImplementation(() => {}),
-      error: vi.spyOn(console, 'error').mockImplementation(() => {}),
-    }
-    await use(mocks)
-    for (const m of Object.values(mocks)) {
-      m.mockRestore()
-    }
-  },
-})
+const ctx = vitestContext.new().add(vitestConsoleContext()).assemble()
 
 describe('getPlatformInfoMemoized', () => {
-  it('repeated invocations are idempotent and memoized', async ({ consoleMock }) => {
+  it('repeated invocations are idempotent and memoized', async () => {
     const platformFirst = await getPlatformInfoMemoized()
     const platformSecond = await getPlatformInfoMemoized()
     expect(platformFirst.binaryTarget).toBe(platformSecond.binaryTarget)
     expect(platformFirst.memoized).toBeFalsy()
     expect(platformSecond.memoized).toBeTruthy()
-    expect(consoleMock.log.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-    expect(consoleMock.warn.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-    expect(consoleMock.error.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+    expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
   })
 })
 
@@ -44,7 +26,7 @@ describe('getBinaryTargetForCurrentPlatformInternal', () => {
 
     // test name convention: <originalDistro> (<familyDistro>), <arch> (<uname -m>), openssl-<libssl>
 
-    it('debian (debian), amd64 (x86_64), openssl-1.1.x', ({ consoleMock }) => {
+    it('debian (debian), amd64 (x86_64), openssl-1.1.x', () => {
       expect(
         getBinaryTargetForCurrentPlatformInternal({
           platform,
@@ -56,12 +38,12 @@ describe('getBinaryTargetForCurrentPlatformInternal', () => {
           targetDistro: 'debian',
         }),
       ).toBe('debian-openssl-1.1.x')
-      expect(consoleMock.log.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-      expect(consoleMock.warn.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-      expect(consoleMock.error.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
     })
 
-    it('opensuse (suse), amd64 (x86_64), openssl-1.1.x', ({ consoleMock }) => {
+    it('opensuse (suse), amd64 (x86_64), openssl-1.1.x', () => {
       expect(
         getBinaryTargetForCurrentPlatformInternal({
           platform,
@@ -73,12 +55,12 @@ describe('getBinaryTargetForCurrentPlatformInternal', () => {
           targetDistro: 'rhel',
         }),
       ).toBe('rhel-openssl-1.1.x')
-      expect(consoleMock.log.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-      expect(consoleMock.warn.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-      expect(consoleMock.error.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
     })
 
-    it('alpine (alpine), amd64 (x86_64), openssl-3.0.x', ({ consoleMock }) => {
+    it('alpine (alpine), amd64 (x86_64), openssl-3.0.x', () => {
       expect(
         getBinaryTargetForCurrentPlatformInternal({
           platform,
@@ -90,12 +72,12 @@ describe('getBinaryTargetForCurrentPlatformInternal', () => {
           targetDistro: 'musl',
         }),
       ).toBe('linux-musl-openssl-3.0.x')
-      expect(consoleMock.log.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-      expect(consoleMock.warn.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-      expect(consoleMock.error.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
     })
 
-    it('alpine (alpine), arm64 (aarch64), openssl-3.0.x', ({ consoleMock }) => {
+    it('alpine (alpine), arm64 (aarch64), openssl-3.0.x', () => {
       expect(
         getBinaryTargetForCurrentPlatformInternal({
           platform,
@@ -107,12 +89,12 @@ describe('getBinaryTargetForCurrentPlatformInternal', () => {
           targetDistro: 'musl',
         }),
       ).toBe('linux-musl-arm64-openssl-3.0.x')
-      expect(consoleMock.log.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-      expect(consoleMock.warn.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-      expect(consoleMock.error.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
     })
 
-    it('alpine (alpine), arm (armv7l), openssl-3.0.x', ({ consoleMock }) => {
+    it('alpine (alpine), arm (armv7l), openssl-3.0.x', () => {
       expect(
         getBinaryTargetForCurrentPlatformInternal({
           platform,
@@ -124,16 +106,16 @@ describe('getBinaryTargetForCurrentPlatformInternal', () => {
           targetDistro: 'musl',
         }),
       ).toBe('linux-arm-openssl-3.0.x')
-      expect(consoleMock.log.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
       // TODO: can't currently use `toMatchInlineSnaphost` here because our snaphost serialiser replaces "arm" with
       // "TEST_PLATFORM" unnecessarily.
-      expect(stripVTControlCharacters(consoleMock.warn.mock.calls.join('\n') as string)).toBe(
+      expect(stripVTControlCharacters(ctx.mocked['console.warn'].mock.calls.join('\n') as string)).toBe(
         `prisma:warn Prisma only officially supports Linux on amd64 (x86_64) and arm64 (aarch64) system architectures (detected "arm" instead). If you are using your own custom Prisma engines, you can ignore this warning, as long as you've compiled the engines for your system architecture "armv7l".`,
       )
-      expect(consoleMock.error.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
     })
 
-    it('ubuntu (debian), amd64 (x86_64), openssl-undefined', ({ consoleMock }) => {
+    it('ubuntu (debian), amd64 (x86_64), openssl-undefined', () => {
       expect(
         getBinaryTargetForCurrentPlatformInternal({
           platform,
@@ -145,15 +127,15 @@ describe('getBinaryTargetForCurrentPlatformInternal', () => {
           targetDistro: 'debian',
         }),
       ).toBe('debian-openssl-1.1.x')
-      expect(consoleMock.log.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-      expect(consoleMock.warn.mock.calls.join('\n')).toMatchInlineSnapshot(`
+      expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
         "prisma:warn Prisma failed to detect the libssl/openssl version to use, and may not work as expected. Defaulting to "openssl-1.1.x".
         Please manually install OpenSSL via \`apt-get update -y && apt-get install -y openssl\` and try installing Prisma again. If you're running Prisma on Docker, add this command to your Dockerfile, or switch to an image that already has OpenSSL installed."
       `)
-      expect(consoleMock.error.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
     })
 
-    it('arch (arch), amd64 (x86_64), openssl-undefined', ({ consoleMock }) => {
+    it('arch (arch), amd64 (x86_64), openssl-undefined', () => {
       expect(
         getBinaryTargetForCurrentPlatformInternal({
           platform,
@@ -165,15 +147,15 @@ describe('getBinaryTargetForCurrentPlatformInternal', () => {
           targetDistro: 'debian',
         }),
       ).toBe('debian-openssl-1.1.x')
-      expect(consoleMock.log.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-      expect(consoleMock.warn.mock.calls.join('\n')).toMatchInlineSnapshot(`
+      expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
         "prisma:warn Prisma failed to detect the libssl/openssl version to use, and may not work as expected. Defaulting to "openssl-1.1.x".
         Please manually install OpenSSL and try installing Prisma again."
       `)
-      expect(consoleMock.error.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
     })
 
-    it('unknown (unknown), amd64 (x86_64), openssl-3.0.x', ({ consoleMock }) => {
+    it('unknown (unknown), amd64 (x86_64), openssl-3.0.x', () => {
       expect(
         getBinaryTargetForCurrentPlatformInternal({
           platform,
@@ -185,12 +167,12 @@ describe('getBinaryTargetForCurrentPlatformInternal', () => {
           targetDistro: undefined,
         }),
       ).toBe('debian-openssl-3.0.x')
-      expect(consoleMock.log.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-      expect(consoleMock.warn.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-      expect(consoleMock.error.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
     })
 
-    it('unknown (unknown), amd64 (x86_64), openssl-undefined', ({ consoleMock }) => {
+    it('unknown (unknown), amd64 (x86_64), openssl-undefined', () => {
       expect(
         getBinaryTargetForCurrentPlatformInternal({
           platform,
@@ -202,12 +184,12 @@ describe('getBinaryTargetForCurrentPlatformInternal', () => {
           targetDistro: undefined,
         }),
       ).toBe('debian-openssl-1.1.x')
-      expect(consoleMock.log.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-      expect(consoleMock.warn.mock.calls.join('\n')).toMatchInlineSnapshot(`
+      expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
         "prisma:warn Prisma failed to detect the libssl/openssl version to use, and may not work as expected. Defaulting to "openssl-1.1.x".
         Please manually install OpenSSL and try installing Prisma again."
       `)
-      expect(consoleMock.error.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
     })
   })
 })

--- a/packages/get-platform/src/__tests__/getPlatform.test.ts
+++ b/packages/get-platform/src/__tests__/getPlatform.test.ts
@@ -19,7 +19,9 @@ const it = test.extend<{
       error: vi.spyOn(console, 'error').mockImplementation(() => {}),
     }
     await use(mocks)
-    Object.values(mocks).forEach((m) => m.mockRestore())
+    for (const m of Object.values(mocks)) {
+      m.mockRestore()
+    }
   },
 })
 

--- a/packages/get-platform/src/__tests__/getPlatform.test.ts
+++ b/packages/get-platform/src/__tests__/getPlatform.test.ts
@@ -1,20 +1,38 @@
 import { stripVTControlCharacters } from 'node:util'
 
-import { getBinaryTargetForCurrentPlatformInternal, getPlatformInfoMemoized } from '../getPlatform'
-import { jestConsoleContext, jestContext } from '../test-utils'
+import { describe, expect, type MockInstance, test, vi } from 'vitest'
 
-const ctx = jestContext.new().add(jestConsoleContext()).assemble()
+import { getBinaryTargetForCurrentPlatformInternal, getPlatformInfoMemoized } from '../getPlatform'
+
+const it = test.extend<{
+  consoleMock: {
+    log: MockInstance
+    warn: MockInstance
+    error: MockInstance
+  }
+}>({
+  // eslint-disable-next-line no-empty-pattern
+  consoleMock: async ({}, use) => {
+    const mocks = {
+      log: vi.spyOn(console, 'log').mockImplementation(() => {}),
+      warn: vi.spyOn(console, 'warn').mockImplementation(() => {}),
+      error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+    }
+    await use(mocks)
+    Object.values(mocks).forEach((m) => m.mockRestore())
+  },
+})
 
 describe('getPlatformInfoMemoized', () => {
-  it('repeated invocations are idempotent and memoized', async () => {
+  it('repeated invocations are idempotent and memoized', async ({ consoleMock }) => {
     const platformFirst = await getPlatformInfoMemoized()
     const platformSecond = await getPlatformInfoMemoized()
     expect(platformFirst.binaryTarget).toBe(platformSecond.binaryTarget)
     expect(platformFirst.memoized).toBeFalsy()
     expect(platformSecond.memoized).toBeTruthy()
-    expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-    expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-    expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+    expect(consoleMock.log.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+    expect(consoleMock.warn.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+    expect(consoleMock.error.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
   })
 })
 
@@ -24,7 +42,7 @@ describe('getBinaryTargetForCurrentPlatformInternal', () => {
 
     // test name convention: <originalDistro> (<familyDistro>), <arch> (<uname -m>), openssl-<libssl>
 
-    it('debian (debian), amd64 (x86_64), openssl-1.1.x', () => {
+    it('debian (debian), amd64 (x86_64), openssl-1.1.x', ({ consoleMock }) => {
       expect(
         getBinaryTargetForCurrentPlatformInternal({
           platform,
@@ -36,12 +54,12 @@ describe('getBinaryTargetForCurrentPlatformInternal', () => {
           targetDistro: 'debian',
         }),
       ).toBe('debian-openssl-1.1.x')
-      expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-      expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(consoleMock.log.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(consoleMock.warn.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(consoleMock.error.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
     })
 
-    it('opensuse (suse), amd64 (x86_64), openssl-1.1.x', () => {
+    it('opensuse (suse), amd64 (x86_64), openssl-1.1.x', ({ consoleMock }) => {
       expect(
         getBinaryTargetForCurrentPlatformInternal({
           platform,
@@ -53,12 +71,12 @@ describe('getBinaryTargetForCurrentPlatformInternal', () => {
           targetDistro: 'rhel',
         }),
       ).toBe('rhel-openssl-1.1.x')
-      expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-      expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(consoleMock.log.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(consoleMock.warn.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(consoleMock.error.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
     })
 
-    it('alpine (alpine), amd64 (x86_64), openssl-3.0.x', () => {
+    it('alpine (alpine), amd64 (x86_64), openssl-3.0.x', ({ consoleMock }) => {
       expect(
         getBinaryTargetForCurrentPlatformInternal({
           platform,
@@ -70,12 +88,12 @@ describe('getBinaryTargetForCurrentPlatformInternal', () => {
           targetDistro: 'musl',
         }),
       ).toBe('linux-musl-openssl-3.0.x')
-      expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-      expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(consoleMock.log.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(consoleMock.warn.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(consoleMock.error.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
     })
 
-    it('alpine (alpine), arm64 (aarch64), openssl-3.0.x', () => {
+    it('alpine (alpine), arm64 (aarch64), openssl-3.0.x', ({ consoleMock }) => {
       expect(
         getBinaryTargetForCurrentPlatformInternal({
           platform,
@@ -87,12 +105,12 @@ describe('getBinaryTargetForCurrentPlatformInternal', () => {
           targetDistro: 'musl',
         }),
       ).toBe('linux-musl-arm64-openssl-3.0.x')
-      expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-      expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(consoleMock.log.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(consoleMock.warn.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(consoleMock.error.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
     })
 
-    it('alpine (alpine), arm (armv7l), openssl-3.0.x', () => {
+    it('alpine (alpine), arm (armv7l), openssl-3.0.x', ({ consoleMock }) => {
       expect(
         getBinaryTargetForCurrentPlatformInternal({
           platform,
@@ -104,16 +122,16 @@ describe('getBinaryTargetForCurrentPlatformInternal', () => {
           targetDistro: 'musl',
         }),
       ).toBe('linux-arm-openssl-3.0.x')
-      expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(consoleMock.log.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
       // TODO: can't currently use `toMatchInlineSnaphost` here because our snaphost serialiser replaces "arm" with
       // "TEST_PLATFORM" unnecessarily.
-      expect(stripVTControlCharacters(ctx.mocked['console.warn'].mock.calls.join('\n') as string)).toBe(
+      expect(stripVTControlCharacters(consoleMock.warn.mock.calls.join('\n') as string)).toBe(
         `prisma:warn Prisma only officially supports Linux on amd64 (x86_64) and arm64 (aarch64) system architectures (detected "arm" instead). If you are using your own custom Prisma engines, you can ignore this warning, as long as you've compiled the engines for your system architecture "armv7l".`,
       )
-      expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(consoleMock.error.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
     })
 
-    it('ubuntu (debian), amd64 (x86_64), openssl-undefined', () => {
+    it('ubuntu (debian), amd64 (x86_64), openssl-undefined', ({ consoleMock }) => {
       expect(
         getBinaryTargetForCurrentPlatformInternal({
           platform,
@@ -125,15 +143,15 @@ describe('getBinaryTargetForCurrentPlatformInternal', () => {
           targetDistro: 'debian',
         }),
       ).toBe('debian-openssl-1.1.x')
-      expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+      expect(consoleMock.log.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(consoleMock.warn.mock.calls.join('\n')).toMatchInlineSnapshot(`
         "prisma:warn Prisma failed to detect the libssl/openssl version to use, and may not work as expected. Defaulting to "openssl-1.1.x".
         Please manually install OpenSSL via \`apt-get update -y && apt-get install -y openssl\` and try installing Prisma again. If you're running Prisma on Docker, add this command to your Dockerfile, or switch to an image that already has OpenSSL installed."
       `)
-      expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(consoleMock.error.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
     })
 
-    it('arch (arch), amd64 (x86_64), openssl-undefined', () => {
+    it('arch (arch), amd64 (x86_64), openssl-undefined', ({ consoleMock }) => {
       expect(
         getBinaryTargetForCurrentPlatformInternal({
           platform,
@@ -145,15 +163,15 @@ describe('getBinaryTargetForCurrentPlatformInternal', () => {
           targetDistro: 'debian',
         }),
       ).toBe('debian-openssl-1.1.x')
-      expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+      expect(consoleMock.log.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(consoleMock.warn.mock.calls.join('\n')).toMatchInlineSnapshot(`
         "prisma:warn Prisma failed to detect the libssl/openssl version to use, and may not work as expected. Defaulting to "openssl-1.1.x".
         Please manually install OpenSSL and try installing Prisma again."
       `)
-      expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(consoleMock.error.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
     })
 
-    it('unknown (unknown), amd64 (x86_64), openssl-3.0.x', () => {
+    it('unknown (unknown), amd64 (x86_64), openssl-3.0.x', ({ consoleMock }) => {
       expect(
         getBinaryTargetForCurrentPlatformInternal({
           platform,
@@ -165,12 +183,12 @@ describe('getBinaryTargetForCurrentPlatformInternal', () => {
           targetDistro: undefined,
         }),
       ).toBe('debian-openssl-3.0.x')
-      expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-      expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(consoleMock.log.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(consoleMock.warn.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(consoleMock.error.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
     })
 
-    it('unknown (unknown), amd64 (x86_64), openssl-undefined', () => {
+    it('unknown (unknown), amd64 (x86_64), openssl-undefined', ({ consoleMock }) => {
       expect(
         getBinaryTargetForCurrentPlatformInternal({
           platform,
@@ -182,12 +200,12 @@ describe('getBinaryTargetForCurrentPlatformInternal', () => {
           targetDistro: undefined,
         }),
       ).toBe('debian-openssl-1.1.x')
-      expect(ctx.mocked['console.log'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
-      expect(ctx.mocked['console.warn'].mock.calls.join('\n')).toMatchInlineSnapshot(`
+      expect(consoleMock.log.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(consoleMock.warn.mock.calls.join('\n')).toMatchInlineSnapshot(`
         "prisma:warn Prisma failed to detect the libssl/openssl version to use, and may not work as expected. Defaulting to "openssl-1.1.x".
         Please manually install OpenSSL and try installing Prisma again."
       `)
-      expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
+      expect(consoleMock.error.mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
     })
   })
 })

--- a/packages/get-platform/src/__tests__/getSSLVersion.test.ts
+++ b/packages/get-platform/src/__tests__/getSSLVersion.test.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path'
 
 import { describe, expect, test } from 'vitest'
 
-import { computeLibSSLSpecificPaths, getArchFromUname, getSSLVersion } from '../../src/getPlatform'
+import { computeLibSSLSpecificPaths, getArchFromUname, getSSLVersion } from '../getPlatform'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
 

--- a/packages/get-platform/src/__tests__/getSSLVersion.test.ts
+++ b/packages/get-platform/src/__tests__/getSSLVersion.test.ts
@@ -1,34 +1,11 @@
-import * as fs from 'node:fs'
-import * as os from 'node:os'
-import * as path from 'node:path'
-
-import { describe, expect, test } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { computeLibSSLSpecificPaths, getArchFromUname, getSSLVersion } from '../getPlatform'
+import { vitestContext } from '../test-utils/vitestContext'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
 
-const fixturesDir = path.join(__dirname, 'fixtures')
-
-const it = test.extend<{
-  fixture: (name: string) => void
-  tmpDir: string
-}>({
-  // eslint-disable-next-line no-empty-pattern
-  tmpDir: async ({}, use) => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'prisma-get-platform-'))
-    await use(dir)
-    fs.rmSync(dir, { recursive: true, force: true })
-  },
-  fixture: async ({ tmpDir }, use) => {
-    await use((name: string) => {
-      const src = path.join(fixturesDir, name)
-      for (const file of fs.readdirSync(src)) {
-        fs.copyFileSync(path.join(src, file), path.join(tmpDir, file))
-      }
-    })
-  },
-})
+const ctx = vitestContext.new().assemble()
 
 describeIf(process.platform === 'linux')('computeLibSSLSpecificPaths', () => {
   it('should not return an error', () => {
@@ -49,28 +26,28 @@ describeIf(process.platform === 'linux')('getSSLVersion', () => {
   describe('strategy: "libssl-specific-path"', () => {
     const focusedStrategy = 'libssl-specific-path'
 
-    it('falls back with nss only', async ({ fixture, tmpDir }) => {
-      fixture('libssl-specific-path/with-nss-only')
-      const { strategy } = await getSSLVersion([tmpDir])
+    it('falls back with nss only', async () => {
+      ctx.fixture('libssl-specific-path/with-nss-only')
+      const { strategy } = await getSSLVersion([ctx.tmpDir])
       expect(strategy).not.toEqual(focusedStrategy)
     })
 
-    it('falls back with unknown versions only', async ({ fixture, tmpDir }) => {
-      fixture('libssl-specific-path/with-unknown-versions-only')
-      const { strategy } = await getSSLVersion([tmpDir])
+    it('falls back with unknown versions only', async () => {
+      ctx.fixture('libssl-specific-path/with-unknown-versions-only')
+      const { strategy } = await getSSLVersion([ctx.tmpDir])
       expect(strategy).not.toEqual(focusedStrategy)
     })
 
-    it('selects the oldest libssl version, excluding libssl-0.x.x', async ({ fixture, tmpDir }) => {
-      fixture('libssl-specific-path/with-libssl-0')
-      const { libssl, strategy } = await getSSLVersion([tmpDir])
+    it('selects the oldest libssl version, excluding libssl-0.x.x', async () => {
+      ctx.fixture('libssl-specific-path/with-libssl-0')
+      const { libssl, strategy } = await getSSLVersion([ctx.tmpDir])
       expect(strategy).toEqual(focusedStrategy)
       expect(libssl).toEqual('1.0.x')
     })
 
-    it('skips libssl.so without version in filename', async ({ fixture, tmpDir }) => {
-      fixture('libssl-specific-path/with-versionless-libssl')
-      const { libssl, strategy } = await getSSLVersion([tmpDir])
+    it('skips libssl.so without version in filename', async () => {
+      ctx.fixture('libssl-specific-path/with-versionless-libssl')
+      const { libssl, strategy } = await getSSLVersion([ctx.tmpDir])
       expect(strategy).toEqual(focusedStrategy)
       expect(libssl).toEqual('1.0.x')
     })

--- a/packages/get-platform/src/__tests__/getSSLVersion.test.ts
+++ b/packages/get-platform/src/__tests__/getSSLVersion.test.ts
@@ -1,12 +1,36 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { describe, expect, test } from 'vitest'
+
 import { computeLibSSLSpecificPaths, getArchFromUname, getSSLVersion } from '../../src/getPlatform'
-import { jestContext } from '..'
 
 const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
 
-const ctx = jestContext.new().assemble()
+const fixturesDir = path.join(__dirname, 'fixtures')
+
+const it = test.extend<{
+  fixture: (name: string) => void
+  tmpDir: string
+}>({
+  // eslint-disable-next-line no-empty-pattern
+  tmpDir: async ({}, use) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'prisma-get-platform-'))
+    await use(dir)
+    fs.rmSync(dir, { recursive: true, force: true })
+  },
+  fixture: async ({ tmpDir }, use) => {
+    await use((name: string) => {
+      const src = path.join(fixturesDir, name)
+      for (const file of fs.readdirSync(src)) {
+        fs.copyFileSync(path.join(src, file), path.join(tmpDir, file))
+      }
+    })
+  },
+})
 
 describeIf(process.platform === 'linux')('computeLibSSLSpecificPaths', () => {
-  // eslint-disable-next-line jest/no-identical-title
   it('should not return an error', () => {
     const arch = 'x64'
     const archFromUname = 'x86_64'
@@ -15,7 +39,6 @@ describeIf(process.platform === 'linux')('computeLibSSLSpecificPaths', () => {
 })
 
 describeIf(process.platform === 'linux')('getSSLVersion', () => {
-  // eslint-disable-next-line jest/no-identical-title
   it('should not return an error', async () => {
     const archFromUname = await getArchFromUname()
     await getSSLVersion([])
@@ -26,28 +49,28 @@ describeIf(process.platform === 'linux')('getSSLVersion', () => {
   describe('strategy: "libssl-specific-path"', () => {
     const focusedStrategy = 'libssl-specific-path'
 
-    it('falls back with nss only', async () => {
-      ctx.fixture('libssl-specific-path/with-nss-only')
-      const { strategy } = await getSSLVersion([ctx.tmpDir])
+    it('falls back with nss only', async ({ fixture, tmpDir }) => {
+      fixture('libssl-specific-path/with-nss-only')
+      const { strategy } = await getSSLVersion([tmpDir])
       expect(strategy).not.toEqual(focusedStrategy)
     })
 
-    it('falls back with unknown versions only', async () => {
-      ctx.fixture('libssl-specific-path/with-unknown-versions-only')
-      const { strategy } = await getSSLVersion([ctx.tmpDir])
+    it('falls back with unknown versions only', async ({ fixture, tmpDir }) => {
+      fixture('libssl-specific-path/with-unknown-versions-only')
+      const { strategy } = await getSSLVersion([tmpDir])
       expect(strategy).not.toEqual(focusedStrategy)
     })
 
-    it('selects the oldest libssl version, excluding libssl-0.x.x', async () => {
-      ctx.fixture('libssl-specific-path/with-libssl-0')
-      const { libssl, strategy } = await getSSLVersion([ctx.tmpDir])
+    it('selects the oldest libssl version, excluding libssl-0.x.x', async ({ fixture, tmpDir }) => {
+      fixture('libssl-specific-path/with-libssl-0')
+      const { libssl, strategy } = await getSSLVersion([tmpDir])
       expect(strategy).toEqual(focusedStrategy)
       expect(libssl).toEqual('1.0.x')
     })
 
-    it('skips libssl.so without version in filename', async () => {
-      ctx.fixture('libssl-specific-path/with-versionless-libssl')
-      const { libssl, strategy } = await getSSLVersion([ctx.tmpDir])
+    it('skips libssl.so without version in filename', async ({ fixture, tmpDir }) => {
+      fixture('libssl-specific-path/with-versionless-libssl')
+      const { libssl, strategy } = await getSSLVersion([tmpDir])
       expect(strategy).toEqual(focusedStrategy)
       expect(libssl).toEqual('1.0.x')
     })

--- a/packages/get-platform/src/__tests__/parseDistro.test.ts
+++ b/packages/get-platform/src/__tests__/parseDistro.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from 'vitest'
+
 import { parseDistro } from '../getPlatform'
 
 describe('parseDistro', () => {

--- a/packages/get-platform/src/__tests__/parseOpenSSLVersion.test.ts
+++ b/packages/get-platform/src/__tests__/parseOpenSSLVersion.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from 'vitest'
+
 import { parseLibSSLVersion, parseOpenSSLVersion } from '../getPlatform'
 
 describe('parseOpenSSLVersion', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1343,15 +1343,6 @@ importers:
       '@codspeed/benchmark.js-plugin':
         specifier: 4.0.0
         version: 4.0.0(benchmark@2.1.4)
-      '@swc/core':
-        specifier: 1.11.5
-        version: 1.11.5
-      '@swc/jest':
-        specifier: 0.2.37
-        version: 0.2.37(@swc/core@1.11.5)
-      '@types/jest':
-        specifier: 29.5.14
-        version: 29.5.14
       '@types/node':
         specifier: ~20.19.24
         version: 20.19.25
@@ -1367,12 +1358,6 @@ importers:
       fs-jetpack:
         specifier: 5.1.0
         version: 5.1.0
-      jest:
-        specifier: 29.7.0
-        version: 29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@swc/core@1.11.5)(@types/node@20.19.25)(typescript@5.4.5))
-      jest-junit:
-        specifier: 16.0.0
-        version: 16.0.0
       kleur:
         specifier: 4.1.5
         version: 4.1.5


### PR DESCRIPTION
This PR migrates get-platform tests from jest to vitest using vitest context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Migrated tests from Jest to Vitest, updated imports, test harnesses and fixture/context setup while preserving assertions and platform-specific scopes.
* **Chores**
  * Removed legacy Jest configuration and testing dev-dependencies; switched package test script to use Vitest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->