### PR TITLE
fix(client): prevent caching of createMany queries to avoid cache bloat and possible node.js crashes

### DIFF
--- a/packages/client/src/runtime/core/engines/client/ClientEngine.ts
+++ b/packages/client/src/runtime/core/engines/client/ClientEngine.ts
@@ -475,14 +475,17 @@ export class ClientEngine implements Engine {
       const cacheKey = JSON.stringify(parameterizedQuery)
       placeholderValues = extractedValues
 
-      const cached = this.#queryPlanCache.getSingle(cacheKey)
+      const isCacheable = query.action !== 'createMany' && query.action !== 'createManyAndReturn'
+      const cached = isCacheable ? this.#queryPlanCache.getSingle(cacheKey) : undefined
       if (cached) {
         debug('query plan cache hit')
         plan = cached
       } else {
         debug('query plan cache miss')
         plan = this.#compileQuery(parameterizedQuery, cacheKey, queryCompiler)
-        this.#queryPlanCache.setSingle(cacheKey, plan)
+        if (isCacheable) {
+          this.#queryPlanCache.setSingle(cacheKey, plan)
+        }
       }
     }
 

--- a/packages/client/src/runtime/core/engines/client/ClientEngine.ts
+++ b/packages/client/src/runtime/core/engines/client/ClientEngine.ts
@@ -475,6 +475,9 @@ export class ClientEngine implements Engine {
       const cacheKey = JSON.stringify(parameterizedQuery)
       placeholderValues = extractedValues
 
+      // We do not cache `createMany` and `createManyAndReturn` queries as they are very unlikely
+      // to benefit from caching due to their high variability in parameters, which leads to a very
+      // high cache miss rate and potential cache bloat.
       const isCacheable = query.action !== 'createMany' && query.action !== 'createManyAndReturn'
       const cached = isCacheable ? this.#queryPlanCache.getSingle(cacheKey) : undefined
       if (cached) {

--- a/packages/client/tests/functional/issues/29331-query-plan-cache-bloat/_matrix.ts
+++ b/packages/client/tests/functional/issues/29331-query-plan-cache-bloat/_matrix.ts
@@ -1,0 +1,4 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+import { allProviders } from '../../_utils/providers'
+
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/issues/29331-query-plan-cache-bloat/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/29331-query-plan-cache-bloat/prisma/_schema.ts
@@ -1,0 +1,42 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+    generator client {
+      provider  = "prisma-client-js"
+    }
+
+    datasource db {
+      provider = "${provider}"
+    }
+
+    model Contact {
+      id ${idForProvider(provider, { includeDefault: true })}
+      analytics ContactAnalytics[]
+    }
+
+    model ContactAnalytics {
+      id ${idForProvider(provider, { includeDefault: true })}
+      contactId String
+      contact Contact @relation(fields: [contactId], references: [id], onDelete: Cascade)
+      date1 DateTime?
+      date2 DateTime?
+      date3 DateTime?
+      date4 DateTime?
+      date5 DateTime?
+      date6 DateTime?
+      date7 DateTime?
+      val1 Int?
+      val2 Int?
+      val3 Int?
+      val4 Int?
+      val5 Int?
+      float1 Float?
+      float2 Float?
+      bool1 Boolean?
+      bool2 Boolean?
+      bool3 Boolean?
+    }
+  `
+})

--- a/packages/client/tests/functional/issues/29331-query-plan-cache-bloat/tests.ts
+++ b/packages/client/tests/functional/issues/29331-query-plan-cache-bloat/tests.ts
@@ -1,0 +1,96 @@
+import { faker } from '@snaplet/copycat'
+
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
+
+declare let prisma: PrismaClient
+
+function daysBefore(days: number): Date {
+  const date = new Date()
+  date.setDate(date.getDate() - days)
+  return date
+}
+
+testMatrix.setupTestSuite(() => {
+  const contactId1 = faker.database.mongodbObjectId()
+  const contactId2 = faker.database.mongodbObjectId()
+  const contactId3 = faker.database.mongodbObjectId()
+
+  afterEach(async () => {
+    await prisma.contactAnalytics.deleteMany()
+    await prisma.contact.deleteMany()
+  })
+
+  beforeEach(async () => {
+    await prisma.contact.createMany({
+      data: [{ id: contactId1 }, { id: contactId2 }, { id: contactId3 }],
+    })
+    await prisma.contactAnalytics.createMany({
+      data: [
+        {
+          contactId: contactId1,
+          date1: daysBefore(180),
+          date2: daysBefore(30),
+          val1: 50,
+          bool1: true,
+        },
+        {
+          contactId: contactId2,
+          date3: daysBefore(14),
+          date4: daysBefore(7),
+          val2: 100,
+        },
+        {
+          contactId: contactId3,
+          date5: daysBefore(3),
+          val3: 10,
+        },
+      ],
+    })
+  })
+
+  const fullStress = process.env.PRISMA_CREATE_MANY_STRESS === 'true'
+  const iterations = fullStress ? 200 : 5
+  const batchSize = fullStress ? 10000 : 20
+  const timeout = fullStress ? 5 * 60 * 1000 : 10 * 1000
+
+  test(
+    'createMany stress test for cache bloat',
+    async () => {
+      console.log(`Running createMany stress test with ${iterations} iterations and batch size of ${batchSize}`)
+      for (let i = 0; i < iterations; i++) {
+        const rows = Array.from({ length: batchSize }, (_, j) => {
+          return {
+            contactId: i % 2 === 0 ? contactId1 : j % 2 === 0 ? contactId2 : contactId3,
+            // Vary which DateTime fields are set to create different parameter patterns
+            date1: j % 3 === 0 ? daysBefore(Math.floor(Math.random() * 180)) : undefined,
+            date2: j % 5 === 0 ? daysBefore(Math.floor(Math.random() * 30)) : undefined,
+            date3: j % 7 === 0 ? daysBefore(Math.floor(Math.random() * 14)) : undefined,
+            date4: j % 4 === 0 ? daysBefore(Math.floor(Math.random() * 7)) : undefined,
+            date5: j % 6 === 0 ? daysBefore(Math.floor(Math.random() * 10)) : undefined,
+            date6: j % 8 === 0 ? daysBefore(Math.floor(Math.random() * 5)) : undefined,
+            date7: j % 2 === 0 ? daysBefore(Math.floor(Math.random() * 3)) : undefined,
+            val1: j % 2 === 0 ? Math.floor(Math.random() * 100) : undefined,
+            val2: j % 3 === 0 ? Math.floor(Math.random() * 100) : undefined,
+            val3: j % 4 === 0 ? Math.floor(Math.random() * 100) : undefined,
+            val4: j % 5 === 0 ? Math.floor(Math.random() * 100) : undefined,
+            val5: j % 6 === 0 ? Math.floor(Math.random() * 100) : undefined,
+            float1: j % 4 === 0 ? Math.random() * 100 : undefined,
+            float2: j % 5 === 0 ? Math.random() * 100 : undefined,
+            bool1: j % 9 === 0 ? Math.random() > 0.8 : undefined,
+            bool2: j % 10 === 0 ? Math.random() > 0.2 : undefined,
+            bool3: j % 7 === 0 ? Math.random() > 0.5 : undefined,
+          }
+        })
+
+        const result = await prisma.contactAnalytics.createMany({ data: rows })
+        expect(result.count).toBe(batchSize)
+      }
+
+      const count = await prisma.contactAnalytics.count()
+      expect(count).toBe(iterations * batchSize + 3)
+    },
+    timeout,
+  ) // Increase timeout for stress test
+})


### PR DESCRIPTION
`createMany` operations inherently have unstable cache keys due to varying row counts and parameter de-duplication.

`createMany` operations are characterized by large cache keys and very large query plans. In large batches, the cache will consume several GB of memory that will not be evicted by the GC even after the query is complete because the plans are still referenced by the cache itself.

This fix opts out of caching such queries with the following rationale:
1. Such queries will most likely create cache-misses and so caching them is ineffective
2. When running batch load/update workloads, these query plans will evict valid queries from the cache thus creating an advert effect on performance

Fixes: prisma#29331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced query-plan cache growth by skipping single-query caching for high-volume bulk create operations, lowering memory use and improving bulk write efficiency.

* **Tests**
  * Added a comprehensive functional test suite (matrix, provider-specific schema setup, and stress tests) that seeds data and runs parameterized create-many scenarios to validate performance and correctness under load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->