### PR TITLE
fix: set @types/pg to ^8.16.0

### DIFF
--- a/packages/adapter-pg/package.json
+++ b/packages/adapter-pg/package.json
@@ -39,7 +39,7 @@
     "@prisma/driver-adapter-utils": "workspace:*",
     "pg": "^8.16.3",
     "postgres-array": "3.0.4",
-    "@types/pg": "8.11.11"
+    "@types/pg": "^8.16.0"
   },
   "devDependencies": {
     "@prisma/debug": "workspace:*"

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -109,18 +109,6 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements SqlQ
           values,
           rowMode: 'array',
           types: {
-            // This is the error expected:
-            // No overload matches this call.
-            // The last overload gave the following error.
-            // Type '(oid: number, format?: any) => (json: string) => unknown' is not assignable to type '{ <T>(oid: number): TypeParser<string, string | T>; <T>(oid: number, format: "text"): TypeParser<string, string | T>; <T>(oid: number, format: "binary"): TypeParser<...>; }'.
-            //   Type '(json: string) => unknown' is not assignable to type 'TypeParser<Buffer, any>'.
-            //     Types of parameters 'json' and 'value' are incompatible.
-            //       Type 'Buffer' is not assignable to type 'string'.ts(2769)
-            //
-            // Because pg-types types expect us to handle both binary and text protocol versions,
-            // where as far we can see, pg will ever pass only text version.
-            //
-            // @ts-expect-error
             getTypeParser: (oid: number, format?) => {
               if (format === 'text' && customParsers[oid]) {
                 return customParsers[oid]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,8 +306,8 @@ importers:
         specifier: workspace:*
         version: link:../driver-adapter-utils
       '@types/pg':
-        specifier: 8.11.11
-        version: 8.11.11
+        specifier: ^8.16.0
+        version: 8.20.0
       pg:
         specifier: ^8.16.3
         version: 8.16.3
@@ -4085,6 +4085,9 @@ packages:
 
   '@types/pg@8.11.6':
     resolution: {integrity: sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
   '@types/pluralize@0.0.33':
     resolution: {integrity: sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg==}
@@ -10601,6 +10604,12 @@ snapshots:
       '@types/node': 20.19.25
       pg-protocol: 1.6.1
       pg-types: 4.0.2
+
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 20.19.25
+      pg-protocol: 1.10.3
+      pg-types: 2.2.0
 
   '@types/pluralize@0.0.33': {}
 


### PR DESCRIPTION
Sets the `@types/pg` to use a more relaxed constraint and a more recent version `^8.16`. The hard constraint has caused issues described here https://github.com/prisma/prisma/issues/29356. I decided to bump it to `^8.16.0` to align it with our `pg` dependency. `8.16.0` is the only `@types/pg` available for `8.16` `pg` series. Reasoning is explained here in more detail: https://github.com/prisma/prisma/pull/29357#discussion_r2983585611

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL type definitions to a newer version
  * Improved TypeScript compatibility by removing outdated type suppression comments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->