### PR TITLE
fix(internals): preserve original line endings and ensure single trailing newline in formatSchema

### DIFF
--- a/packages/internals/src/engine-commands/formatSchema.ts
+++ b/packages/internals/src/engine-commands/formatSchema.ts
@@ -45,7 +45,25 @@ export async function formatSchema(
   const { formattedMultipleSchemas, lintDiagnostics } = handleFormatPanic(() => {
     // the only possible error here is a Rust panic
     const formattedMultipleSchemasRaw = formatWasm(JSON.stringify(schemas), documentFormattingParams)
-    const formattedMultipleSchemas = JSON.parse(formattedMultipleSchemasRaw) as MultipleSchemas
+    const formattedMultipleSchemas = (
+      JSON.parse(formattedMultipleSchemasRaw) as MultipleSchemas
+    ).map(([filename, content]) => {
+      const originalSchemaTuple = schemas.find((s) => s[0] === filename)
+      if (originalSchemaTuple) {
+        const [, originalSchema] = originalSchemaTuple
+        const isCrlf = originalSchema.includes('\r\n')
+        const expectedLineEnding = isCrlf ? '\r\n' : '\n'
+
+        // Normalize line endings to match input
+        let result = content.replace(/\r?\n/g, expectedLineEnding)
+
+        // Ensure single trailing newline
+        result = result.trimEnd() + expectedLineEnding
+
+        return [filename, result] as [string, string]
+      }
+      return [filename, content] as [string, string]
+    })
 
     const lintDiagnostics = lintSchema({ schemas: formattedMultipleSchemas })
     return { formattedMultipleSchemas, lintDiagnostics }

--- a/packages/internals/src/engine-commands/formatSchema.ts
+++ b/packages/internals/src/engine-commands/formatSchema.ts
@@ -51,13 +51,21 @@ export async function formatSchema(
       const originalSchemaTuple = schemas.find((s) => s[0] === filename)
       if (originalSchemaTuple) {
         const [, originalSchema] = originalSchemaTuple
+
+        /**
+         * Detect the original line ending style (CRLF or LF).
+         */
         const isCrlf = originalSchema.includes('\r\n')
         const expectedLineEnding = isCrlf ? '\r\n' : '\n'
 
-        // Normalize line endings to match input
+        /**
+         * Normalize all line endings in the formatted output to match the original schema.
+         */
         let result = content.replace(/\r?\n/g, expectedLineEnding)
 
-        // Ensure single trailing newline
+        /**
+         * Ensure the file ends with exactly one trailing newline of the correct type.
+         */
         result = result.trimEnd() + expectedLineEnding
 
         return [filename, result] as [string, string]


### PR DESCRIPTION
This PR addresses issue #8548 by ensuring that `prisma format` preserves the original line ending style (CRLF or LF) from the input schema. It also ensures the output always ends with a single trailing newline of the correct type, fixing the issue where an extra CRLF was added on Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve each schema's original line-ending style (CRLF or LF) when formatting and ensure exactly one trailing newline of that style to avoid cross-platform inconsistencies.
  * Leave formatted content unchanged for files not present in the original input.
  * Maintain existing linting, diagnostics, and error-handling behavior so validation and reporting remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->