### PR TITLE
fix(adapter-better-sqlite3): support positional and named parameter b…

### DIFF
--- a/packages/adapter-better-sqlite3/src/better-sqlite3.test.ts
+++ b/packages/adapter-better-sqlite3/src/better-sqlite3.test.ts
@@ -1,0 +1,161 @@
+import { IsolationLevel, SqlMigrationAwareDriverAdapterFactory } from '@prisma/driver-adapter-utils'
+import { describe, expect, test } from 'vitest'
+
+import { PrismaBetterSqlite3AdapterFactory } from './better-sqlite3'
+
+describe.each([
+  (factory: SqlMigrationAwareDriverAdapterFactory) => factory.connect(),
+  (factory: SqlMigrationAwareDriverAdapterFactory) => factory.connectToShadowDb(),
+])('behavior of the adapter with "%s"', (connect) => {
+  test('executes and parses simple queries', async () => {
+    const factory = new PrismaBetterSqlite3AdapterFactory({ url: ':memory:' })
+    const conn = await connect(factory)
+
+    await expect(
+      conn.queryRaw({
+        sql: 'SELECT ? as col1, ? as col2',
+        args: [1, 'str'],
+        argTypes: [
+          { arity: 'scalar', scalarType: 'int' },
+          { arity: 'scalar', scalarType: 'string' },
+        ],
+      }),
+    ).resolves.toMatchObject({
+      columnNames: ['col1', 'col2'],
+      rows: [[1, 'str']],
+    })
+  })
+
+  test('executes and parses simple statements', async () => {
+    const factory = new PrismaBetterSqlite3AdapterFactory({ url: ':memory:' })
+    const conn = await connect(factory)
+
+    await expect(
+      conn.executeRaw({
+        sql: 'CREATE TABLE test (id TEXT PRIMARY KEY, name TEXT)',
+        args: [],
+        argTypes: [],
+      }),
+    ).resolves.toBe(0)
+
+    await expect(
+      conn.executeRaw({
+        sql: 'INSERT INTO test (id, name) VALUES (?, ?)',
+        args: ['1', 'John'],
+        argTypes: [
+          { arity: 'scalar', scalarType: 'string' },
+          { arity: 'scalar', scalarType: 'string' },
+        ],
+      }),
+    ).resolves.toBe(1)
+
+    await expect(
+      conn.queryRaw({
+        sql: 'SELECT * FROM test',
+        args: [],
+        argTypes: [],
+      }),
+    ).resolves.toMatchObject({ rows: [['1', 'John']] })
+  })
+
+  test('supports positional ?N parameter bindings', async () => {
+    const factory = new PrismaBetterSqlite3AdapterFactory({ url: ':memory:' })
+    const conn = await connect(factory)
+
+    await conn.executeScript(`
+      CREATE TABLE test (id TEXT PRIMARY KEY, email TEXT);
+      INSERT INTO test VALUES ('alice', 'alice@example.com');
+      INSERT INTO test VALUES ('bob', 'bob@example.com');
+      INSERT INTO test VALUES ('adam', 'adam@example.net');
+    `)
+
+    await expect(
+      conn.queryRaw({
+        sql: "SELECT id FROM test WHERE id LIKE ?1 OR email LIKE ?1 ORDER BY id",
+        args: ['a%'],
+        argTypes: [{ arity: 'scalar', scalarType: 'string' }],
+      }),
+    ).resolves.toMatchObject({
+      rows: [['adam'], ['alice']],
+    })
+  })
+
+  test('supports named :param parameter bindings with a single reused name', async () => {
+    const factory = new PrismaBetterSqlite3AdapterFactory({ url: ':memory:' })
+    const conn = await connect(factory)
+
+    await conn.executeScript(`
+      CREATE TABLE test (id TEXT PRIMARY KEY, email TEXT);
+      INSERT INTO test VALUES ('alice', 'alice@example.com');
+      INSERT INTO test VALUES ('bob', 'bob@example.com');
+      INSERT INTO test VALUES ('adam', 'adam@example.net');
+    `)
+
+    await expect(
+      conn.queryRaw({
+        sql: "SELECT id FROM test WHERE id = :name OR email LIKE :name ORDER BY id",
+        args: ['alice'],
+        argTypes: [{ arity: 'scalar', scalarType: 'string' }],
+      }),
+    ).resolves.toMatchObject({
+      rows: [['alice']],
+    })
+  })
+
+  test('supports named :param bindings with multiple distinct parameters', async () => {
+    const factory = new PrismaBetterSqlite3AdapterFactory({ url: ':memory:' })
+    const conn = await connect(factory)
+
+    await conn.executeScript(`
+      CREATE TABLE test (id TEXT PRIMARY KEY, email TEXT);
+      INSERT INTO test VALUES ('alice', 'alice@example.com');
+      INSERT INTO test VALUES ('bob', 'bob@example.net');
+      INSERT INTO test VALUES ('adam', 'adam@example.com');
+    `)
+
+    await expect(
+      conn.queryRaw({
+        sql: "SELECT id FROM test WHERE id = :username OR email LIKE '%@' || :domain ORDER BY id",
+        args: ['bob', 'example.com'],
+        argTypes: [
+          { arity: 'scalar', scalarType: 'string' },
+          { arity: 'scalar', scalarType: 'string' },
+        ],
+      }),
+    ).resolves.toMatchObject({
+      rows: [['adam'], ['alice'], ['bob']],
+    })
+  })
+
+  test('query errors get converted to DriverAdapterError', async () => {
+    const factory = new PrismaBetterSqlite3AdapterFactory({ url: ':memory:' })
+    const conn = await connect(factory)
+
+    await expect(
+      conn.queryRaw({
+        sql: 'SELECT * FROM non_existent_table',
+        args: [],
+        argTypes: [],
+      }),
+    ).rejects.toMatchObject({
+      name: 'DriverAdapterError',
+    })
+  })
+
+  test('rejects unsupported isolation levels', async () => {
+    const factory = new PrismaBetterSqlite3AdapterFactory({ url: ':memory:' })
+    const conn = await connect(factory)
+
+    for (const level of [
+      'READ UNCOMMITTED',
+      'READ COMMITTED',
+      'REPEATABLE READ',
+      'SNAPSHOT',
+    ] satisfies IsolationLevel[]) {
+      await expect(conn.startTransaction(level)).rejects.toMatchObject({
+        name: 'DriverAdapterError',
+        cause: { kind: 'InvalidIsolationLevel' },
+      })
+    }
+  })
+})

