### PR TITLE
feat: pg statement name generator

### DIFF
--- a/packages/adapter-pg/src/__tests__/pg.test.ts
+++ b/packages/adapter-pg/src/__tests__/pg.test.ts
@@ -1,4 +1,5 @@
 import { getLogs } from '@prisma/debug'
+import type { SqlQuery } from '@prisma/driver-adapter-utils'
 import pg, { DatabaseError } from 'pg'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -106,6 +107,48 @@ describe('PrismaPgAdapterFactory', () => {
     await transaction.rollback()
     expect(mockConnection.removeListener).toHaveBeenCalledWith('error', expect.any(Function))
     expect(mockConnection.listenerCount('error')).toEqual(0)
+
+    await adapter.dispose()
+  })
+
+  it('should pass generated name when statement name generator is provided', async () => {
+    const mockGenerator = vi.fn(() => 'test-name')
+    const factory = new PrismaPgAdapterFactory('postgresql://test:test@localhost/test', {
+      statementNameGenerator: mockGenerator,
+    })
+    const adapter = await factory.connect()
+
+    const mockQuery = vi.fn().mockResolvedValue({
+      rows: [],
+      fields: [],
+      rowCount: 0,
+    })
+    adapter['client'].query = mockQuery
+
+    const query: SqlQuery = { sql: 'SELECT 1', args: [], argTypes: [] }
+    await adapter.queryRaw(query)
+
+    expect(mockGenerator).toHaveBeenCalledWith(query)
+    expect(mockQuery).toHaveBeenCalledWith(expect.objectContaining({ name: 'test-name' }), [])
+
+    await adapter.dispose()
+  })
+
+  it('should not pass name when statement name generator is not provided', async () => {
+    const factory = new PrismaPgAdapterFactory('postgresql://test:test@localhost/test')
+    const adapter = await factory.connect()
+
+    const mockQuery = vi.fn().mockResolvedValue({
+      rows: [],
+      fields: [],
+      rowCount: 0,
+    })
+    adapter['client'].query = mockQuery
+
+    const query: SqlQuery = { sql: 'SELECT 1', args: [], argTypes: [] }
+    await adapter.queryRaw(query)
+
+    expect(mockQuery).toHaveBeenCalledWith(expect.objectContaining({ name: undefined }), [])
 
     await adapter.dispose()
   })

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -105,6 +105,7 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements SqlQ
     try {
       const result = await this.client.query(
         {
+          name: this.pgOptions?.statementNameGenerator?.(query),
           text: sql,
           values,
           rowMode: 'array',
@@ -171,14 +172,32 @@ class PgTransaction extends PgQueryable<TransactionClient> implements Transactio
 }
 
 export type PrismaPgOptions = {
+  /** The name of the schema to use in generated queries */
   schema?: string
+  /**
+   * Whether to call `pool.end()` on an externally provided pool when the adapter is disposed.
+   * Defaults to `false`.
+   */
   disposeExternalPool?: boolean
+  /** Callback attached to the pool's 'error' events. */
   onPoolError?: (err: Error) => void
+  /** Callback attached to connection's 'error' events. */
   onConnectionError?: (err: Error) => void
+  /**
+   * Optional parser for user-defined types. Called with the type's OID, the value to parse, and
+   * a queryable for performing additional queries if necessary.
+   */
   userDefinedTypeParser?: UserDefinedTypeParser
+  /**
+   * Optional function to generate names for prepared statements. The generated strings are passed
+   * as the `name` property in the query to `pg.Client#query()`, which uses them to cache the
+   * underlying statements. If not provided, prepared statements are not cached.
+   */
+  statementNameGenerator?: StatementNameGenerator
 }
 
 export type UserDefinedTypeParser = (oid: number, value: unknown, adapter: SqlQueryable) => Promise<unknown>
+export type StatementNameGenerator = (query: SqlQuery) => string
 
 export class PrismaPgAdapter extends PgQueryable<StdClient> implements SqlDriverAdapter {
   constructor(


### PR DESCRIPTION
Adds a `statementNameGenerator` `pg` setting for pasing a custom name generator to allow users to leverage `pg` statement caching

Tackles https://github.com/prisma/prisma/discussions/28683

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `statementNameGenerator` configuration option to the PostgreSQL adapter, enabling customization of how statement names are generated and assigned.
  * Introduced `StatementNameGenerator` type to standardize the callback signature used for generating custom statement name identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->