### PR TITLE
Bump studio-core dependency to 0.21.1

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -183,7 +183,7 @@
     "@prisma/config": "workspace:*",
     "@prisma/dev": "0.20.0",
     "@prisma/engines": "workspace:*",
-    "@prisma/studio-core": "0.16.3",
+    "@prisma/studio-core": "0.21.1",
     "mysql2": "3.15.3",
     "postgres": "3.4.7"
   },

--- a/packages/cli/src/Studio.ts
+++ b/packages/cli/src/Studio.ts
@@ -4,7 +4,7 @@ import { serve } from '@hono/node-server'
 import type { PrismaConfigInternal } from '@prisma/config'
 import { arg, type Command, format, HelpError, isError } from '@prisma/internals'
 import type { Executor, SequenceExecutor } from '@prisma/studio-core/data'
-import { serializeError, type StudioBFFRequest } from '@prisma/studio-core/data/bff'
+import { type SerializedError, serializeError, type StudioBFFRequest } from '@prisma/studio-core/data/bff'
 import { createMySQL2Executor } from '@prisma/studio-core/data/mysql2'
 import { createNodeSQLiteExecutor } from '@prisma/studio-core/data/node-sqlite'
 import { createPostgresJSExecutor } from '@prisma/studio-core/data/postgresjs'
@@ -347,7 +347,7 @@ ${bold('Examples')}
         const [error, results] = await executor.execute(request.query)
 
         if (error) {
-          return ctx.json([serializeError(error)])
+          return ctx.json([serializeBffError(error)])
         }
 
         return ctx.json([null, results])
@@ -355,25 +355,42 @@ ${bold('Examples')}
 
       if (procedure === 'sequence') {
         if (!('executeSequence' in executor)) {
-          return ctx.json([[serializeError(new Error('Executor does not support sequences'))]])
+          return ctx.json([[serializeBffError(new Error('Executor does not support sequences'))]])
         }
 
         const [[error0, result0], maybeResult1] = await (executor as SequenceExecutor).executeSequence(request.sequence)
 
         if (error0) {
-          return ctx.json([[serializeError(error0)]])
+          return ctx.json([[serializeBffError(error0)]])
         }
 
         const [error1, result1] = maybeResult1 || []
 
         if (error1) {
-          return ctx.json([[null, result0], [serializeError(error1)]])
+          return ctx.json([[null, result0], [serializeBffError(error1)]])
         }
 
         return ctx.json([
           [null, result0],
           [null, result1],
         ])
+      }
+
+      if (procedure === 'sql-lint') {
+        if (!executor.lintSql) {
+          return ctx.json([serializeBffError(new Error('Executor does not support SQL lint'))])
+        }
+
+        const [error, result] = await executor.lintSql({
+          schemaVersion: request.schemaVersion,
+          sql: request.sql,
+        })
+
+        if (error) {
+          return ctx.json([serializeBffError(error)])
+        }
+
+        return ctx.json([null, result])
       }
 
       procedure satisfies undefined
