### PR TITLE
fix(client-generator-ts): preserve Cloudflare ts imports in native Deno projects

### DIFF
--- a/packages/client-generator-ts/src/deno-config.ts
+++ b/packages/client-generator-ts/src/deno-config.ts
@@ -1,0 +1,22 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+/**
+ * Walks upward from the generated output directory to detect native Deno
+ * projects via a nearby `deno.json` or `deno.jsonc`.
+ */
+export function findDenoConfigFromOutputDir(outputDir: string): boolean {
+  let currentDir = path.resolve(outputDir)
+
+  while (true) {
+    if (fs.existsSync(path.join(currentDir, 'deno.json')) || fs.existsSync(path.join(currentDir, 'deno.jsonc'))) {
+      return true
+    }
+
+    const parentDir = path.dirname(currentDir)
+    if (parentDir === currentDir) {
+      return false
+    }
+    currentDir = parentDir
+  }
+}

--- a/packages/client-generator-ts/src/file-extensions.ts
+++ b/packages/client-generator-ts/src/file-extensions.ts
@@ -61,14 +61,22 @@ type InferImportFileExtensionOptions = {
   tsconfig: TsConfigJsonResolved | undefined
   generatedFileExtension: GeneratedFileExtension
   target: RuntimeTargetInternal
+  hasDenoConfig?: boolean
 }
 
 export function inferImportFileExtension({
   tsconfig,
   generatedFileExtension,
   target,
+  hasDenoConfig,
 }: InferImportFileExtensionOptions): ImportFileExtension {
   if (target === 'deno') {
+    return generatedFileExtension
+  }
+
+  // Native Deno projects still require explicit relative TypeScript extensions
+  // even when using the Cloudflare runtime target.
+  if (target === 'workerd' && hasDenoConfig) {
     return generatedFileExtension
   }
 

--- a/packages/client-generator-ts/src/file-extensions.ts
+++ b/packages/client-generator-ts/src/file-extensions.ts
@@ -61,9 +61,14 @@ type InferImportFileExtensionOptions = {
   tsconfig: TsConfigJsonResolved | undefined
   generatedFileExtension: GeneratedFileExtension
   target: RuntimeTargetInternal
+  /** Whether the generated client is being emitted into a native Deno project. */
   hasDenoConfig?: boolean
 }
 
+/**
+ * Determines which extension generated relative imports should use for the
+ * current runtime and surrounding project configuration.
+ */
 export function inferImportFileExtension({
   tsconfig,
   generatedFileExtension,

--- a/packages/client-generator-ts/src/generator.ts
+++ b/packages/client-generator-ts/src/generator.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
 import { enginesVersion } from '@prisma/engines-version'
 import { Generator, GeneratorConfig, GeneratorManifest, GeneratorOptions } from '@prisma/generator'
 import { parseEnvValue } from '@prisma/internals'
@@ -43,9 +46,11 @@ export class PrismaClientTsGenerator implements Generator {
   async generate(options: GeneratorOptions): Promise<void> {
     const { config } = options.generator
     const outputDir = getOutputPath(options.generator)
-    const tsconfig = getTsconfig(outputDir)?.config
+    const tsconfigResult = getTsconfig(outputDir)
+    const tsconfig = tsconfigResult?.config
 
     const target = config.runtime !== undefined ? parseRuntimeTargetFromUnknown(config.runtime) : 'nodejs'
+    const hasDenoConfig = target === 'workerd' ? findDenoConfig(path.dirname(tsconfigResult?.path ?? outputDir)) : false
 
     const generatedFileExtension =
       config.generatedFileExtension !== undefined ? parseGeneratedFileExtension(config.generatedFileExtension) : 'ts'
@@ -57,6 +62,7 @@ export class PrismaClientTsGenerator implements Generator {
             tsconfig,
             generatedFileExtension,
             target,
+            hasDenoConfig,
           })
 
     const moduleFormat =
@@ -88,6 +94,22 @@ export class PrismaClientTsGenerator implements Generator {
       tsNoCheckPreamble: true, // Set to false only during internal tests
       compilerBuild: parseCompilerBuildFromUnknown(options.generator.config.compilerBuild, target),
     })
+  }
+}
+
+function findDenoConfig(startDir: string): boolean {
+  let currentDir = path.resolve(startDir)
+
+  while (true) {
+    if (fs.existsSync(path.join(currentDir, 'deno.json')) || fs.existsSync(path.join(currentDir, 'deno.jsonc'))) {
+      return true
+    }
+
+    const parentDir = path.dirname(currentDir)
+    if (parentDir === currentDir) {
+      return false
+    }
+    currentDir = parentDir
   }
 }
 

--- a/packages/client-generator-ts/src/generator.ts
+++ b/packages/client-generator-ts/src/generator.ts
@@ -97,6 +97,10 @@ export class PrismaClientTsGenerator implements Generator {
   }
 }
 
