### PR TITLE
perf(adapter-pg): use deterministic prepared statement names

### DIFF
--- a/packages/adapter-pg/src/__tests__/pg.test.ts
+++ b/packages/adapter-pg/src/__tests__/pg.test.ts
@@ -3,25 +3,25 @@ import type { SqlQuery } from '@prisma/driver-adapter-utils'
 import pg, { DatabaseError } from 'pg'
 import { describe, expect, it, vi } from 'vitest'
 
-import { getStatementName, PrismaPgAdapterFactory } from '../pg'
+import { defaultStatementNameGenerator, PrismaPgAdapterFactory } from '../pg'
 
-describe('getStatementName', () => {
+describe('defaultStatementNameGenerator', () => {
   it('returns a deterministic name for the same SQL', () => {
     const query: SqlQuery = { sql: 'SELECT $1', args: [], argTypes: [] }
-    const name1 = getStatementName(query)
-    const name2 = getStatementName(query)
+    const name1 = defaultStatementNameGenerator(query)
+    const name2 = defaultStatementNameGenerator(query)
     expect(name1).toBe(name2)
   })
 
   it('returns names prefixed with p_', () => {
     const query: SqlQuery = { sql: 'SELECT 1', args: [], argTypes: [] }
-    expect(getStatementName(query)).toMatch(/^p_[0-9a-f]{16}$/)
+    expect(defaultStatementNameGenerator(query)).toMatch(/^p_[0-9a-f]{24}$/)
   })
 
   it('returns different names for different SQL', () => {
     const q1: SqlQuery = { sql: 'SELECT 1', args: [], argTypes: [] }
     const q2: SqlQuery = { sql: 'SELECT 2', args: [], argTypes: [] }
-    expect(getStatementName(q1)).not.toBe(getStatementName(q2))
+    expect(defaultStatementNameGenerator(q1)).not.toBe(defaultStatementNameGenerator(q2))
   })
 
   it('includes argTypes in the hash', () => {
@@ -35,7 +35,7 @@ describe('getStatementName', () => {
       args: ['hello'],
       argTypes: [{ scalarType: 'string', arity: 'scalar' }],
     }
-    expect(getStatementName(q1)).not.toBe(getStatementName(q2))
+    expect(defaultStatementNameGenerator(q1)).not.toBe(defaultStatementNameGenerator(q2))
   })
 
   it('distinguishes scalar vs list arity', () => {
@@ -49,7 +49,7 @@ describe('getStatementName', () => {
       args: [[1, 2]],
       argTypes: [{ scalarType: 'int', arity: 'list' }],
     }
-    expect(getStatementName(q1)).not.toBe(getStatementName(q2))
+    expect(defaultStatementNameGenerator(q1)).not.toBe(defaultStatementNameGenerator(q2))
   })
 
   it('is stable for queries with multiple argTypes', () => {
@@ -62,8 +62,8 @@ describe('getStatementName', () => {
         { scalarType: 'boolean', arity: 'scalar' },
       ],
     }
-    const name1 = getStatementName(query)
-    const name2 = getStatementName(query)
+    const name1 = defaultStatementNameGenerator(query)
+    const name2 = defaultStatementNameGenerator(query)
     expect(name1).toBe(name2)
   })
 
@@ -78,10 +78,10 @@ describe('getStatementName', () => {
       args: [999],
       argTypes: [{ scalarType: 'int', arity: 'scalar' }],
     }
-    expect(getStatementName(q1)).toBe(getStatementName(q2))
+    expect(defaultStatementNameGenerator(q1)).toBe(defaultStatementNameGenerator(q2))
   })
 
-  it('ignores dbType (only scalarType and arity matter)', () => {
+  it('distinguishes different dbType values', () => {
     const q1: SqlQuery = {
       sql: 'SELECT $1',
       args: ['2026-01-01'],
@@ -92,13 +92,13 @@ describe('getStatementName', () => {
       args: ['2026-01-01T00:00:00Z'],
       argTypes: [{ scalarType: 'datetime', dbType: 'TIMESTAMPTZ', arity: 'scalar' }],
     }
-    expect(getStatementName(q1)).toBe(getStatementName(q2))
+    expect(defaultStatementNameGenerator(q1)).not.toBe(defaultStatementNameGenerator(q2))
   })
 
   it('produces different names for near-miss SQL (single character difference)', () => {
     const q1: SqlQuery = { sql: 'SELECT * FROM "User" WHERE id = $1', args: [], argTypes: [] }
     const q2: SqlQuery = { sql: 'SELECT * FROM "User" WHERE id = $2', args: [], argTypes: [] }
-    expect(getStatementName(q1)).not.toBe(getStatementName(q2))
+    expect(defaultStatementNameGenerator(q1)).not.toBe(defaultStatementNameGenerator(q2))
   })
 
   it('produces deterministic names for transaction control statements', () => {
@@ -106,18 +106,22 @@ describe('getStatementName', () => {
     const commit: SqlQuery = { sql: 'COMMIT', args: [], argTypes: [] }
     const rollback: SqlQuery = { sql: 'ROLLBACK', args: [], argTypes: [] }
 
-    expect(getStatementName(begin)).toBe(getStatementName(begin))
-    expect(getStatementName(commit)).toBe(getStatementName(commit))
-    expect(getStatementName(rollback)).toBe(getStatementName(rollback))
+    expect(defaultStatementNameGenerator(begin)).toBe(defaultStatementNameGenerator(begin))
+    expect(defaultStatementNameGenerator(commit)).toBe(defaultStatementNameGenerator(commit))
+    expect(defaultStatementNameGenerator(rollback)).toBe(defaultStatementNameGenerator(rollback))
 
     // Each should be distinct from the others
-    const names = new Set([getStatementName(begin), getStatementName(commit), getStatementName(rollback)])
+    const names = new Set([
+      defaultStatementNameGenerator(begin),
+      defaultStatementNameGenerator(commit),
+      defaultStatementNameGenerator(rollback),
+    ])
     expect(names.size).toBe(3)
   })
 })
 
-describe('PrismaPgAdapter passes statement name to client.query', () => {
-  it('includes name property in the query config', async () => {
+describe('statementNameGenerator option', () => {
+  it('does not set name when statementNameGenerator is not provided', async () => {
     const config: pg.PoolConfig = { user: 'test', password: 'test', database: 'test', port: 5432, host: 'localhost' }
     const factory = new PrismaPgAdapterFactory(config)
     const adapter = await factory.connect()
@@ -134,11 +138,36 @@ describe('PrismaPgAdapter passes statement name to client.query', () => {
 
     const tx = await adapter.startTransaction()
 
-    // The BEGIN query should have been sent with a name
-    expect(mockConnection.query).toHaveBeenCalledTimes(1)
     const queryConfig = mockConnection.query.mock.calls[0][0]
-    expect(queryConfig).toHaveProperty('name')
-    expect(queryConfig.name).toMatch(/^p_[0-9a-f]{16}$/)
+    expect(queryConfig.name).toBeUndefined()
+    expect(queryConfig.text).toBe('BEGIN')
+
+    mockConnection.listenerCount.mockReturnValue(0)
+    await tx.rollback()
+    await adapter.dispose()
+  })
+
+  it('sets name when statementNameGenerator is provided', async () => {
+    const config: pg.PoolConfig = { user: 'test', password: 'test', database: 'test', port: 5432, host: 'localhost' }
+    const factory = new PrismaPgAdapterFactory(config, {
+      statementNameGenerator: defaultStatementNameGenerator,
+    })
+    const adapter = await factory.connect()
+
+    const mockConnection = {
+      on: vi.fn(),
+      removeListener: vi.fn(),
+      query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0, fields: [] }),
+      release: vi.fn(),
+      listenerCount: vi.fn().mockReturnValue(1),
+    }
+
+    adapter['client'].connect = vi.fn().mockResolvedValue(mockConnection)
+
+    const tx = await adapter.startTransaction()
+
+    const queryConfig = mockConnection.query.mock.calls[0][0]
+    expect(queryConfig.name).toMatch(/^p_[0-9a-f]{24}$/)
     expect(queryConfig.text).toBe('BEGIN')
 
     mockConnection.listenerCount.mockReturnValue(0)
@@ -148,7 +177,9 @@ describe('PrismaPgAdapter passes statement name to client.query', () => {
 
   it('passes name through queryRaw and returns results correctly', async () => {
     const config: pg.PoolConfig = { user: 'test', password: 'test', database: 'test', port: 5432, host: 'localhost' }
-    const factory = new PrismaPgAdapterFactory(config)
+    const factory = new PrismaPgAdapterFactory(config, {
+      statementNameGenerator: defaultStatementNameGenerator,
+    })
     const adapter = await factory.connect()
 
     const mockConnection = {
@@ -193,7 +224,7 @@ describe('PrismaPgAdapter passes statement name to client.query', () => {
     // Verify name was passed
     const queryConfig = mockConnection.query.mock.calls[0][0]
     expect(queryConfig).toHaveProperty('name')
-    expect(queryConfig.name).toMatch(/^p_[0-9a-f]{16}$/)
+    expect(queryConfig.name).toMatch(/^p_[0-9a-f]{24}$/)
 
     // Verify results still parse correctly
     expect(result.columnNames).toEqual(['id', 'name'])
@@ -206,7 +237,9 @@ describe('PrismaPgAdapter passes statement name to client.query', () => {
 
   it('passes the same name for identical queries', async () => {
     const config: pg.PoolConfig = { user: 'test', password: 'test', database: 'test', port: 5432, host: 'localhost' }
-    const factory = new PrismaPgAdapterFactory(config)
+    const factory = new PrismaPgAdapterFactory(config, {
+      statementNameGenerator: defaultStatementNameGenerator,
+    })
     const adapter = await factory.connect()
 
     const mockConnection = {
@@ -240,6 +273,35 @@ describe('PrismaPgAdapter passes statement name to client.query', () => {
     const name1 = mockConnection.query.mock.calls[0][0].name
     const name2 = mockConnection.query.mock.calls[1][0].name
     expect(name1).toBe(name2)
+
+    mockConnection.listenerCount.mockReturnValue(0)
+    await tx.rollback()
+    await adapter.dispose()
+  })
+
+  it('uses a custom statementNameGenerator', async () => {
+    const config: pg.PoolConfig = { user: 'test', password: 'test', database: 'test', port: 5432, host: 'localhost' }
+    const customGenerator = vi.fn().mockReturnValue('custom_name')
+    const factory = new PrismaPgAdapterFactory(config, {
+      statementNameGenerator: customGenerator,
+    })
+    const adapter = await factory.connect()
+
+    const mockConnection = {
+      on: vi.fn(),
+      removeListener: vi.fn(),
+      query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0, fields: [] }),
+      release: vi.fn(),
+      listenerCount: vi.fn().mockReturnValue(1),
+    }
+
+    adapter['client'].connect = vi.fn().mockResolvedValue(mockConnection)
+
+    const tx = await adapter.startTransaction()
+
+    const queryConfig = mockConnection.query.mock.calls[0][0]
+    expect(queryConfig.name).toBe('custom_name')
+    expect(customGenerator).toHaveBeenCalledWith({ sql: 'BEGIN', args: [], argTypes: [] })
 
     mockConnection.listenerCount.mockReturnValue(0)
     await tx.rollback()

--- a/packages/adapter-pg/src/__tests__/pg.test.ts
+++ b/packages/adapter-pg/src/__tests__/pg.test.ts
@@ -110,7 +110,6 @@ describe('generateStatementName', () => {
     expect(generateStatementName(commit)).toBe(generateStatementName(commit))
     expect(generateStatementName(rollback)).toBe(generateStatementName(rollback))
 
-    // Each should be distinct from the others
     const names = new Set([
       generateStatementName(begin),
       generateStatementName(commit),
@@ -200,7 +199,6 @@ describe('enableStatementCaching option', () => {
     adapter['client'].connect = vi.fn().mockResolvedValue(mockConnection)
 
     const tx = await adapter.startTransaction()
-    // Reset mock to clear the BEGIN call
     mockConnection.query.mockClear()
 
     mockConnection.query.mockResolvedValueOnce({
@@ -221,12 +219,10 @@ describe('enableStatementCaching option', () => {
       ],
     })
 
-    // Verify name was passed
     const queryConfig = mockConnection.query.mock.calls[0][0]
     expect(queryConfig).toHaveProperty('name')
     expect(queryConfig.name).toMatch(/^p_[0-9a-f]{24}$/)
 
-    // Verify results still parse correctly
     expect(result.columnNames).toEqual(['id', 'name'])
     expect(result.rows).toEqual([[1, 'alice']])
 

--- a/packages/adapter-pg/src/__tests__/pg.test.ts
+++ b/packages/adapter-pg/src/__tests__/pg.test.ts
@@ -1,8 +1,251 @@
 import { getLogs } from '@prisma/debug'
+import type { SqlQuery } from '@prisma/driver-adapter-utils'
 import pg, { DatabaseError } from 'pg'
 import { describe, expect, it, vi } from 'vitest'
 
-import { PrismaPgAdapterFactory } from '../pg'
+import { getStatementName, PrismaPgAdapterFactory } from '../pg'
+
+describe('getStatementName', () => {
+  it('returns a deterministic name for the same SQL', () => {
+    const query: SqlQuery = { sql: 'SELECT $1', args: [], argTypes: [] }
+    const name1 = getStatementName(query)
+    const name2 = getStatementName(query)
+    expect(name1).toBe(name2)
+  })
+
+  it('returns names prefixed with p_', () => {
+    const query: SqlQuery = { sql: 'SELECT 1', args: [], argTypes: [] }
+    expect(getStatementName(query)).toMatch(/^p_[0-9a-f]{16}$/)
+  })
+
+  it('returns different names for different SQL', () => {
+    const q1: SqlQuery = { sql: 'SELECT 1', args: [], argTypes: [] }
+    const q2: SqlQuery = { sql: 'SELECT 2', args: [], argTypes: [] }
+    expect(getStatementName(q1)).not.toBe(getStatementName(q2))
+  })
+
+  it('includes argTypes in the hash', () => {
+    const q1: SqlQuery = {
+      sql: 'SELECT $1',
+      args: [1],
+      argTypes: [{ scalarType: 'int', arity: 'scalar' }],
+    }
+    const q2: SqlQuery = {
+      sql: 'SELECT $1',
+      args: ['hello'],
+      argTypes: [{ scalarType: 'string', arity: 'scalar' }],
+    }
+    expect(getStatementName(q1)).not.toBe(getStatementName(q2))
+  })
+
+  it('distinguishes scalar vs list arity', () => {
+    const q1: SqlQuery = {
+      sql: 'SELECT $1',
+      args: [1],
+      argTypes: [{ scalarType: 'int', arity: 'scalar' }],
+    }
+    const q2: SqlQuery = {
+      sql: 'SELECT $1',
+      args: [[1, 2]],
+      argTypes: [{ scalarType: 'int', arity: 'list' }],
+    }
+    expect(getStatementName(q1)).not.toBe(getStatementName(q2))
+  })
+
+  it('is stable for queries with multiple argTypes', () => {
+    const query: SqlQuery = {
+      sql: 'SELECT $1, $2, $3',
+      args: [1, 'hello', true],
+      argTypes: [
+        { scalarType: 'int', arity: 'scalar' },
+        { scalarType: 'string', arity: 'scalar' },
+        { scalarType: 'boolean', arity: 'scalar' },
+      ],
+    }
+    const name1 = getStatementName(query)
+    const name2 = getStatementName(query)
+    expect(name1).toBe(name2)
+  })
+
+  it('ignores arg values (only SQL and argTypes matter)', () => {
+    const q1: SqlQuery = {
+      sql: 'SELECT $1',
+      args: [1],
+      argTypes: [{ scalarType: 'int', arity: 'scalar' }],
+    }
+    const q2: SqlQuery = {
+      sql: 'SELECT $1',
+      args: [999],
+      argTypes: [{ scalarType: 'int', arity: 'scalar' }],
+    }
+    expect(getStatementName(q1)).toBe(getStatementName(q2))
+  })
+
+  it('ignores dbType (only scalarType and arity matter)', () => {
+    const q1: SqlQuery = {
+      sql: 'SELECT $1',
+      args: ['2026-01-01'],
+      argTypes: [{ scalarType: 'datetime', dbType: 'DATE', arity: 'scalar' }],
+    }
+    const q2: SqlQuery = {
+      sql: 'SELECT $1',
+      args: ['2026-01-01T00:00:00Z'],
+      argTypes: [{ scalarType: 'datetime', dbType: 'TIMESTAMPTZ', arity: 'scalar' }],
+    }
+    expect(getStatementName(q1)).toBe(getStatementName(q2))
+  })
+
+  it('produces different names for near-miss SQL (single character difference)', () => {
+    const q1: SqlQuery = { sql: 'SELECT * FROM "User" WHERE id = $1', args: [], argTypes: [] }
+    const q2: SqlQuery = { sql: 'SELECT * FROM "User" WHERE id = $2', args: [], argTypes: [] }
+    expect(getStatementName(q1)).not.toBe(getStatementName(q2))
+  })
+
+  it('produces deterministic names for transaction control statements', () => {
+    const begin: SqlQuery = { sql: 'BEGIN', args: [], argTypes: [] }
+    const commit: SqlQuery = { sql: 'COMMIT', args: [], argTypes: [] }
+    const rollback: SqlQuery = { sql: 'ROLLBACK', args: [], argTypes: [] }
+
+    expect(getStatementName(begin)).toBe(getStatementName(begin))
+    expect(getStatementName(commit)).toBe(getStatementName(commit))
+    expect(getStatementName(rollback)).toBe(getStatementName(rollback))
+
+    // Each should be distinct from the others
+    const names = new Set([getStatementName(begin), getStatementName(commit), getStatementName(rollback)])
+    expect(names.size).toBe(3)
+  })
+})
+
+describe('PrismaPgAdapter passes statement name to client.query', () => {
+  it('includes name property in the query config', async () => {
+    const config: pg.PoolConfig = { user: 'test', password: 'test', database: 'test', port: 5432, host: 'localhost' }
+    const factory = new PrismaPgAdapterFactory(config)
+    const adapter = await factory.connect()
+
+    const mockConnection = {
+      on: vi.fn(),
+      removeListener: vi.fn(),
+      query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0, fields: [] }),
+      release: vi.fn(),
+      listenerCount: vi.fn().mockReturnValue(1),
+    }
+
+    adapter['client'].connect = vi.fn().mockResolvedValue(mockConnection)
+
+    const tx = await adapter.startTransaction()
+
+    // The BEGIN query should have been sent with a name
+    expect(mockConnection.query).toHaveBeenCalledTimes(1)
+    const queryConfig = mockConnection.query.mock.calls[0][0]
+    expect(queryConfig).toHaveProperty('name')
+    expect(queryConfig.name).toMatch(/^p_[0-9a-f]{16}$/)
+    expect(queryConfig.text).toBe('BEGIN')
+
+    mockConnection.listenerCount.mockReturnValue(0)
+    await tx.rollback()
+    await adapter.dispose()
+  })
+
+  it('passes name through queryRaw and returns results correctly', async () => {
+    const config: pg.PoolConfig = { user: 'test', password: 'test', database: 'test', port: 5432, host: 'localhost' }
+    const factory = new PrismaPgAdapterFactory(config)
+    const adapter = await factory.connect()
+
+    const mockConnection = {
+      on: vi.fn(),
+      removeListener: vi.fn(),
+      query: vi.fn().mockResolvedValue({
+        rows: [[1, 'alice']],
+        rowCount: 1,
+        fields: [
+          { name: 'id', dataTypeID: 23 },
+          { name: 'name', dataTypeID: 25 },
+        ],
+      }),
+      release: vi.fn(),
+      listenerCount: vi.fn().mockReturnValue(1),
+    }
+
+    adapter['client'].connect = vi.fn().mockResolvedValue(mockConnection)
+
+    const tx = await adapter.startTransaction()
+    // Reset mock to clear the BEGIN call
+    mockConnection.query.mockClear()
+
+    mockConnection.query.mockResolvedValueOnce({
+      rows: [[1, 'alice']],
+      rowCount: 1,
+      fields: [
+        { name: 'id', dataTypeID: 23 },
+        { name: 'name', dataTypeID: 25 },
+      ],
+    })
+
+    const result = await tx.queryRaw({
+      sql: 'SELECT $1, $2',
+      args: [1, 'alice'],
+      argTypes: [
+        { scalarType: 'int', arity: 'scalar' },
+        { scalarType: 'string', arity: 'scalar' },
+      ],
+    })
+
+    // Verify name was passed
+    const queryConfig = mockConnection.query.mock.calls[0][0]
+    expect(queryConfig).toHaveProperty('name')
+    expect(queryConfig.name).toMatch(/^p_[0-9a-f]{16}$/)
+
+    // Verify results still parse correctly
+    expect(result.columnNames).toEqual(['id', 'name'])
+    expect(result.rows).toEqual([[1, 'alice']])
+
+    mockConnection.listenerCount.mockReturnValue(0)
+    await tx.rollback()
+    await adapter.dispose()
+  })
+
+  it('passes the same name for identical queries', async () => {
+    const config: pg.PoolConfig = { user: 'test', password: 'test', database: 'test', port: 5432, host: 'localhost' }
+    const factory = new PrismaPgAdapterFactory(config)
+    const adapter = await factory.connect()
+
+    const mockConnection = {
+      on: vi.fn(),
+      removeListener: vi.fn(),
+      query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0, fields: [] }),
+      release: vi.fn(),
+      listenerCount: vi.fn().mockReturnValue(1),
+    }
+
+    adapter['client'].connect = vi.fn().mockResolvedValue(mockConnection)
+
+    const tx = await adapter.startTransaction()
+    mockConnection.query.mockClear()
+
+    const query = {
+      sql: 'SELECT $1',
+      args: [1],
+      argTypes: [{ scalarType: 'int' as const, arity: 'scalar' as const }],
+    }
+
+    mockConnection.query.mockResolvedValue({
+      rows: [[1]],
+      rowCount: 1,
+      fields: [{ name: 'col', dataTypeID: 23 }],
+    })
+
+    await tx.queryRaw(query)
+    await tx.queryRaw({ ...query, args: [999] }) // different value, same shape
+
+    const name1 = mockConnection.query.mock.calls[0][0].name
+    const name2 = mockConnection.query.mock.calls[1][0].name
+    expect(name1).toBe(name2)
+
+    mockConnection.listenerCount.mockReturnValue(0)
+    await tx.rollback()
+    await adapter.dispose()
+  })
+})
 
 describe('PrismaPgAdapterFactory', () => {
   it('should subscribe to pool error events', async () => {

--- a/packages/adapter-pg/src/__tests__/pg.test.ts
+++ b/packages/adapter-pg/src/__tests__/pg.test.ts
@@ -3,25 +3,25 @@ import type { SqlQuery } from '@prisma/driver-adapter-utils'
 import pg, { DatabaseError } from 'pg'
 import { describe, expect, it, vi } from 'vitest'
 
-import { defaultStatementNameGenerator, PrismaPgAdapterFactory } from '../pg'
+import { generateStatementName, PrismaPgAdapterFactory } from '../pg'
 
-describe('defaultStatementNameGenerator', () => {
+describe('generateStatementName', () => {
   it('returns a deterministic name for the same SQL', () => {
     const query: SqlQuery = { sql: 'SELECT $1', args: [], argTypes: [] }
-    const name1 = defaultStatementNameGenerator(query)
-    const name2 = defaultStatementNameGenerator(query)
+    const name1 = generateStatementName(query)
+    const name2 = generateStatementName(query)
     expect(name1).toBe(name2)
   })
 
   it('returns names prefixed with p_', () => {
     const query: SqlQuery = { sql: 'SELECT 1', args: [], argTypes: [] }
-    expect(defaultStatementNameGenerator(query)).toMatch(/^p_[0-9a-f]{24}$/)
+    expect(generateStatementName(query)).toMatch(/^p_[0-9a-f]{24}$/)
   })
 
   it('returns different names for different SQL', () => {
     const q1: SqlQuery = { sql: 'SELECT 1', args: [], argTypes: [] }
     const q2: SqlQuery = { sql: 'SELECT 2', args: [], argTypes: [] }
-    expect(defaultStatementNameGenerator(q1)).not.toBe(defaultStatementNameGenerator(q2))
+    expect(generateStatementName(q1)).not.toBe(generateStatementName(q2))
   })
 
   it('includes argTypes in the hash', () => {
@@ -35,7 +35,7 @@ describe('defaultStatementNameGenerator', () => {
       args: ['hello'],
       argTypes: [{ scalarType: 'string', arity: 'scalar' }],
     }
-    expect(defaultStatementNameGenerator(q1)).not.toBe(defaultStatementNameGenerator(q2))
+    expect(generateStatementName(q1)).not.toBe(generateStatementName(q2))
   })
 
   it('distinguishes scalar vs list arity', () => {
@@ -49,7 +49,7 @@ describe('defaultStatementNameGenerator', () => {
       args: [[1, 2]],
       argTypes: [{ scalarType: 'int', arity: 'list' }],
     }
-    expect(defaultStatementNameGenerator(q1)).not.toBe(defaultStatementNameGenerator(q2))
+    expect(generateStatementName(q1)).not.toBe(generateStatementName(q2))
   })
 
   it('is stable for queries with multiple argTypes', () => {
@@ -62,8 +62,8 @@ describe('defaultStatementNameGenerator', () => {
         { scalarType: 'boolean', arity: 'scalar' },
       ],
     }
-    const name1 = defaultStatementNameGenerator(query)
-    const name2 = defaultStatementNameGenerator(query)
+    const name1 = generateStatementName(query)
+    const name2 = generateStatementName(query)
     expect(name1).toBe(name2)
   })
 
@@ -78,7 +78,7 @@ describe('defaultStatementNameGenerator', () => {
       args: [999],
       argTypes: [{ scalarType: 'int', arity: 'scalar' }],
     }
-    expect(defaultStatementNameGenerator(q1)).toBe(defaultStatementNameGenerator(q2))
+    expect(generateStatementName(q1)).toBe(generateStatementName(q2))
   })
 
   it('distinguishes different dbType values', () => {
@@ -92,13 +92,13 @@ describe('defaultStatementNameGenerator', () => {
       args: ['2026-01-01T00:00:00Z'],
       argTypes: [{ scalarType: 'datetime', dbType: 'TIMESTAMPTZ', arity: 'scalar' }],
     }
-    expect(defaultStatementNameGenerator(q1)).not.toBe(defaultStatementNameGenerator(q2))
+    expect(generateStatementName(q1)).not.toBe(generateStatementName(q2))
   })
 
   it('produces different names for near-miss SQL (single character difference)', () => {
     const q1: SqlQuery = { sql: 'SELECT * FROM "User" WHERE id = $1', args: [], argTypes: [] }
     const q2: SqlQuery = { sql: 'SELECT * FROM "User" WHERE id = $2', args: [], argTypes: [] }
-    expect(defaultStatementNameGenerator(q1)).not.toBe(defaultStatementNameGenerator(q2))
+    expect(generateStatementName(q1)).not.toBe(generateStatementName(q2))
   })
 
   it('produces deterministic names for transaction control statements', () => {
@@ -106,22 +106,22 @@ describe('defaultStatementNameGenerator', () => {
     const commit: SqlQuery = { sql: 'COMMIT', args: [], argTypes: [] }
     const rollback: SqlQuery = { sql: 'ROLLBACK', args: [], argTypes: [] }
 
-    expect(defaultStatementNameGenerator(begin)).toBe(defaultStatementNameGenerator(begin))
-    expect(defaultStatementNameGenerator(commit)).toBe(defaultStatementNameGenerator(commit))
-    expect(defaultStatementNameGenerator(rollback)).toBe(defaultStatementNameGenerator(rollback))
+    expect(generateStatementName(begin)).toBe(generateStatementName(begin))
+    expect(generateStatementName(commit)).toBe(generateStatementName(commit))
+    expect(generateStatementName(rollback)).toBe(generateStatementName(rollback))
 
     // Each should be distinct from the others
     const names = new Set([
-      defaultStatementNameGenerator(begin),
-      defaultStatementNameGenerator(commit),
-      defaultStatementNameGenerator(rollback),
+      generateStatementName(begin),
+      generateStatementName(commit),
+      generateStatementName(rollback),
     ])
     expect(names.size).toBe(3)
   })
 })
 
-describe('statementNameGenerator option', () => {
-  it('does not set name when statementNameGenerator is not provided', async () => {
+describe('enableStatementCaching option', () => {
+  it('does not set name when enableStatementCaching is not provided', async () => {
     const config: pg.PoolConfig = { user: 'test', password: 'test', database: 'test', port: 5432, host: 'localhost' }
     const factory = new PrismaPgAdapterFactory(config)
     const adapter = await factory.connect()
@@ -147,10 +147,10 @@ describe('statementNameGenerator option', () => {
     await adapter.dispose()
   })
 
-  it('sets name when statementNameGenerator is provided', async () => {
+  it('sets name when enableStatementCaching is true', async () => {
     const config: pg.PoolConfig = { user: 'test', password: 'test', database: 'test', port: 5432, host: 'localhost' }
     const factory = new PrismaPgAdapterFactory(config, {
-      statementNameGenerator: defaultStatementNameGenerator,
+      enableStatementCaching: true,
     })
     const adapter = await factory.connect()
 
@@ -178,7 +178,7 @@ describe('statementNameGenerator option', () => {
   it('passes name through queryRaw and returns results correctly', async () => {
     const config: pg.PoolConfig = { user: 'test', password: 'test', database: 'test', port: 5432, host: 'localhost' }
     const factory = new PrismaPgAdapterFactory(config, {
-      statementNameGenerator: defaultStatementNameGenerator,
+      enableStatementCaching: true,
     })
     const adapter = await factory.connect()
 
@@ -238,7 +238,7 @@ describe('statementNameGenerator option', () => {
   it('passes the same name for identical queries', async () => {
     const config: pg.PoolConfig = { user: 'test', password: 'test', database: 'test', port: 5432, host: 'localhost' }
     const factory = new PrismaPgAdapterFactory(config, {
-      statementNameGenerator: defaultStatementNameGenerator,
+      enableStatementCaching: true,
     })
     const adapter = await factory.connect()
 
@@ -273,35 +273,6 @@ describe('statementNameGenerator option', () => {
     const name1 = mockConnection.query.mock.calls[0][0].name
     const name2 = mockConnection.query.mock.calls[1][0].name
     expect(name1).toBe(name2)
-
-    mockConnection.listenerCount.mockReturnValue(0)
-    await tx.rollback()
-    await adapter.dispose()
-  })
-
-  it('uses a custom statementNameGenerator', async () => {
-    const config: pg.PoolConfig = { user: 'test', password: 'test', database: 'test', port: 5432, host: 'localhost' }
-    const customGenerator = vi.fn().mockReturnValue('custom_name')
-    const factory = new PrismaPgAdapterFactory(config, {
-      statementNameGenerator: customGenerator,
-    })
-    const adapter = await factory.connect()
-
-    const mockConnection = {
-      on: vi.fn(),
-      removeListener: vi.fn(),
-      query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0, fields: [] }),
-      release: vi.fn(),
-      listenerCount: vi.fn().mockReturnValue(1),
-    }
-
-    adapter['client'].connect = vi.fn().mockResolvedValue(mockConnection)
-
-    const tx = await adapter.startTransaction()
-
-    const queryConfig = mockConnection.query.mock.calls[0][0]
-    expect(queryConfig.name).toBe('custom_name')
-    expect(customGenerator).toHaveBeenCalledWith({ sql: 'BEGIN', args: [], argTypes: [] })
 
     mockConnection.listenerCount.mockReturnValue(0)
     await tx.rollback()

--- a/packages/adapter-pg/src/__tests__/pg.test.ts
+++ b/packages/adapter-pg/src/__tests__/pg.test.ts
@@ -15,7 +15,7 @@ describe('generateStatementName', () => {
 
   it('returns names prefixed with p_', () => {
     const query: SqlQuery = { sql: 'SELECT 1', args: [], argTypes: [] }
-    expect(generateStatementName(query)).toMatch(/^p_[0-9a-f]{24}$/)
+    expect(generateStatementName(query)).toMatch(/^p_[A-Za-z0-9_-]{16}$/)
   })
 
   it('returns different names for different SQL', () => {
@@ -166,7 +166,7 @@ describe('enableStatementCaching option', () => {
     const tx = await adapter.startTransaction()
 
     const queryConfig = mockConnection.query.mock.calls[0][0]
-    expect(queryConfig.name).toMatch(/^p_[0-9a-f]{24}$/)
+    expect(queryConfig.name).toMatch(/^p_[A-Za-z0-9_-]{16}$/)
     expect(queryConfig.text).toBe('BEGIN')
 
     mockConnection.listenerCount.mockReturnValue(0)
@@ -221,7 +221,7 @@ describe('enableStatementCaching option', () => {
 
     const queryConfig = mockConnection.query.mock.calls[0][0]
     expect(queryConfig).toHaveProperty('name')
-    expect(queryConfig.name).toMatch(/^p_[0-9a-f]{24}$/)
+    expect(queryConfig.name).toMatch(/^p_[A-Za-z0-9_-]{16}$/)
 
     expect(result.columnNames).toEqual(['id', 'name'])
     expect(result.rows).toEqual([[1, 'alice']])

--- a/packages/adapter-pg/src/index.ts
+++ b/packages/adapter-pg/src/index.ts
@@ -1,1 +1,1 @@
-export { PrismaPgAdapterFactory as PrismaPg } from './pg'
+export { defaultStatementNameGenerator, PrismaPgAdapterFactory as PrismaPg } from './pg'

--- a/packages/adapter-pg/src/index.ts
+++ b/packages/adapter-pg/src/index.ts
@@ -1,1 +1,1 @@
-export { defaultStatementNameGenerator, PrismaPgAdapterFactory as PrismaPg } from './pg'
+export { PrismaPgAdapterFactory as PrismaPg } from './pg'

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -39,7 +39,7 @@ const debug = Debug('prisma:driver-adapter:pg')
  */
 export function generateStatementName(query: SqlQuery): string {
   const hashInput = query.sql + '\0' + JSON.stringify(query.argTypes)
-  return 'p_' + crypto.hash('sha1', hashInput, 'hex').slice(0, 24)
+  return 'p_' + crypto.hash('sha1', hashInput, 'base64url').slice(0, 16)
 }
 
 type StdClient = pg.Pool
@@ -124,7 +124,9 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements SqlQ
         {
           text: sql,
           values,
-          name: this.pgOptions?.enableStatementCaching ? generateStatementName(query) : undefined,
+          name: this.pgOptions?.enableStatementCaching
+            ? (this.pgOptions.getStatementName ?? generateStatementName)(query)
+            : undefined,
           rowMode: 'array',
           types: {
             // This is the error expected:
@@ -214,6 +216,16 @@ export interface PrismaPgOptions {
    * acceptable for Prisma workloads because the set of query shapes is bounded.
    */
   enableStatementCaching?: boolean
+  /**
+   * Overrides the default statement name generator used for PostgreSQL named
+   * prepared statements. The function receives a {@link SqlQuery} and must return
+   * a stable name for queries with the same SQL text and parameter types.
+   *
+   * Defaults to {@link generateStatementName} for hash-based naming.
+   *
+   * Requires {@link enableStatementCaching} to be set to `true`.
+   */
+  getStatementName?: (query: SqlQuery) => string
 }
 
 export type UserDefinedTypeParser = (oid: number, value: unknown, adapter: SqlQueryable) => Promise<unknown>

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -37,12 +37,9 @@ const debug = Debug('prisma:driver-adapter:pg')
  * Named statements live for the lifetime of the connection, which is likely acceptable for
  * Prisma workloads because the set of query shapes is typically bounded.
  */
-export function getStatementName(query: SqlQuery): string {
-  const hashInput =
-    query.argTypes.length > 0
-      ? query.sql + '\0' + query.argTypes.map((t) => `${t.scalarType}:${t.arity}`).join(',')
-      : query.sql
-  return 'p_' + crypto.hash('sha1', hashInput, 'hex').slice(0, 16)
+export function defaultStatementNameGenerator(query: SqlQuery): string {
+  const hashInput = query.sql + '\0' + JSON.stringify(query.argTypes)
+  return 'p_' + crypto.hash('sha1', hashInput, 'hex').slice(0, 24)
 }
 
 type StdClient = pg.Pool
@@ -127,7 +124,7 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements SqlQ
         {
           text: sql,
           values,
-          name: getStatementName(query),
+          name: this.pgOptions?.statementNameGenerator?.(query),
           rowMode: 'array',
           types: {
             // This is the error expected:
@@ -209,6 +206,15 @@ export type PrismaPgOptions = {
   onPoolError?: (err: Error) => void
   onConnectionError?: (err: Error) => void
   userDefinedTypeParser?: UserDefinedTypeParser
+  /**
+   * When provided, enables PostgreSQL named prepared statements for query plan caching.
+   * The function receives a {@link SqlQuery} and must return a stable name for queries
+   * with the same SQL text and parameter types.
+   *
+   * Use {@link defaultStatementNameGenerator} for hash-based naming, or provide a custom
+   * implementation.
+   */
+  statementNameGenerator?: (query: SqlQuery) => string
 }
 
 export type UserDefinedTypeParser = (oid: number, value: unknown, adapter: SqlQueryable) => Promise<unknown>

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -200,7 +200,7 @@ class PgTransaction extends PgQueryable<TransactionClient> implements Transactio
   }
 }
 
-export type PrismaPgOptions = {
+export interface PrismaPgOptions {
   schema?: string
   disposeExternalPool?: boolean
   onPoolError?: (err: Error) => void

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -37,7 +37,7 @@ const debug = Debug('prisma:driver-adapter:pg')
  * Named statements live for the lifetime of the connection, which is likely acceptable for
  * Prisma workloads because the set of query shapes is typically bounded.
  */
-export function defaultStatementNameGenerator(query: SqlQuery): string {
+export function generateStatementName(query: SqlQuery): string {
   const hashInput = query.sql + '\0' + JSON.stringify(query.argTypes)
   return 'p_' + crypto.hash('sha1', hashInput, 'hex').slice(0, 24)
 }
@@ -124,7 +124,7 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements SqlQ
         {
           text: sql,
           values,
-          name: this.pgOptions?.statementNameGenerator?.(query),
+          name: this.pgOptions?.enableStatementCaching ? generateStatementName(query) : undefined,
           rowMode: 'array',
           types: {
             // This is the error expected:
@@ -207,14 +207,13 @@ export type PrismaPgOptions = {
   onConnectionError?: (err: Error) => void
   userDefinedTypeParser?: UserDefinedTypeParser
   /**
-   * When provided, enables PostgreSQL named prepared statements for query plan caching.
-   * The function receives a {@link SqlQuery} and must return a stable name for queries
-   * with the same SQL text and parameter types.
+   * When enabled, uses PostgreSQL named prepared statements for query plan caching.
+   * Repeated query shapes will reuse server-side plans on the same connection.
    *
-   * Use {@link defaultStatementNameGenerator} for hash-based naming, or provide a custom
-   * implementation.
+   * Named statements live for the lifetime of the connection, which is typically
+   * acceptable for Prisma workloads because the set of query shapes is bounded.
    */
-  statementNameGenerator?: (query: SqlQuery) => string
+  enableStatementCaching?: boolean
 }
 
 export type UserDefinedTypeParser = (oid: number, value: unknown, adapter: SqlQueryable) => Promise<unknown>

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/require-await */
 
+import crypto from 'node:crypto'
+
 import type {
   ColumnType,
   ConnectionInfo,
@@ -24,6 +26,24 @@ import { convertDriverError } from './errors'
 const types = pg.types
 
 const debug = Debug('prisma:driver-adapter:pg')
+
+/**
+ * Derive a stable prepared statement name from the SQL text and argument types.
+ *
+ * Passing a `name` makes `pg` use PostgreSQL named prepared statements, so repeated
+ * query shapes can reuse server-side plans on the same connection. We key the name
+ * by SQL text and parameter types, mirroring the Rust implementation.
+ *
+ * Named statements live for the lifetime of the connection, which is likely acceptable for
+ * Prisma workloads because the set of query shapes is typically bounded.
+ */
+export function getStatementName(query: SqlQuery): string {
+  const hashInput =
+    query.argTypes.length > 0
+      ? query.sql + '\0' + query.argTypes.map((t) => `${t.scalarType}:${t.arity}`).join(',')
+      : query.sql
+  return 'p_' + crypto.hash('sha1', hashInput, 'hex').slice(0, 16)
+}
 
 type StdClient = pg.Pool
 type TransactionClient = pg.PoolClient
@@ -107,6 +127,7 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements SqlQ
         {
           text: sql,
           values,
+          name: getStatementName(query),
           rowMode: 'array',
           types: {
             // This is the error expected:


### PR DESCRIPTION
This adds a prepared statement name when executing SQL queries with the `pg` driver. It addresses the issue identified in this discussion: https://github.com/prisma/prisma/discussions/28683

I created a repro here: https://github.com/jekh/prisma-stmt-test

It shows a dramatic difference in plan reuse and a corresponding reduction in network traffic, in line with the behavior of the legacy rust engine.

This intentionally doesn't add any sort of eviction or LRU for the client-side statement cache, because it doesn't look like the Rust adapter ever called DEALLOCATE, even when entries were evicted from the cache. Theoretically DEALLOCATE could be called when an entry is evicted, but that involves adding some kind of LRU cache and running DEALLOCATE on underlying pg, which is rather complicated. This change is basically a return to the old Rust behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional statement caching for the PostgreSQL adapter to enable prepared-statement reuse and improve query performance.
  * New public option to customize statement naming and a public helper that produces stable, short prepared-statement names.

* **Tests**
  * Expanded test coverage for statement name generation, caching behavior, transaction (BEGIN/COMMIT/ROLLBACK) handling, name propagation into query execution, and stability across identical query shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->