### PR TITLE
fix(adapter-pg): update @types/pg

### DIFF
--- a/packages/adapter-pg/package.json
+++ b/packages/adapter-pg/package.json
@@ -39,7 +39,7 @@
     "@prisma/driver-adapter-utils": "workspace:*",
     "pg": "^8.16.3",
     "postgres-array": "3.0.4",
-    "@types/pg": "8.11.11"
+    "@types/pg": "^8.18.0"
   },
   "devDependencies": {
     "@prisma/debug": "workspace:*"

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -109,18 +109,6 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements SqlQ
           values,
           rowMode: 'array',
           types: {
-            // This is the error expected:
-            // No overload matches this call.
-            // The last overload gave the following error.
-            // Type '(oid: number, format?: any) => (json: string) => unknown' is not assignable to type '{ <T>(oid: number): TypeParser<string, string | T>; <T>(oid: number, format: "text"): TypeParser<string, string | T>; <T>(oid: number, format: "binary"): TypeParser<...>; }'.
-            //   Type '(json: string) => unknown' is not assignable to type 'TypeParser<Buffer, any>'.
-            //     Types of parameters 'json' and 'value' are incompatible.
-            //       Type 'Buffer' is not assignable to type 'string'.ts(2769)
-            //
-            // Because pg-types types expect us to handle both binary and text protocol versions,
-            // where as far we can see, pg will ever pass only text version.
-            //
-            // @ts-expect-error
             getTypeParser: (oid: number, format?) => {
               if (format === 'text' && customParsers[oid]) {
                 return customParsers[oid]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,8 +306,8 @@ importers:
         specifier: workspace:*
         version: link:../driver-adapter-utils
       '@types/pg':
-        specifier: 8.11.11
-        version: 8.11.11
+        specifier: ^8.18.0
+        version: 8.18.0
       pg:
         specifier: ^8.16.3
         version: 8.16.3
@@ -4008,6 +4008,9 @@ packages:
 
   '@types/pg@8.11.6':
     resolution: {integrity: sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==}
+
+  '@types/pg@8.18.0':
+    resolution: {integrity: sha512-gT+oueVQkqnj6ajGJXblFR4iavIXWsGAFCk3dP4Kki5+a9R4NMt0JARdk6s8cUKcfUoqP5dAtDSLU8xYUTFV+Q==}
 
   '@types/pluralize@0.0.33':
     resolution: {integrity: sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg==}
@@ -10484,6 +10487,12 @@ snapshots:
       '@types/node': 20.19.25
       pg-protocol: 1.6.1
       pg-types: 4.0.2
+
+  '@types/pg@8.18.0':
+    dependencies:
+      '@types/node': 20.19.25
+      pg-protocol: 1.10.3
+      pg-types: 2.2.0
 
   '@types/pluralize@0.0.33': {}
 


### PR DESCRIPTION
Supports pg@8.18+ type changes

Closes #29356

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a PostgreSQL-related dependency to a newer semver range for improved compatibility and stability.
* **Style**
  * Minor internal code cleanup with no functional changes to runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->