+/**
+ * Walks upward from the generated output directory to detect native Deno
+ * projects via a nearby `deno.json` or `deno.jsonc`.
+ */
 function findDenoConfig(startDir: string): boolean {
   let currentDir = path.resolve(startDir)
 

--- a/packages/client-generator-ts/src/generator.ts
+++ b/packages/client-generator-ts/src/generator.ts
@@ -1,6 +1,3 @@
-import fs from 'node:fs'
-import path from 'node:path'
-
 import { enginesVersion } from '@prisma/engines-version'
 import { Generator, GeneratorConfig, GeneratorManifest, GeneratorOptions } from '@prisma/generator'
 import { parseEnvValue } from '@prisma/internals'
@@ -8,6 +5,7 @@ import { getTsconfig } from 'get-tsconfig'
 import { bold, dim, green } from 'kleur/colors'
 
 import { version as clientVersion } from '../package.json'
+import { findDenoConfigFromOutputDir } from './deno-config'
 import { inferImportFileExtension, parseGeneratedFileExtension, parseImportFileExtension } from './file-extensions'
 import { generateClient } from './generateClient'
 import { inferModuleFormat, parseModuleFormatFromUnknown } from './module-format'
@@ -46,11 +44,10 @@ export class PrismaClientTsGenerator implements Generator {
   async generate(options: GeneratorOptions): Promise<void> {
     const { config } = options.generator
     const outputDir = getOutputPath(options.generator)
-    const tsconfigResult = getTsconfig(outputDir)
-    const tsconfig = tsconfigResult?.config
+    const tsconfig = getTsconfig(outputDir)?.config
 
     const target = config.runtime !== undefined ? parseRuntimeTargetFromUnknown(config.runtime) : 'nodejs'
-    const hasDenoConfig = target === 'workerd' ? findDenoConfig(path.dirname(tsconfigResult?.path ?? outputDir)) : false
+    const hasDenoConfig = target === 'workerd' ? findDenoConfigFromOutputDir(outputDir) : false
 
     const generatedFileExtension =
       config.generatedFileExtension !== undefined ? parseGeneratedFileExtension(config.generatedFileExtension) : 'ts'
@@ -94,26 +91,6 @@ export class PrismaClientTsGenerator implements Generator {
       tsNoCheckPreamble: true, // Set to false only during internal tests
       compilerBuild: parseCompilerBuildFromUnknown(options.generator.config.compilerBuild, target),
     })
-  }
-}
-
-/**
- * Walks upward from the generated output directory to detect native Deno
- * projects via a nearby `deno.json` or `deno.jsonc`.
- */
-function findDenoConfig(startDir: string): boolean {
-  let currentDir = path.resolve(startDir)
-
-  while (true) {
-    if (fs.existsSync(path.join(currentDir, 'deno.json')) || fs.existsSync(path.join(currentDir, 'deno.jsonc'))) {
-      return true
-    }
-
-    const parentDir = path.dirname(currentDir)
-    if (parentDir === currentDir) {
-      return false
-    }
-    currentDir = parentDir
   }
 }
 

--- a/packages/client-generator-ts/tests/file-extensions.test.ts
+++ b/packages/client-generator-ts/tests/file-extensions.test.ts
@@ -1,0 +1,34 @@
+import type { TsConfigJsonResolved } from 'get-tsconfig'
+import { describe, expect, it } from 'vitest'
+
+import { inferImportFileExtension } from '../src/file-extensions'
+
+const bundlerTsConfig = {
+  compilerOptions: {
+    module: 'preserve',
+    moduleResolution: 'bundler',
+  },
+} as TsConfigJsonResolved
+
+describe('inferImportFileExtension', () => {
+  it('keeps TypeScript extensions for cloudflare runtime in native Deno projects', () => {
+    expect(
+      inferImportFileExtension({
+        tsconfig: bundlerTsConfig,
+        generatedFileExtension: 'ts',
+        target: 'workerd',
+        hasDenoConfig: true,
+      }),
+    ).toBe('ts')
+  })
+
+  it('keeps bundler-style bare imports for non-Deno cloudflare projects', () => {
+    expect(
+      inferImportFileExtension({
+        tsconfig: bundlerTsConfig,
+        generatedFileExtension: 'ts',
+        target: 'workerd',
+      }),
+    ).toBe('')
+  })
+})

