### PR TITLE
fix(client-generator-ts): type browser null singleton exports

### DIFF
--- a/packages/client-generator-ts/src/TSClient/NullTypes.ts
+++ b/packages/client-generator-ts/src/TSClient/NullTypes.ts
@@ -9,19 +9,19 @@ export const NullTypes = {
  *
  * @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-on-a-json-field
  */
-export const DbNull = runtime.DbNull
+export const DbNull: typeof runtime.DbNull = runtime.DbNull
 
 /**
  * Helper for filtering JSON entries that have JSON \`null\` values (not empty on the db)
  *
  * @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-on-a-json-field
  */
-export const JsonNull = runtime.JsonNull
+export const JsonNull: typeof runtime.JsonNull = runtime.JsonNull
 
 /**
  * Helper for filtering JSON entries that are \`Prisma.DbNull\` or \`Prisma.JsonNull\`
  *
  * @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-on-a-json-field
  */
-export const AnyNull = runtime.AnyNull
+export const AnyNull: typeof runtime.AnyNull = runtime.AnyNull
 `

--- a/packages/client-generator-ts/tests/generator.test.ts
+++ b/packages/client-generator-ts/tests/generator.test.ts
@@ -139,6 +139,25 @@ describe('generator', () => {
     const clientDir = path.join(__dirname, 'generated')
     expect(fs.existsSync(clientDir)).toBe(true)
     expect(fs.existsSync(path.join(clientDir, 'client.ts'))).toBe(true)
+
+    generator.stop()
+  })
+
+  test('emits portable typed null singleton exports in the browser namespace', async () => {
+    const generator = await getGenerator({
+      schemaPath: path.join(__dirname, 'schema.prisma'),
+      printDownloadProgress: false,
+      skipDownload: true,
+      registry,
+    })
+
+    await generator.generate()
+    const clientDir = path.join(__dirname, 'generated')
+    const browserNamespace = fs.readFileSync(path.join(clientDir, 'internal', 'prismaNamespaceBrowser.ts'), 'utf8')
+    expect(browserNamespace).toContain('export const DbNull: typeof runtime.DbNull = runtime.DbNull')
+    expect(browserNamespace).toContain('export const JsonNull: typeof runtime.JsonNull = runtime.JsonNull')
+    expect(browserNamespace).toContain('export const AnyNull: typeof runtime.AnyNull = runtime.AnyNull')
+
     generator.stop()
   })
 

--- a/packages/client-generator-ts/tests/generator.test.ts
+++ b/packages/client-generator-ts/tests/generator.test.ts
@@ -94,53 +94,55 @@ describe('generator', () => {
       registry,
     })
 
-    const manifest = omit(generator.manifest!, ['version'])
+    try {
+      const manifest = omit(generator.manifest!, ['version'])
 
-    if (manifest.requiresEngineVersion?.length !== 40) {
-      throw new Error(`Generator manifest should have "requiresEngineVersion" with length 40`)
-    }
-    manifest.requiresEngineVersion = 'ENGINE_VERSION_TEST'
-
-    expect(manifest).toMatchInlineSnapshot(`
-      {
-        "defaultOutput": "./generated",
-        "prettyName": "Prisma Client",
-        "requiresEngineVersion": "ENGINE_VERSION_TEST",
-        "requiresEngines": [],
+      if (manifest.requiresEngineVersion?.length !== 40) {
+        throw new Error(`Generator manifest should have "requiresEngineVersion" with length 40`)
       }
-    `)
+      manifest.requiresEngineVersion = 'ENGINE_VERSION_TEST'
 
-    expect(omit(generator.options!.generator, ['output'])).toMatchInlineSnapshot(`
-      {
-        "binaryTargets": [
-          {
+      expect(manifest).toMatchInlineSnapshot(`
+        {
+          "defaultOutput": "./generated",
+          "prettyName": "Prisma Client",
+          "requiresEngineVersion": "ENGINE_VERSION_TEST",
+          "requiresEngines": [],
+        }
+      `)
+
+      expect(omit(generator.options!.generator, ['output'])).toMatchInlineSnapshot(`
+        {
+          "binaryTargets": [
+            {
+              "fromEnvVar": null,
+              "native": true,
+              "value": "NATIVE_BINARY_TARGET",
+            },
+          ],
+          "config": {},
+          "isCustomOutput": true,
+          "name": "client",
+          "previewFeatures": [],
+          "provider": {
             "fromEnvVar": null,
-            "native": true,
-            "value": "NATIVE_BINARY_TARGET",
+            "value": "prisma-client-ts",
           },
-        ],
-        "config": {},
-        "isCustomOutput": true,
-        "name": "client",
-        "previewFeatures": [],
-        "provider": {
-          "fromEnvVar": null,
-          "value": "prisma-client-ts",
-        },
-        "sourceFilePath": "/project/schema.prisma",
-      }
-    `)
+          "sourceFilePath": "/project/schema.prisma",
+        }
+      `)
 
-    expect(path.relative(__dirname, parseEnvValue(generator.options!.generator.output!))).toMatchInlineSnapshot(
-      `"generated"`,
-    )
+      expect(path.relative(__dirname, parseEnvValue(generator.options!.generator.output!))).toMatchInlineSnapshot(
+        `"generated"`,
+      )
 
-    await generator.generate()
-    const clientDir = path.join(__dirname, 'generated')
-    expect(fs.existsSync(clientDir)).toBe(true)
-    expect(fs.existsSync(path.join(clientDir, 'client.ts'))).toBe(true)
-
-    generator.stop()
+      await generator.generate()
+      const clientDir = path.join(__dirname, 'generated')
+      expect(fs.existsSync(clientDir)).toBe(true)
+      expect(fs.existsSync(path.join(clientDir, 'client.ts'))).toBe(true)
+    } finally {
+      generator.stop()
+    }
   })
 
   test('emits portable typed null singleton exports in the browser namespace', async () => {
@@ -151,14 +153,16 @@ describe('generator', () => {
       registry,
     })
 
-    await generator.generate()
-    const clientDir = path.join(__dirname, 'generated')
-    const browserNamespace = fs.readFileSync(path.join(clientDir, 'internal', 'prismaNamespaceBrowser.ts'), 'utf8')
-    expect(browserNamespace).toContain('export const DbNull: typeof runtime.DbNull = runtime.DbNull')
-    expect(browserNamespace).toContain('export const JsonNull: typeof runtime.JsonNull = runtime.JsonNull')
-    expect(browserNamespace).toContain('export const AnyNull: typeof runtime.AnyNull = runtime.AnyNull')
-
-    generator.stop()
+    try {
+      await generator.generate()
+      const clientDir = path.join(__dirname, 'generated')
+      const browserNamespace = fs.readFileSync(path.join(clientDir, 'internal', 'prismaNamespaceBrowser.ts'), 'utf8')
+      expect(browserNamespace).toContain('export const DbNull: typeof runtime.DbNull = runtime.DbNull')
+      expect(browserNamespace).toContain('export const JsonNull: typeof runtime.JsonNull = runtime.JsonNull')
+      expect(browserNamespace).toContain('export const AnyNull: typeof runtime.AnyNull = runtime.AnyNull')
+    } finally {
+      generator.stop()
+    }
   })
 
   test('denylist from engine validation', async () => {


### PR DESCRIPTION
## Summary
- add explicit `typeof runtime.*` annotations to the generated browser-side `DbNull`, `JsonNull`, and `AnyNull` singleton exports
- keep the emitted declarations portable in pnpm monorepos instead of leaving declaration emit to infer names that trigger TS2742
- add a focused generator regression that checks the emitted `internal/prismaNamespaceBrowser.ts` text directly

## Testing
- `pnpm.cmd install --frozen-lockfile`
- `pnpm.cmd --filter @prisma/client-generator-ts... build`
- `pnpm.cmd --filter @prisma/client-generator-ts exec vitest run tests/generator.test.ts -t "emits portable typed null singleton exports in the browser namespace"`
- `pnpm.cmd exec eslint packages/client-generator-ts/src/TSClient/NullTypes.ts packages/client-generator-ts/tests/generator.test.ts`
- `git diff --check HEAD~1..HEAD`

Fixes #28581

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced TypeScript type annotations for null singleton constants for stricter typing.

* **Tests**
  * Added coverage for typed null singleton exports in browser builds.
  * Improved test cleanup to ensure generator shutdown runs even on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->