@@ -439,6 +456,54 @@ ${bold('Examples')}
 
 function getUrlBasePath(url: string | undefined, configPath: string | null): string {
   return url ? process.cwd() : configPath ? dirname(configPath) : process.cwd()
+}
+
+function serializeBffError(error: unknown): SerializedError {
+  return getSerializedBffError(error) ?? serializeError(error)
+}
+
+function getSerializedBffError(error: unknown): SerializedError | null {
+  if (isSerializedError(error)) {
+    return error
+  }
+
+  if (!isRecord(error)) {
+    return null
+  }
+
+  const nestedError = error.error
+
+  if (isSerializedError(nestedError)) {
+    return nestedError
+  }
+
+  const rpcSerializedError = error['@@error']
+
+  if (isSerializedError(rpcSerializedError)) {
+    return rpcSerializedError
+  }
+
+  return null
+}
+
+function isSerializedError(error: unknown): error is SerializedError {
+  if (!isRecord(error)) {
+    return false
+  }
+
+  if (typeof error.name !== 'string' || typeof error.message !== 'string') {
+    return false
+  }
+
+  if (error.errors === undefined) {
+    return true
+  }
+
+  return Array.isArray(error.errors) && error.errors.every(isSerializedError)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
 }
 
 function isAccelerateProtocol(protocol: string): boolean {

--- a/packages/cli/src/__tests__/Studio.vitest.ts
+++ b/packages/cli/src/__tests__/Studio.vitest.ts
@@ -6,10 +6,19 @@ const serveMock = vi.fn(() => ({ close: vi.fn() }))
 const createPostgresJSExecutorMock = vi.fn(() => ({
   execute: vi.fn(),
 }))
-const serializeErrorMock = vi.fn((error: Error) => ({
-  message: error.message,
-  name: error.name,
-}))
+const serializeErrorMock = vi.fn((error: unknown) => {
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      name: error.name,
+    }
+  }
+
+  return {
+    message: JSON.stringify(error),
+    name: 'UnknownError',
+  }
+})
 
 vi.mock('mysql2/promise', () => {
   return {
@@ -150,17 +159,10 @@ describe('Studio BFF', () => {
       ]),
     )
 
-    createPostgresJSExecutorMock.mockReturnValueOnce({
+    await startStudioBff({
       execute: vi.fn(),
       lintSql: lintSqlMock,
     })
-
-    const { Studio } = await import('../Studio')
-
-    await Studio.new().parse(
-      ['--browser', 'none', '--port', '5555', '--url', 'postgresql://user:password@localhost:5432/db'],
-      defaultTestConfig(),
-    )
 
     const response = await getBffResponse({
       procedure: 'sql-lint',
@@ -182,7 +184,7 @@ describe('Studio BFF', () => {
   })
 
   test('unwraps RPC-serialized sql-lint errors', async () => {
-    createPostgresJSExecutorMock.mockReturnValueOnce({
+    await startStudioBff({
       execute: vi.fn(),
       lintSql: vi.fn(() =>
         Promise.resolve([
@@ -196,13 +198,6 @@ describe('Studio BFF', () => {
       ),
     })
 
-    const { Studio } = await import('../Studio')
-
-    await Studio.new().parse(
-      ['--browser', 'none', '--port', '5555', '--url', 'postgresql://user:password@localhost:5432/db'],
-      defaultTestConfig(),
-    )
-
     const response = await getBffResponse({
       procedure: 'sql-lint',
       schemaVersion: 'v1',
@@ -214,6 +209,91 @@ describe('Studio BFF', () => {
       {
         message: 'relation "missing_table" does not exist',
         name: 'PostgresError',
+      },
+    ])
+  })
+
+  test('passes through top-level serialized sql-lint errors', async () => {
+    await startStudioBff({
+      execute: vi.fn(),
+      lintSql: vi.fn(() =>
+        Promise.resolve([
+          {
+            message: 'syntax error at or near "from"',
+            name: 'PostgresError',
+          },
+        ]),
+      ),
+    })
+
+    const response = await getBffResponse({
+      procedure: 'sql-lint',
+      schemaVersion: 'v1',
+      sql: 'select from',
+    })
+
+    expect(serializeErrorMock).not.toHaveBeenCalled()
+    expect(await response.json()).toEqual([
+      {
+        message: 'syntax error at or near "from"',
+        name: 'PostgresError',
+      },
+    ])
+  })
+
+  test('unwraps nested serialized sql-lint errors', async () => {
+    await startStudioBff({
+      execute: vi.fn(),
+      lintSql: vi.fn(() =>
+        Promise.resolve([
+          {
+            error: {
+              message: 'relation "users" does not exist',
+              name: 'PostgresError',
+            },
+          },
+        ]),
+      ),
+    })
+
+    const response = await getBffResponse({
+      procedure: 'sql-lint',
+      schemaVersion: 'v1',
+      sql: 'select * from users',
+    })
+
+    expect(serializeErrorMock).not.toHaveBeenCalled()
+    expect(await response.json()).toEqual([
+      {
+        message: 'relation "users" does not exist',
+        name: 'PostgresError',
+      },
+    ])
+  })
+
+  test('falls back to serializeError for unknown sql-lint error shapes', async () => {
+    await startStudioBff({
+      execute: vi.fn(),
+      lintSql: vi.fn(() =>
+        Promise.resolve([
+          {
+            message: 'missing name field',
+          } as never,
+        ]),
+      ),
+    })
+
+    const response = await getBffResponse({
+      procedure: 'sql-lint',
+      schemaVersion: 'v1',
+      sql: 'select 1',
+    })
+
+    expect(serializeErrorMock).toHaveBeenCalledTimes(1)
+    expect(await response.json()).toEqual([
+      {
+        message: '{"message":"missing name field"}',
+        name: 'UnknownError',
       },
     ])
   })
@@ -234,5 +314,16 @@ async function getBffResponse(body: unknown): Promise<Response> {
       },
       method: 'POST',
     }),
+  )
+}
+
+async function startStudioBff(executor: { execute: ReturnType<typeof vi.fn>; lintSql?: ReturnType<typeof vi.fn> }) {
+  createPostgresJSExecutorMock.mockReturnValueOnce(executor)
+
+  const { Studio } = await import('../Studio')
+
+  await Studio.new().parse(
+    ['--browser', 'none', '--port', '5555', '--url', 'postgresql://user:password@localhost:5432/db'],
+    defaultTestConfig(),
   )
 }

--- a/packages/cli/src/__tests__/Studio.vitest.ts
+++ b/packages/cli/src/__tests__/Studio.vitest.ts
@@ -2,6 +2,14 @@ import { defaultTestConfig } from '@prisma/config'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 const createPoolMock = vi.fn(() => ({ end: vi.fn() }))
+const serveMock = vi.fn(() => ({ close: vi.fn() }))
+const createPostgresJSExecutorMock = vi.fn(() => ({
+  execute: vi.fn(),
+}))
+const serializeErrorMock = vi.fn((error: Error) => ({
+  message: error.message,
+  name: error.name,
+}))
 
 vi.mock('mysql2/promise', () => {
   return {
@@ -11,7 +19,7 @@ vi.mock('mysql2/promise', () => {
 
 vi.mock('@hono/node-server', () => {
   return {
-    serve: vi.fn(() => ({ close: vi.fn() })),
+    serve: serveMock,
   }
 })
 
@@ -25,7 +33,7 @@ vi.mock('@prisma/studio-core/data/mysql2', () => {
 
 vi.mock('@prisma/studio-core/data/bff', () => {
   return {
-    serializeError: vi.fn(() => ({ message: 'mock-error' })),
+    serializeError: serializeErrorMock,
   }
 })
 
@@ -39,9 +47,7 @@ vi.mock('@prisma/studio-core/data/node-sqlite', () => {
 
 vi.mock('@prisma/studio-core/data/postgresjs', () => {
   return {
-    createPostgresJSExecutor: vi.fn(() => ({
-      execute: vi.fn(),
-    })),
+    createPostgresJSExecutor: createPostgresJSExecutorMock,
   }
 })
 
@@ -49,6 +55,9 @@ describe('Studio MySQL URL compatibility', () => {
   beforeEach(() => {
     vi.resetModules()
     createPoolMock.mockClear()
+    createPostgresJSExecutorMock.mockClear()
+    serveMock.mockClear()
+    serializeErrorMock.mockClear()
   })
 
   test('converts sslaccept=strict to mysql2 ssl JSON', async () => {
@@ -120,3 +129,110 @@ describe('Studio MySQL URL compatibility', () => {
     expect(passedUrl.searchParams.get('ssl')).toBe('{"rejectUnauthorized":false}')
   })
 })
+
+describe('Studio BFF', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    createPoolMock.mockClear()
+    createPostgresJSExecutorMock.mockClear()
+    serveMock.mockClear()
+    serializeErrorMock.mockClear()
+  })
+
+  test('routes sql-lint requests to executor.lintSql', async () => {
+    const lintSqlMock = vi.fn(() =>
+      Promise.resolve([
+        null,
+        {
+          diagnostics: [{ from: 0, message: 'lint-ok', severity: 'info', to: 1 }],
+          schemaVersion: 'v1',
+        },
+      ]),
+    )
+
+    createPostgresJSExecutorMock.mockReturnValueOnce({
+      execute: vi.fn(),
+      lintSql: lintSqlMock,
+    })
+
+    const { Studio } = await import('../Studio')
+
+    await Studio.new().parse(
+      ['--browser', 'none', '--port', '5555', '--url', 'postgresql://user:password@localhost:5432/db'],
+      defaultTestConfig(),
+    )
+
+    const response = await getBffResponse({
+      procedure: 'sql-lint',
+      schemaVersion: 'v1',
+      sql: 'select 1',
+    })
+
+    expect(lintSqlMock).toHaveBeenCalledWith({
+      schemaVersion: 'v1',
+      sql: 'select 1',
+    })
+    expect(await response.json()).toEqual([
+      null,
+      {
+        diagnostics: [{ from: 0, message: 'lint-ok', severity: 'info', to: 1 }],
+        schemaVersion: 'v1',
+      },
+    ])
+  })
+
+  test('unwraps RPC-serialized sql-lint errors', async () => {
+    createPostgresJSExecutorMock.mockReturnValueOnce({
+      execute: vi.fn(),
+      lintSql: vi.fn(() =>
+        Promise.resolve([
+          {
+            '@@error': {
+              message: 'relation "missing_table" does not exist',
+              name: 'PostgresError',
+            },
+          },
+        ]),
+      ),
+    })
+
+    const { Studio } = await import('../Studio')
+
+    await Studio.new().parse(
+      ['--browser', 'none', '--port', '5555', '--url', 'postgresql://user:password@localhost:5432/db'],
+      defaultTestConfig(),
+    )
+
+    const response = await getBffResponse({
+      procedure: 'sql-lint',
+      schemaVersion: 'v1',
+      sql: 'select * from missing_table',
+    })
+
+    expect(serializeErrorMock).not.toHaveBeenCalled()
+    expect(await response.json()).toEqual([
+      {
+        message: 'relation "missing_table" does not exist',
+        name: 'PostgresError',
+      },
+    ])
+  })
+})
+
+async function getBffResponse(body: unknown): Promise<Response> {
+  const fetchHandler = serveMock.mock.calls.at(-1)?.[0]?.fetch as ((request: Request) => Promise<Response>) | undefined
+
+  if (!fetchHandler) {
+    throw new Error('Studio server fetch handler was not registered')
+  }
+
+  return fetchHandler(
+    new Request('http://localhost:5555/bff', {
+      body: JSON.stringify(body),
+      headers: {
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    }),
+  )
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -431,8 +431,8 @@ importers:
         specifier: workspace:*
         version: link:../engines
       '@prisma/studio-core':
-        specifier: 0.16.3
-        version: 0.16.3
+        specifier: 0.21.1
+        version: 0.21.1
       mysql2:
         specifier: 3.15.3
         version: 3.15.3
@@ -3590,8 +3590,8 @@ packages:
   '@prisma/schema-engine-wasm@7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919':
     resolution: {integrity: sha512-v7E/pxOvzJyILTK5ZvBs7fLjcoFPG2t6BdnAsfKIZtQZlQz7TyTC3kkZvcigtnV/6/ktVOsd0RQFIk0rD4e5lg==}
 
-  '@prisma/studio-core@0.16.3':
-    resolution: {integrity: sha512-mlORrIeF2GwshPqRR6Oho3b4GC9oupTjWu0R09qosjtORfihgYoJmW201Yvnyj99wZRz+vw9NnS9pH6LQ5Dx5w==}
+  '@prisma/studio-core@0.21.1':
+    resolution: {integrity: sha512-bOGqG/eMQtKC0XVvcVLRmhWWzm/I+0QUWqAEhEBtetpuS3k3V4IWqKGUONkAIT223DNXJMxMtZp36b1FmcdPeg==}
     engines: {node: ^20.19 || ^22.12 || ^24.0, pnpm: '8'}
     peerDependencies:
       '@types/react': ^18.0.0 || ^19.0.0
@@ -10084,7 +10084,7 @@ snapshots:
 
   '@prisma/schema-engine-wasm@7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919': {}
 
-  '@prisma/studio-core@0.16.3': {}
+  '@prisma/studio-core@0.21.1': {}
 
   '@redocly/ajv@8.17.1':
     dependencies:


### PR DESCRIPTION
Summary
- update `@prisma/studio-core` in `packages/cli` and the lockfile to the new `0.21.1` release so Studio pulls the latest bundle
- Adapted BFF to support SQL linting
- refresh lockfile metadata so downstream installs resolve the updated package version

Studio Features
- More intuitive filtering
- Filter by SQL
- fulltext search across all columns
- SQL Query tab

## BFF changes

Implemented the CLI-side BFF extension needed for newer Studio SQL linting.

What changed:
- Added support for the `sql-lint` BFF procedure in `packages/cli/src/Studio.ts`
- Forwarded `sql-lint` requests to `executor.lintSql(...)` when the executor supports it
- Kept an explicit fallback for executors that do not implement SQL lint
- Improved BFF error normalization so already-serialized upstream errors are passed through unchanged, including RPC envelopes like `{"@@error": ...}`

Why this is needed:
- `@prisma/studio-core` now sends SQL lint requests through the BFF as `procedure: "sql-lint"`
- Without handling that procedure in the CLI, Studio falls through to `Unknown procedure`
- Some upstream failures arrive as serialized RPC error envelopes rather than native `Error` instances, so the CLI needs to unwrap those instead of turning them into generic fallback errors

Result:
- SQL query linting works through the CLI BFF
- When linting fails, Studio now gets the real database error payload instead of a generic `Unknown procedure` or fallback error

Validation:
- Added focused Vitest coverage for:
  - routing `sql-lint` requests through the BFF
  - unwrapping `@@error`-serialized failures
- `pnpm --filter prisma test src/__tests__/Studio.vitest.ts` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-side SQL linting for the Studio backend endpoint.
* **Bug Fixes**
  * Standardized BFF-style error formatting and unwrapping for more consistent backend error responses.
* **Tests**
  * New tests for the SQL lint flow, error-unwrapping behavior, and related server-side handling.
* **Chores**
  * Updated dependency versions for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->