--- a/packages/client-generator-ts/tests/generator.test.ts
+++ b/packages/client-generator-ts/tests/generator.test.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 import { stripVTControlCharacters } from 'node:util'
 
@@ -6,6 +7,7 @@ import { omit } from '@prisma/client-common'
 import { GeneratorRegistry, getGenerator, parseEnvValue } from '@prisma/internals'
 import { describe, expect, test } from 'vitest'
 
+import { findDenoConfigFromOutputDir } from '../src/deno-config'
 import { PrismaClientTsGenerator } from '../src/generator'
 
 function addSnapshotPathSanitizer({
@@ -86,6 +88,24 @@ const registry = {
 } satisfies GeneratorRegistry
 
 describe('generator', () => {
+  test('detects package-local deno config from the generated output directory', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prisma-client-generator-'))
+
+    try {
+      const packageDir = path.join(tempDir, 'packages', 'worker-app')
+      const outputDir = path.join(packageDir, 'generated')
+
+      fs.mkdirSync(outputDir, { recursive: true })
+      fs.writeFileSync(path.join(tempDir, 'tsconfig.json'), '{}')
+      fs.writeFileSync(path.join(packageDir, 'deno.json'), '{}')
+
+      expect(findDenoConfigFromOutputDir(outputDir)).toBe(true)
+      expect(findDenoConfigFromOutputDir(path.dirname(path.join(tempDir, 'tsconfig.json')))).toBe(false)
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
   test('minimal', async () => {
     const generator = await getGenerator({
       schemaPath: path.join(__dirname, 'schema.prisma'),

--- a/packages/client-generator-ts/tests/generator.test.ts
+++ b/packages/client-generator-ts/tests/generator.test.ts
@@ -88,23 +88,26 @@ const registry = {
 } satisfies GeneratorRegistry
 
 describe('generator', () => {
-  test('detects package-local deno config from the generated output directory', () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prisma-client-generator-'))
+  test.each(['deno.json', 'deno.jsonc'])(
+    'detects package-local %s from the generated output directory',
+    (configFileName) => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prisma-client-generator-'))
 
-    try {
-      const packageDir = path.join(tempDir, 'packages', 'worker-app')
-      const outputDir = path.join(packageDir, 'generated')
+      try {
+        const packageDir = path.join(tempDir, 'packages', 'worker-app')
+        const outputDir = path.join(packageDir, 'generated')
 
-      fs.mkdirSync(outputDir, { recursive: true })
-      fs.writeFileSync(path.join(tempDir, 'tsconfig.json'), '{}')
-      fs.writeFileSync(path.join(packageDir, 'deno.json'), '{}')
+        fs.mkdirSync(outputDir, { recursive: true })
+        fs.writeFileSync(path.join(tempDir, 'tsconfig.json'), '{}')
+        fs.writeFileSync(path.join(packageDir, configFileName), '{}')
 
-      expect(findDenoConfigFromOutputDir(outputDir)).toBe(true)
-      expect(findDenoConfigFromOutputDir(path.dirname(path.join(tempDir, 'tsconfig.json')))).toBe(false)
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true })
-    }
-  })
+        expect(findDenoConfigFromOutputDir(outputDir)).toBe(true)
+        expect(findDenoConfigFromOutputDir(path.dirname(path.join(tempDir, 'tsconfig.json')))).toBe(false)
+      } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true })
+      }
+    },
+  )
 
   test('minimal', async () => {
     const generator = await getGenerator({


### PR DESCRIPTION
## Summary
- preserve generated TypeScript import/export extensions for `runtime = "cloudflare"` when Prisma is generating into a native Deno project
- keep the existing bundler-style bare import behavior for non-Deno Cloudflare projects
- add focused regression coverage for the Deno-vs-non-Deno inference split

Fixes #29403

## Validation
- `corepack pnpm exec vitest run packages/client-generator-ts/tests/file-extensions.test.ts`
- `corepack pnpm exec prettier --check packages/client-generator-ts/src/file-extensions.ts packages/client-generator-ts/src/generator.ts packages/client-generator-ts/tests/file-extensions.test.ts`
- `corepack pnpm exec eslint packages/client-generator-ts/src/file-extensions.ts packages/client-generator-ts/src/generator.ts packages/client-generator-ts/tests/file-extensions.test.ts`
- direct local generator repro against the built package: without `deno.json`, generated Cloudflare imports stay bare; with `deno.json`, `models.ts` and `models/User.ts` keep explicit `.ts` suffixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved import file extension selection for workerd targets by detecting nearby Deno configuration and adjusting generated extensions accordingly.

* **Tests**
  * Added tests covering import-extension behavior for workerd with and without a Deno config present, and tests verifying the Deno-config detection across directory layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->