### PR TITLE
fix(client-engine-runtime): preserve Decimal precision in increment/decrement operations

### DIFF
--- a/packages/client-engine-runtime/src/interpreter/query-interpreter.test.ts
+++ b/packages/client-engine-runtime/src/interpreter/query-interpreter.test.ts
@@ -144,6 +144,24 @@ describe('mapRecord field operations', () => {
       expect((result as Record<string, unknown>).amount).toBeNull()
     })
 
+    test('add preserves precision beyond 20 significant digits', async () => {
+      const adapter = new MockDriverAdapter()
+      adapter.setQueryResult('SELECT', {
+        columnNames: ['id', 'amount'],
+        columnTypes: [0, 1],
+        rows: [[1, '1234567890123456789012345678']],
+      })
+
+      const plan = makeMapRecordPlan('SELECT id, amount FROM Account WHERE id = 1', {
+        amount: { type: 'add', value: '1' },
+      })
+
+      const interpreter = QueryInterpreter.forSql(createInterpreterOptions())
+      const result = await interpreter.run(plan, createRuntimeOptions(adapter))
+
+      expect((result as Record<string, unknown>).amount).toBe('1234567890123456789012345679')
+    })
+
     test('add with string value and number operand uses Decimal', async () => {
       const adapter = new MockDriverAdapter()
       adapter.setQueryResult('SELECT', {

--- a/packages/client-engine-runtime/src/interpreter/query-interpreter.test.ts
+++ b/packages/client-engine-runtime/src/interpreter/query-interpreter.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test } from 'vitest'
+
+import { MockDriverAdapter, mockTracingHelper } from '../../bench/mock-adapter'
+import type { QueryPlanNode } from '../query-plan'
+import { QueryInterpreter, QueryInterpreterOptions } from './query-interpreter'
+import { serializeSql } from './serialize-sql'
+
+function createInterpreterOptions(): QueryInterpreterOptions {
+  return {
+    tracingHelper: mockTracingHelper,
+    serializer: serializeSql,
+    provider: 'postgres',
+    connectionInfo: { supportsRelationJoins: false },
+  }
+}
+
+function createRuntimeOptions(adapter: MockDriverAdapter) {
+  return {
+    queryable: adapter,
+    scope: {},
+    transactionManager: { enabled: false },
+  } as const
+}
+
+/**
+ * Constructs a query plan that SELECTs a record and then applies a mapRecord
+ * field operation, simulating an update with increment/decrement.
+ */
+function makeMapRecordPlan(
+  selectSql: string,
+  fields: Record<string, { type: 'add' | 'subtract' | 'multiply' | 'divide'; value: unknown }>,
+): QueryPlanNode {
+  return {
+    type: 'mapRecord',
+    args: {
+      expr: {
+        type: 'unique',
+        args: {
+          type: 'query',
+          args: {
+            type: 'templateSql',
+            fragments: [{ type: 'stringChunk', chunk: selectSql }],
+            placeholderFormat: { prefix: '$', hasNumbering: true },
+            args: [],
+            argTypes: [],
+            chunkable: false,
+          },
+        },
+      },
+      fields,
+    },
+  }
+}
+
+describe('mapRecord field operations', () => {
+  describe('decimal precision', () => {
+    test('add preserves precision for large decimal strings', async () => {
+      const adapter = new MockDriverAdapter()
+      adapter.setQueryResult('SELECT', {
+        columnNames: ['id', 'amount'],
+        columnTypes: [0, 1],
+        rows: [[1, '5000000000000000000000000000']],
+      })
+
+      const plan = makeMapRecordPlan('SELECT id, amount FROM Account WHERE id = 1', {
+        amount: { type: 'add', value: '1000000000000000000000' },
+      })
+
+      const interpreter = QueryInterpreter.forSql(createInterpreterOptions())
+      const result = await interpreter.run(plan, createRuntimeOptions(adapter))
+
+      expect((result as Record<string, unknown>).amount).toBe('5000001000000000000000000000')
+    })
+
+    test('subtract preserves precision for large decimal strings', async () => {
+      const adapter = new MockDriverAdapter()
+      adapter.setQueryResult('SELECT', {
+        columnNames: ['id', 'amount'],
+        columnTypes: [0, 1],
+        rows: [[1, '5000000000000000000000000000']],
+      })
+
+      const plan = makeMapRecordPlan('SELECT id, amount FROM Account WHERE id = 1', {
+        amount: { type: 'subtract', value: '1000000000000000000000' },
+      })
+
+      const interpreter = QueryInterpreter.forSql(createInterpreterOptions())
+      const result = await interpreter.run(plan, createRuntimeOptions(adapter))
+
+      expect((result as Record<string, unknown>).amount).toBe('4999999000000000000000000000')
+    })
+
+    test('multiply preserves precision for large decimal strings', async () => {
+      const adapter = new MockDriverAdapter()
+      adapter.setQueryResult('SELECT', {
+        columnNames: ['id', 'amount'],
+        columnTypes: [0, 1],
+        rows: [[1, '1000000000000000000']],
+      })
+
+      const plan = makeMapRecordPlan('SELECT id, amount FROM Account WHERE id = 1', {
+        amount: { type: 'multiply', value: '1000000000' },
+      })
+
+      const interpreter = QueryInterpreter.forSql(createInterpreterOptions())
+      const result = await interpreter.run(plan, createRuntimeOptions(adapter))
+
+      expect((result as Record<string, unknown>).amount).toBe('1000000000000000000000000000')
+    })
+
+    test('divide preserves precision for large decimal strings', async () => {
+      const adapter = new MockDriverAdapter()
+      adapter.setQueryResult('SELECT', {
+        columnNames: ['id', 'amount'],
+        columnTypes: [0, 1],
+        rows: [[1, '1000000000000000000000000000']],
+      })
+
+      const plan = makeMapRecordPlan('SELECT id, amount FROM Account WHERE id = 1', {
+        amount: { type: 'divide', value: '1000000000' },
+      })
+
+      const interpreter = QueryInterpreter.forSql(createInterpreterOptions())
+      const result = await interpreter.run(plan, createRuntimeOptions(adapter))
+
+      expect((result as Record<string, unknown>).amount).toBe('1000000000000000000')
+    })
+
+    test('divide by zero returns null for decimal strings', async () => {
+      const adapter = new MockDriverAdapter()
+      adapter.setQueryResult('SELECT', {
+        columnNames: ['id', 'amount'],
+        columnTypes: [0, 1],
+        rows: [[1, '1000000000000000000000000000']],
+      })
+
+      const plan = makeMapRecordPlan('SELECT id, amount FROM Account WHERE id = 1', {
+        amount: { type: 'divide', value: '0' },
+      })
+
+      const interpreter = QueryInterpreter.forSql(createInterpreterOptions())
+      const result = await interpreter.run(plan, createRuntimeOptions(adapter))
+
+      expect((result as Record<string, unknown>).amount).toBeNull()
+    })
+
+    test('add with string value and number operand uses Decimal', async () => {
+      const adapter = new MockDriverAdapter()
+      adapter.setQueryResult('SELECT', {
+        columnNames: ['id', 'amount'],
+        columnTypes: [0, 1],
+        rows: [[1, '99999999999999999']],
+      })
+
+      const plan = makeMapRecordPlan('SELECT id, amount FROM Account WHERE id = 1', {
+        amount: { type: 'add', value: 1 },
+      })
+
+      const interpreter = QueryInterpreter.forSql(createInterpreterOptions())
+      const result = await interpreter.run(plan, createRuntimeOptions(adapter))
+
+      expect((result as Record<string, unknown>).amount).toBe('100000000000000000')
+    })
+  })
+
+  describe('regular number arithmetic', () => {
+    test('add works correctly for regular numbers', async () => {
+      const adapter = new MockDriverAdapter()
+      adapter.setQueryResult('SELECT', {
+        columnNames: ['id', 'count'],
+        columnTypes: [0, 0],
+        rows: [[1, 10]],
+      })
+
+      const plan = makeMapRecordPlan('SELECT id, count FROM Counter WHERE id = 1', {
+        count: { type: 'add', value: 5 },
+      })
+
+      const interpreter = QueryInterpreter.forSql(createInterpreterOptions())
+      const result = await interpreter.run(plan, createRuntimeOptions(adapter))
+
+      expect((result as Record<string, unknown>).count).toBe(15)
+    })
+
+    test('divide by zero returns null for regular numbers', async () => {
+      const adapter = new MockDriverAdapter()
+      adapter.setQueryResult('SELECT', {
+        columnNames: ['id', 'count'],
+        columnTypes: [0, 0],
+        rows: [[1, 10]],
+      })
+
+      const plan = makeMapRecordPlan('SELECT id, count FROM Counter WHERE id = 1', {
+        count: { type: 'divide', value: 0 },
+      })
+
+      const interpreter = QueryInterpreter.forSql(createInterpreterOptions())
+      const result = await interpreter.run(plan, createRuntimeOptions(adapter))
+
+      expect((result as Record<string, unknown>).count).toBeNull()
+    })
+
+    test('float arithmetic still works', async () => {
+      const adapter = new MockDriverAdapter()
+      adapter.setQueryResult('SELECT', {
+        columnNames: ['id', 'credit'],
+        columnTypes: [0, 0],
+        rows: [[1, 10.5]],
+      })
+
+      const plan = makeMapRecordPlan('SELECT id, credit FROM Account WHERE id = 1', {
+        credit: { type: 'add', value: 1.5 },
+      })
+
+      const interpreter = QueryInterpreter.forSql(createInterpreterOptions())
+      const result = await interpreter.run(plan, createRuntimeOptions(adapter))
+
+      expect((result as Record<string, unknown>).credit).toBe(12)
+    })
+  })
+})

--- a/packages/client-engine-runtime/src/interpreter/query-interpreter.test.ts
+++ b/packages/client-engine-runtime/src/interpreter/query-interpreter.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest'
 
 import { MockDriverAdapter, mockTracingHelper } from '../../bench/mock-adapter'
-import type { QueryPlanNode } from '../query-plan'
+import type { FieldOperation, QueryPlanNode } from '../query-plan'
 import { QueryInterpreter, QueryInterpreterOptions } from './query-interpreter'
 import { serializeSql } from './serialize-sql'
 
@@ -47,7 +47,7 @@ function makeMapRecordPlan(
           },
         },
       },
-      fields,
+      fields: fields as Record<string, FieldOperation>,
     },
   }
 }

