### PR TITLE
fix: fix DATE cursor comparison

### DIFF
--- a/packages/client-engine-runtime/src/interpreter/render-query.ts
+++ b/packages/client-engine-runtime/src/interpreter/render-query.ts
@@ -48,7 +48,17 @@ export function evaluateArg(arg: unknown, scope: ScopeBindings, generators: Gene
       if (found === undefined) {
         throw new Error(`Missing value for query variable ${arg.prisma__value.name}`)
       }
-      arg = found
+      if (arg.prisma__value.type === 'DateTime' && typeof found === 'string') {
+        // Convert input datetime strings to Date objects. This is done to prevent issues that
+        // arise when query input values end up being directly compared to values retrieved from
+        // the database. One example of this is a query containing a DateTime cursor value being
+        // used against a DATE MySQL column. The pagination logic doesn't have parameter type
+        // information, therefore it ends up comparing the two datetimes as strings and would yield
+        // false even if the two date datetime strings represent the same Date.
+        arg = new Date(found)
+      } else {
+        arg = found
+      }
     } else if (isPrismaValueGenerator(arg)) {
       const { name, args } = arg.prisma__value
       const generator = generators[name]

--- a/packages/client/tests/functional/issues/29309-datetime-cursor/_matrix.ts
+++ b/packages/client/tests/functional/issues/29309-datetime-cursor/_matrix.ts
@@ -1,0 +1,4 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+import { Providers, sqlProviders } from '../../_utils/providers'
+
+export default defineMatrix(() => [sqlProviders.filter(({ provider }) => provider !== Providers.SQLITE)])

--- a/packages/client/tests/functional/issues/29309-datetime-cursor/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/29309-datetime-cursor/prisma/_schema.ts
@@ -1,0 +1,21 @@
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+    generator client {
+      provider = "prisma-client-js"
+    }
+
+    datasource db {
+      provider = "${provider}"
+    }
+
+    model Event {
+      appId     Int
+      createdAt DateTime @db.Date
+      value     Int
+
+      @@id([appId, createdAt])
+    }
+  `
+})

--- a/packages/client/tests/functional/issues/29309-datetime-cursor/tests.ts
+++ b/packages/client/tests/functional/issues/29309-datetime-cursor/tests.ts
@@ -11,7 +11,7 @@ testMatrix.setupTestSuite(
       for (let day = 1; day <= 10; day++) {
         rows.push({
           appId: 1,
-          createdAt: new Date(`2025-01-${String(day).padStart(2, '0')}`),
+          createdAt: new Date(`2025-01-${String(day).padStart(2, '0')}Z`),
           value: day * 100,
         })
       }

--- a/packages/client/tests/functional/issues/29309-datetime-cursor/tests.ts
+++ b/packages/client/tests/functional/issues/29309-datetime-cursor/tests.ts
@@ -1,0 +1,65 @@
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { Event, PrismaClient } from './generated/prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(
+  () => {
+    test('retrieves a cursor against a DATE column', async () => {
+      const rows: Event[] = []
+      for (let day = 1; day <= 10; day++) {
+        rows.push({
+          appId: 1,
+          createdAt: new Date(`2025-01-${String(day).padStart(2, '0')}`),
+          value: day * 100,
+        })
+      }
+      await prisma.event.createMany({ data: rows })
+
+      const firstThree = await prisma.event.findMany({
+        where: { appId: 1 },
+        orderBy: { createdAt: 'asc' },
+        take: 3,
+      })
+      const cursorRow = firstThree[2] // 2025-01-03
+
+      const withCursor = await prisma.event.findMany({
+        where: { appId: 1 },
+        cursor: {
+          appId_createdAt: {
+            appId: cursorRow.appId,
+            createdAt: cursorRow.createdAt,
+          },
+        },
+        orderBy: { createdAt: 'asc' },
+        take: 3,
+        skip: 1,
+      })
+
+      expect(withCursor).toEqual([
+        {
+          appId: 1,
+          createdAt: new Date('2025-01-04T00:00:00.000Z'),
+          value: 400,
+        },
+        {
+          appId: 1,
+          createdAt: new Date('2025-01-05T00:00:00.000Z'),
+          value: 500,
+        },
+        {
+          appId: 1,
+          createdAt: new Date('2025-01-06T00:00:00.000Z'),
+          value: 600,
+        },
+      ])
+    })
+  },
+  {
+    optOut: {
+      from: ['mongodb', 'sqlite'],
+      reason: 'MongoDB and SQLite do not support DATE columns',
+    },
+  },
+)


### PR DESCRIPTION
[TML-2059](https://linear.app/prisma-company/issue/TML-2059/fix-a-datetime-compound-cursor-issue)

Fixes https://github.com/prisma/prisma/issues/29309

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed DateTime parameter handling so string values that represent dates are converted to Date objects during query resolution, preventing string-vs-date comparison issues.

* **Tests**
  * Added functional tests for cursor-based pagination on DateTime columns (including composite key scenarios).
  * Added test matrix/schema setup and provider filtering to run the new tests while excluding engines that lack DATE support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->