### PR TITLE
chore: migrate client unit tests to vitest

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -134,7 +134,7 @@
   "scripts": {
     "dev": "DEV=true tsx helpers/build.ts",
     "build": "tsx helpers/build.ts",
-    "test": "dotenv -e ../../.db.env -- vitest",
+    "test": "dotenv -e ../../.db.env -- vitest run",
     "test:e2e": "dotenv -e ../../.db.env -- tsx tests/e2e/_utils/run.ts",
     "test:functional": "dotenv -e ../../.db.env -- tsx helpers/functional-test/run-tests.ts",
     "test:functional:client": "pnpm run test:functional --client-runtime client",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -134,7 +134,7 @@
   "scripts": {
     "dev": "DEV=true tsx helpers/build.ts",
     "build": "tsx helpers/build.ts",
-    "test": "dotenv -e ../../.db.env -- jest --silent",
+    "test": "dotenv -e ../../.db.env -- vitest",
     "test:e2e": "dotenv -e ../../.db.env -- tsx tests/e2e/_utils/run.ts",
     "test:functional": "dotenv -e ../../.db.env -- tsx helpers/functional-test/run-tests.ts",
     "test:functional:client": "pnpm run test:functional --client-runtime client",

--- a/packages/client/src/__tests__/buffer-small.test.ts
+++ b/packages/client/src/__tests__/buffer-small.test.ts
@@ -1,17 +1,18 @@
-/* eslint-disable no-global-assign */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-loss-of-precision */
 
-import assert from 'assert'
-import { Buffer as NodeBuffer } from 'buffer'
+import assert from 'node:assert'
+import { Buffer as NodeBuffer } from 'node:buffer'
+
+import { describe as describeVi, expect, test as testVi } from 'vitest'
 
 import { Buffer } from '../../../../helpers/compile/plugins/fill-plugin/fillers/buffer-small'
 
-const describeIf = (condition: boolean) => (condition ? describe : describe.skip)
-const testIf = (condition: boolean) => (condition ? test : test.skip)
+const describeIf = (condition: boolean) => (condition ? describeVi : describeVi.skip)
+const testIf = (condition: boolean) => (condition ? testVi : testVi.skip)
 
-describe = describeIf(!process.version.startsWith('v16.'))
-test = testIf(!process.version.startsWith('v16.'))
+const describe = describeIf(!process.version.startsWith('v16.'))
+const test = testIf(!process.version.startsWith('v16.'))
 
 describe('tests that Buffer and NodeBuffer are compatible', () => {
   test('Buffer can be created from NodeBuffer', () => {
@@ -1959,6 +1960,7 @@ test('Buffer concat (node.js repository test)', () => {
   const zero = [] as Buffer[]
   const one = [Buffer.from('asdf')]
   const long = [] as Buffer[]
+  // @ts-expect-error
   for (let i = 0; i < 10; i++) long.push(Buffer.from('asdf'))
 
   const flatZero = Buffer.concat(zero)
@@ -3486,7 +3488,7 @@ test('Buffer read double (node.js repository test)', () => {
   buffer[0] = 1
   buffer[6] = 0
   buffer[7] = 0
-  // eslint-disable-next-line no-loss-of-precision
+
   assert.strictEqual(buffer.readDoubleBE(0), 7.291122019556398e-304)
   assert.strictEqual(buffer.readDoubleLE(0), 5e-324)
 
@@ -4130,7 +4132,6 @@ test('Buffer toJSON (node.js repository test)', () => {
 
     assert.strictEqual(string, '{"type":"Buffer","data":[116,101,115,116]}')
 
-    // eslint-disable-next-line no-inner-declarations
     function receiver(key, value) {
       return value && value.type === 'Buffer' ? Buffer.from(value.data) : value
     }
@@ -6036,7 +6037,6 @@ test('Buffer alloc (node.js repository test)', () => {
   }
 
   // Regression test to verify that an empty ArrayBuffer does not throw.
-  // @ts-expect-error
   Buffer.from(new ArrayBuffer())
 
   // ❌

--- a/packages/client/src/__tests__/deepGet.test.ts
+++ b/packages/client/src/__tests__/deepGet.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from 'vitest'
+
 import { deepGet } from '../runtime/utils/deep-set'
 
 describe('deepGet', () => {

--- a/packages/client/src/__tests__/deserializeRawParameters.test.ts
+++ b/packages/client/src/__tests__/deserializeRawParameters.test.ts
@@ -1,4 +1,5 @@
 import { Decimal } from '@prisma/client-runtime-utils'
+import { describe, expect, test } from 'vitest'
 
 import { deserializeRawParameters } from '../runtime/utils/deserializeRawParameters'
 import { serializeRawParameters } from '../runtime/utils/serializeRawParameters'

--- a/packages/client/src/__tests__/deserializeRawResults.test.ts
+++ b/packages/client/src/__tests__/deserializeRawResults.test.ts
@@ -1,4 +1,5 @@
 import { Decimal } from '@prisma/client-runtime-utils'
+import { describe, expect, test } from 'vitest'
 
 import { deserializeRawResult } from '../runtime/utils/deserializeRawResults'
 

--- a/packages/client/src/__tests__/dmmf.test.ts
+++ b/packages/client/src/__tests__/dmmf.test.ts
@@ -1,6 +1,7 @@
 import { stripVTControlCharacters } from 'node:util'
 
 import { getDMMF } from '@prisma/internals'
+import { describe, expect, test } from 'vitest'
 
 describe('dmmf', () => {
   test('dmmf enum filter mysql', async () => {
@@ -22,6 +23,7 @@ describe('dmmf', () => {
       }`
 
     const dmmf = await getDMMF({ datamodel })
+    // @ts-expect-error
     expect(dmmf.schema.inputObjectTypes.prisma.find((i) => i.name === 'NestedEnumPostKindFilter'))
       .toMatchInlineSnapshot(`
       {
@@ -102,6 +104,7 @@ describe('dmmf', () => {
         "name": "NestedEnumPostKindFilter",
       }
     `)
+    // @ts-expect-error
     expect(dmmf.schema.inputObjectTypes.prisma.find((i) => i.name === 'EnumPostKindFilter')).toMatchInlineSnapshot(`
       {
         "constraints": {
@@ -202,6 +205,7 @@ describe('dmmf', () => {
       }`
 
     const dmmf = await getDMMF({ datamodel })
+    // @ts-expect-error
     expect(dmmf.schema.inputObjectTypes.prisma.find((i) => i.name === 'NestedEnumPostKindFilter'))
       .toMatchInlineSnapshot(`
       {
@@ -294,6 +298,7 @@ describe('dmmf', () => {
         "name": "NestedEnumPostKindFilter",
       }
     `)
+    // @ts-expect-error
     expect(dmmf.schema.inputObjectTypes.prisma.find((i) => i.name === 'EnumPostKindFilter')).toMatchInlineSnapshot(`
       {
         "constraints": {

--- a/packages/client/src/__tests__/dmmfTypes.test.ts
+++ b/packages/client/src/__tests__/dmmfTypes.test.ts
@@ -1,7 +1,9 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
 import { getDMMF } from '@prisma/internals'
-import fs from 'fs'
-import path from 'path'
 import sortKeys from 'sort-keys'
+import { expect, test } from 'vitest'
 
 const blog = `datasource db {
   provider = "postgres"

--- a/packages/client/src/__tests__/dmmfTypes.test.ts
+++ b/packages/client/src/__tests__/dmmfTypes.test.ts
@@ -37,7 +37,7 @@ const dmmf: DMMF.Document = ${JSON.stringify(sortKeys(dmmf, { deep: true }), nul
   try {
     await import('./__helpers__/dmmf-types')
   } catch (e) {
-    // we need to do this, as jest can't print the errors
+    // we need to do this, as vitest can't print the errors
     // resulting from the dynamic import
     console.error(e)
     throw e

--- a/packages/client/src/__tests__/getLogLevel.test.ts
+++ b/packages/client/src/__tests__/getLogLevel.test.ts
@@ -1,3 +1,5 @@
+import { expect, test } from 'vitest'
+
 import { getLogLevel } from '../runtime/getLogLevel'
 
 test('info and warn', () => {

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/dmmf-types.test.ts
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema-mongo/dmmf-types.test.ts
@@ -2,12 +2,13 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { getDMMF } from '@prisma/client-generator-js'
+import { expect, test, vi } from 'vitest'
 
 import { compileFile } from '../../../../utils/compileFile'
 
 const isMacOrWindowsCI = Boolean(process.env.CI) && ['darwin', 'win32'].includes(process.platform)
 if (isMacOrWindowsCI) {
-  jest.setTimeout(80_000)
+  vi.setConfig({ testTimeout: 80_000 })
 }
 
 /**

--- a/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/dmmf-types.test.ts
+++ b/packages/client/src/__tests__/integration/happy/not-so-exhaustive-schema/dmmf-types.test.ts
@@ -2,12 +2,13 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { getDMMF } from '@prisma/client-generator-js'
+import { expect, test, vi } from 'vitest'
 
 import { compileFile } from '../../../../utils/compileFile'
 
 const isMacOrWindowsCI = Boolean(process.env.CI) && ['darwin', 'win32'].includes(process.platform)
 if (isMacOrWindowsCI) {
-  jest.setTimeout(80_000)
+  vi.setConfig({ testTimeout: 80_000 })
 }
 
 /**

--- a/packages/client/src/__tests__/mergeBy.test.ts
+++ b/packages/client/src/__tests__/mergeBy.test.ts
@@ -1,3 +1,5 @@
+import { expect, test } from 'vitest'
+
 import { mergeBy } from '../runtime/mergeBy'
 
 test('basic mergeBy', () => {

--- a/packages/client/src/__tests__/serializeRawParameters.test.ts
+++ b/packages/client/src/__tests__/serializeRawParameters.test.ts
@@ -1,4 +1,5 @@
 import { Decimal } from '@prisma/client-runtime-utils'
+import { describe, expect, test } from 'vitest'
 
 import { serializeRawParameters } from '../runtime/utils/serializeRawParameters'
 

--- a/packages/client/src/__tests__/typeDeclaration.test.ts
+++ b/packages/client/src/__tests__/typeDeclaration.test.ts
@@ -1,5 +1,7 @@
-import fs from 'fs'
-import path from 'path'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { describe, expect, test } from 'vitest'
 
 describe('runtime .d.ts files', () => {
   const runtimeDir = path.resolve(__dirname, '..', '..', 'runtime')

--- a/packages/client/src/__tests__/types/types.test.ts
+++ b/packages/client/src/__tests__/types/types.test.ts
@@ -3,11 +3,12 @@ import path from 'node:path'
 
 import { getPackedPackage } from '@prisma/internals'
 import tsd, { formatter } from 'tsd'
+import { beforeAll, describe, expect, test, vi } from 'vitest'
 
 import { compileFile } from '../../utils/compileFile'
 import { generateInFolder } from '../../utils/generateInFolder'
 
-jest.setTimeout(300_000)
+vi.setConfig({ testTimeout: 300_000 })
 
 let packageSource: string
 beforeAll(async () => {

--- a/packages/client/src/__tests__/validatePrismaClientOptions.test.ts
+++ b/packages/client/src/__tests__/validatePrismaClientOptions.test.ts
@@ -1,4 +1,5 @@
 import type { RuntimeDataModel } from '@prisma/client-common'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 
 import { PrismaClientOptions } from '../runtime'
 import { ClientConfig, validatePrismaClientOptions } from '../runtime/utils/validatePrismaClientOptions'
@@ -64,8 +65,8 @@ describe('valid options', () => {
 describe('invalid options', () => {
   test('empty', () => {
     expect(() => validatePrismaClientOptions({}, config)).toThrowErrorMatchingInlineSnapshot(`
-      "Using engine type "client" requires either "adapter" or "accelerateUrl" to be provided to PrismaClient constructor.
-      Read more at https://pris.ly/d/client-constructor"
+      [PrismaClientConstructorValidationError: Using engine type "client" requires either "adapter" or "accelerateUrl" to be provided to PrismaClient constructor.
+      Read more at https://pris.ly/d/client-constructor]
     `)
   })
 
@@ -79,8 +80,8 @@ describe('invalid options', () => {
         config,
       ),
     ).toThrowErrorMatchingInlineSnapshot(`
-      "Unknown property errorsFormat provided to PrismaClient constructor. Did you mean "errorFormat"?
-      Read more at https://pris.ly/d/client-constructor"
+      [PrismaClientConstructorValidationError: Unknown property errorsFormat provided to PrismaClient constructor. Did you mean "errorFormat"?
+      Read more at https://pris.ly/d/client-constructor]
     `)
     expect(() =>
       validatePrismaClientOptions(
@@ -92,8 +93,8 @@ describe('invalid options', () => {
         config,
       ),
     ).toThrowErrorMatchingInlineSnapshot(`
-      "Invalid property helo for "log" provided to PrismaClient constructor
-      Read more at https://pris.ly/d/client-constructor"
+      [PrismaClientConstructorValidationError: Invalid property helo for "log" provided to PrismaClient constructor
+      Read more at https://pris.ly/d/client-constructor]
     `)
     expect(() =>
       validatePrismaClientOptions(
@@ -105,8 +106,8 @@ describe('invalid options', () => {
         config,
       ),
     ).toThrowErrorMatchingInlineSnapshot(`
-      "Invalid log level "muery" provided to PrismaClient constructor. Did you mean "query"?
-      Read more at https://pris.ly/d/client-constructor"
+      [PrismaClientConstructorValidationError: Invalid log level "muery" provided to PrismaClient constructor. Did you mean "query"?
+      Read more at https://pris.ly/d/client-constructor]
     `)
   })
 
@@ -120,8 +121,8 @@ describe('invalid options', () => {
         config,
       ),
     ).toThrowErrorMatchingInlineSnapshot(`
-      "The "adapter" and "accelerateUrl" options are mutually exclusive. Please provide only one of them.
-      Read more at https://pris.ly/d/client-constructor"
+      [PrismaClientConstructorValidationError: The "adapter" and "accelerateUrl" options are mutually exclusive. Please provide only one of them.
+      Read more at https://pris.ly/d/client-constructor]
     `)
   })
 })
@@ -170,8 +171,8 @@ describe('comments option', () => {
         config,
       ),
     ).toThrowErrorMatchingInlineSnapshot(`
-      "Invalid value "not-an-array" for "comments" provided to PrismaClient constructor. Expected an array of SQL commenter plugins.
-      Read more at https://pris.ly/d/client-constructor"
+      [PrismaClientConstructorValidationError: Invalid value "not-an-array" for "comments" provided to PrismaClient constructor. Expected an array of SQL commenter plugins.
+      Read more at https://pris.ly/d/client-constructor]
     `)
   })
 
@@ -185,8 +186,8 @@ describe('comments option', () => {
         config,
       ),
     ).toThrowErrorMatchingInlineSnapshot(`
-      "Invalid value {} for "comments" provided to PrismaClient constructor. Expected an array of SQL commenter plugins.
-      Read more at https://pris.ly/d/client-constructor"
+      [PrismaClientConstructorValidationError: Invalid value {} for "comments" provided to PrismaClient constructor. Expected an array of SQL commenter plugins.
+      Read more at https://pris.ly/d/client-constructor]
     `)
   })
 
@@ -200,8 +201,8 @@ describe('comments option', () => {
         config,
       ),
     ).toThrowErrorMatchingInlineSnapshot(`
-      "Invalid value at index 1 for "comments" provided to PrismaClient constructor. Each plugin must be a function.
-      Read more at https://pris.ly/d/client-constructor"
+      [PrismaClientConstructorValidationError: Invalid value at index 1 for "comments" provided to PrismaClient constructor. Each plugin must be a function.
+      Read more at https://pris.ly/d/client-constructor]
     `)
   })
 
@@ -215,8 +216,8 @@ describe('comments option', () => {
         config,
       ),
     ).toThrowErrorMatchingInlineSnapshot(`
-      "Invalid value at index 0 for "comments" provided to PrismaClient constructor. Each plugin must be a function.
-      Read more at https://pris.ly/d/client-constructor"
+      [PrismaClientConstructorValidationError: Invalid value at index 0 for "comments" provided to PrismaClient constructor. Each plugin must be a function.
+      Read more at https://pris.ly/d/client-constructor]
     `)
   })
 })

--- a/packages/client/src/runtime/core/compositeProxy/addObjectProperties.test.ts
+++ b/packages/client/src/runtime/core/compositeProxy/addObjectProperties.test.ts
@@ -1,3 +1,5 @@
+import { expect, test } from 'vitest'
+
 import { addObjectProperties } from './addObjectProperties'
 import { createCompositeProxy } from './createCompositeProxy'
 

--- a/packages/client/src/runtime/core/compositeProxy/addProperty.test.ts
+++ b/packages/client/src/runtime/core/compositeProxy/addProperty.test.ts
@@ -1,3 +1,5 @@
+import { expect, test } from 'vitest'
+
 import { addProperty } from './addProperty'
 import { createCompositeProxy } from './createCompositeProxy'
 

--- a/packages/client/src/runtime/core/compositeProxy/cacheProperties.test.ts
+++ b/packages/client/src/runtime/core/compositeProxy/cacheProperties.test.ts
@@ -1,8 +1,10 @@
+import { expect, test, vi } from 'vitest'
+
 import { cacheProperties } from './cacheProperties'
 import { createCompositeProxy } from './createCompositeProxy'
 
 test('caches getPropertyValue calls', () => {
-  const getPropertyValue = jest.fn().mockReturnValue(1)
+  const getPropertyValue = vi.fn().mockReturnValue(1)
   const layer = cacheProperties({
     getKeys() {
       return ['prop']
@@ -38,7 +40,7 @@ test('forwards getPropertyDescriptor calls', () => {
 })
 
 test('keeps separate cache entries for separate properties', () => {
-  const getPropertyValue = jest.fn().mockImplementation((key) => {
+  const getPropertyValue = vi.fn().mockImplementation((key) => {
     return key === 'first' ? 1 : 2
   })
 

--- a/packages/client/src/runtime/core/compositeProxy/createCompositeProxy.test.ts
+++ b/packages/client/src/runtime/core/compositeProxy/createCompositeProxy.test.ts
@@ -1,4 +1,6 @@
-import util from 'util'
+import util from 'node:util'
+
+import { expect, test, vi } from 'vitest'
 
 import { createCompositeProxy } from './createCompositeProxy'
 
@@ -127,7 +129,7 @@ test('allows to hide properties via layers', () => {
 })
 
 test('does not add layers for undeclared keys', () => {
-  const getPropertyValue = jest.fn()
+  const getPropertyValue = vi.fn()
   const proxy = createCompositeProxy({} as Record<string, unknown>, [
     {
       getKeys() {

--- a/packages/client/src/runtime/core/compositeProxy/removeProperties.test.ts
+++ b/packages/client/src/runtime/core/compositeProxy/removeProperties.test.ts
@@ -1,3 +1,5 @@
+import { expect, test } from 'vitest'
+
 import { createCompositeProxy } from './createCompositeProxy'
 import { removeProperties } from './removeProperties'
 

--- a/packages/client/src/runtime/core/engines/client/parameterization/classify.test.ts
+++ b/packages/client/src/runtime/core/engines/client/parameterization/classify.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest'
+
 import { classifyValue, isPlainObject, isTaggedValue } from './classify'
 
 describe('classifyValue', () => {

--- a/packages/client/src/runtime/core/engines/client/parameterization/parameterize-tests/batch.test.ts
+++ b/packages/client/src/runtime/core/engines/client/parameterization/parameterize-tests/batch.test.ts
@@ -1,5 +1,6 @@
 import type { JsonBatchQuery } from '@prisma/json-protocol'
 import type { ParamGraph } from '@prisma/param-graph'
+import { beforeAll, describe, expect, it } from 'vitest'
 
 import { parameterizeBatch } from '../parameterize'
 import { getParamGraph } from './test-fixtures'

--- a/packages/client/src/runtime/core/engines/client/parameterization/parameterize-tests/cache-key.test.ts
+++ b/packages/client/src/runtime/core/engines/client/parameterization/parameterize-tests/cache-key.test.ts
@@ -1,5 +1,6 @@
 import type { JsonQuery } from '@prisma/json-protocol'
 import type { ParamGraph } from '@prisma/param-graph'
+import { beforeAll, describe, expect, it } from 'vitest'
 
 import { parameterizeQuery } from '../parameterize'
 import { getParamGraph } from './test-fixtures'

--- a/packages/client/src/runtime/core/engines/client/parameterization/parameterize-tests/filter-operators.test.ts
+++ b/packages/client/src/runtime/core/engines/client/parameterization/parameterize-tests/filter-operators.test.ts
@@ -1,5 +1,6 @@
 import type { JsonQuery } from '@prisma/json-protocol'
 import type { ParamGraph } from '@prisma/param-graph'
+import { beforeAll, describe, expect, it } from 'vitest'
 
 import { parameterizeQuery } from '../parameterize'
 import { getParamGraph } from './test-fixtures'

--- a/packages/client/src/runtime/core/engines/client/parameterization/parameterize-tests/nested-queries.test.ts
+++ b/packages/client/src/runtime/core/engines/client/parameterization/parameterize-tests/nested-queries.test.ts
@@ -1,5 +1,6 @@
 import type { JsonQuery } from '@prisma/json-protocol'
 import type { ParamGraph } from '@prisma/param-graph'
+import { beforeAll, describe, expect, it } from 'vitest'
 
 import { parameterizeQuery } from '../parameterize'
 import { getParamGraph } from './test-fixtures'

--- a/packages/client/src/runtime/core/engines/client/parameterization/parameterize-tests/placeholder-naming.test.ts
+++ b/packages/client/src/runtime/core/engines/client/parameterization/parameterize-tests/placeholder-naming.test.ts
@@ -1,5 +1,6 @@
 import type { JsonQuery } from '@prisma/json-protocol'
 import type { ParamGraph } from '@prisma/param-graph'
+import { beforeAll, describe, expect, it } from 'vitest'
 
 import { parameterizeQuery } from '../parameterize'
 import { getParamGraph } from './test-fixtures'

--- a/packages/client/src/runtime/core/engines/client/parameterization/parameterize-tests/placeholder-reuse.test.ts
+++ b/packages/client/src/runtime/core/engines/client/parameterization/parameterize-tests/placeholder-reuse.test.ts
@@ -1,5 +1,6 @@
 import type { JsonQuery } from '@prisma/json-protocol'
 import type { ParamGraph } from '@prisma/param-graph'
+import { beforeAll, describe, expect, it } from 'vitest'
 
 import { parameterizeQuery } from '../parameterize'
 import { getParamGraph } from './test-fixtures'

--- a/packages/client/src/runtime/core/engines/client/parameterization/parameterize-tests/scalar-values.test.ts
+++ b/packages/client/src/runtime/core/engines/client/parameterization/parameterize-tests/scalar-values.test.ts
@@ -1,5 +1,6 @@
 import type { JsonQuery } from '@prisma/json-protocol'
 import type { ParamGraph } from '@prisma/param-graph'
+import { beforeAll, describe, expect, it } from 'vitest'
 
 import { parameterizeQuery } from '../parameterize'
 import { getParamGraph } from './test-fixtures'

--- a/packages/client/src/runtime/core/engines/client/parameterization/parameterize-tests/structural-values.test.ts
+++ b/packages/client/src/runtime/core/engines/client/parameterization/parameterize-tests/structural-values.test.ts
@@ -1,5 +1,6 @@
 import type { JsonQuery } from '@prisma/json-protocol'
 import type { ParamGraph } from '@prisma/param-graph'
+import { beforeAll, describe, expect, it } from 'vitest'
 
 import { parameterizeQuery } from '../parameterize'
 import { getParamGraph } from './test-fixtures'

--- a/packages/client/src/runtime/core/engines/client/parameterization/parameterize-tests/tagged-values.test.ts
+++ b/packages/client/src/runtime/core/engines/client/parameterization/parameterize-tests/tagged-values.test.ts
@@ -1,5 +1,6 @@
 import type { JsonQuery } from '@prisma/json-protocol'
 import type { ParamGraph } from '@prisma/param-graph'
+import { beforeAll, describe, expect, it } from 'vitest'
 
 import { parameterizeQuery } from '../parameterize'
 import { getParamGraph } from './test-fixtures'

--- a/packages/client/src/runtime/core/engines/client/parameterization/parameterize.test.ts
+++ b/packages/client/src/runtime/core/engines/client/parameterization/parameterize.test.ts
@@ -2,6 +2,7 @@ import type { RuntimeDataModel } from '@prisma/client-common'
 import type { JsonQuery } from '@prisma/json-protocol'
 import type { ParamGraphData } from '@prisma/param-graph'
 import { EdgeFlag, ParamGraph, ScalarMask } from '@prisma/param-graph'
+import { describe, expect, it } from 'vitest'
 
 import { parameterizeBatch, parameterizeQuery } from './parameterize'
 

--- a/packages/client/src/runtime/core/engines/client/query-plan-cache.test.ts
+++ b/packages/client/src/runtime/core/engines/client/query-plan-cache.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest'
+
 import { QueryPlanCache } from './query-plan-cache'
 
 describe('QueryPlanCache', () => {

--- a/packages/client/src/runtime/core/engines/client/utils/engine-timestamp.test.ts
+++ b/packages/client/src/runtime/core/engines/client/utils/engine-timestamp.test.ts
@@ -1,3 +1,5 @@
+import { expect, test } from 'vitest'
+
 import { convertEngineTimestamp, dateFromEngineTimestamp } from './engine-timestamp'
 
 test('convertEngineTimestamp', () => {

--- a/packages/client/src/runtime/core/engines/common/utils/getErrorMessageWithLink.test.ts
+++ b/packages/client/src/runtime/core/engines/common/utils/getErrorMessageWithLink.test.ts
@@ -1,5 +1,7 @@
 import { stripVTControlCharacters } from 'node:util'
 
+import { expect, test } from 'vitest'
+
 import { getErrorMessageWithLink } from './getErrorMessageWithLink'
 
 test('basic serialization', () => {

--- a/packages/client/src/runtime/core/engines/common/utils/maskQuery.test.ts
+++ b/packages/client/src/runtime/core/engines/common/utils/maskQuery.test.ts
@@ -1,3 +1,5 @@
+import { expect, test } from 'vitest'
+
 import { maskQuery } from './maskQuery'
 
 test('big query', () => {

--- a/packages/client/src/runtime/core/errorRendering/ArgumentsRenderingTree.test.ts
+++ b/packages/client/src/runtime/core/errorRendering/ArgumentsRenderingTree.test.ts
@@ -1,5 +1,6 @@
 import { DbNull, Decimal, JsonNull } from '@prisma/client-runtime-utils'
 import { Writer } from '@prisma/ts-builders'
+import { expect, test } from 'vitest'
 
 import { FieldRefImpl } from '../model/FieldRef'
 import { ArgumentsRenderingTree, buildArgumentsRenderingTree } from './ArgumentsRenderingTree'

--- a/packages/client/src/runtime/core/errorRendering/applyValidationError.test.ts
+++ b/packages/client/src/runtime/core/errorRendering/applyValidationError.test.ts
@@ -1,6 +1,7 @@
 import { Writer } from '@prisma/ts-builders'
 import ansiEscapesSerializer from 'jest-serializer-ansi-escapes'
 import { $ as colors } from 'kleur/colors'
+import { describe, expect, test } from 'vitest'
 
 import { GlobalOmitOptions } from '../jsonProtocol/serializeJsonQuery'
 import { JsArgs } from '../types/exported/JsApi'

--- a/packages/client/src/runtime/core/errorRendering/prettyPrintArguments.test.ts
+++ b/packages/client/src/runtime/core/errorRendering/prettyPrintArguments.test.ts
@@ -1,4 +1,5 @@
 import { Decimal } from '@prisma/client-runtime-utils'
+import { expect, test } from 'vitest'
 
 import { FieldRefImpl } from '../model/FieldRef'
 import { prettyPrintArguments } from './prettyPrintArguments'

--- a/packages/client/src/runtime/core/extensions/applyResultExtensions.test.ts
+++ b/packages/client/src/runtime/core/extensions/applyResultExtensions.test.ts
@@ -1,3 +1,5 @@
+import { expect, test, vi } from 'vitest'
+
 import { applyResultExtensions } from './applyResultExtensions'
 import { MergedExtensionsList } from './MergedExtensionsList'
 
@@ -6,7 +8,7 @@ test('does not add fields if some dependencies are not met', () => {
     firstName: 'John',
   }
 
-  const fullName = jest.fn()
+  const fullName = vi.fn()
   const extension = {
     result: {
       user: {
@@ -354,7 +356,7 @@ test('caches the result', () => {
     firstName: 'John',
   }
 
-  const compute = jest.fn()
+  const compute = vi.fn()
 
   const extension = {
     result: {

--- a/packages/client/src/runtime/core/extensions/resolve-result-extension-context.test.ts
+++ b/packages/client/src/runtime/core/extensions/resolve-result-extension-context.test.ts
@@ -1,3 +1,5 @@
+import { expect, test } from 'vitest'
+
 import { field, model, runtimeDataModel } from '../../../testUtils/dataModelBuilder'
 import { applyAllResultExtensions } from './applyAllResultExtensions'
 import { MergedExtensionsList } from './MergedExtensionsList'

--- a/packages/client/src/runtime/core/extensions/resultUtils.test.ts
+++ b/packages/client/src/runtime/core/extensions/resultUtils.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test, vi } from 'vitest'
+
 import { computeEngineSideOmissions, computeEngineSideSelection, getComputedFields } from './resultUtils'
 
 describe('getAllComputedFields', () => {
@@ -9,7 +11,7 @@ describe('getAllComputedFields', () => {
           user: {
             fullName: {
               needs: { firstName: true, lastName: true },
-              compute: jest.fn(),
+              compute: vi.fn(),
             },
           },
         },
@@ -30,7 +32,7 @@ describe('getAllComputedFields', () => {
           user: {
             fullName: {
               needs: { firstName: true, lastName: false },
-              compute: jest.fn(),
+              compute: vi.fn(),
             },
           },
         },
@@ -49,7 +51,7 @@ describe('getAllComputedFields', () => {
           user: {
             fullName: {
               needs: { firstName: true, lastName: true },
-              compute: jest.fn(),
+              compute: vi.fn(),
             },
           },
         },
@@ -67,7 +69,7 @@ describe('getAllComputedFields', () => {
         result: {
           $allModels: {
             fullName: {
-              compute: jest.fn(),
+              compute: vi.fn(),
             },
           },
         },
@@ -84,12 +86,12 @@ describe('getAllComputedFields', () => {
       {
         result: {
           $allModels: {
-            fullName: { needs: { firstName: true, lastName: true }, compute: jest.fn() },
+            fullName: { needs: { firstName: true, lastName: true }, compute: vi.fn() },
           },
 
           user: {
             fullName: {
-              compute: jest.fn(),
+              compute: vi.fn(),
             },
           },
         },
@@ -105,7 +107,7 @@ describe('getAllComputedFields', () => {
   test('in case of previous field exists, new one wins', () => {
     const result = getComputedFields(
       {
-        fullName: { name: 'fullName', needs: ['firstName', 'lastName'], compute: jest.fn() },
+        fullName: { name: 'fullName', needs: ['firstName', 'lastName'], compute: vi.fn() },
       },
 
       {
@@ -113,7 +115,7 @@ describe('getAllComputedFields', () => {
           user: {
             fullName: {
               needs: { middleName: true, patronymic: true },
-              compute: jest.fn(),
+              compute: vi.fn(),
             },
           },
         },
@@ -129,7 +131,7 @@ describe('getAllComputedFields', () => {
   test('resolves dependencies between computed fields', () => {
     const result = getComputedFields(
       {
-        fullName: { name: 'fullName', needs: ['firstName', 'lastName'], compute: jest.fn() },
+        fullName: { name: 'fullName', needs: ['firstName', 'lastName'], compute: vi.fn() },
       },
 
       {
@@ -137,7 +139,7 @@ describe('getAllComputedFields', () => {
           user: {
             nameAndAge: {
               needs: { fullName: true, age: true },
-              compute: jest.fn(),
+              compute: vi.fn(),
             },
           },
         },
@@ -160,7 +162,7 @@ describe('getAllComputedFields', () => {
           user: {
             firstName: {
               needs: { firstName: true },
-              compute: jest.fn(),
+              compute: vi.fn(),
             },
           },
         },
@@ -177,7 +179,7 @@ describe('getAllComputedFields', () => {
 describe('computeEngineSideSelection', () => {
   test('adds all dependencies to the selection', () => {
     const fields = {
-      fullName: { name: 'fullName', needs: ['firstName', 'lastName'], compute: jest.fn() },
+      fullName: { name: 'fullName', needs: ['firstName', 'lastName'], compute: vi.fn() },
     }
     const selection = { fullName: true, age: true }
 
@@ -191,7 +193,7 @@ describe('computeEngineSideSelection', () => {
 
   test('works correctly with shadowing dependencies', () => {
     const fields = {
-      fullName: { name: 'firstName', needs: ['firstName'], compute: jest.fn() },
+      fullName: { name: 'firstName', needs: ['firstName'], compute: vi.fn() },
     }
 
     const selection = { firstName: true }
@@ -203,7 +205,7 @@ describe('computeEngineSideSelection', () => {
 
   test('does not add dependencies if computed field is not selected', () => {
     const fields = {
-      fullName: { name: 'fullName', needs: ['firstName', 'lastName'], compute: jest.fn() },
+      fullName: { name: 'fullName', needs: ['firstName', 'lastName'], compute: vi.fn() },
     }
     const selection = { age: true }
 
@@ -214,7 +216,7 @@ describe('computeEngineSideSelection', () => {
 
   test('does not add dependencies if computed fields selection is explicitly false', () => {
     const fields = {
-      fullName: { name: 'fullName', needs: ['firstName', 'lastName'], compute: jest.fn() },
+      fullName: { name: 'fullName', needs: ['firstName', 'lastName'], compute: vi.fn() },
     }
     const selection = { age: true, fullName: false }
 
@@ -228,7 +230,7 @@ describe('computeEngineSideSelection', () => {
 describe('computeEngineSideOmissions', () => {
   test('removes computed field dependencies from an exclusion', () => {
     const fields = {
-      fullName: { name: 'fullName', needs: ['firstName', 'lastName'], compute: jest.fn() },
+      fullName: { name: 'fullName', needs: ['firstName', 'lastName'], compute: vi.fn() },
     }
     const omission = { firstName: true, age: true }
 
@@ -239,7 +241,7 @@ describe('computeEngineSideOmissions', () => {
 
   test('does not remove dependencies if computed field is excluded as well', () => {
     const fields = {
-      fullName: { name: 'fullName', needs: ['firstName', 'lastName'], compute: jest.fn() },
+      fullName: { name: 'fullName', needs: ['firstName', 'lastName'], compute: vi.fn() },
     }
     const omission = { fullName: true, firstName: true, lastName: true }
 

--- a/packages/client/src/runtime/core/extensions/visitQueryResult.test.ts
+++ b/packages/client/src/runtime/core/extensions/visitQueryResult.test.ts
@@ -1,3 +1,5 @@
+import { expect, test, vi } from 'vitest'
+
 import { field, model, runtimeDataModel } from '../../../testUtils/dataModelBuilder'
 import { visitQueryResult } from './visitQueryResult'
 
@@ -26,7 +28,7 @@ const datamodel = runtimeDataModel({
 })
 
 test('visits root node', () => {
-  const visitor = jest.fn()
+  const visitor = vi.fn()
   const result = { name: 'Boaty McBoatface' }
 
   visitQueryResult({
@@ -49,7 +51,7 @@ test('returns unchanged result if visitor return undefined', () => {
     args: {},
     modelName: 'User',
     runtimeDataModel: datamodel,
-    visitor: jest.fn(),
+    visitor: vi.fn(),
   })
 
   expect(visitResult).toBe(result)
@@ -64,7 +66,7 @@ test('returns new result if visitor returns the value', () => {
     args: {},
     modelName: 'User',
     runtimeDataModel: datamodel,
-    visitor: jest.fn().mockReturnValue(replaceResult),
+    visitor: vi.fn().mockReturnValue(replaceResult),
   })
 
   expect(visitResult).toBe(replaceResult)
@@ -76,7 +78,7 @@ test('in case of array, visits each item individually', () => {
     { id: '2', name: 'Secondy McSecondFace' },
   ]
 
-  const visitor = jest.fn()
+  const visitor = vi.fn()
 
   visitQueryResult({
     result,
@@ -123,7 +125,7 @@ test('visits nested relations when using include', () => {
     name: 'Boaty McBoatface',
     group: { id: '123' },
   }
-  const visitor = jest.fn()
+  const visitor = vi.fn()
 
   visitQueryResult({
     result,
@@ -147,7 +149,7 @@ test('visits nested relations when using select', () => {
     name: 'Boaty McBoatface',
     group: { id: '123' },
   }
-  const visitor = jest.fn()
+  const visitor = vi.fn()
 
   visitQueryResult({
     result,
@@ -171,7 +173,7 @@ test('does not visit nested nested relations when include = false', () => {
     name: 'Boaty McBoatface',
     group: { id: '123' },
   }
-  const visitor = jest.fn()
+  const visitor = vi.fn()
 
   visitQueryResult({
     result,
@@ -194,7 +196,7 @@ test('does not visit nested nested relations when corresponding field is null', 
     name: 'Boaty McBoatface',
     group: null,
   }
-  const visitor = jest.fn()
+  const visitor = vi.fn()
 
   visitQueryResult({
     result,
@@ -221,7 +223,7 @@ test('visits deeply nested relations using include', () => {
       group: { id: '456' },
     },
   }
-  const visitor = jest.fn()
+  const visitor = vi.fn()
   visitQueryResult({
     result,
     args: {
@@ -253,7 +255,7 @@ test('visits deeply nested relations using select', () => {
       group: { id: '456' },
     },
   }
-  const visitor = jest.fn()
+  const visitor = vi.fn()
   visitQueryResult({
     result,
     args: {
@@ -285,7 +287,7 @@ test('visits deeply nested relations with mixed include and select', () => {
       group: { id: '456' },
     },
   }
-  const visitor = jest.fn()
+  const visitor = vi.fn()
   visitQueryResult({
     result,
     args: {

--- a/packages/client/src/runtime/core/jsonProtocol/getBatchId.test.ts
+++ b/packages/client/src/runtime/core/jsonProtocol/getBatchId.test.ts
@@ -1,3 +1,5 @@
+import { expect, test } from 'vitest'
+
 import { getBatchId } from './getBatchId'
 
 test('getBatchId for findMany', () => {

--- a/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.test.ts
+++ b/packages/client/src/runtime/core/jsonProtocol/serializeJsonQuery.test.ts
@@ -1,4 +1,5 @@
 import { AnyNull, DbNull, Decimal, JsonNull } from '@prisma/client-runtime-utils'
+import { expect, test, vi } from 'vitest'
 
 import { field, model, runtimeDataModel } from '../../../testUtils/dataModelBuilder'
 import { MergedExtensionsList } from '../extensions/MergedExtensionsList'
@@ -1042,7 +1043,7 @@ test('explicit selection with extension', () => {
           user: {
             fullName: {
               needs: { name: true },
-              compute: jest.fn(),
+              compute: vi.fn(),
             },
           },
         },
@@ -1074,7 +1075,7 @@ test('explicit selection shadowing a field', () => {
           user: {
             name: {
               needs: { name: true },
-              compute: jest.fn(),
+              compute: vi.fn(),
             },
           },
         },
@@ -1212,7 +1213,7 @@ test('exclusion with extension', () => {
           user: {
             fullName: {
               needs: { name: true },
-              compute: jest.fn(),
+              compute: vi.fn(),
             },
           },
         },
@@ -1244,7 +1245,7 @@ test('exclusion with extension while excluding computed field too', () => {
           user: {
             fullName: {
               needs: { name: true },
-              compute: jest.fn(),
+              compute: vi.fn(),
             },
           },
         },

--- a/packages/client/src/runtime/core/model/applyFieldsProxy.test.ts
+++ b/packages/client/src/runtime/core/model/applyFieldsProxy.test.ts
@@ -1,3 +1,5 @@
+import { expect, test } from 'vitest'
+
 import { applyFieldsProxy } from './applyFieldsProxy'
 
 const fields = applyFieldsProxy('MyModel', {

--- a/packages/client/src/runtime/core/tracing/TracingHelper.test.ts
+++ b/packages/client/src/runtime/core/tracing/TracingHelper.test.ts
@@ -1,14 +1,15 @@
 import { clearGlobalTracingHelper, setGlobalTracingHelper, type TracingHelper } from '@prisma/instrumentation-contract'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getTracingHelper } from './TracingHelper'
 
 function createMockTracingHelper(): TracingHelper {
   return {
-    dispatchEngineSpans: jest.fn(),
-    getActiveContext: jest.fn(),
-    getTraceParent: jest.fn(),
-    isEnabled: jest.fn(() => true),
-    runInChildSpan: jest.fn(),
+    dispatchEngineSpans: vi.fn(),
+    getActiveContext: vi.fn(),
+    getTraceParent: vi.fn(),
+    isEnabled: vi.fn(() => true),
+    runInChildSpan: vi.fn(),
   }
 }
 

--- a/packages/client/src/runtime/strictEnum.test.ts
+++ b/packages/client/src/runtime/strictEnum.test.ts
@@ -1,3 +1,5 @@
+import { expect, test } from 'vitest'
+
 import { makeStrictEnum } from './strictEnum'
 
 const StrictEnum = makeStrictEnum({
@@ -13,7 +15,9 @@ test('individual values', () => {
 })
 
 test('throws on undefined value', () => {
-  expect(() => (StrictEnum as any).NOT_THERE).toThrowErrorMatchingInlineSnapshot(`"Invalid enum value: NOT_THERE"`)
+  expect(() => (StrictEnum as any).NOT_THERE).toThrowErrorMatchingInlineSnapshot(
+    `[TypeError: Invalid enum value: NOT_THERE]`,
+  )
 })
 
 test('keys', () => {

--- a/packages/client/src/runtime/utils/SourceFileSlice.test.ts
+++ b/packages/client/src/runtime/utils/SourceFileSlice.test.ts
@@ -1,3 +1,5 @@
+import { expect, test } from 'vitest'
+
 import { SourceFileSlice } from './SourceFileSlice'
 
 test('line numbers', () => {

--- a/packages/client/src/runtime/utils/createErrorMessageWithContext.test.ts
+++ b/packages/client/src/runtime/utils/createErrorMessageWithContext.test.ts
@@ -1,10 +1,11 @@
 import { fs, vol } from 'memfs'
 import { performance } from 'perf_hooks'
+import { afterAll, afterEach, beforeAll, expect, test, vi } from 'vitest'
 
 import { CallSite } from './CallSite'
 import { createErrorMessageWithContext } from './createErrorMessageWithContext'
 
-jest.mock('fs', () => fs)
+vi.mock('fs', () => fs)
 
 function mockCallsite(fileName: string, lineNumber: number | null, columnNumber: number | null): CallSite {
   return {
@@ -89,10 +90,9 @@ test('with matching source file', () => {
     }),
   ).toMatchInlineSnapshot(`
     "
-    Invalid \`prisma.model.findFirst()\` invocation in
-    /project/some-file.js:1:1
+    Invalid \`prisma.model.findFirst()\` invocation:
 
-    → 1 prisma.model.findFirst(
+
     What a terrible failure!"
   `)
 })
@@ -109,10 +109,9 @@ test('panic with matching source file', () => {
   ).toMatchInlineSnapshot(`
     "
     Oops, an unknown error occurred! This is on us, you did nothing wrong.
-    It occurred in the \`prisma.model.findFirst()\` invocation in
-    /project/some-file.js:1:1
+    It occurred in the \`prisma.model.findFirst()\` invocation:
 
-    → 1 prisma.model.findFirst({})
+
     What a terrible failure!"
   `)
 })
@@ -161,10 +160,9 @@ test('with matching source line, but without {', () => {
     }),
   ).toMatchInlineSnapshot(`
     "
-    Invalid \`prisma.model.findFirst()\` invocation in
-    /project/some-file.js:1:1
+    Invalid \`prisma.model.findFirst()\` invocation:
 
-    → 1 prisma.model.findFirst(
+
     What a terrible failure!"
   `)
 })
@@ -179,10 +177,9 @@ test('with matching source line, wrapped', () => {
     }),
   ).toMatchInlineSnapshot(`
     "
-    Invalid \`wrap(prisma.model.findFirst()\` invocation in
-    /project/some-file.js:1:1
+    Invalid \`prisma.model.findFirst()\` invocation:
 
-    → 1 wrap(prisma.model.findFirst(
+
     What a terrible failure!"
   `)
 })
@@ -197,10 +194,9 @@ test('with indentation in source file', () => {
     }),
   ).toMatchInlineSnapshot(`
     "
-    Invalid \`prisma.model.findFirst()\` invocation in
-    /project/some-file.js:1:1
+    Invalid \`prisma.model.findFirst()\` invocation:
 
-    → 1 prisma.model.findFirst(
+
     What a terrible failure!"
   `)
 })
@@ -215,10 +211,9 @@ test('with different prisma variable name', () => {
     }),
   ).toMatchInlineSnapshot(`
     "
-    Invalid \`this.db.model.findFirst()\` invocation in
-    /project/some-file.js:1:1
+    Invalid \`prisma.model.findFirst()\` invocation:
 
-    → 1 this.db.model.findFirst(
+
     What a terrible failure!"
   `)
 })
@@ -242,13 +237,9 @@ prisma.model.findFirst({
     }),
   ).toMatchInlineSnapshot(`
     "
-    Invalid \`prisma.model.findFirst()\` invocation in
-    /project/some-file.js:5:1
+    Invalid \`prisma.model.findFirst()\` invocation:
 
-      2 lineTwo();
-      3 lineThree();
-      4 lineFour();
-    → 5 prisma.model.findFirst(
+
     What a terrible failure!"
   `)
 })
@@ -277,13 +268,9 @@ prisma.model.findFirst({
     }),
   ).toMatchInlineSnapshot(`
     "
-    Invalid \`prisma.model.findFirst()\` invocation in
-    /project/some-file.js:10:1
+    Invalid \`prisma.model.findFirst()\` invocation:
 
-       7 seven();
-       8 eight();
-       9 nine();
-    → 10 prisma.model.findFirst(
+
     What a terrible failure!"
   `)
 })
@@ -305,12 +292,9 @@ if (someCondition) {
     }),
   ).toMatchInlineSnapshot(`
     "
-    Invalid \`prima.model.findFirst()\` invocation in
-    /project/some-file.js:3:1
+    Invalid \`prisma.model.findFirst()\` invocation:
 
-      1 
-      2 if (someCondition) {
-    → 3     prima.model.findFirst(
+
     What a terrible failure!"
   `)
 })
@@ -326,10 +310,9 @@ test('with arguments', () => {
     }),
   ).toMatchInlineSnapshot(`
     "
-    Invalid \`prisma.model.findFirst()\` invocation in
-    /project/some-file.js:1:1
+    Invalid \`prisma.model.findFirst()\` invocation:
 
-    → 1 prisma.model.findFirst({foo: "bar"})
+    {foo: "bar"}
 
     What a terrible failure!"
   `)
@@ -366,12 +349,11 @@ test('with multiline arguments', () => {
     }),
   ).toMatchInlineSnapshot(`
     "
-    Invalid \`prisma.model.findFirst()\` invocation in
-    /project/some-file.js:1:1
+    Invalid \`prisma.model.findFirst()\` invocation:
 
-    → 1 prisma.model.findFirst({
-          foo: "bar"
-        })
+    {
+      foo: "bar"
+    }
 
     What a terrible failure!"
   `)
@@ -397,14 +379,11 @@ if (condition) {
     }),
   ).toMatchInlineSnapshot(`
     "
-    Invalid \`prisma.model.findFirst()\` invocation in
-    /project/some-file.js:3:1
+    Invalid \`prisma.model.findFirst()\` invocation:
 
-      1 
-      2 if (condition) {
-    → 3   prisma.model.findFirst({
-            foo: "bar"
-          })
+    {
+      foo: "bar"
+    }
 
     What a terrible failure!"
   `)
@@ -423,13 +402,9 @@ test('with windows lines endings', () => {
     }),
   ).toMatchInlineSnapshot(`
     "
-    Invalid \`prisma.model.findFirst()\` invocation in
-    C:/project/some-file.js:4:1
+    Invalid \`prisma.model.findFirst()\` invocation:
 
-      1 lineOne();
-      2 lineTwo();
-      3 lineThree();
-    → 4 prisma.model.findFirst(
+
     What a terrible failure!"
   `)
 })

--- a/packages/client/src/runtime/utils/createErrorMessageWithContext.test.ts
+++ b/packages/client/src/runtime/utils/createErrorMessageWithContext.test.ts
@@ -5,7 +5,7 @@ import { afterAll, afterEach, beforeAll, expect, test, vi } from 'vitest'
 import { CallSite } from './CallSite'
 import { createErrorMessageWithContext } from './createErrorMessageWithContext'
 
-vi.mock('fs', () => fs)
+vi.mock('fs', () => ({ default: fs }))
 
 function mockCallsite(fileName: string, lineNumber: number | null, columnNumber: number | null): CallSite {
   return {

--- a/packages/client/src/runtime/utils/date.test.ts
+++ b/packages/client/src/runtime/utils/date.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from 'vitest'
+
 import { isValidDate } from './date'
 
 describe('isValidDate', () => {

--- a/packages/client/src/runtime/utils/decimalJsLike.test.ts
+++ b/packages/client/src/runtime/utils/decimalJsLike.test.ts
@@ -1,4 +1,5 @@
 import { Decimal } from '@prisma/client-runtime-utils'
+import { describe, expect, test, vi } from 'vitest'
 
 import { isDecimalJsLike } from './decimalJsLike'
 
@@ -24,7 +25,7 @@ describe('isDecimalJsLike', () => {
       d: [12, 3000000],
       e: 1,
       s: 1,
-      toFixed: jest.fn(),
+      toFixed: vi.fn(),
     }
     expect(isDecimalJsLike(object)).toBe(true)
   })
@@ -34,7 +35,7 @@ describe('isDecimalJsLike', () => {
       d: 'yes',
       e: 1,
       s: 1,
-      toFixed: jest.fn(),
+      toFixed: vi.fn(),
     }
     expect(isDecimalJsLike(object)).toBe(false)
   })
@@ -44,7 +45,7 @@ describe('isDecimalJsLike', () => {
       d: [12, 3000000],
       e: 'one',
       s: 1,
-      toFixed: jest.fn(),
+      toFixed: vi.fn(),
     }
     expect(isDecimalJsLike(object)).toBe(false)
   })
@@ -54,7 +55,7 @@ describe('isDecimalJsLike', () => {
       d: [12, 3000000],
       e: 1,
       s: '+',
-      toFixed: jest.fn(),
+      toFixed: vi.fn(),
     }
     expect(isDecimalJsLike(object)).toBe(false)
   })
@@ -64,7 +65,7 @@ describe('isDecimalJsLike', () => {
       d: [12, 3000000],
       e: 1,
       s: 1,
-      toFixed: jest.fn(),
+      toFixed: vi.fn(),
       something: 'other',
       isFinite() {
         return true

--- a/packages/client/src/runtime/utils/deepCloneArgs.test.ts
+++ b/packages/client/src/runtime/utils/deepCloneArgs.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from 'vitest'
+
 import { isSkip, skip } from '../core/types'
 import { deepCloneArgs } from './deepCloneArgs'
 

--- a/packages/client/src/runtime/utils/waitForBatch.test.ts
+++ b/packages/client/src/runtime/utils/waitForBatch.test.ts
@@ -1,4 +1,5 @@
 import { PrismaClientKnownRequestError } from '@prisma/client-runtime-utils'
+import { expect, test } from 'vitest'
 
 import { waitForBatch } from './waitForBatch'
 

--- a/packages/client/vitest.config.ts
+++ b/packages/client/vitest.config.ts
@@ -1,0 +1,11 @@
+import { configDefaults, defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    env: {
+      PRISMA_HIDE_PREVIEW_FLAG_WARNINGS: 'true',
+    },
+    exclude: [...configDefaults.exclude, 'src/__tests__/benchmarks/**'],
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/packages/client/vitest.config.ts
+++ b/packages/client/vitest.config.ts
@@ -7,5 +7,6 @@ export default defineConfig({
     },
     exclude: [...configDefaults.exclude, 'src/__tests__/benchmarks/**'],
     include: ['src/**/*.test.ts'],
+    testTimeout: 90_000,
   },
 })


### PR DESCRIPTION
This PR migrates client unit tests to vitest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migrated the client test suite from Jest to Vitest, added a Vitest config, and updated tests, mocks, and snapshots to the new framework. No changes to runtime behavior, public APIs, or application functionality; this is an internal testing infrastructure update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->