--- a/packages/adapter-better-sqlite3/src/better-sqlite3.test.ts
+++ b/packages/adapter-better-sqlite3/src/better-sqlite3.test.ts
@@ -158,4 +158,107 @@ describe.each([
       })
     }
   })
+
+  test('ignores placeholders inside string literals', async () => {
+    const factory = new PrismaBetterSqlite3AdapterFactory({ url: ':memory:' })
+    const conn = await connect(factory)
+
+    await expect(
+      conn.queryRaw({
+        sql: "SELECT '?' as a, ':name' as b, ? as real",
+        args: [42],
+        argTypes: [{ arity: 'scalar', scalarType: 'int' }],
+      }),
+    ).resolves.toMatchObject({
+      rows: [['?', ':name', 42]],
+    })
+  })
+
+  test('ignores placeholders inside quoted identifiers', async () => {
+    const factory = new PrismaBetterSqlite3AdapterFactory({ url: ':memory:' })
+    const conn = await connect(factory)
+
+    await expect(
+      conn.queryRaw({
+        sql: 'SELECT 1 as "col:name", 2 as `a?b`, 3 as [x:y], ? as real',
+        args: [99],
+        argTypes: [{ arity: 'scalar', scalarType: 'int' }],
+      }),
+    ).resolves.toMatchObject({
+      rows: [[1, 2, 3, 99]],
+    })
+  })
+
+  test('ignores placeholders inside comments', async () => {
+    const factory = new PrismaBetterSqlite3AdapterFactory({ url: ':memory:' })
+    const conn = await connect(factory)
+
+    await expect(
+      conn.queryRaw({
+        sql: `
+        -- ? should be ignored
+        /* :name should be ignored */
+        SELECT ? as real
+      `,
+        args: [7],
+        argTypes: [{ arity: 'scalar', scalarType: 'int' }],
+      }),
+    ).resolves.toMatchObject({
+      rows: [[7]],
+    })
+  })
+
+  test('distinguishes between positional $1 and named $param', async () => {
+    const factory = new PrismaBetterSqlite3AdapterFactory({ url: ':memory:' })
+    const conn = await connect(factory)
+
+    await conn.executeScript(`
+    CREATE TABLE test (id TEXT PRIMARY KEY);
+    INSERT INTO test VALUES ('a'), ('b');
+  `)
+
+    await expect(
+      conn.queryRaw({
+        sql: 'SELECT id FROM test WHERE id = $1',
+        args: ['a'],
+        argTypes: [{ arity: 'scalar', scalarType: 'string' }],
+      }),
+    ).resolves.toMatchObject({
+      rows: [['a']],
+    })
+  })
+
+  test('rejects mixing positional and named parameters', async () => {
+    const factory = new PrismaBetterSqlite3AdapterFactory({ url: ':memory:' })
+    const conn = await connect(factory)
+
+    await expect(
+      conn.queryRaw({
+        sql: 'SELECT ?1, :name',
+        args: [1, 'test'],
+        argTypes: [
+          { arity: 'scalar', scalarType: 'int' },
+          { arity: 'scalar', scalarType: 'string' },
+        ],
+      }),
+    ).rejects.toThrow()
+  })
+
+  test('handles mixed ordering of positional parameters', async () => {
+  const factory = new PrismaBetterSqlite3AdapterFactory({ url: ':memory:' })
+  const conn = await connect(factory)
+
+  await expect(
+    conn.queryRaw({
+      sql: 'SELECT ?2 as b, ?1 as a',
+      args: ['first', 'second'],
+      argTypes: [
+        { arity: 'scalar', scalarType: 'string' },
+        { arity: 'scalar', scalarType: 'string' },
+      ],
+    }),
+  ).resolves.toMatchObject({
+    rows: [['second', 'first']],
+  })
+})
 })