--- a/packages/client-engine-runtime/src/interpreter/query-interpreter.test.ts
+++ b/packages/client-engine-runtime/src/interpreter/query-interpreter.test.ts
@@ -218,6 +218,24 @@ describe('mapRecord field operations', () => {
       expect((result as Record<string, unknown>).count).toBeNull()
     })
 
+    test('number value with string operand uses Decimal path', async () => {
+      const adapter = new MockDriverAdapter()
+      adapter.setQueryResult('SELECT', {
+        columnNames: ['id', 'count'],
+        columnTypes: [0, 0],
+        rows: [[1, 10]],
+      })
+
+      const plan = makeMapRecordPlan('SELECT id, count FROM Counter WHERE id = 1', {
+        count: { type: 'add', value: '5' },
+      })
+
+      const interpreter = QueryInterpreter.forSql(createInterpreterOptions())
+      const result = await interpreter.run(plan, createRuntimeOptions(adapter))
+
+      expect((result as Record<string, unknown>).count).toBe('15')
+    })
+
     test('float arithmetic still works', async () => {
       const adapter = new MockDriverAdapter()
       adapter.setQueryResult('SELECT', {

--- a/packages/client-engine-runtime/src/interpreter/query-interpreter.ts
+++ b/packages/client-engine-runtime/src/interpreter/query-interpreter.ts
@@ -1,3 +1,4 @@
+import { Decimal } from '@prisma/client-runtime-utils'
 import { ConnectionInfo, SqlQuery, SqlQueryable, SqlResultSet } from '@prisma/driver-adapter-utils'
 import type { SqlCommenterPlugin, SqlCommenterQueryInfo } from '@prisma/sqlcommenter'
 import { klona } from 'klona'
@@ -405,6 +406,48 @@ function asNumber(value: Value): number {
   throw new Error(`Expected number, got ${typeof value}`)
 }
 
+/**
+ * Performs an arithmetic operation using Decimal when either operand is a string,
+ * which happens for Decimal database columns. This avoids precision loss that
+ * occurs when converting large decimal strings to JavaScript numbers.
+ * See: https://github.com/prisma/prisma/issues/29160
+ */
+function evalArithmetic(lhs: Value, rhs: Value, op: 'add' | 'sub' | 'mul' | 'div'): Value {
+  if (typeof lhs === 'string' || typeof rhs === 'string') {
+    const left = new Decimal(lhs as string | number)
+    const right = new Decimal(rhs as string | number)
+    switch (op) {
+      case 'add':
+        return left.plus(right).toFixed()
+      case 'sub':
+        return left.minus(right).toFixed()
+      case 'mul':
+        return left.times(right).toFixed()
+      case 'div':
+        if (right.isZero()) {
+          return null
+        }
+        return left.dividedBy(right).toFixed()
+    }
+  }
+
+  const left = asNumber(lhs)
+  const right = asNumber(rhs)
+  switch (op) {
+    case 'add':
+      return left + right
+    case 'sub':
+      return left - right
+    case 'mul':
+      return left * right
+    case 'div':
+      if (right === 0) {
+        return null
+      }
+      return left / right
+  }
+}
+
 function asRecord(value: Value): PrismaObject {
   if (typeof value === 'object' && value !== null) {
     return value as PrismaObject
@@ -540,23 +583,17 @@ function evalFieldOperation(
     case 'set':
       return evaluateArg(op.value, scope, generators)
     case 'add':
-      return asNumber(value) + asNumber(evaluateArg(op.value, scope, generators))
+      return evalArithmetic(value, evaluateArg(op.value, scope, generators), 'add')
     case 'subtract':
-      return asNumber(value) - asNumber(evaluateArg(op.value, scope, generators))
+      return evalArithmetic(value, evaluateArg(op.value, scope, generators), 'sub')
     case 'multiply':
-      return asNumber(value) * asNumber(evaluateArg(op.value, scope, generators))
-    case 'divide': {
-      const lhs = asNumber(value)
-      const rhs = asNumber(evaluateArg(op.value, scope, generators))
+      return evalArithmetic(value, evaluateArg(op.value, scope, generators), 'mul')
+    case 'divide':
       // SQLite and older versions of MySQL return NULL for division by zero, so we emulate
       // that behavior here.
       // If the database does not permit division by zero, a database error should be raised,
       // preventing this case from being executed.
-      if (rhs === 0) {
-        return null
-      }
-      return lhs / rhs
-    }
+      return evalArithmetic(value, evaluateArg(op.value, scope, generators), 'div')
     default:
       assertNever(op, `Unexpected field operation type: ${op['type']}`)
   }

--- a/packages/client-engine-runtime/src/interpreter/query-interpreter.ts
+++ b/packages/client-engine-runtime/src/interpreter/query-interpreter.ts
@@ -161,7 +161,13 @@ export class QueryInterpreter {
       }
 
       case 'execute': {
-        const queries = renderQuery(node.args, context.scope, context.generators, this.#maxChunkSize(), this.#provider)
+        const queries = renderQuery(
+          node.args,
+          context.scope,
+          context.generators,
+          this.#maxChunkSize(),
+          this.#provider ?? context.queryable.provider,
+        )
 
         let sum = 0
         for (const query of queries) {
@@ -179,7 +185,13 @@ export class QueryInterpreter {
       }
 
       case 'query': {
-        const queries = renderQuery(node.args, context.scope, context.generators, this.#maxChunkSize(), this.#provider)
+        const queries = renderQuery(
+          node.args,
+          context.scope,
+          context.generators,
+          this.#maxChunkSize(),
+          this.#provider ?? context.queryable.provider,
+        )
 
         let results: SqlResultSet | undefined
         for (const query of queries) {

--- a/packages/client-engine-runtime/src/interpreter/query-interpreter.ts
+++ b/packages/client-engine-runtime/src/interpreter/query-interpreter.ts
@@ -161,7 +161,7 @@ export class QueryInterpreter {
       }
 
       case 'execute': {
-        const queries = renderQuery(node.args, context.scope, context.generators, this.#maxChunkSize())
+        const queries = renderQuery(node.args, context.scope, context.generators, this.#maxChunkSize(), this.#provider)
 
         let sum = 0
         for (const query of queries) {
@@ -179,7 +179,7 @@ export class QueryInterpreter {
       }
 
       case 'query': {
-        const queries = renderQuery(node.args, context.scope, context.generators, this.#maxChunkSize())
+        const queries = renderQuery(node.args, context.scope, context.generators, this.#maxChunkSize(), this.#provider)
 
         let results: SqlResultSet | undefined
         for (const query of queries) {

--- a/packages/client-engine-runtime/src/interpreter/query-interpreter.ts
+++ b/packages/client-engine-runtime/src/interpreter/query-interpreter.ts
@@ -406,16 +406,22 @@ function asNumber(value: Value): number {
   throw new Error(`Expected number, got ${typeof value}`)
 }
 
+// Decimal.js defaults to 20 significant digits of precision, which silently
+// truncates larger values during arithmetic. We use a higher-precision clone
+// to support the full range of database decimal types (e.g. PostgreSQL NUMERIC
+// can store up to ~131000 digits, MySQL DECIMAL up to 65, SQL Server up to 38).
+// https://github.com/prisma/prisma/issues/29160
+const ArithmeticDecimal = Decimal.clone({ precision: 1000 })
+
 /**
  * Performs an arithmetic operation using Decimal when either operand is a string,
  * which happens for Decimal database columns. This avoids precision loss that
  * occurs when converting large decimal strings to JavaScript numbers.
- * See: https://github.com/prisma/prisma/issues/29160
  */
 function evalArithmetic(lhs: Value, rhs: Value, op: 'add' | 'sub' | 'mul' | 'div'): Value {
   if (typeof lhs === 'string' || typeof rhs === 'string') {
-    const left = new Decimal(lhs as string | number)
-    const right = new Decimal(rhs as string | number)
+    const left = new ArithmeticDecimal(lhs as string | number)
+    const right = new ArithmeticDecimal(rhs as string | number)
     switch (op) {
       case 'add':
         return left.plus(right).toFixed()

--- a/packages/client-engine-runtime/src/interpreter/render-query.ts
+++ b/packages/client-engine-runtime/src/interpreter/render-query.ts
@@ -20,6 +20,7 @@ export function renderQuery(
   scope: ScopeBindings,
   generators: GeneratorRegistrySnapshot,
   maxChunkSize?: number,
+  provider?: string,
 ): DeepReadonly<SqlQuery>[] {
   const args = dbQuery.args.map((arg) => evaluateArg(arg, scope, generators))
 
@@ -33,7 +34,7 @@ export function renderQuery(
           throw new UserFacingError('The query parameter limit supported by your database is exceeded.', 'P2029')
         }
 
-        return renderTemplateSql(dbQuery.fragments, dbQuery.placeholderFormat, params, dbQuery.argTypes)
+        return renderTemplateSql(dbQuery.fragments, dbQuery.placeholderFormat, params, dbQuery.argTypes, provider)
       })
     }
     default:
@@ -73,6 +74,7 @@ function renderTemplateSql(
   placeholderFormat: PlaceholderFormat,
   params: unknown[],
   argTypes: DeepReadonly<DynamicArgType[]>,
+  provider?: string,
 ): SqlQuery {
   let sql = ''
   const ctx = { placeholderNumber: 1 }
@@ -80,7 +82,7 @@ function renderTemplateSql(
   const flattenedArgTypes: ArgType[] = []
 
   for (const fragment of pairFragmentsWithParams(fragments, params, argTypes)) {
-    sql += renderFragment(fragment, placeholderFormat, ctx)
+    sql += renderFragment(fragment, placeholderFormat, ctx, provider)
     if (fragment.type === 'stringChunk') {
       continue
     }
@@ -116,11 +118,21 @@ function renderFragment<Type extends DeepReadonly<DynamicArgType> | undefined>(
   fragment: FragmentWithParams<Type>,
   placeholderFormat: PlaceholderFormat,
   ctx: { placeholderNumber: number },
+  provider?: string,
 ): string {
   const fragmentType = fragment.type
   switch (fragmentType) {
-    case 'parameter':
-      return formatPlaceholder(placeholderFormat, ctx.placeholderNumber++)
+    case 'parameter': {
+      const placeholder = formatPlaceholder(placeholderFormat, ctx.placeholderNumber++)
+      // MySQL treats parameterized values as doubles in arithmetic expressions,
+      // losing precision for large decimals. Wrapping with CAST ensures MySQL
+      // interprets the value as DECIMAL with full precision.
+      // https://github.com/prisma/prisma/issues/29160
+      if (provider === 'mysql' && hasDecimalArgType(fragment)) {
+        return `CAST(${placeholder} AS DECIMAL(65,30))`
+      }
+      return placeholder
+    }
 
     case 'stringChunk':
       return fragment.chunk
@@ -365,4 +377,13 @@ function chunkArray<T>(array: T[], chunkSize: number): T[][] {
     result.push(array.slice(i, i + chunkSize))
   }
   return result
+}
+
+function hasDecimalArgType(fragment: FragmentWithParams<DeepReadonly<DynamicArgType> | undefined>): boolean {
+  const argType = (fragment as { argType?: DeepReadonly<DynamicArgType> }).argType
+  if (argType === undefined) return false
+  if ('scalarType' in argType) {
+    return argType.scalarType === 'decimal'
+  }
+  return false
 }

--- a/packages/client/tests/functional/decimal/increment-precision/_matrix.ts
+++ b/packages/client/tests/functional/decimal/increment-precision/_matrix.ts
@@ -1,0 +1,19 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+import { Providers } from '../../_utils/providers'
+
+export default defineMatrix(() => [
+  [
+    {
+      provider: Providers.MYSQL,
+    },
+    {
+      provider: Providers.POSTGRESQL,
+    },
+    {
+      provider: Providers.COCKROACHDB,
+    },
+    {
+      provider: Providers.SQLSERVER,
+    },
+  ],
+])

--- a/packages/client/tests/functional/decimal/increment-precision/prisma/_schema.ts
+++ b/packages/client/tests/functional/decimal/increment-precision/prisma/_schema.ts
@@ -1,0 +1,19 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+
+  datasource db {
+    provider = "${provider}"
+  }
+
+  model Account {
+    id     ${idForProvider(provider)}
+    amount Decimal @db.Decimal(30, 0)
+  }
+  `
+})

--- a/packages/client/tests/functional/decimal/increment-precision/tests.ts
+++ b/packages/client/tests/functional/decimal/increment-precision/tests.ts
@@ -1,0 +1,73 @@
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
+
+declare let prisma: PrismaClient
+declare let Prisma: typeof PrismaNamespace
+
+// Reproduces https://github.com/prisma/prisma/issues/29160
+testMatrix.setupTestSuite(
+  () => {
+    test('increment preserves precision for large Decimal values', async () => {
+      const created = await prisma.account.create({
+        data: {
+          amount: new Prisma.Decimal('0'),
+        },
+      })
+
+      const afterDeposit = await prisma.account.update({
+        where: { id: created.id },
+        data: {
+          amount: { increment: new Prisma.Decimal('5000000000000000000000000000') },
+        },
+      })
+      expect(afterDeposit.amount.toFixed()).toBe('5000000000000000000000000000')
+
+      const afterWithdrawal1 = await prisma.account.update({
+        where: { id: created.id },
+        data: {
+          amount: { decrement: new Prisma.Decimal('1000000000000000000000') },
+        },
+      })
+      expect(afterWithdrawal1.amount.toFixed()).toBe('4999999000000000000000000000')
+
+      const afterWithdrawal2 = await prisma.account.update({
+        where: { id: created.id },
+        data: {
+          amount: { decrement: new Prisma.Decimal('1000000000000000000000') },
+        },
+      })
+      expect(afterWithdrawal2.amount.toFixed()).toBe('4999998000000000000000000000')
+
+      const afterWithdrawal3 = await prisma.account.update({
+        where: { id: created.id },
+        data: {
+          amount: { decrement: new Prisma.Decimal('1000000000000000000000') },
+        },
+      })
+      expect(afterWithdrawal3.amount.toFixed()).toBe('4999997000000000000000000000')
+    })
+
+    test('multiply preserves precision for large Decimal values', async () => {
+      const created = await prisma.account.create({
+        data: {
+          amount: new Prisma.Decimal('1000000000000000000'),
+        },
+      })
+
+      const afterMultiply = await prisma.account.update({
+        where: { id: created.id },
+        data: {
+          amount: { multiply: new Prisma.Decimal('1000000000') },
+        },
+      })
+      expect(afterMultiply.amount.toFixed()).toBe('1000000000000000000000000000')
+    })
+  },
+  {
+    optOut: {
+      from: ['sqlite', 'mongodb'],
+      reason: 'sqlite uses floating point, mongodb does not support Decimal',
+    },
+  },
+)


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma/issues/29160

## Problem

When using `increment` or `decrement` operations on `Decimal` fields with large values (>2^53), Prisma loses precision because the query interpreter's `evalFieldOperation()` converts all operands to JavaScript `number` via `Number()`. JavaScript numbers are IEEE 754 doubles and cannot safely represent integers larger than `Number.MAX_SAFE_INTEGER` (2^53 - 1).

For example, incrementing `5000000000000000000000000000` by `1000000000000000000000` produces an incorrect result due to floating-point precision loss. This is critical for financial and blockchain applications that require precise arithmetic with large numbers.

## Fix

Added `evalArithmetic()` which detects when either operand is a string (the representation used for Decimal database columns) and uses the `decimal.js` library (already a dependency via `@prisma/client-runtime-utils`) for the computation. When both operands are regular numbers (integer/float columns), the existing JavaScript arithmetic is preserved unchanged.

The key insight is that database drivers return Decimal column values as strings (because they can't be represented as JS numbers), while integer and float columns return numbers. This makes `typeof value === 'string'` a reliable indicator for when Decimal-safe arithmetic is needed.

## Tests

Added unit tests in `packages/client-engine-runtime/src/interpreter/query-interpreter.test.ts` covering:
- Add/subtract/multiply/divide with large decimal strings (precision preserved)
- Division by zero returns null for both decimal and number paths
- Mixed operands (string value + number operand) use Decimal path
- Regular number arithmetic is unchanged (integers, floats)
- All existing tests (100/100) continue to pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decimal arithmetic (add, subtract, multiply, divide) to preserve very large and long-decimal values and handle mixed string/number operands.
  * Division-by-zero now consistently returns null.
  * Preserved decimal precision when sending parameters to MySQL.

* **Tests**
  * Added comprehensive unit and functional tests covering field-level arithmetic, mixed-type scenarios, decimal precision edge cases, and division-by-zero across multiple providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->