### PR TITLE
feat(adapter-pg): accept connection string URL in PrismaPg constructor

### DIFF
--- a/packages/adapter-pg/src/__tests__/pg.test.ts
+++ b/packages/adapter-pg/src/__tests__/pg.test.ts
@@ -34,6 +34,15 @@ describe('PrismaPgAdapterFactory', () => {
     await adapter.dispose()
   })
 
+  it('should accept a connection string URL', async () => {
+    const connectionString = 'postgresql://test:test@localhost:5432/test'
+    const factory = new PrismaPgAdapterFactory(connectionString)
+    const adapter = await factory.connect()
+    expect(adapter).toBeDefined()
+    expect(adapter.adapterName).toBeDefined()
+    await adapter.dispose()
+  })
+
   it('should add and remove error event listener when using an external Pool', async () => {
     const pool = new pg.Pool({ user: 'test', password: 'test', database: 'test', port: 5432, host: 'localhost' })
     pool.on('error', () => {})

--- a/packages/adapter-pg/src/__tests__/pg.test.ts
+++ b/packages/adapter-pg/src/__tests__/pg.test.ts
@@ -37,9 +37,11 @@ describe('PrismaPgAdapterFactory', () => {
   it('should accept a connection string URL', async () => {
     const connectionString = 'postgresql://test:test@localhost:5432/test'
     const factory = new PrismaPgAdapterFactory(connectionString)
+
+    expect((factory as any).config).toEqual({ connectionString })
+
     const adapter = await factory.connect()
-    expect(adapter).toBeDefined()
-    expect(adapter.adapterName).toBeDefined()
+    expect(adapter.underlyingDriver().options.connectionString).toBe(connectionString)
     await adapter.dispose()
   })
 

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -278,12 +278,15 @@ export class PrismaPgAdapterFactory implements SqlMigrationAwareDriverAdapterFac
   private externalPool: pg.Pool | null
 
   constructor(
-    poolOrConfig: pg.Pool | pg.PoolConfig,
+    poolOrConfig: pg.Pool | pg.PoolConfig | string,
     private readonly options?: PrismaPgOptions,
   ) {
     if (poolOrConfig instanceof pg.Pool) {
       this.externalPool = poolOrConfig
       this.config = poolOrConfig.options
+    } else if (typeof poolOrConfig === 'string') {
+      this.externalPool = null
+      this.config = { connectionString: poolOrConfig }
     } else {
       this.externalPool = null
       this.config = poolOrConfig


### PR DESCRIPTION
## Summary

- Adds support for passing a raw connection string URL directly to `PrismaPg` (e.g., `new PrismaPg(process.env.DATABASE_URL)`)
- The constructor now accepts `pg.Pool | pg.PoolConfig | string`, converting strings to `{ connectionString: string }` internally
- This is a convenience feature — `pg.PoolConfig` already supports `{ connectionString: '...' }`, but accepting a plain string is more ergonomic

Related: #29151

## Test plan

- [x] Added unit test verifying `PrismaPgAdapterFactory` accepts a connection string URL and creates a working adapter
- [x] All existing adapter-pg tests pass (36/36)
- [x] Lint passes with no new warnings

> **Note:** The CodSpeed regression (`compile findUnique -97.77%`) is unrelated — this PR only touches `adapter-pg` constructor logic, not query compilation.