### PR TITLE
fix(client): restore decimal number encoding inside Json params

### DIFF
--- a/packages/client/src/runtime/core/engines/client/parameterization/parameterize.test.ts
+++ b/packages/client/src/runtime/core/engines/client/parameterization/parameterize.test.ts
@@ -526,6 +526,67 @@ describe('parameterizeQuery', () => {
         },
       })
     })
+
+    it('applies nested Json toJSON handlers only once per object', () => {
+      const replacement = {
+        count: 1,
+        toJSON: jest.fn(() => ({ count: 2 })),
+      }
+
+      const query: JsonQuery = {
+        modelName: 'User',
+        action: 'createOne',
+        query: {
+          arguments: {
+            data: {
+              properties: {
+                toJSON() {
+                  return replacement
+                },
+              },
+            },
+          },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result = parameterizeQuery(query, paramGraph)
+
+      expect(result.placeholderValues).toEqual({
+        '%1': '{"count":1}',
+      })
+      expect(replacement.toJSON).not.toHaveBeenCalled()
+    })
+
+    it('serializes non-finite Decimal tagged values nested inside Json inputs as null', () => {
+      const query: JsonQuery = {
+        modelName: 'User',
+        action: 'createOne',
+        query: {
+          arguments: {
+            data: {
+              properties: {
+                nan: { $type: 'Decimal', value: 'NaN' },
+                positiveInfinity: { $type: 'Decimal', value: 'Infinity' },
+                negativeInfinity: { $type: 'Decimal', value: '-Infinity' },
+              },
+            },
+          },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result = parameterizeQuery(query, paramGraph)
+
+      expect(result.placeholderValues).toEqual({
+        '%1': '{"nan":null,"positiveInfinity":null,"negativeInfinity":null}',
+      })
+      expect(result.parameterizedQuery.query.arguments).toEqual({
+        data: {
+          properties: { $type: 'Param', value: { name: '%1', type: 'Json' } },
+        },
+      })
+    })
   })
 
   describe('cache key consistency', () => {

--- a/packages/client/src/runtime/core/engines/client/parameterization/parameterize.test.ts
+++ b/packages/client/src/runtime/core/engines/client/parameterization/parameterize.test.ts
@@ -435,6 +435,67 @@ describe('parameterizeQuery', () => {
         },
       })
     })
+
+    it('serializes sparse Json arrays with holes as null entries', () => {
+      const properties: any[] = []
+      properties[0] = 1
+      properties[2] = { $type: 'Decimal', value: '3.5' }
+
+      const query: JsonQuery = {
+        modelName: 'User',
+        action: 'createOne',
+        query: {
+          arguments: {
+            data: {
+              properties,
+            },
+          },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result = parameterizeQuery(query, paramGraph)
+
+      expect(result.placeholderValues).toEqual({
+        '%1': '[1,null,3.5]',
+      })
+      expect(result.parameterizedQuery.query.arguments).toEqual({
+        data: {
+          properties: { $type: 'Param', value: { name: '%1', type: 'Json' } },
+        },
+      })
+    })
+
+    it('serializes self-returning toJSON objects nested inside Json inputs', () => {
+      const query: JsonQuery = {
+        modelName: 'User',
+        action: 'createOne',
+        query: {
+          arguments: {
+            data: {
+              properties: {
+                count: 1,
+                toJSON() {
+                  return this
+                },
+              },
+            },
+          },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result = parameterizeQuery(query, paramGraph)
+
+      expect(result.placeholderValues).toEqual({
+        '%1': '{"count":1}',
+      })
+      expect(result.parameterizedQuery.query.arguments).toEqual({
+        data: {
+          properties: { $type: 'Param', value: { name: '%1', type: 'Json' } },
+        },
+      })
+    })
   })
 
   describe('cache key consistency', () => {

--- a/packages/client/src/runtime/core/engines/client/parameterization/parameterize.test.ts
+++ b/packages/client/src/runtime/core/engines/client/parameterization/parameterize.test.ts
@@ -557,36 +557,6 @@ describe('parameterizeQuery', () => {
       })
       expect(replacement.toJSON).not.toHaveBeenCalled()
     })
-
-    it('serializes non-finite Decimal tagged values nested inside Json inputs as null', () => {
-      const query: JsonQuery = {
-        modelName: 'User',
-        action: 'createOne',
-        query: {
-          arguments: {
-            data: {
-              properties: {
-                nan: { $type: 'Decimal', value: 'NaN' },
-                positiveInfinity: { $type: 'Decimal', value: 'Infinity' },
-                negativeInfinity: { $type: 'Decimal', value: '-Infinity' },
-              },
-            },
-          },
-          selection: { $scalars: true },
-        },
-      }
-
-      const result = parameterizeQuery(query, paramGraph)
-
-      expect(result.placeholderValues).toEqual({
-        '%1': '{"nan":null,"positiveInfinity":null,"negativeInfinity":null}',
-      })
-      expect(result.parameterizedQuery.query.arguments).toEqual({
-        data: {
-          properties: { $type: 'Param', value: { name: '%1', type: 'Json' } },
-        },
-      })
-    })
   })
 
   describe('cache key consistency', () => {

--- a/packages/client/src/runtime/core/engines/client/parameterization/parameterize.test.ts
+++ b/packages/client/src/runtime/core/engines/client/parameterization/parameterize.test.ts
@@ -30,6 +30,7 @@ describe('parameterizeQuery', () => {
       'status',
       'Status',
       'createdAt',
+      'properties',
     ],
     inputNodes: [
       // Node 0: UserWhereInput
@@ -62,6 +63,7 @@ describe('parameterizeQuery', () => {
           1: { flags: EdgeFlag.ParamScalar, scalarMask: ScalarMask.String }, // id
           2: { flags: EdgeFlag.ParamScalar, scalarMask: ScalarMask.String }, // email
           3: { flags: EdgeFlag.ParamScalar, scalarMask: ScalarMask.String }, // name
+          14: { flags: EdgeFlag.ParamScalar, scalarMask: ScalarMask.Json }, // properties
         },
       },
       // Node 4: CreateUserArgs
@@ -403,6 +405,34 @@ describe('parameterizeQuery', () => {
         '%1': '123',
         '%2': 'test@example.com',
         '%3': 'John',
+      })
+    })
+
+    it('serializes Decimal tagged values nested inside Json inputs as JSON numbers', () => {
+      const query: JsonQuery = {
+        modelName: 'User',
+        action: 'createOne',
+        query: {
+          arguments: {
+            data: {
+              properties: {
+                someDecimal: { $type: 'Decimal', value: '-11000' },
+              },
+            },
+          },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result = parameterizeQuery(query, paramGraph)
+
+      expect(result.placeholderValues).toEqual({
+        '%1': '{"someDecimal":-11000}',
+      })
+      expect(result.parameterizedQuery.query.arguments).toEqual({
+        data: {
+          properties: { $type: 'Param', value: { name: '%1', type: 'Json' } },
+        },
       })
     })
   })

--- a/packages/client/src/runtime/core/engines/client/parameterization/parameterize.test.ts
+++ b/packages/client/src/runtime/core/engines/client/parameterization/parameterize.test.ts
@@ -436,6 +436,36 @@ describe('parameterizeQuery', () => {
       })
     })
 
+    it('serializes non-finite Decimal tagged values nested inside Json inputs as null', () => {
+      const query: JsonQuery = {
+        modelName: 'User',
+        action: 'createOne',
+        query: {
+          arguments: {
+            data: {
+              properties: {
+                positiveInfinity: { $type: 'Decimal', value: 'Infinity' },
+                negativeInfinity: { $type: 'Decimal', value: '-Infinity' },
+                notANumber: { $type: 'Decimal', value: 'NaN' },
+              },
+            },
+          },
+          selection: { $scalars: true },
+        },
+      }
+
+      const result = parameterizeQuery(query, paramGraph)
+
+      expect(result.placeholderValues).toEqual({
+        '%1': '{"positiveInfinity":null,"negativeInfinity":null,"notANumber":null}',
+      })
+      expect(result.parameterizedQuery.query.arguments).toEqual({
+        data: {
+          properties: { $type: 'Param', value: { name: '%1', type: 'Json' } },
+        },
+      })
+    })
+
     it('serializes sparse Json arrays with holes as null entries', () => {
       const properties: any[] = []
       properties[0] = 1

--- a/packages/client/src/runtime/core/engines/client/parameterization/parameterize.ts
+++ b/packages/client/src/runtime/core/engines/client/parameterization/parameterize.ts
@@ -429,7 +429,7 @@ function serializeJsonValue(value: unknown, seen: Set<object>): string {
   }
 
   if (Decimal.isDecimal(value)) {
-    return value.toFixed()
+    return value.isFinite() ? value.toFixed() : 'null'
   }
 
   if (value instanceof Date) {

--- a/packages/client/src/runtime/core/engines/client/parameterization/parameterize.ts
+++ b/packages/client/src/runtime/core/engines/client/parameterization/parameterize.ts
@@ -6,7 +6,7 @@
  * both schema rules and runtime value types agree.
  */
 
-import { deserializeJsonObject, safeJsonStringify } from '@prisma/client-engine-runtime'
+import { deserializeJsonObject } from '@prisma/client-engine-runtime'
 import { Decimal } from '@prisma/client-runtime-utils'
 import type {
   JsonArgumentValue,
@@ -447,7 +447,11 @@ function serializeJsonValue(value: unknown, seen: Set<object>): string {
 
     seen.add(value)
     try {
-      return `[${value.map((item) => serializeJsonValue(item, seen)).join(',')}]`
+      const serializedItems = Array.from({ length: value.length }, (_, index) =>
+        index in value ? serializeJsonValue(value[index], seen) : 'null',
+      )
+
+      return `[${serializedItems.join(',')}]`
     } finally {
       seen.delete(value)
     }
@@ -456,7 +460,13 @@ function serializeJsonValue(value: unknown, seen: Set<object>): string {
   const objectValue = value as Record<string, unknown> & { toJSON?: () => unknown }
 
   if (typeof objectValue.toJSON === 'function') {
-    return serializeJsonValue(objectValue.toJSON(), seen)
+    const jsonValue = objectValue.toJSON()
+
+    // Match JSON.stringify: if toJSON returns the same object, serialize its
+    // enumerable properties instead of recursing forever through toJSON().
+    if (jsonValue !== objectValue) {
+      return serializeJsonValue(jsonValue, seen)
+    }
   }
 
   if (seen.has(objectValue)) {

--- a/packages/client/src/runtime/core/engines/client/parameterization/parameterize.ts
+++ b/packages/client/src/runtime/core/engines/client/parameterization/parameterize.ts
@@ -408,7 +408,7 @@ function stringifyJsonPlaceholderValue(value: unknown): string {
   return serializeJsonValue(value, new Set())
 }
 
-function serializeJsonValue(value: unknown, seen: Set<object>): string {
+function serializeJsonValue(value: unknown, seen: Set<object>, applyToJson = true): string {
   if (value === null) {
     return 'null'
   }
@@ -459,13 +459,13 @@ function serializeJsonValue(value: unknown, seen: Set<object>): string {
 
   const objectValue = value as Record<string, unknown> & { toJSON?: () => unknown }
 
-  if (typeof objectValue.toJSON === 'function') {
+  if (applyToJson && typeof objectValue.toJSON === 'function') {
     const jsonValue = objectValue.toJSON()
 
     // Match JSON.stringify: if toJSON returns the same object, serialize its
     // enumerable properties instead of recursing forever through toJSON().
     if (jsonValue !== objectValue) {
-      return serializeJsonValue(jsonValue, seen)
+      return serializeJsonValue(jsonValue, seen, false)
     }
   }
 

--- a/packages/client/src/runtime/core/engines/client/parameterization/parameterize.ts
+++ b/packages/client/src/runtime/core/engines/client/parameterization/parameterize.ts
@@ -7,6 +7,7 @@
  */
 
 import { deserializeJsonObject, safeJsonStringify } from '@prisma/client-engine-runtime'
+import { Decimal } from '@prisma/client-runtime-utils'
 import type {
   JsonArgumentValue,
   JsonBatchQuery,
@@ -273,7 +274,7 @@ class Parameterizer {
    */
   #handleArray(items: unknown[], originalValue: unknown, edge: InputEdge): unknown {
     if (hasFlag(edge, EdgeFlag.ParamScalar) && getScalarMask(edge) & ScalarMask.Json) {
-      const jsonValue = safeJsonStringify(deserializeJsonObject(items))
+      const jsonValue = stringifyJsonPlaceholderValue(deserializeJsonObject(items))
       const type: PlaceholderType = { type: 'Json' }
       return this.#getOrCreatePlaceholder(jsonValue, type)
     }
@@ -324,7 +325,7 @@ class Parameterizer {
 
     const mask = getScalarMask(edge)
     if (mask & ScalarMask.Json) {
-      const jsonValue = safeJsonStringify(deserializeJsonObject(obj))
+      const jsonValue = stringifyJsonPlaceholderValue(deserializeJsonObject(obj))
       const type: PlaceholderType = { type: 'Json' }
       return this.#getOrCreatePlaceholder(jsonValue, type)
     }
@@ -401,6 +402,81 @@ function serializeValue(value: unknown): string {
     return bufView.toString('base64')
   }
   return JSON.stringify(value)
+}
+
+function stringifyJsonPlaceholderValue(value: unknown): string {
+  return serializeJsonValue(value, new Set())
+}
+
+function serializeJsonValue(value: unknown, seen: Set<object>): string {
+  if (value === null) {
+    return 'null'
+  }
+
+  switch (typeof value) {
+    case 'string':
+      return JSON.stringify(value)
+    case 'number':
+      return JSON.stringify(value) ?? 'null'
+    case 'boolean':
+      return value ? 'true' : 'false'
+    case 'bigint':
+      return JSON.stringify(value.toString())
+    case 'undefined':
+    case 'function':
+    case 'symbol':
+      return 'null'
+  }
+
+  if (Decimal.isDecimal(value)) {
+    return value.toFixed()
+  }
+
+  if (value instanceof Date) {
+    return JSON.stringify(value.toJSON())
+  }
+
+  if (ArrayBuffer.isView(value)) {
+    return JSON.stringify(Buffer.from(value.buffer, value.byteOffset, value.byteLength).toString('base64'))
+  }
+
+  if (Array.isArray(value)) {
+    if (seen.has(value)) {
+      throw new TypeError('Converting circular structure to JSON')
+    }
+
+    seen.add(value)
+    try {
+      return `[${value.map((item) => serializeJsonValue(item, seen)).join(',')}]`
+    } finally {
+      seen.delete(value)
+    }
+  }
+
+  const objectValue = value as Record<string, unknown> & { toJSON?: () => unknown }
+
+  if (typeof objectValue.toJSON === 'function') {
+    return serializeJsonValue(objectValue.toJSON(), seen)
+  }
+
+  if (seen.has(objectValue)) {
+    throw new TypeError('Converting circular structure to JSON')
+  }
+
+  seen.add(objectValue)
+  try {
+    const entries: string[] = []
+    for (const key of Object.keys(objectValue)) {
+      const propertyValue = objectValue[key]
+      if (propertyValue === undefined || typeof propertyValue === 'function' || typeof propertyValue === 'symbol') {
+        continue
+      }
+      entries.push(`${JSON.stringify(key)}:${serializeJsonValue(propertyValue, seen)}`)
+    }
+    return `{${entries.join(',')}}`
+  } finally {
+    seen.delete(objectValue)
+  }
 }
 
 /**

--- a/packages/client/tests/functional/issues/29387-decimal-in-json/_matrix.ts
+++ b/packages/client/tests/functional/issues/29387-decimal-in-json/_matrix.ts
@@ -1,0 +1,4 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+import { Providers } from '../../_utils/providers'
+
+export default defineMatrix(() => [[{ provider: Providers.POSTGRESQL }]])

--- a/packages/client/tests/functional/issues/29387-decimal-in-json/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/29387-decimal-in-json/prisma/_schema.ts
@@ -1,3 +1,4 @@
+import { idForProvider } from '../../../_utils/idForProvider'
 import testMatrix from '../_matrix'
 
 export default testMatrix.setupSchema(({ provider }) => {
@@ -11,7 +12,7 @@ export default testMatrix.setupSchema(({ provider }) => {
     }
 
     model ModelWithJson {
-      id         String @id
+      id         ${idForProvider(provider)}
       properties Json
     }
   `

--- a/packages/client/tests/functional/issues/29387-decimal-in-json/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/29387-decimal-in-json/prisma/_schema.ts
@@ -1,0 +1,18 @@
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+    generator client {
+      provider = "prisma-client-js"
+    }
+
+    datasource db {
+      provider = "${provider}"
+    }
+
+    model ModelWithJson {
+      id         String @id
+      properties Json
+    }
+  `
+})

--- a/packages/client/tests/functional/issues/29387-decimal-in-json/tests.ts
+++ b/packages/client/tests/functional/issues/29387-decimal-in-json/tests.ts
@@ -1,0 +1,32 @@
+import { Decimal } from '@prisma/client-runtime-utils'
+
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(
+  () => {
+    test('serializes Decimal nested in Json as a numeric JSON value', async () => {
+      const record = await prisma.modelWithJson.create({
+        data: {
+          id: '1',
+          properties: {
+            someDecimal: new Decimal('-11000'),
+          },
+        },
+      })
+
+      expect(record.properties).toEqual({
+        someDecimal: -11000,
+      })
+    })
+  },
+  {
+    optOut: {
+      from: ['sqlite', 'mysql', 'mongodb', 'cockroachdb', 'sqlserver'],
+      reason: 'Issue #29387 reports the PostgreSQL Json path specifically.',
+    },
+  },
+)


### PR DESCRIPTION
## Summary
- restore numeric JSON encoding for Decimal values nested inside Json inputs when parameterizing client-engine queries
- keep the newer Date, BigInt, Bytes, and 	oJSON() handling intact for Json placeholder generation
- add a focused parameterization regression plus a PostgreSQL issue fixture for #29387

## Testing
- corepack pnpm --dir packages/client test -- src/runtime/core/engines/client/parameterization/parameterize.test.ts --runInBand
- corepack pnpm --filter @prisma/client build
- corepack pnpm exec prettier --check packages/client/src/runtime/core/engines/client/parameterization/parameterize.ts packages/client/src/runtime/core/engines/client/parameterization/parameterize.test.ts packages/client/tests/functional/issues/29387-decimal-in-json/_matrix.ts packages/client/tests/functional/issues/29387-decimal-in-json/prisma/_schema.ts packages/client/tests/functional/issues/29387-decimal-in-json/tests.ts
- git diff --check

## Notes
- Added packages/client/tests/functional/issues/29387-decimal-in-json/ with the exact PostgreSQL repro from the issue.
- A direct functional run reached the new js_pg suite but is locally blocked on this host by schema-engine auth (P1000) against postgres://prisma:prisma@localhost:5432/..., so that end-to-end validation still needs a machine with valid Prisma test DB credentials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More consistent JSON handling in create/parameterized operations: finite Decimal values persist as numbers; non-finite Decimals become null; sparse arrays keep holes as null; Date and binary views serialize predictably; object cycles now error instead of producing corrupt output; object toJSON semantics match JSON.stringify.
* **Tests**
  * Added functional tests and schemas validating JSON serialization cases (Decimal, sparse arrays, toJSON behavior) to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->