### PR TITLE
fix: fix typescript 6 E2E errors

### DIFF
--- a/packages/client/tests/e2e/issues/27128-generate-watch/tsconfig.json
+++ b/packages/client/tests/e2e/issues/27128-generate-watch/tsconfig.json
@@ -3,6 +3,7 @@
   "exclude": ["_steps.ts"],
   "compilerOptions": {
     "module": "Node16",
-    "moduleResolution": "node16"
+    "moduleResolution": "node16",
+    "types": ["node"]
   }
 }

--- a/packages/client/tests/e2e/prisma-client-generator/node-tsup-esm/tsconfig.json
+++ b/packages/client/tests/e2e/prisma-client-generator/node-tsup-esm/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,
-    "skipLibCheck": false
+    "skipLibCheck": false,
+    "types": ["node"]
   }
 }

--- a/packages/client/tests/e2e/prisma-client-generator/node-tsx-cjs/tsconfig.json
+++ b/packages/client/tests/e2e/prisma-client-generator/node-tsx-cjs/tsconfig.json
@@ -3,8 +3,10 @@
   "compilerOptions": {
     "target": "ESNext",
     "module": "CommonJS",
-    "moduleResolution": "node",
+    "moduleResolution": "node10",
+    "ignoreDeprecations": "6.0",
     "strict": true,
-    "skipLibCheck": false
+    "skipLibCheck": false,
+    "types": ["node"]
   }
 }

--- a/packages/client/tests/e2e/prisma-client-generator/node-tsx-esm-mts/tsconfig.json
+++ b/packages/client/tests/e2e/prisma-client-generator/node-tsx-esm-mts/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "strict": true,
-    "skipLibCheck": false
+    "skipLibCheck": false,
+    "types": ["node"]
   }
 }

--- a/packages/client/tests/e2e/prisma-client-generator/node-tsx-esm/tsconfig.json
+++ b/packages/client/tests/e2e/prisma-client-generator/node-tsx-esm/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "strict": true,
-    "skipLibCheck": false
+    "skipLibCheck": false,
+    "types": ["node"]
   }
 }

--- a/packages/client/tests/e2e/tsconfig.base.json
+++ b/packages/client/tests/e2e/tsconfig.base.json
@@ -6,6 +6,7 @@
     "declaration": true,
     "esModuleInterop": true,
     "strict": true,
-    "skipLibCheck": false
+    "skipLibCheck": false,
+    "types": ["jest", "node"]
   }
 }


### PR DESCRIPTION
Fixes errors for recently released Typescript 6 in E2E tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript compiler configurations across test environments to explicitly include Node.js and Jest type definitions, ensuring consistent type checking and compilation settings during development and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->