### PR TITLE
feat: mariadb protocol options

### DIFF
--- a/packages/adapter-mariadb/src/credentials.test.ts
+++ b/packages/adapter-mariadb/src/credentials.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest'
+
+import { PrismaMariaDbAdapterFactory } from './mariadb'
+
+describe('credential sanitization', () => {
+  test('connection string parse error should not expose password', async () => {
+    const secretPassword = 'super_secret_password_12345'
+    // IPv6 address in brackets - causes parse error in mariadb driver
+    const connectionString = `mariadb://user:${secretPassword}@[64:ff9b::23be:d64c]/db`
+
+    const factory = new PrismaMariaDbAdapterFactory(connectionString)
+
+    try {
+      await factory.connect()
+      expect.fail('Expected connection to fail')
+    } catch (error) {
+      const errorMessage = String(error)
+      expect(errorMessage).not.toContain(secretPassword)
+    }
+  })
+})

--- a/packages/adapter-mariadb/src/mariadb.test.ts
+++ b/packages/adapter-mariadb/src/mariadb.test.ts
@@ -1,5 +1,5 @@
 import * as mariadb from 'mariadb'
-import { describe, expect, test, vi, beforeAll, afterAll } from 'vitest'
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 
 import {
   inferCapabilities,
@@ -7,73 +7,6 @@ import {
   PrismaMariaDbAdapterFactory,
   rewriteConnectionString,
 } from './mariadb'
-
-describe.each([
-  ['8.0.12', { supportsRelationJoins: false }],
-  ['8.0.13', { supportsRelationJoins: true }],
-  ['8.1.0', { supportsRelationJoins: true }],
-  ['8.4.5', { supportsRelationJoins: true }],
-  ['8.4.13', { supportsRelationJoins: true }],
-  ['11.4.7-MariaDB-ubu2404', { supportsRelationJoins: false }],
-])('infer capabilities for %s', (version, capabilities) => {
-  test(`inferCapabilities(${version})`, () => {
-    expect(inferCapabilities(version)).toEqual(capabilities)
-  })
-})
-
-describe('rewriteConnectionString', () => {
-  test('should rewrite mysql:// to mariadb://', () => {
-    const input = 'mysql://user:password@localhost:3306/database?ssl=true&connectionLimit=10&charset=utf8mb4'
-    const expected = 'mariadb://user:password@localhost:3306/database?ssl=true&connectionLimit=10&charset=utf8mb4'
-    expect(rewriteConnectionString(new URL(input)).toString()).toBe(expected)
-  })
-
-  test('should preserve mariadb:// connection strings', () => {
-    const input = 'mariadb://user:pass@localhost:3306/db'
-    expect(rewriteConnectionString(new URL(input)).toString()).toBe(input)
-  })
-})
-
-describe('credential sanitization', () => {
-  test('connection string parse error should not expose password', async () => {
-    const secretPassword = 'super_secret_password_12345'
-    // IPv6 address in brackets - causes parse error in mariadb driver
-    const connectionString = `mariadb://user:${secretPassword}@[64:ff9b::23be:d64c]/db`
-
-    const factory = new PrismaMariaDbAdapterFactory(connectionString)
-
-    try {
-      await factory.connect()
-      expect.fail('Expected connection to fail')
-    } catch (error) {
-      const errorMessage = String(error)
-      expect(errorMessage).not.toContain(secretPassword)
-    }
-  })
-})
-
-describe('useTextProtocol option', () => {
-  const flagToMethod = {
-    true: 'query',
-    false: 'execute',
-  }
-
-  test.each([false, undefined, true].map((flag) => ({ flag, method: flagToMethod[String(!!flag)] })))(
-    'should use client.$method when useTextProtocol is $flag',
-    async ({ flag, method }) => {
-      const mockClient = {
-        execute: vi.fn().mockResolvedValue({ meta: [], affectedRows: 1 }),
-        query: vi.fn().mockResolvedValue({ meta: [], affectedRows: 1 }),
-      } as unknown as mariadb.Pool
-
-      const adapter = new PrismaMariaDbAdapter(mockClient, { supportsRelationJoins: true }, { useTextProtocol: flag })
-      await adapter.executeRaw({ sql: 'SELECT 1', args: [], argTypes: [] })
-      expect(mockClient[method]).toHaveBeenCalledWith(expect.objectContaining({ sql: 'SELECT 1' }), [])
-
-      expect(mockClient[flagToMethod[String(!flag)]]).not.toHaveBeenCalled()
-    },
-  )
-})
 
 describe('PrismaMariaDbAdapterFactory constructor', () => {
   beforeAll(() => {
@@ -122,4 +55,53 @@ describe('PrismaMariaDbAdapterFactory constructor', () => {
     expect(mockCreatePool).toHaveBeenCalledWith(expected)
     mockCreatePool.mockClear()
   })
+})
+
+describe.each([
+  ['8.0.12', { supportsRelationJoins: false }],
+  ['8.0.13', { supportsRelationJoins: true }],
+  ['8.1.0', { supportsRelationJoins: true }],
+  ['8.4.5', { supportsRelationJoins: true }],
+  ['8.4.13', { supportsRelationJoins: true }],
+  ['11.4.7-MariaDB-ubu2404', { supportsRelationJoins: false }],
+])('infer capabilities for %s', (version, capabilities) => {
+  test(`inferCapabilities(${version})`, () => {
+    expect(inferCapabilities(version)).toEqual(capabilities)
+  })
+})
+
+describe('rewriteConnectionString', () => {
+  test('should rewrite mysql:// to mariadb://', () => {
+    const input = 'mysql://user:password@localhost:3306/database?ssl=true&connectionLimit=10&charset=utf8mb4'
+    const expected = 'mariadb://user:password@localhost:3306/database?ssl=true&connectionLimit=10&charset=utf8mb4'
+    expect(rewriteConnectionString(new URL(input)).toString()).toBe(expected)
+  })
+
+  test('should preserve mariadb:// connection strings', () => {
+    const input = 'mariadb://user:pass@localhost:3306/db'
+    expect(rewriteConnectionString(new URL(input)).toString()).toBe(input)
+  })
+})
+
+describe('useTextProtocol option', () => {
+  const flagToMethod = {
+    true: 'query',
+    false: 'execute',
+  }
+
+  test.each([false, undefined, true].map((flag) => ({ flag, method: flagToMethod[String(!!flag)] })))(
+    'should use client.$method when useTextProtocol is $flag',
+    async ({ flag, method }) => {
+      const mockClient = {
+        execute: vi.fn().mockResolvedValue({ meta: [], affectedRows: 1 }),
+        query: vi.fn().mockResolvedValue({ meta: [], affectedRows: 1 }),
+      } as unknown as mariadb.Pool
+
+      const adapter = new PrismaMariaDbAdapter(mockClient, { supportsRelationJoins: true }, { useTextProtocol: flag })
+      await adapter.executeRaw({ sql: 'SELECT 1', args: [], argTypes: [] })
+      expect(mockClient[method]).toHaveBeenCalledWith(expect.objectContaining({ sql: 'SELECT 1' }), [])
+
+      expect(mockClient[flagToMethod[String(!flag)]]).not.toHaveBeenCalled()
+    },
+  )
 })

--- a/packages/adapter-mariadb/src/mariadb.test.ts
+++ b/packages/adapter-mariadb/src/mariadb.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test, vi, beforeAll, afterAll } from 'vitest'
 import * as mariadb from 'mariadb'
+import { describe, expect, test, vi, beforeAll, afterAll } from 'vitest'
 
 import {
   inferCapabilities,

--- a/packages/adapter-mariadb/src/mariadb.test.ts
+++ b/packages/adapter-mariadb/src/mariadb.test.ts
@@ -8,6 +8,11 @@ import {
   rewriteConnectionString,
 } from './mariadb'
 
+// Mock the mariadb module
+vi.mock('mariadb', () => ({
+  createPool: vi.fn(),
+}))
+
 describe.each([
   ['8.0.12', { supportsRelationJoins: false }],
   ['8.0.13', { supportsRelationJoins: true }],
@@ -81,4 +86,40 @@ describe('useTextProtocol option', () => {
       expect(mockClient[expectedMethod]).toHaveBeenCalledWith(expect.objectContaining({ sql: 'SELECT 1' }), [])
     },
   )
+})
+
+describe('PrismaMariaDbAdapterFactory constructor', () => {
+  test('should create a config with prepareCacheLength set to 0 when config has no prepareCacheLength', async () => {
+    const config = {}
+
+    const mockCreatePool = vi.mocked(mariadb.createPool)
+    mockCreatePool.mockReturnValue({
+      query: vi.fn().mockResolvedValue([['8.0.13']]),
+      end: vi.fn(),
+    } as unknown as mariadb.Pool)
+
+    const factory = new PrismaMariaDbAdapterFactory(config)
+    await factory.connect()
+
+    expect(mockCreatePool).toHaveBeenCalledWith(expect.objectContaining({ prepareCacheLength: 0 }))
+    mockCreatePool.mockClear()
+  })
+
+  test('should preserve existing prepareCacheLength when config is object and prepareCacheLength is set', async () => {
+    const config = {
+      prepareCacheLength: 10,
+    }
+
+    const mockCreatePool = vi.mocked(mariadb.createPool)
+    mockCreatePool.mockReturnValue({
+      query: vi.fn().mockResolvedValue([['8.0.13']]),
+      end: vi.fn(),
+    } as unknown as mariadb.Pool)
+
+    const factory = new PrismaMariaDbAdapterFactory(config)
+    await factory.connect()
+
+    expect(mockCreatePool).toHaveBeenCalledWith(expect.objectContaining({ prepareCacheLength: 10 }))
+    mockCreatePool.mockClear()
+  })
 })

--- a/packages/adapter-mariadb/src/mariadb.test.ts
+++ b/packages/adapter-mariadb/src/mariadb.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi, beforeAll, afterAll } from 'vitest'
 import * as mariadb from 'mariadb'
 
 import {
@@ -7,11 +7,6 @@ import {
   PrismaMariaDbAdapterFactory,
   rewriteConnectionString,
 } from './mariadb'
-
-// Mock the mariadb module
-vi.mock('mariadb', () => ({
-  createPool: vi.fn(),
-}))
 
 describe.each([
   ['8.0.12', { supportsRelationJoins: false }],
@@ -30,23 +25,12 @@ describe('rewriteConnectionString', () => {
   test('should rewrite mysql:// to mariadb://', () => {
     const input = 'mysql://user:password@localhost:3306/database?ssl=true&connectionLimit=10&charset=utf8mb4'
     const expected = 'mariadb://user:password@localhost:3306/database?ssl=true&connectionLimit=10&charset=utf8mb4'
-    expect(rewriteConnectionString(input)).toBe(expected)
+    expect(rewriteConnectionString(new URL(input)).toString()).toBe(expected)
   })
 
   test('should preserve mariadb:// connection strings', () => {
     const input = 'mariadb://user:pass@localhost:3306/db'
-    expect(rewriteConnectionString(input)).toBe(input)
-  })
-
-  test('should preserve configuration objects', () => {
-    const config = {
-      host: 'localhost',
-      port: 3306,
-      user: 'user',
-      password: 'pass',
-      database: 'db',
-    }
-    expect(rewriteConnectionString(config)).toBe(config)
+    expect(rewriteConnectionString(new URL(input)).toString()).toBe(input)
   })
 })
 
@@ -69,29 +53,43 @@ describe('credential sanitization', () => {
 })
 
 describe('useTextProtocol option', () => {
-  test.each([
-    { useTextProtocol: false, expectedMethod: 'execute' },
-    { useTextProtocol: undefined, expectedMethod: 'execute' },
-    { useTextProtocol: true, expectedMethod: 'query' },
-  ])(
-    'should use client.$expectedMethod when useTextProtocol is $useTextProtocol',
-    async ({ useTextProtocol, expectedMethod }) => {
+  const flagToMethod = {
+    true: 'query',
+    false: 'execute',
+  }
+
+  test.each([false, undefined, true].map((flag) => ({ flag, method: flagToMethod[String(!!flag)] })))(
+    'should use client.$method when useTextProtocol is $flag',
+    async ({ flag, method }) => {
       const mockClient = {
         execute: vi.fn().mockResolvedValue({ meta: [], affectedRows: 1 }),
         query: vi.fn().mockResolvedValue({ meta: [], affectedRows: 1 }),
       } as unknown as mariadb.Pool
 
-      const adapter = new PrismaMariaDbAdapter(mockClient, { supportsRelationJoins: true }, { useTextProtocol })
+      const adapter = new PrismaMariaDbAdapter(mockClient, { supportsRelationJoins: true }, { useTextProtocol: flag })
       await adapter.executeRaw({ sql: 'SELECT 1', args: [], argTypes: [] })
-      expect(mockClient[expectedMethod]).toHaveBeenCalledWith(expect.objectContaining({ sql: 'SELECT 1' }), [])
+      expect(mockClient[method]).toHaveBeenCalledWith(expect.objectContaining({ sql: 'SELECT 1' }), [])
+
+      expect(mockClient[flagToMethod[String(!flag)]]).not.toHaveBeenCalled()
     },
   )
 })
 
 describe('PrismaMariaDbAdapterFactory constructor', () => {
-  test('should create a config with prepareCacheLength set to 0 when config has no prepareCacheLength', async () => {
-    const config = {}
+  beforeAll(() => {
+    vi.mock('mariadb', () => ({
+      createPool: vi.fn(),
+    }))
+  })
 
+  afterAll(() => {
+    vi.doUnmock('mariadb')
+  })
+
+  test.each([
+    { config: {}, expected: expect.objectContaining({ prepareCacheLength: 0 }) },
+    { config: 'mariadb://user:pass@localhost:3306/db', expected: expect.stringContaining('prepareCacheLength=0') },
+  ])('should set prepareCacheLength to 0 when config has no prepareCacheLength', async ({ config, expected }) => {
     const mockCreatePool = vi.mocked(mariadb.createPool)
     mockCreatePool.mockReturnValue({
       query: vi.fn().mockResolvedValue([['8.0.13']]),
@@ -101,15 +99,17 @@ describe('PrismaMariaDbAdapterFactory constructor', () => {
     const factory = new PrismaMariaDbAdapterFactory(config)
     await factory.connect()
 
-    expect(mockCreatePool).toHaveBeenCalledWith(expect.objectContaining({ prepareCacheLength: 0 }))
+    expect(mockCreatePool).toHaveBeenCalledWith(expected)
     mockCreatePool.mockClear()
   })
 
-  test('should preserve existing prepareCacheLength when config is object and prepareCacheLength is set', async () => {
-    const config = {
-      prepareCacheLength: 10,
-    }
-
+  test.each([
+    { config: { prepareCacheLength: 10 }, expected: expect.objectContaining({ prepareCacheLength: 10 }) },
+    {
+      config: 'mariadb://user:pass@localhost:3306/db?prepareCacheLength=10',
+      expected: expect.stringContaining('prepareCacheLength=10'),
+    },
+  ])('set when is set', async ({ config, expected }) => {
     const mockCreatePool = vi.mocked(mariadb.createPool)
     mockCreatePool.mockReturnValue({
       query: vi.fn().mockResolvedValue([['8.0.13']]),
@@ -119,7 +119,7 @@ describe('PrismaMariaDbAdapterFactory constructor', () => {
     const factory = new PrismaMariaDbAdapterFactory(config)
     await factory.connect()
 
-    expect(mockCreatePool).toHaveBeenCalledWith(expect.objectContaining({ prepareCacheLength: 10 }))
+    expect(mockCreatePool).toHaveBeenCalledWith(expected)
     mockCreatePool.mockClear()
   })
 })

--- a/packages/adapter-mariadb/src/mariadb.test.ts
+++ b/packages/adapter-mariadb/src/mariadb.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
+import * as mariadb from 'mariadb'
 
-import { inferCapabilities, PrismaMariaDbAdapterFactory, rewriteConnectionString } from './mariadb'
+import {
+  inferCapabilities,
+  PrismaMariaDbAdapter,
+  PrismaMariaDbAdapterFactory,
+  rewriteConnectionString,
+} from './mariadb'
 
 describe.each([
   ['8.0.12', { supportsRelationJoins: false }],
@@ -55,4 +61,24 @@ describe('credential sanitization', () => {
       expect(errorMessage).not.toContain(secretPassword)
     }
   })
+})
+
+describe('useTextProtocol option', () => {
+  test.each([
+    { useTextProtocol: false, expectedMethod: 'execute' },
+    { useTextProtocol: undefined, expectedMethod: 'execute' },
+    { useTextProtocol: true, expectedMethod: 'query' },
+  ])(
+    'should use client.$expectedMethod when useTextProtocol is $useTextProtocol',
+    async ({ useTextProtocol, expectedMethod }) => {
+      const mockClient = {
+        execute: vi.fn().mockResolvedValue({ meta: [], affectedRows: 1 }),
+        query: vi.fn().mockResolvedValue({ meta: [], affectedRows: 1 }),
+      } as unknown as mariadb.Pool
+
+      const adapter = new PrismaMariaDbAdapter(mockClient, { supportsRelationJoins: true }, { useTextProtocol })
+      await adapter.executeRaw({ sql: 'SELECT 1', args: [], argTypes: [] })
+      expect(mockClient[expectedMethod]).toHaveBeenCalledWith(expect.objectContaining({ sql: 'SELECT 1' }), [])
+    },
+  )
 })

--- a/packages/adapter-mariadb/src/mariadb.ts
+++ b/packages/adapter-mariadb/src/mariadb.ts
@@ -134,7 +134,7 @@ class MariaDbTransaction extends MariaDbQueryable<mariadb.Connection> implements
 }
 
 export type PrismaMariadbOptions = {
-  /** The name of the database to connect to. */
+  /** The name of the database to use in generated queries */
   database?: string
   /** Use the driver's text protocol (`query`) instead of the binary protocol (`execute`). */
   useTextProtocol?: boolean
@@ -223,11 +223,18 @@ export class PrismaMariaDbAdapterFactory implements SqlDriverAdapterFactory {
 
   constructor(config: mariadb.PoolConfig | string, options?: PrismaMariadbOptions) {
     if (typeof config === 'string') {
-      const url = new URL(config)
-      if (!url.searchParams.has('prepareCacheLength')) {
-        url.searchParams.set('prepareCacheLength', '0')
+      try {
+        const url = new URL(config)
+        if (!url.searchParams.has('prepareCacheLength')) {
+          url.searchParams.set('prepareCacheLength', '0')
+        }
+        this.#config = rewriteConnectionString(url).toString()
+      } catch (error) {
+        debug('Error parsing connection string: %O', error)
+        // If we can't parse the connection string, use it as-is and let the driver fail with
+        // its own error.
+        this.#config = config
       }
-      this.#config = rewriteConnectionString(url).toString()
     } else {
       if (config.prepareCacheLength === undefined) {
         this.#config = { ...config, prepareCacheLength: 0 }

--- a/packages/adapter-mariadb/src/mariadb.ts
+++ b/packages/adapter-mariadb/src/mariadb.ts
@@ -134,19 +134,11 @@ class MariaDbTransaction extends MariaDbQueryable<mariadb.Connection> implements
 }
 
 export type PrismaMariadbOptions = {
-  /*
-   * The name of the database to connect to. If not provided, the adapter will attempt to infer
-   * it from the connection string.
-   */
+  /** The name of the database to connect to. */
   database?: string
-  /*
-   * Whether to use the text protocol for all queries. If false or not set, the adapter will use
-   * the binary protocol.
-   */
+  /** Use the driver's text protocol (`query`) instead of the binary protocol (`execute`). */
   useTextProtocol?: boolean
-  /*
-   * The callback to be attached to the connection's 'error' event.
-   */
+  /** Callback attached to transaction connection `error` events. */
   onConnectionError?: (err: mariadb.SqlError) => void
 }
 

--- a/packages/adapter-mariadb/src/mariadb.ts
+++ b/packages/adapter-mariadb/src/mariadb.ts
@@ -134,8 +134,19 @@ class MariaDbTransaction extends MariaDbQueryable<mariadb.Connection> implements
 }
 
 export type PrismaMariadbOptions = {
+  /*
+   * The name of the database to connect to. If not provided, the adapter will attempt to infer
+   * it from the connection string.
+   */
   database?: string
+  /*
+   * Whether to use the text protocol for all queries. If false or not set, the adapter will use
+   * the binary protocol.
+   */
   useTextProtocol?: boolean
+  /*
+   * The callback to be attached to the connection's 'error' event.
+   */
   onConnectionError?: (err: mariadb.SqlError) => void
 }
 
@@ -219,9 +230,18 @@ export class PrismaMariaDbAdapterFactory implements SqlDriverAdapterFactory {
   #options?: PrismaMariadbOptions
 
   constructor(config: mariadb.PoolConfig | string, options?: PrismaMariadbOptions) {
-    this.#config = rewriteConnectionString(config)
-    if (typeof this.#config !== 'string' && this.#config.prepareCacheLength === undefined) {
-      this.#config = { ...this.#config, prepareCacheLength: 0 }
+    if (typeof config === 'string') {
+      const url = new URL(config)
+      if (!url.searchParams.has('prepareCacheLength')) {
+        url.searchParams.set('prepareCacheLength', '0')
+      }
+      this.#config = rewriteConnectionString(url).toString()
+    } else {
+      if (config.prepareCacheLength === undefined) {
+        this.#config = { ...config, prepareCacheLength: 0 }
+      } else {
+        this.#config = config
+      }
     }
     this.#options = options
   }
@@ -290,16 +310,11 @@ export function inferCapabilities(version: unknown): Capabilities {
  * Rewrites mysql:// connection strings to mariadb:// format.
  * This allows users to use mysql:// connection strings with the MariaDB adapter.
  */
-export function rewriteConnectionString(config: mariadb.PoolConfig | string): mariadb.PoolConfig | string {
-  if (typeof config !== 'string') {
-    return config
+export function rewriteConnectionString(url: URL): URL {
+  if (url.protocol === 'mysql:') {
+    url.protocol = 'mariadb:'
   }
-
-  if (!config.startsWith('mysql://')) {
-    return config
-  }
-
-  return config.replace(/^mysql:\/\//, 'mariadb://')
+  return url
 }
 
 type ArrayModeResult = unknown[][] & { meta?: mariadb.FieldInfo[]; affectedRows?: number; insertId?: BigInt }

--- a/packages/adapter-mariadb/src/mariadb.ts
+++ b/packages/adapter-mariadb/src/mariadb.ts
@@ -22,7 +22,10 @@ class MariaDbQueryable<Connection extends mariadb.Pool | mariadb.Connection> imp
   readonly provider = 'mysql'
   readonly adapterName = packageName
 
-  constructor(protected client: Connection) {}
+  constructor(
+    protected readonly client: Connection,
+    protected readonly mariadbOptions?: { useTextProtocol?: boolean },
+  ) {}
 
   async queryRaw(query: SqlQuery): Promise<SqlResultSet> {
     const tag = '[js::query_raw]'
@@ -63,8 +66,10 @@ class MariaDbQueryable<Connection extends mariadb.Pool | mariadb.Connection> imp
         typeCast,
       }
       const values = args.map((arg, i) => mapArg(arg, query.argTypes[i]))
-      // We intentionally use `execute` here, because it uses the binary protocol, unlike `query`.
-      return await this.client.execute(req, values)
+      const execute = this.mariadbOptions?.useTextProtocol
+        ? this.client.query.bind(this.client)
+        : this.client.execute.bind(this.client)
+      return await execute(req, values)
     } catch (e) {
       const error = e as Error
       this.onError(error)
@@ -82,10 +87,11 @@ class MariaDbQueryable<Connection extends mariadb.Pool | mariadb.Connection> imp
 class MariaDbTransaction extends MariaDbQueryable<mariadb.Connection> implements Transaction {
   constructor(
     readonly conn: mariadb.Connection,
+    mariadbOptions: PrismaMariadbOptions | undefined,
     readonly options: TransactionOptions,
-    readonly cleanup?: () => void,
+    protected readonly cleanup?: () => void,
   ) {
-    super(conn)
+    super(conn, mariadbOptions)
   }
 
   async commit(): Promise<void> {
@@ -129,6 +135,7 @@ class MariaDbTransaction extends MariaDbQueryable<mariadb.Connection> implements
 
 export type PrismaMariadbOptions = {
   database?: string
+  useTextProtocol?: boolean
   onConnectionError?: (err: mariadb.SqlError) => void
 }
 
@@ -140,9 +147,9 @@ export class PrismaMariaDbAdapter extends MariaDbQueryable<mariadb.Pool> impleme
   constructor(
     client: mariadb.Pool,
     private readonly capabilities: Capabilities,
-    private readonly options?: PrismaMariadbOptions,
+    protected readonly mariadbOptions?: PrismaMariadbOptions,
   ) {
-    super(client)
+    super(client, mariadbOptions)
   }
 
   executeScript(_script: string): Promise<void> {
@@ -151,7 +158,7 @@ export class PrismaMariaDbAdapter extends MariaDbQueryable<mariadb.Pool> impleme
 
   getConnectionInfo(): ConnectionInfo {
     return {
-      schemaName: this.options?.database,
+      schemaName: this.mariadbOptions?.database,
       supportsRelationJoins: this.capabilities.supportsRelationJoins,
     }
   }
@@ -167,7 +174,7 @@ export class PrismaMariaDbAdapter extends MariaDbQueryable<mariadb.Pool> impleme
     const conn = await this.client.getConnection().catch((error) => this.onError(error))
     const onError = (err: mariadb.SqlError) => {
       debug(`Error from connection: ${err.message} %O`, err)
-      this.options?.onConnectionError?.(err)
+      this.mariadbOptions?.onConnectionError?.(err)
     }
     conn.on('error', onError)
 
@@ -176,7 +183,7 @@ export class PrismaMariaDbAdapter extends MariaDbQueryable<mariadb.Pool> impleme
     }
 
     try {
-      const tx = new MariaDbTransaction(conn, options, cleanup)
+      const tx = new MariaDbTransaction(conn, this.mariadbOptions, options, cleanup)
       if (isolationLevel) {
         await tx.executeRaw({
           sql: `SET TRANSACTION ISOLATION LEVEL ${isolationLevel}`,

--- a/packages/adapter-mariadb/src/mariadb.ts
+++ b/packages/adapter-mariadb/src/mariadb.ts
@@ -220,6 +220,9 @@ export class PrismaMariaDbAdapterFactory implements SqlDriverAdapterFactory {
 
   constructor(config: mariadb.PoolConfig | string, options?: PrismaMariadbOptions) {
     this.#config = rewriteConnectionString(config)
+    if (typeof this.#config !== 'string' && this.#config.prepareCacheLength === undefined) {
+      this.#config = { ...this.#config, prepareCacheLength: 0 }
+    }
     this.#options = options
   }
 


### PR DESCRIPTION
Adds a `useTextProtocol` option that allows the user to use the text protocol if they don't care about some edge case issues it has.
Also defaults `prepareCacheLength` to 0 when it's not provided due to users reporting the driver to leak statements.

Fixes https://github.com/prisma/prisma/issues/29364

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a useTextProtocol option to toggle text vs binary query protocol.

* **Behavior Change**
  * Connection pooling now defaults the statement prepare-cache length to 0 when not explicitly set.
  * Connection-string handling normalizes protocol form (mysql → mariadb) consistently.

* **Tests**
  * Expanded tests for protocol selection, pool defaulting, connection-string normalization, and credential sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->