### PR TITLE
docs: add Prisma CLI installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,30 @@ Prisma Client can be used in _any_ Node.js or TypeScript backend application (in
 
 ## Getting started
 
+### Installation
+
+Install the Prisma CLI globally using your preferred package manager:
+
+**npm:**
+```bash
+npm install -g prisma
+```
+
+**yarn:**
+```bash
+yarn global add prisma
+```
+
+**pnpm:**
+```bash
+pnpm add -g prisma
+```
+
+You can also use the Prisma CLI without installing it globally by using `npx`:
+```bash
+npx prisma
+```
+
 ### Quickstart (5min)
 
 The fastest way to get started with Prisma is by following the quickstart guides. You can choose either of two databases:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <h1>Prisma</h1>
+  <h1>Prisma CLI</h1>
   <a href="https://www.npmjs.com/package/prisma"><img src="https://img.shields.io/npm/v/prisma.svg?style=flat" /></a>
   <a href="https://github.com/prisma/prisma/blob/main/CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" /></a>
   <a href="https://github.com/prisma/prisma/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202-blue" /></a>
@@ -22,6 +22,30 @@
   <br />
   <hr />
 </div>
+
+## Installation
+
+Install the Prisma CLI globally using your preferred package manager:
+
+**npm:**
+```bash
+npm install -g prisma
+```
+
+**yarn:**
+```bash
+yarn global add prisma
+```
+
+**pnpm:**
+```bash
+pnpm add -g prisma
+```
+
+You can also use the Prisma CLI without installing it globally by using `npx`:
+```bash
+npx prisma
+```
 
 ## What is Prisma?
 


### PR DESCRIPTION
## Description

This PR adds clear installation instructions for the Prisma CLI to the documentation.

### Changes

- Added a dedicated "Installation" section under "Getting started" in the main README.md
- Added installation instructions to packages/cli/README.md

### Installation methods covered

- **npm**: `npm install -g prisma`
- **yarn**: `yarn global add prisma`
- **pnpm**: `pnpm add -g prisma`
- **npx**: Alternative option for using without global installation

Fixes #29400

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Installation section with step-by-step instructions for the Prisma CLI
  * Documented global installation options via npm, yarn, and pnpm
  * Included instructions for running the CLI without global installation using npx

<!-- end of auto-generated comment: release notes by coderabbit.ai -->