### PR TITLE
fix(adapter-pg): transform prisma+postgres://localhost URLs for local...

### DIFF
--- a/packages/adapter-pg/src/__tests__/pg.test.ts
+++ b/packages/adapter-pg/src/__tests__/pg.test.ts
@@ -4,6 +4,58 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { PrismaPgAdapterFactory } from '../pg'
 
+describe('PrismaPgAdapterFactory URL transformation', () => {
+  it('should transform prisma+postgres://localhost URLs to postgres:// URLs', () => {
+    const config: pg.PoolConfig = {
+      connectionString: 'prisma+postgres://localhost:51216/?api_key=test123',
+    }
+    const factory = new PrismaPgAdapterFactory(config)
+    // The factory should transform the URL internally
+    expect(factory).toBeDefined()
+  })
+
+  it('should transform prisma+postgres://127.0.0.1 URLs to postgres:// URLs', () => {
+    const config: pg.PoolConfig = {
+      connectionString: 'prisma+postgres://127.0.0.1:5432/mydb',
+    }
+    const factory = new PrismaPgAdapterFactory(config)
+    expect(factory).toBeDefined()
+  })
+
+  it('should transform prisma+postgres://[::1] URLs to postgres:// URLs', () => {
+    const config: pg.PoolConfig = {
+      connectionString: 'prisma+postgres://[::1]:5432/mydb',
+    }
+    const factory = new PrismaPgAdapterFactory(config)
+    expect(factory).toBeDefined()
+  })
+
+  it('should throw error for remote prisma+postgres:// URLs (Accelerate)', () => {
+    const config: pg.PoolConfig = {
+      connectionString: 'prisma+postgres://accelerate.prisma-data.net/db?api_key=test123',
+    }
+    expect(() => new PrismaPgAdapterFactory(config)).toThrow(
+      'The "prisma+postgres://" protocol is not supported by @prisma/adapter-pg',
+    )
+  })
+
+  it('should leave standard postgres:// URLs unchanged', () => {
+    const config: pg.PoolConfig = {
+      connectionString: 'postgres://user:password@localhost:5432/mydb',
+    }
+    const factory = new PrismaPgAdapterFactory(config)
+    expect(factory).toBeDefined()
+  })
+
+  it('should leave standard postgresql:// URLs unchanged', () => {
+    const config: pg.PoolConfig = {
+      connectionString: 'postgresql://user:password@localhost:5432/mydb',
+    }
+    const factory = new PrismaPgAdapterFactory(config)
+    expect(factory).toBeDefined()
+  })
+})
+
 describe('PrismaPgAdapterFactory', () => {
   it('should subscribe to pool error events', async () => {
     const config: pg.PoolConfig = { user: 'test', password: 'test', database: 'test', port: 5432, host: 'localhost' }

--- a/packages/adapter-pg/src/__tests__/pg.test.ts
+++ b/packages/adapter-pg/src/__tests__/pg.test.ts
@@ -5,29 +5,44 @@ import { describe, expect, it, vi } from 'vitest'
 import { PrismaPgAdapterFactory } from '../pg'
 
 describe('PrismaPgAdapterFactory URL transformation', () => {
-  it('should transform prisma+postgres://localhost URLs to postgres:// URLs', () => {
+  // Helper to create a base64url-encoded api_key payload matching the local PPg format
+  function encodeApiKey(databaseUrl: string, shadowDatabaseUrl = databaseUrl): string {
+    return Buffer.from(JSON.stringify({ databaseUrl, shadowDatabaseUrl })).toString('base64url')
+  }
+
+  it('should extract databaseUrl from api_key for prisma+postgres://localhost URLs', () => {
+    const apiKey = encodeApiKey('postgres://localhost:51216/postgres')
     const config: pg.PoolConfig = {
-      connectionString: 'prisma+postgres://localhost:51216/?api_key=test123',
+      connectionString: `prisma+postgres://localhost:51216/?api_key=${apiKey}`,
     }
     const factory = new PrismaPgAdapterFactory(config)
-    // The factory should transform the URL internally
-    expect(factory).toBeDefined()
+    expect(factory['config'].connectionString).toBe('postgres://localhost:51216/postgres')
   })
 
-  it('should transform prisma+postgres://127.0.0.1 URLs to postgres:// URLs', () => {
+  it('should extract databaseUrl from api_key for prisma+postgres://127.0.0.1 URLs', () => {
+    const apiKey = encodeApiKey('postgres://127.0.0.1:5432/mydb')
     const config: pg.PoolConfig = {
-      connectionString: 'prisma+postgres://127.0.0.1:5432/mydb',
+      connectionString: `prisma+postgres://127.0.0.1:5432/mydb?api_key=${apiKey}`,
     }
     const factory = new PrismaPgAdapterFactory(config)
-    expect(factory).toBeDefined()
+    expect(factory['config'].connectionString).toBe('postgres://127.0.0.1:5432/mydb')
   })
 
-  it('should transform prisma+postgres://[::1] URLs to postgres:// URLs', () => {
+  it('should extract databaseUrl from api_key for prisma+postgres://[::1] URLs', () => {
+    const apiKey = encodeApiKey('postgres://[::1]:5432/mydb')
     const config: pg.PoolConfig = {
-      connectionString: 'prisma+postgres://[::1]:5432/mydb',
+      connectionString: `prisma+postgres://[::1]:5432/mydb?api_key=${apiKey}`,
     }
     const factory = new PrismaPgAdapterFactory(config)
-    expect(factory).toBeDefined()
+    expect(factory['config'].connectionString).toBe('postgres://[::1]:5432/mydb')
+  })
+
+  it('should fall back to simple URL transformation when api_key is not a valid payload', () => {
+    const config: pg.PoolConfig = {
+      connectionString: 'prisma+postgres://localhost:51216/?api_key=plain-text-key',
+    }
+    const factory = new PrismaPgAdapterFactory(config)
+    expect(factory['config'].connectionString).toBe('postgres://localhost:51216/postgres')
   })
 
   it('should throw error for remote prisma+postgres:// URLs (Accelerate)', () => {
@@ -44,7 +59,7 @@ describe('PrismaPgAdapterFactory URL transformation', () => {
       connectionString: 'postgres://user:password@localhost:5432/mydb',
     }
     const factory = new PrismaPgAdapterFactory(config)
-    expect(factory).toBeDefined()
+    expect(factory['config'].connectionString).toBe('postgres://user:password@localhost:5432/mydb')
   })
 
   it('should leave standard postgresql:// URLs unchanged', () => {
@@ -52,7 +67,7 @@ describe('PrismaPgAdapterFactory URL transformation', () => {
       connectionString: 'postgresql://user:password@localhost:5432/mydb',
     }
     const factory = new PrismaPgAdapterFactory(config)
-    expect(factory).toBeDefined()
+    expect(factory['config'].connectionString).toBe('postgresql://user:password@localhost:5432/mydb')
   })
 })
 

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -292,25 +292,49 @@ function isPrismaPostgresDevUrl(connectionString: string): boolean {
 }
 
 /**
- * Transforms a `prisma+postgres://` URL to a standard `postgres://` URL
+ * The contents of the JSON payload in the `api_key` query string parameter
+ * in local Prisma Postgres connection strings. The `api_key` is a
+ * base64url-encoded JSON object.
+ */
+interface LocalPpgApiKey {
+  databaseUrl: string
+  shadowDatabaseUrl: string
+}
+
+/**
+ * Transforms a local `prisma+postgres://` URL to a standard `postgres://` URL
  * for direct TCP connection with the pg driver.
  *
- * Example: `prisma+postgres://localhost:51216/?api_key=xxx`
- * becomes: `postgres://localhost:51216/postgres?api_key=xxx`
+ * The `api_key` parameter contains a base64url-encoded JSON object with the
+ * actual database connection string. This function decodes it and returns the
+ * embedded `databaseUrl`.
+ *
+ * Example: `prisma+postgres://localhost:51216/?api_key=<base64url-encoded JSON>`
+ * becomes: the `databaseUrl` value from the decoded JSON payload
  */
 function transformPrismaPostgresToPgUrl(connectionString: string): string {
   const url = new URL(connectionString)
+  const apiKey = url.searchParams.get('api_key')
 
-  // Replace prisma+postgres: with postgres:
+  if (apiKey) {
+    try {
+      const json = Buffer.from(apiKey, 'base64url').toString('utf-8')
+      const payload: LocalPpgApiKey = JSON.parse(json)
+      if (payload.databaseUrl) {
+        return payload.databaseUrl
+      }
+    } catch {
+      // If decoding fails, fall through to simple URL transformation
+    }
+  }
+
+  // Fallback: simple protocol replacement for URLs without a valid api_key payload
   const transformedUrl = new URL(url.href.replace(PRISMA_POSTGRES_PROTOCOL, 'postgres:'))
 
-  // Ensure there's a database name (pg driver requires one)
-  // Default to 'postgres' if not specified
   if (!transformedUrl.pathname || transformedUrl.pathname === '/') {
     transformedUrl.pathname = '/postgres'
   }
 
-  // Remove the api_key parameter as it's not used by the pg driver
   transformedUrl.searchParams.delete('api_key')
 
   return transformedUrl.href

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -271,6 +271,51 @@ export class PrismaPgAdapter extends PgQueryable<StdClient> implements SqlDriver
   }
 }
 
+const PRISMA_POSTGRES_PROTOCOL = 'prisma+postgres:'
+
+/**
+ * Checks if the given connection string uses the `prisma+postgres://` protocol
+ * and points to a local development server (localhost, 127.0.0.1, or ::1).
+ */
+function isPrismaPostgresDevUrl(connectionString: string): boolean {
+  if (!connectionString.startsWith(`${PRISMA_POSTGRES_PROTOCOL}//`)) {
+    return false
+  }
+
+  try {
+    const url = new URL(connectionString)
+    const hostname = url.hostname
+    return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Transforms a `prisma+postgres://` URL to a standard `postgres://` URL
+ * for direct TCP connection with the pg driver.
+ *
+ * Example: `prisma+postgres://localhost:51216/?api_key=xxx`
+ * becomes: `postgres://localhost:51216/postgres?api_key=xxx`
+ */
+function transformPrismaPostgresToPgUrl(connectionString: string): string {
+  const url = new URL(connectionString)
+
+  // Replace prisma+postgres: with postgres:
+  const transformedUrl = new URL(url.href.replace(PRISMA_POSTGRES_PROTOCOL, 'postgres:'))
+
+  // Ensure there's a database name (pg driver requires one)
+  // Default to 'postgres' if not specified
+  if (!transformedUrl.pathname || transformedUrl.pathname === '/') {
+    transformedUrl.pathname = '/postgres'
+  }
+
+  // Remove the api_key parameter as it's not used by the pg driver
+  transformedUrl.searchParams.delete('api_key')
+
+  return transformedUrl.href
+}
+
 export class PrismaPgAdapterFactory implements SqlMigrationAwareDriverAdapterFactory {
   readonly provider = 'postgres'
   readonly adapterName = packageName
@@ -286,6 +331,22 @@ export class PrismaPgAdapterFactory implements SqlMigrationAwareDriverAdapterFac
       this.config = poolOrConfig.options
     } else {
       this.externalPool = null
+      // Transform prisma+postgres:// URLs for local development to standard postgres:// URLs
+      if (typeof poolOrConfig.connectionString === 'string') {
+        if (isPrismaPostgresDevUrl(poolOrConfig.connectionString)) {
+          poolOrConfig = {
+            ...poolOrConfig,
+            connectionString: transformPrismaPostgresToPgUrl(poolOrConfig.connectionString),
+          }
+        } else if (poolOrConfig.connectionString.startsWith(`${PRISMA_POSTGRES_PROTOCOL}//`)) {
+          // Remote prisma+postgres:// URLs (Accelerate) are not supported by adapter-pg
+          throw new Error(
+            `The "prisma+postgres://" protocol is not supported by @prisma/adapter-pg. ` +
+              `For remote Prisma Postgres (Accelerate), use @prisma/adapter-ppg or configure accelerateUrl in PrismaClient options. ` +
+              `For local development with "prisma dev", use the DATABASE_URL with a direct postgres:// connection string.`,
+          )
+        }
+      }
       this.config = poolOrConfig
     }
   }


### PR DESCRIPTION
Fixes #29191

## Summary

Users using `npx prisma dev` to create a local Prisma Postgres database receive a connection string with the `prisma+postgres://` protocol (e.g., `prisma+postgres://localhost:51216/?api_key=xxx`). When they try to use this URL with `@prisma/adapter-pg`, the `pg` library fails to connect because it doesn't recognize the `prisma+postgres://` protocol, resulting in a "Connection terminated unexpectedly" error.

This PR adds URL transformation logic to the `PrismaPgAdapterFactory` constructor that:
1. Detects `prisma+postgres://` URLs pointing to localhost (local development servers)
2. Transforms them to standard `postgres://` URLs that the `pg` driver can use
3. Throws a clear error for remote `prisma+postgres://` URLs (Accelerate) with guidance to use `@prisma/adapter-ppg` or `accelerateUrl` instead

## Changes

- **packages/adapter-pg/src/pg.ts**: Added URL transformation logic in `PrismaPgAdapterFactory` constructor
  - Added `isPrismaPostgresDevUrl()` helper to detect local dev URLs
  - Added `transformPrismaPostgresToPgUrl()` to convert `prisma+postgres://` to `postgres://`
  - Transforms local dev URLs automatically, throws error for remote Accelerate URLs
- **packages/adapter-pg/src/__tests__/pg.test.ts**: Added 6 new tests for URL transformation

## Testing

All 41 tests pass including the new URL transformation tests:
- `should transform prisma+postgres://localhost URLs to postgres:// URLs`
- `should transform prisma+postgres://127.0.0.1 URLs to postgres:// URLs`
- `should transform prisma+postgres://[::1] URLs to postgres:// URLs`
- `should throw error for remote prisma+postgres:// URLs (Accelerate)`
- `should leave standard postgres:// URLs unchanged`
- `should leave standard postgresql:// URLs unchanged`

## Diff stats

```
 packages/adapter-pg/src/__tests__/pg.test.ts | 52 ++++++++++++++++++++++++
 packages/adapter-pg/src/pg.ts                | 61 ++++++++++++++++++++++++++++
 2 files changed, 113 insertions(+)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local Prisma Postgres development URLs are automatically converted to standard PostgreSQL format for seamless local usage.
  * Remote Prisma Postgres URLs are explicitly rejected with clear error messages to prevent unsupported remote usage.

* **Tests**
  * Added comprehensive tests covering URL transformation, local credential decoding, fallback behavior, and rejection cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->