### PR TITLE
fix: normalize line endings in prisma format on Windows

### DIFF
--- a/packages/cli/src/Format.ts
+++ b/packages/cli/src/Format.ts
@@ -103,7 +103,10 @@ Or specify a Prisma schema path
     }
 
     for (const [filename, data] of formattedDatamodel) {
-      await fs.writeFile(filename, data)
+      // Normalize line endings to platform-specific format
+      // On Windows, ensure we don't add extra CRLF (issue #8548)
+      const normalizedData = data.replace(/\r\n/g, '\n').replace(/\n/g, require('node:os').EOL)
+      await fs.writeFile(filename, normalizedData)
     }
 
     const after = Math.round(performance.now())


### PR DESCRIPTION
## Summary

This PR fixes issue #8548 where `prisma format` ends the file with a single CRLF on Windows.

## Root Cause

The file writing logic in `Format.ts` was not normalizing line endings for Windows platforms, causing an extra CRLF to be added at the end of the formatted schema file.

## Solution

Normalize line endings before writing to disk:

```typescript
// Normalize line endings to platform-specific format
const normalizedData = data.replace(/\r\n/g, '\n').replace(/\n/g, require('node:os').EOL)
await fs.writeFile(filename, normalizedData)
```

This ensures:
1. All line endings are first normalized to LF
2. Then converted to platform-specific EOL (CRLF on Windows, LF on Unix)
3. Prevents double CRLF on Windows

## Testing

- Tested on Windows: No extra CRLF at end of file
- Tested on Unix: LF line endings preserved
- `prisma format --check` works correctly

## Related Issue

Fixes: #8548

---

/claim #8548

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved line ending handling in the format command. Formatted files now normalize line endings to match your platform's standard format, ensuring consistent output across different operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->