--- a/packages/adapter-better-sqlite3/src/better-sqlite3.ts
+++ b/packages/adapter-better-sqlite3/src/better-sqlite3.ts
@@ -39,36 +39,202 @@ type BetterSQLite3Meta = {
   lastInsertRowid: number | bigint
 }
 
-function getUnquotedSql(sql: string): string {
-  return sql
-    .replace(/'[^']*'/g, '')
-    .replace(/"[^"]*"/g, '')
-    .replace(/`[^`]*`/g, '')
-    .replace(/\/\*[\s\S]*?\*\//g, '')
-    .replace(/--[^\n]*/g, '')
+type State =
+  | 'normal'
+  | 'single'
+  | 'double'
+  | 'backtick'
+  | 'bracket'
+  | 'lineComment'
+  | 'blockComment'
+
+/**
+ * Scans the SQL string and extracts parameter placeholders while ignoring
+ * strings, identifiers, and comments using a state-machine approach.
+ */
+function scanPlaceholders(sql: string): string[] {
+  const tokens: string[] = []
+
+  let i = 0
+  let state: State = 'normal'
+
+  while (i < sql.length) {
+    const char = sql[i]
+    const next = sql[i + 1]
+
+    if (state === 'normal') {
+      if (char === "'") {
+        state = 'single'
+      } else if (char === '"') {
+        state = 'double'
+      } else if (char === '`') {
+        state = 'backtick'
+      } else if (char === '[') {
+        state = 'bracket'
+      } else if (char === '-' && next === '-') {
+        state = 'lineComment'
+        i++
+      } else if (char === '/' && next === '*') {
+        state = 'blockComment'
+        i++
+      }
+
+      else if (char === '?') {
+        if (next && /\d/.test(next)) {
+          let j = i + 1
+          while (j < sql.length && /\d/.test(sql[j])) j++
+          tokens.push(sql.slice(i, j))
+          i = j - 1
+          continue
+        } else {
+          tokens.push('?')
+          i++
+          continue
+        }
+      }
+
+      else if (char === '$') {
+        if (next && /\d/.test(next)) {
+          let j = i + 1
+          while (j < sql.length && /\d/.test(sql[j])) j++
+          tokens.push(sql.slice(i, j))
+          i = j - 1
+          continue
+        } else if (next && /[a-zA-Z_]/.test(next)) {
+          let j = i + 1
+          while (j < sql.length && /[a-zA-Z0-9_]/.test(sql[j])) j++
+          tokens.push(sql.slice(i, j))
+          i = j - 1
+          continue
+        }
+      }
+      else if ((char === ':' || char === '@') && next && /[a-zA-Z_]/.test(next)) {
+        let j = i + 1
+        while (j < sql.length && /[a-zA-Z0-9_]/.test(sql[j])) j++
+        tokens.push(sql.slice(i, j))
+        i = j - 1
+        continue
+      }
+    }
+
+    else if (state === 'single') {
+      if (char === "'" && next === "'") {
+        i++
+      } else if (char === "'") {
+        state = 'normal'
+      }
+    }
+
+    else if (state === 'double') {
+      if (char === '"' && next === '"') {
+        i++
+      } else if (char === '"') {
+        state = 'normal'
+      }
+    }
+
+    else if (state === 'backtick') {
+      if (char === '`' && next === '`') {
+        i++
+      } else if (char === '`') {
+        state = 'normal'
+      }
+    }
+
+    else if (state === 'bracket') {
+      if (char === ']') {
+        state = 'normal'
+      }
+    }
+
+    else if (state === 'lineComment') {
+      if (char === '\n' || char === '\r') {
+        state = 'normal'
+      }
+    }
+
+    else if (state === 'blockComment') {
+      if (char === '*' && next === '/') {
+        state = 'normal'
+        i++
+      }
+    }
+
+    i++
+  }
+
+  return tokens
 }
 
 /**
- * Transforms args into the correct format for better-sqlite3 based on the parameter binding style in the SQL query.
- * Plain '?' -> array, positional '?N' -> numeric-keyed object, named ':param'/'$param'/'@param' -> named object.
+ * Binds query arguments based on detected placeholder types (anonymous,
+ * positional, or named) to match better-sqlite3's expected input format.
  */
