### PR TITLE
fix: export Get<Model>GroupByPayload type in prisma-client generator

### DIFF
--- a/packages/client-generator-ts/src/TSClient/Model.ts
+++ b/packages/client-generator-ts/src/TSClient/Model.ts
@@ -207,7 +207,7 @@ ${indent(
 
 ${ts.stringify(buildOutputType(groupByType))}
 
-type ${getGroupByPayloadName(model.name)}<T extends ${groupByArgsName}> = Prisma.PrismaPromise<
+export type ${getGroupByPayloadName(model.name)}<T extends ${groupByArgsName}> = Prisma.PrismaPromise<
   Array<
     Prisma.PickEnumerable<${groupByType.name}, T['by']> &
       {


### PR DESCRIPTION
## Summary

- Adds `export` keyword to the `Get<Model>GroupByPayload` type in `client-generator-ts` so it's accessible to users after generation

Fixes https://github.com/prisma/prisma/issues/29345

## Problem

In the `prisma-client` generator (Prisma 7), `Get<Model>GroupByPayload` is defined as a **private type** in each model file:

```typescript
// generated/models/MealInteraction.ts
export type MealInteractionGroupByArgs = { ... }        // ✅ exported
export type MealInteractionGroupByOutputType = { ... }   // ✅ exported
type GetMealInteractionGroupByPayload<T> = ...           // ❌ NOT exported
```

In the old `prisma-client-js` generator, this type was accessible via the `Prisma` namespace (`Prisma.GetMealInteractionGroupByPayload<{...}>`). With the new per-model-file architecture, the missing `export` makes it completely unreachable.

## Fix

One-line change in `packages/client-generator-ts/src/TSClient/Model.ts`:

```diff
-type ${getGroupByPayloadName(model.name)}<T extends ${groupByArgsName}> = Prisma.PrismaPromise<
+export type ${getGroupByPayloadName(model.name)}<T extends ${groupByArgsName}> = Prisma.PrismaPromise<
```

## Test plan

- [ ] Run `prisma generate` with `prisma-client` generator
- [ ] Verify `GetMealInteractionGroupByPayload` is now exported from the generated model file
- [ ] Verify it can be imported from the models barrel export
- [ ] Verify `Awaited<GetMealInteractionGroupByPayload<{ by: [...], _count: {...} }>>` resolves correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The GroupBy payload type is now publicly exportable and can be imported for use in your TypeScript applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->