### PR TITLE
fix(adapter-pg): handle both quoted/unquoted column names in ColumnNotFound error

### DIFF
--- a/packages/adapter-pg/src/__tests__/errors.test.ts
+++ b/packages/adapter-pg/src/__tests__/errors.test.ts
@@ -126,81 +126,22 @@ describe('convertDriverError', () => {
     })
   })
 
-  it('should handle ColumnNotFound (42703) with unquoted column name', () => {
-    const error = { code: '42703', message: 'column foo does not exist', severity: 'ERROR' }
+  it.each([
+    ['unquoted column name', 'column foo does not exist', 'foo'],
+    ['quoted column name', 'column "foo" does not exist', 'foo'],
+    ['unquoted qualified column name', 'column users.first_name does not exist', 'users.first_name'],
+    ['quoted qualified column name', 'column "users"."first name" does not exist', 'users.first name'],
+    ['partially quoted qualified column name (1)', 'column users."first name" does not exist', 'users.first name'],
+    ['partially quoted qualified column name (2)', 'column "users".first_name does not exist', 'users.first_name'],
+    ['quoted column name containing spaces', 'column "first name" does not exist', 'first name'],
+    ['quoted column name containing dots', 'column "first.name" does not exist', 'first.name'],
+    ['quoted qualified column name containing dots', 'column "users"."first.name" does not exist', 'users.first.name'],
+    ['quoted column name containing escaped quotes', 'column "a""b" does not exist', 'a"b'],
+  ])('should handle ColumnNotFound (42703) with %s', (description, message, expectedColumn) => {
+    const error = { code: '42703', message, severity: 'ERROR' }
     expect(convertDriverError(error)).toEqual({
       kind: 'ColumnNotFound',
-      column: 'foo',
-      originalCode: error.code,
-      originalMessage: error.message,
-    })
-  })
-
-  it('should handle ColumnNotFound (42703) with quoted column name', () => {
-    const error = { code: '42703', message: 'column "foo" does not exist', severity: 'ERROR' }
-    expect(convertDriverError(error)).toEqual({
-      kind: 'ColumnNotFound',
-      column: 'foo',
-      originalCode: error.code,
-      originalMessage: error.message,
-    })
-  })
-
-  it('should handle ColumnNotFound (42703) with unquoted qualified column name', () => {
-    const error = { code: '42703', message: 'column users.first_name does not exist', severity: 'ERROR' }
-    expect(convertDriverError(error)).toEqual({
-      kind: 'ColumnNotFound',
-      column: 'users.first_name',
-      originalCode: error.code,
-      originalMessage: error.message,
-    })
-  })
-
-  it('should handle ColumnNotFound (42703) with quoted qualified column name', () => {
-    const error = { code: '42703', message: 'column "users"."first name" does not exist', severity: 'ERROR' }
-    expect(convertDriverError(error)).toEqual({
-      kind: 'ColumnNotFound',
-      column: 'users.first name',
-      originalCode: error.code,
-      originalMessage: error.message,
-    })
-  })
-
-  it('should handle ColumnNotFound (42703) with partially quoted qualified column name (1)', () => {
-    const error = { code: '42703', message: 'column users."first name" does not exist', severity: 'ERROR' }
-    expect(convertDriverError(error)).toEqual({
-      kind: 'ColumnNotFound',
-      column: 'users.first name',
-      originalCode: error.code,
-      originalMessage: error.message,
-    })
-  })
-
-  it('should handle ColumnNotFound (42703) with partially quoted qualified column name (2)', () => {
-    const error = { code: '42703', message: 'column "users".first_name does not exist', severity: 'ERROR' }
-    expect(convertDriverError(error)).toEqual({
-      kind: 'ColumnNotFound',
-      column: 'users.first_name',
-      originalCode: error.code,
-      originalMessage: error.message,
-    })
-  })
-
-  it('should handle ColumnNotFound (42703) with quoted column name containing spaces', () => {
-    const error = { code: '42703', message: 'column "first name" does not exist', severity: 'ERROR' }
-    expect(convertDriverError(error)).toEqual({
-      kind: 'ColumnNotFound',
-      column: 'first name',
-      originalCode: error.code,
-      originalMessage: error.message,
-    })
-  })
-
-  it('should handle ColumnNotFound (42703) with quoted column name containing escaped quotes', () => {
-    const error = { code: '42703', message: 'column "a""b" does not exist', severity: 'ERROR' }
-    expect(convertDriverError(error)).toEqual({
-      kind: 'ColumnNotFound',
-      column: 'a"b',
+      column: expectedColumn,
       originalCode: error.code,
       originalMessage: error.message,
     })

--- a/packages/adapter-pg/src/__tests__/errors.test.ts
+++ b/packages/adapter-pg/src/__tests__/errors.test.ts
@@ -126,11 +126,81 @@ describe('convertDriverError', () => {
     })
   })
 
-  it('should handle ColumnNotFound (42703)', () => {
+  it('should handle ColumnNotFound (42703) with unquoted column name', () => {
+    const error = { code: '42703', message: 'column foo does not exist', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'ColumnNotFound',
+      column: 'foo',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle ColumnNotFound (42703) with quoted column name', () => {
     const error = { code: '42703', message: 'column "foo" does not exist', severity: 'ERROR' }
     expect(convertDriverError(error)).toEqual({
       kind: 'ColumnNotFound',
       column: 'foo',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle ColumnNotFound (42703) with unquoted qualified column name', () => {
+    const error = { code: '42703', message: 'column users.first_name does not exist', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'ColumnNotFound',
+      column: 'users.first_name',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle ColumnNotFound (42703) with quoted qualified column name', () => {
+    const error = { code: '42703', message: 'column "users"."first name" does not exist', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'ColumnNotFound',
+      column: 'users.first name',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle ColumnNotFound (42703) with partially quoted qualified column name (1)', () => {
+    const error = { code: '42703', message: 'column users."first name" does not exist', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'ColumnNotFound',
+      column: 'users.first name',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle ColumnNotFound (42703) with partially quoted qualified column name (2)', () => {
+    const error = { code: '42703', message: 'column "users".first_name does not exist', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'ColumnNotFound',
+      column: 'users.first_name',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle ColumnNotFound (42703) with quoted column name containing spaces', () => {
+    const error = { code: '42703', message: 'column "first name" does not exist', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'ColumnNotFound',
+      column: 'first name',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle ColumnNotFound (42703) with quoted column name containing escaped quotes', () => {
+    const error = { code: '42703', message: 'column "a""b" does not exist', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'ColumnNotFound',
+      column: 'a"b',
       originalCode: error.code,
       originalMessage: error.message,
     })

--- a/packages/adapter-pg/src/errors.ts
+++ b/packages/adapter-pg/src/errors.ts
@@ -136,11 +136,16 @@ function mapDriverError(error: DatabaseError): MappedError {
         kind: 'TableDoesNotExist',
         table: error.message.split(' ').at(1)?.split('"').at(1),
       }
-    case '42703':
+    case '42703': {
+      const rawColumn = error.message.match(/^column (.+) does not exist$/)?.at(1)
       return {
         kind: 'ColumnNotFound',
-        column: error.message.split(' ').at(1)?.split('"').at(1),
+        column: rawColumn
+          ?.split('.')
+          .map((s) => (s.startsWith('"') ? s.replace(/^"|"$/g, '').replaceAll('""', '"') : s))
+          .join('.'),
       }
+    }
     case '42P04':
       return {
         kind: 'DatabaseAlreadyExists',

--- a/packages/adapter-pg/src/errors.ts
+++ b/packages/adapter-pg/src/errors.ts
@@ -140,10 +140,7 @@ function mapDriverError(error: DatabaseError): MappedError {
       const rawColumn = error.message.match(/^column (.+) does not exist$/)?.at(1)
       return {
         kind: 'ColumnNotFound',
-        column: rawColumn
-          ?.split('.')
-          .map((s) => (s.startsWith('"') ? s.replace(/^"|"$/g, '').replaceAll('""', '"') : s))
-          .join('.'),
+        column: rawColumn?.replace(/"((?:""|[^"])*)"/g, (_, id) => id.replaceAll('""', '"')),
       }
     }
     case '42P04':


### PR DESCRIPTION
This pull request improves the handling and testing of PostgreSQL "ColumnNotFound" errors in the adapter. The main focus is on correctly extracting column names from error messages, regardless of whether the column name is quoted, and ensuring the tests cover both scenarios.

We were getting "The column `(not available)` does not exist in the current database" error all the time, the sql was trying to get qualified name (e.g. schema.table_name) which generated postgres error message without quotes:
`column table.column does not exist` vs `column "column" does not exist`.
Our setup included:
- multi-schema DB
- custom @@map() fields.
- Postgres v18.3

Error handling improvements:

* Updated the `mapDriverError` function in `errors.ts` to strip quotes from column names when parsing "ColumnNotFound" (42703) errors, ensuring consistent extraction of the column name.

Testing enhancements:

* Added a new test case for handling unquoted column names and clarified the description of the existing test for quoted column names in `errors.test.ts`, ensuring both cases are covered for "ColumnNotFound" errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and normalization of PostgreSQL "column not found" errors so column names are identified correctly for unquoted, quoted, qualified, spaced, and escaped-quote formats, providing clearer, consistent error details.

* **Tests**
  * Added comprehensive tests covering many column-name formats to ensure accurate detection and unchanged original error messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->