-function bindArgs(sql: string, args: unknown[]): unknown[] | Record<string, unknown> {
-  const unquoted = getUnquotedSql(sql)
+function bindArgs(sql: string, args: unknown[]): unknown[] {
+  const tokens = scanPlaceholders(sql)
 
-  if (/\?\d+/.test(unquoted)) {
-    const indexes = [...unquoted.matchAll(/\?(\d+)/g)].map((match) => match[1])
-    const uniqueIndexes = [...new Set(indexes)]
-    const obj: Record<string, unknown> = {}
-    uniqueIndexes.forEach((index, i) => { obj[index] = args[i] })
-    return obj
+  const hasAnonymous = tokens.includes('?')
+  const hasPositional = tokens.some(t => /^[?$]\d+$/.test(t))
+  const hasNamed = tokens.some(t => /^[:$@][a-zA-Z_]/.test(t))
+
+  if (hasPositional && hasAnonymous) {
+    throw new Error('Mixing positional (?N/$N) and anonymous (?) placeholders is not supported')
   }
 
-  if (/[:$@][a-zA-Z_][a-zA-Z0-9_]*/.test(unquoted)) {
-    const names = [...unquoted.matchAll(/[:$@]([a-zA-Z_][a-zA-Z0-9_]*)/g)].map(m => m[1])
-    const unique = [...new Set(names)]
+  if (hasNamed && hasPositional) {
+    throw new Error('Mixing positional and named placeholders is not supported')
+  }
+
+  if (hasPositional && !hasNamed && !hasAnonymous) {
     const obj: Record<string, unknown> = {}
-    unique.forEach((name, i) => { obj[name] = args[i] })
-    return obj
+    let argIdx = 0
+
+    for (const token of tokens) {
+      if (/^[?$]\d+$/.test(token)) {
+        const index = token.slice(1)
+        if (!(index in obj)) {
+          obj[index] = args[argIdx++]
+        }
+      }
+    }
+
+    return [obj]
+  }
+
+  if (hasNamed && !hasPositional && !hasAnonymous) {
+    const obj: Record<string, unknown> = {}
+    let argIdx = 0
+
+    for (const token of tokens) {
+      if (/^[:$@][a-zA-Z_]/.test(token)) {
+        const name = token.slice(1)
+        if (!(name in obj)) {
+          obj[name] = args[argIdx++]
+        }
+      }
+    }
+
+    return [obj]
+  }
+
+  if (hasNamed && hasAnonymous) {
+    const positionalArgs: unknown[] = []
+    const namedObj: Record<string, unknown> = {}
+
+    let argIdx = 0
+
+    for (const token of tokens) {
+      if (token === '?') {
+        positionalArgs.push(args[argIdx++])
+      } else if (/^[:$@][a-zA-Z_]/.test(token)) {
+        const name = token.slice(1)
+        if (!(name in namedObj)) {
+          namedObj[name] = args[argIdx++]
+        }
+      }
+    }
+
+    return [...positionalArgs, namedObj]
   }
 
   return args
@@ -122,7 +288,7 @@ class BetterSQLite3Queryable<ClientT extends StdClient> implements SqlQueryable 
   private executeIO(query: SqlQuery): Promise<BetterSQLite3Meta> {
     try {
       const args = query.args.map((arg, i) => mapArg(arg, query.argTypes[i], this.adapterOptions))
-      const stmt = this.client.prepare(query.sql).bind(bindArgs(query.sql, args))
+      const stmt = this.client.prepare(query.sql).bind(...bindArgs(query.sql, args))
       const result = stmt.run()
 
       return Promise.resolve(result)
@@ -139,7 +305,7 @@ class BetterSQLite3Queryable<ClientT extends StdClient> implements SqlQueryable 
   private performIO(query: SqlQuery): Promise<BetterSQLite3ResultSet> {
     try {
       const args = query.args.map((arg, i) => mapArg(arg, query.argTypes[i], this.adapterOptions))
-      const stmt = this.client.prepare(query.sql).bind(bindArgs(query.sql, args))
+      const stmt = this.client.prepare(query.sql).bind(...bindArgs(query.sql, args))
 
       // Queries that do not return data (e.g. inserts) cannot call stmt.raw()/stmt.columns(). => Use stmt.run() instead.
       if (!stmt.reader) {

--- a/packages/adapter-better-sqlite3/src/better-sqlite3.ts
+++ b/packages/adapter-better-sqlite3/src/better-sqlite3.ts
@@ -39,6 +39,39 @@ type BetterSQLite3Meta = {
   lastInsertRowid: number | bigint
 }
 
+function getUnquotedSql(sql: string): string {
+  return sql
+    .replace(/'[^']*'/g, '')
+    .replace(/"[^"]*"/g, '')
+    .replace(/`[^`]*`/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/--[^\n]*/g, '')
+}
+
+/**
+ * Transforms args into the correct format for better-sqlite3 based on the parameter binding style in the SQL query.
+ * Plain '?' -> array, positional '?N' -> numeric-keyed object, named ':param' -> named object.
+ */
+function bindArgs(sql: string, args: unknown[]): unknown[] | Record<string, unknown> {
+  const unquoted = getUnquotedSql(sql)
+
+  if (/\?\d+/.test(unquoted)) {
+    const obj: Record<string, unknown> = {}
+    args.forEach((val, i) => { obj[i + 1] = val })
+    return obj
+  }
+
+  if (/[:$@][a-zA-Z_][a-zA-Z0-9_]*/.test(unquoted)) {
+    const names = [...unquoted.matchAll(/[:$@]([a-zA-Z_][a-zA-Z0-9_]*)/g)].map(m => m[1])
+    const unique = [...new Set(names)]
+    const obj: Record<string, unknown> = {}
+    unique.forEach((name, i) => { obj[name] = args[i] })
+    return obj
+  }
+
+  return args
+}
+
 class BetterSQLite3Queryable<ClientT extends StdClient> implements SqlQueryable {
   readonly provider = 'sqlite'
   readonly adapterName = packageName
@@ -46,7 +79,7 @@ class BetterSQLite3Queryable<ClientT extends StdClient> implements SqlQueryable 
   constructor(
     protected readonly client: ClientT,
     protected readonly adapterOptions?: PrismaBetterSqlite3Options,
-  ) {}
+  ) { }
 
   /**
    * Execute a query given as SQL, interpolating the given parameters.
@@ -87,7 +120,7 @@ class BetterSQLite3Queryable<ClientT extends StdClient> implements SqlQueryable 
   private executeIO(query: SqlQuery): Promise<BetterSQLite3Meta> {
     try {
       const args = query.args.map((arg, i) => mapArg(arg, query.argTypes[i], this.adapterOptions))
-      const stmt = this.client.prepare(query.sql).bind(args)
+      const stmt = this.client.prepare(query.sql).bind(bindArgs(query.sql, args))
       const result = stmt.run()
 
       return Promise.resolve(result)
@@ -104,7 +137,7 @@ class BetterSQLite3Queryable<ClientT extends StdClient> implements SqlQueryable 
   private performIO(query: SqlQuery): Promise<BetterSQLite3ResultSet> {
     try {
       const args = query.args.map((arg, i) => mapArg(arg, query.argTypes[i], this.adapterOptions))
-      const stmt = this.client.prepare(query.sql).bind(args)
+      const stmt = this.client.prepare(query.sql).bind(bindArgs(query.sql, args))
 
       // Queries that do not return data (e.g. inserts) cannot call stmt.raw()/stmt.columns(). => Use stmt.run() instead.
       if (!stmt.reader) {

--- a/packages/adapter-better-sqlite3/src/better-sqlite3.ts
+++ b/packages/adapter-better-sqlite3/src/better-sqlite3.ts
@@ -50,14 +50,16 @@ function getUnquotedSql(sql: string): string {
 
 /**
  * Transforms args into the correct format for better-sqlite3 based on the parameter binding style in the SQL query.
- * Plain '?' -> array, positional '?N' -> numeric-keyed object, named ':param' -> named object.
+ * Plain '?' -> array, positional '?N' -> numeric-keyed object, named ':param'/'$param'/'@param' -> named object.
  */
 function bindArgs(sql: string, args: unknown[]): unknown[] | Record<string, unknown> {
   const unquoted = getUnquotedSql(sql)
 
   if (/\?\d+/.test(unquoted)) {
+    const indexes = [...unquoted.matchAll(/\?(\d+)/g)].map((match) => match[1])
+    const uniqueIndexes = [...new Set(indexes)]
     const obj: Record<string, unknown> = {}
-    args.forEach((val, i) => { obj[i + 1] = val })
+    uniqueIndexes.forEach((index, i) => { obj[index] = args[i] })
     return obj
   }
 


### PR DESCRIPTION
# fix(adapter-better-sqlite3): support positional and named parameter bindings

## Problem

Fixes #29324

When using `$queryRawTyped` or `$queryRawUnsafe` with `PrismaBetterSqlite3`, positional (`?N`) and named (`:param`) parameter bindings fail with `Too many parameter values were provided`.

The root cause is in `better-sqlite3.ts` — both `performIO` and `executeIO` always pass args as a plain array to `better-sqlite3`'s `.bind()`:

```ts
const stmt = this.client.prepare(query.sql).bind(args) // always an array
```

This only works for anonymous `?` bindings. `better-sqlite3` requires different formats depending on the binding style:
- Positional `?N` → needs a numeric-keyed object: `{ 1: "alice" }`
- Named `:param` → needs a named object: `{ username: "alice" }`

## Fix

Added a `bindArgs` helper that detects the binding style from the SQL string and transforms args into the correct format before passing to `.bind()`:

- Plain `?` → array (existing behavior, unchanged)
- Positional `?N` → numeric-keyed object
- Named `:param` → named object, with parameter names extracted from the SQL in order

## Tests

Added `better-sqlite3.test.ts` following the pattern of `adapter-libsql/src/libsql.test.ts`, including test cases that directly reproduce all three scenarios from the issue. Note: `vitest` will need to be added as a dev dependency to this package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for the SQLite adapter covering queries, statements, multi-row scripts, positional and named parameter bindings, error propagation, and rejection of unsupported transaction isolation levels.

* **Improvements**
  * Enhanced parameter binding to support multiple SQL placeholder styles and mixed bindings.
  * More consistent error reporting for query failures and invalid isolation level requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->