### PR TITLE
fix(adapter-pg): properly serialize string values for JSON fields

### DIFF
--- a/packages/adapter-pg/src/conversion.ts
+++ b/packages/adapter-pg/src/conversion.ts
@@ -1,4 +1,4 @@
-import { ArgType, type ColumnType, ColumnTypeEnum } from '@prisma/driver-adapter-utils'
+﻿import { ArgType, type ColumnType, ColumnTypeEnum } from '@prisma/driver-adapter-utils'
 import pg from 'pg'
 import { parse as parseArray } from 'postgres-array'
 
@@ -440,6 +440,14 @@ export function mapArg<A>(arg: A | Date, argType: ArgType): null | unknown[] | s
     return new Uint8Array(arg.buffer, arg.byteOffset, arg.byteLength)
   }
 
+  // For JSON fields, we need to stringify the value to ensure PostgreSQL
+  // receives valid JSON. Without this, plain strings would fail with
+  // "invalid input syntax for type json" because node-postgres passes
+  // the string directly without quotes.
+  if (argType.scalarType === 'json') {
+    return JSON.stringify(arg)
+  }
+
   return arg
 }
 
@@ -479,3 +487,4 @@ function formatTime(date: Date): string {
     (ms ? '.' + String(ms).padStart(3, '0') : '')
   )
 }
+

--- a/packages/client/tests/functional/issues/29330-json-string-serialization/_matrix.ts
+++ b/packages/client/tests/functional/issues/29330-json-string-serialization/_matrix.ts
@@ -1,0 +1,6 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+import { Providers, sqlProviders } from '../../_utils/providers'
+
+export default defineMatrix(() => [
+  sqlProviders.filter(({ provider }) => provider !== Providers.SQLITE)
+])

--- a/packages/client/tests/functional/issues/29330-json-string-serialization/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/29330-json-string-serialization/prisma/_schema.ts
@@ -1,0 +1,19 @@
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+    generator client {
+      provider = "prisma-client-js"
+    }
+
+    datasource db {
+      provider = "${provider}"
+    }
+
+    model Document {
+      id        Int     @id @default(autoincrement())
+      content   Json
+      metadata  Json?
+    }
+  `
+})

--- a/packages/client/tests/functional/issues/29330-json-string-serialization/tests.ts
+++ b/packages/client/tests/functional/issues/29330-json-string-serialization/tests.ts
@@ -1,0 +1,54 @@
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(
+  () => {
+    test('writes and reads string values to JSON fields correctly', async () => {
+      // Test plain string value in JSON field
+      const document = await prisma.document.create({
+        data: {
+          content: 'hello world',
+          metadata: { author: 'test' },
+        },
+      })
+
+      expect(document.content).toBe('hello world')
+      expect(document.metadata).toEqual({ author: 'test' })
+
+      // Test with findMany
+      const found = await prisma.document.findFirst({
+        where: { id: document.id },
+      })
+
+      expect(found?.content).toBe('hello world')
+      expect(found?.metadata).toEqual({ author: 'test' })
+    })
+
+    test('writes various JSON types correctly', async () => {
+      const testCases = [
+        { content: 'string value', desc: 'string' },
+        { content: 42, desc: 'number' },
+        { content: true, desc: 'boolean' },
+        { content: null, desc: 'null' },
+        { content: { nested: 'object' }, desc: 'object' },
+        { content: [1, 2, 3], desc: 'array' },
+      ]
+
+      for (const { content, desc } of testCases) {
+        const doc = await prisma.document.create({
+          data: { content, metadata: null },
+        })
+        expect(doc.content).toEqual(content)
+      }
+    })
+  },
+  {
+    optOut: {
+      from: ['sqlite'],
+      reason: 'SQLite does not support native JSON type',
+    },
+  },
+)

--- a/packages/client/tests/functional/issues/29330-json-string-serialization/tests.ts
+++ b/packages/client/tests/functional/issues/29330-json-string-serialization/tests.ts
@@ -29,15 +29,15 @@ testMatrix.setupTestSuite(
 
     test('writes various JSON types correctly', async () => {
       const testCases = [
-        { content: 'string value', desc: 'string' },
-        { content: 42, desc: 'number' },
-        { content: true, desc: 'boolean' },
-        { content: null, desc: 'null' },
-        { content: { nested: 'object' }, desc: 'object' },
-        { content: [1, 2, 3], desc: 'array' },
+        { content: 'string value' },
+        { content: 42 },
+        { content: true },
+        { content: null },
+        { content: { nested: 'object' } },
+        { content: [1, 2, 3] },
       ]
 
-      for (const { content, desc } of testCases) {
+      for (const { content } of testCases) {
         const doc = await prisma.document.create({
           data: { content, metadata: null },
         })


### PR DESCRIPTION
## Summary

Fixes a bug where plain string values could not be written to JSON fields in PostgreSQL.

## Problem

When writing a plain string to a JSON field:

```ts
prisma.simple.create({data: {value: "hello"}})
```

PostgreSQL would reject with:
```
invalid input syntax for type json
```

This happened because the adapter was passing the string directly to node-postgres without JSON.stringify.

## Fix

Ensure string values for JSON fields are properly serialized using JSON.stringify before being passed to the postgres driver.

## Testing

- [x] Verified plain strings work in JSON fields
- [x] All existing adapter-pg tests pass
- [x] Numbers and booleans still work correctly

Fixes prisma/prisma#29330

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JSON values are now correctly formatted when sent to PostgreSQL, preventing invalid JSON input errors.

* **Tests**
  * Added functional tests for JSON string-serialization behavior, a test matrix that excludes SQLite, and a schema setup used by the new tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->