### PR TITLE
fix(migrate): avoid recreating indexes for Prisma 6 m-n upgrade

### DIFF
--- a/packages/migrate/src/Migrate.ts
+++ b/packages/migrate/src/Migrate.ts
@@ -101,6 +101,7 @@ export class Migrate {
       extension,
       migrationName: generatedMigrationName,
       script: migrationScript,
+      connectorType,
     }).catch((e: Error) => {
       throw new Error(`Failed to write migration script to ${directoryPath}: ${e.message}`)
     })

--- a/packages/migrate/src/commands/MigrateDiff.ts
+++ b/packages/migrate/src/commands/MigrateDiff.ts
@@ -22,6 +22,7 @@ import { Migrate } from '../Migrate'
 import type { EngineArgs, EngineResults } from '../types'
 import { CaptureStdout } from '../utils/captureStdout'
 import { listMigrations } from '../utils/listMigrations'
+import { transformPostgresMnPrimaryKeyUpgrade } from '../utils/transformMigrationScript'
 
 const debug = Debug('prisma:migrate:diff')
 
@@ -295,12 +296,17 @@ ${bold('Examples')}
       await migrate.stop()
     }
 
-    // Write output to file if --output is defined
     if (isOutputDefined) {
       captureStdout.stopCapture()
-      const diffOutput = captureStdout.getCapturedText()
+      let output = captureStdout.getCapturedText().join('')
       captureStdout.clearCaptureText()
-      await fs.writeAsync(outputPath!, diffOutput.join('\n'))
+      if (args['--script']) {
+        const url = config.datasource?.url ?? ''
+        if (url.startsWith('postgresql://') || url.startsWith('postgres://')) {
+          output = transformPostgresMnPrimaryKeyUpgrade(output)
+        }
+      }
+      await fs.writeAsync(outputPath!, output)
     }
 
     // Note: only contains the exitCode

--- a/packages/migrate/src/utils/createMigration.ts
+++ b/packages/migrate/src/utils/createMigration.ts
@@ -4,6 +4,8 @@ import path from 'node:path'
 import type { ActiveConnectorType } from '@prisma/generator'
 import type { MigrateTypes } from '@prisma/internals'
 
+import { transformPostgresMnPrimaryKeyUpgrade } from './transformMigrationScript'
+
 type CreateMigrationInput = {
   baseDir: string
   generatedMigrationName: string
@@ -25,6 +27,7 @@ type WriteMigrationScriptInput = {
   migrationName: string
   extension: string
   script: string
+  connectorType?: ActiveConnectorType
 }
 
 export async function writeMigrationScript({
@@ -32,8 +35,14 @@ export async function writeMigrationScript({
   extension,
   migrationName,
   script,
+  connectorType,
 }: WriteMigrationScriptInput): Promise<void> {
-  await fs.promises.writeFile(path.join(baseDir, migrationName, `migration.${extension}`), script, {
+  let finalScript = script
+  if (connectorType === 'postgresql') {
+    finalScript = transformPostgresMnPrimaryKeyUpgrade(script)
+  }
+
+  await fs.promises.writeFile(path.join(baseDir, migrationName, `migration.${extension}`), finalScript, {
     encoding: 'utf-8',
   })
 }

--- a/packages/migrate/src/utils/transformMigrationScript.ts
+++ b/packages/migrate/src/utils/transformMigrationScript.ts
@@ -1,0 +1,9 @@
+
+export function transformPostgresMnPrimaryKeyUpgrade(script: string): string {
+  const pattern =
+    /ALTER TABLE "([^"]+)" ADD CONSTRAINT "([^"]+)_pkey" PRIMARY KEY \([^)]+\);\s*\n(?:\s*--[^\n]*\n)?\s*DROP INDEX (?:IF EXISTS )?((?:"[^"]+"\.)?"[^"]+_unique");/g
+
+  return script.replace(pattern, (_, table, constraintBase, indexIdentifier) => {
+    return `ALTER TABLE "${table}" ADD CONSTRAINT "${constraintBase}_pkey" PRIMARY KEY USING INDEX ${indexIdentifier};`
+  })
+}


### PR DESCRIPTION
### description:

- Problem: m-n upgrade migration added a new PK and dropped the unique index → long locks on big tables.
- Change: For PostgreSQL, emit PRIMARY KEY USING INDEX "..." so the existing unique index is promoted.
- Where: migrate dev and migrate diff --script --output (PostgreSQL only).
- Result: Metadata-only change, near constant time, no index rebuild.

fix : #29326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added database-aware migration script transformations to optimize PostgreSQL primary key constraint handling.

* **Bug Fixes**
  * Improved handling of PostgreSQL primary key statements in migration scripts when using output and script options in migration diff commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->