### PR TITLE
chore(client): use typescript 6 in e2e tests

### DIFF
--- a/packages/client/tests/e2e/_utils/standard.dockerfile
+++ b/packages/client/tests/e2e/_utils/standard.dockerfile
@@ -8,7 +8,7 @@ RUN npm -v
 RUN npm i -g \
   zx@7 \
   pnpm \
-  typescript@5.9.3 \
+  typescript@6.0.x \
   ts-node \
   esbuild \
   tsx \

--- a/packages/client/tests/e2e/prisma-client-generator/node-tsup-esm/tsconfig.json
+++ b/packages/client/tests/e2e/prisma-client-generator/node-tsup-esm/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,
-    "skipLibCheck": false
+    "skipLibCheck": false,
+    "types": ["node"]
   }
 }


### PR DESCRIPTION
Follow up to https://github.com/prisma/prisma/pull/29383