### PR TITLE
fix: pin E2E typescript to prevent 6 upgrade

### DIFF
--- a/packages/client/tests/e2e/_utils/standard.dockerfile
+++ b/packages/client/tests/e2e/_utils/standard.dockerfile
@@ -2,13 +2,13 @@ FROM node:20.19
 
 RUN npm -v
 
-# zx is pinned to v7 because v8 fails with: 
+# zx is pinned to v7 because v8 fails with:
 # [esbuild Error]: Top-level await is currently not supported with the "cjs" output format
 # at /usr/local/lib/node_modules/zx/build/vendor.js:2:17
 RUN npm i -g \
   zx@7 \
   pnpm \
-  typescript \
+  typescript@5.9.3 \
   ts-node \
   esbuild \
   tsx \


### PR DESCRIPTION
E2E tests run into errors due to recently released Typescript 6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript version pinning in test infrastructure to ensure consistent build environments.
  * Resolved minor whitespace formatting in configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->