### PR TITLE
fix(cli): bootstrap UX — auto-install deps, resumable flow, timeout handling

### DIFF
--- a/packages/cli/src/bootstrap/Bootstrap.ts
+++ b/packages/cli/src/bootstrap/Bootstrap.ts
@@ -344,7 +344,6 @@ ${bold('Examples')}
             })
           }
         } else {
-          const pm = detectPackageManager(baseDir)
           console.log(`\n  Install them manually, then re-run:`)
           console.log(`  ${dim('$')} ${pm} add -D ${missingDeps.join(' ')}`)
           console.log(`  ${dim('$')} npx prisma@latest bootstrap`)

--- a/packages/cli/src/bootstrap/Bootstrap.ts
+++ b/packages/cli/src/bootstrap/Bootstrap.ts
@@ -195,46 +195,29 @@ ${bold('Examples')}
           console.log(
             `  Initialize one with: ${dim('npm init -y')}, ${dim('pnpm init')}, ${dim('yarn init')}, or ${dim('bun init')}\n`,
           )
-        }
 
-        const useTemplate = templateName ?? (await this.askAboutTemplate())
+          const useTemplate = templateName ?? (await this.askAboutTemplate())
 
-        if (useTemplate) {
-          const spinner = ora(`Downloading ${bold(useTemplate)} template...`).start()
-          const stepStart = performance.now()
-
-          try {
-            await downloadAndExtractTemplate(useTemplate, baseDir)
-            spinner.succeed(`Template ${bold(useTemplate)} scaffolded`)
-            steps.template = 'completed'
-            steps.init = 'skipped'
-            templateScaffolded = true
-            stepsCompleted.push('template')
-            await emitStepCompleted(telemetryCtx, 'template', performance.now() - stepStart)
-          } catch (err) {
-            const isTimeout = err instanceof DOMException && err.name === 'TimeoutError'
-            const msg = isTimeout
-              ? 'Download timed out — check your network connection and try again'
-              : err instanceof Error
-                ? err.message
-                : String(err)
-            spinner.fail(`Template download failed: ${sanitizeErrorMessage(msg)}`)
-
-            if (isEmptyProject) {
+          if (useTemplate) {
+            await this.scaffoldTemplate(useTemplate, baseDir, steps, stepsCompleted, telemetryCtx)
+            templateScaffolded = steps.template === 'completed'
+            if (!templateScaffolded) {
               return new HelpError(
                 `\n${bold(red('!'))} Template download failed and no project exists to fall back to.\n\nInitialize a project first, then re-run ${bold('prisma bootstrap')}:\n  ${dim('$')} npm init -y ${dim('  (or pnpm init / yarn init / bun init)')}\n  ${dim('$')} npx prisma bootstrap`,
               )
             }
-
+          } else {
+            return new HelpError(
+              `\n${bold(red('!'))} Cannot proceed without a project.\n\nInitialize a project first, then re-run ${bold('prisma bootstrap')}:\n  ${dim('$')} npm init -y ${dim('  (or pnpm init / yarn init / bun init)')}\n  ${dim('$')} npx prisma bootstrap`,
+            )
+          }
+        } else if (templateName) {
+          await this.scaffoldTemplate(templateName, baseDir, steps, stepsCompleted, telemetryCtx)
+          templateScaffolded = steps.template === 'completed'
+          if (!templateScaffolded) {
             console.log(`${dim('  Falling back to prisma init...')}`)
-            steps.template = 'failed'
-            await emitStepFailed(telemetryCtx, 'template', sanitizeErrorMessage(msg))
             await this.runInit(steps, stepsCompleted, telemetryCtx, config, await this.askAboutSampleModel())
           }
-        } else if (isEmptyProject) {
-          return new HelpError(
-            `\n${bold(red('!'))} Cannot proceed without a project.\n\nInitialize a project first, then re-run ${bold('prisma bootstrap')}:\n  ${dim('$')} npm init -y ${dim('  (or pnpm init / yarn init / bun init)')}\n  ${dim('$')} npx prisma bootstrap`,
-          )
         } else {
           steps.template = 'not-applicable'
           await this.runInit(steps, stepsCompleted, telemetryCtx, config, await this.askAboutSampleModel())
@@ -314,24 +297,14 @@ ${bold('Examples')}
       // Re-detect project state after init/template + link may have changed files
       const updatedState = detectProjectState(baseDir)
 
-      // Reload config after init/template may have created prisma.config.ts
-      let activeConfig = config
-      if (!initialState.hasPrismaConfig && updatedState.hasPrismaConfig) {
-        try {
-          const { config: reloadedConfig, error } = await loadConfigFromFile({})
-          if (!error) {
-            activeConfig = reloadedConfig
-          }
-        } catch {
-          console.log(`${yellow('warn')} Could not reload config — using initial config for migrate/seed`)
-        }
-      }
-
       // --- Deps gate: check if Prisma dependencies are available ---
       //
       // The generated prisma.config.ts imports dotenv/config, and migrate/generate
       // shell out to the local prisma binary when a schema file exists. Both must
       // be installed for subsequent steps to work.
+      //
+      // This runs BEFORE config reload — prisma.config.ts imports dotenv/config,
+      // so dotenv must be installed first or the config load will fail.
       const missingDeps: string[] = []
       if (!templateScaffolded) {
         for (const pkg of ['dotenv', 'prisma']) {
@@ -383,6 +356,20 @@ ${bold('Examples')}
             hasModels: updatedState.hasModels,
             pendingDepsInstall: true,
           })
+        }
+      }
+
+      // Reload config after deps are installed — prisma.config.ts imports
+      // dotenv/config, so this must happen after the deps gate above.
+      let activeConfig = config
+      if (!initialState.hasPrismaConfig && updatedState.hasPrismaConfig) {
+        try {
+          const { config: reloadedConfig, error } = await loadConfigFromFile({})
+          if (!error) {
+            activeConfig = reloadedConfig
+          }
+        } catch {
+          console.log(`${yellow('warn')} Could not reload config — using initial config for migrate/seed`)
         }
       }
 
@@ -558,6 +545,41 @@ ${bold('Examples')}
       message: 'Add a sample User model to get started?',
       default: true,
     })
+  }
+
+  private async scaffoldTemplate(
+    templateName: string,
+    baseDir: string,
+    steps: BootstrapStepStatus,
+    stepsCompleted: string[],
+    telemetryCtx: {
+      distinctId: string
+      databaseId: string | undefined
+      linkResult: LinkResult | null
+      projectState: ReturnType<typeof detectProjectState>
+    },
+  ): Promise<void> {
+    const spinner = ora(`Downloading ${bold(templateName)} template...`).start()
+    const stepStart = performance.now()
+
+    try {
+      await downloadAndExtractTemplate(templateName, baseDir)
+      spinner.succeed(`Template ${bold(templateName)} scaffolded`)
+      steps.template = 'completed'
+      steps.init = 'skipped'
+      stepsCompleted.push('template')
+      await emitStepCompleted(telemetryCtx, 'template', performance.now() - stepStart)
+    } catch (err) {
+      const isTimeout = err instanceof DOMException && err.name === 'TimeoutError'
+      const msg = isTimeout
+        ? 'Download timed out — check your network connection and try again'
+        : err instanceof Error
+          ? err.message
+          : String(err)
+      spinner.fail(`Template download failed: ${sanitizeErrorMessage(msg)}`)
+      steps.template = 'failed'
+      await emitStepFailed(telemetryCtx, 'template', sanitizeErrorMessage(msg))
+    }
   }
 
   private async runInit(

--- a/packages/cli/src/bootstrap/Bootstrap.ts
+++ b/packages/cli/src/bootstrap/Bootstrap.ts
@@ -317,6 +317,25 @@ ${bold('Examples')}
       if (missingDeps.length > 0) {
         const pm = detectPackageManager(baseDir)
         const depsLabel = bold(missingDeps.join(', '))
+
+        const manualInstallAndReturn = () => {
+          console.log(`\n  Install them manually, then re-run:`)
+          console.log(`  ${dim('$')} ${pm} add -D ${missingDeps.join(' ')}`)
+          console.log(`  ${dim('$')} npx prisma@latest bootstrap`)
+
+          return formatBootstrapOutput({
+            databaseId: telemetryCtx.linkResult?.databaseId ?? databaseId ?? 'unknown',
+            isNewProject: !initialState.hasPackageJson,
+            steps,
+            hasModels: updatedState.hasModels,
+            pendingDepsInstall: true,
+          })
+        }
+
+        if (pm === 'deno') {
+          return manualInstallAndReturn()
+        }
+
         const shouldInstall = await confirm({
           message: `Install missing Prisma dependencies (${missingDeps.join(', ')}) with ${pm}?`,
           default: true,
@@ -331,30 +350,10 @@ ${bold('Examples')}
           } catch (err) {
             const msg = err instanceof Error ? err.message : String(err)
             installSpinner.fail(`Failed to install dependencies: ${sanitizeErrorMessage(msg)}`)
-            console.log(`\n  Install them manually, then re-run:`)
-            console.log(`  ${dim('$')} ${pm} add -D ${missingDeps.join(' ')}`)
-            console.log(`  ${dim('$')} npx prisma@latest bootstrap`)
-
-            return formatBootstrapOutput({
-              databaseId: telemetryCtx.linkResult?.databaseId ?? databaseId ?? 'unknown',
-              isNewProject: !initialState.hasPackageJson,
-              steps,
-              hasModels: updatedState.hasModels,
-              pendingDepsInstall: true,
-            })
+            return manualInstallAndReturn()
           }
         } else {
-          console.log(`\n  Install them manually, then re-run:`)
-          console.log(`  ${dim('$')} ${pm} add -D ${missingDeps.join(' ')}`)
-          console.log(`  ${dim('$')} npx prisma@latest bootstrap`)
-
-          return formatBootstrapOutput({
-            databaseId: telemetryCtx.linkResult?.databaseId ?? databaseId ?? 'unknown',
-            isNewProject: !initialState.hasPackageJson,
-            steps,
-            hasModels: updatedState.hasModels,
-            pendingDepsInstall: true,
-          })
+          return manualInstallAndReturn()
         }
       }
 

--- a/packages/cli/src/bootstrap/Bootstrap.ts
+++ b/packages/cli/src/bootstrap/Bootstrap.ts
@@ -319,8 +319,10 @@ ${bold('Examples')}
         const depsLabel = bold(missingDeps.join(', '))
 
         const manualInstallAndReturn = () => {
+          const installHint =
+            pm === 'npm' ? `npm install --save-dev ${missingDeps.join(' ')}` : `${pm} add -D ${missingDeps.join(' ')}`
           console.log(`\n  Install them manually, then re-run:`)
-          console.log(`  ${dim('$')} ${pm} add -D ${missingDeps.join(' ')}`)
+          console.log(`  ${dim('$')} ${installHint}`)
           console.log(`  ${dim('$')} npx prisma@latest bootstrap`)
 
           return formatBootstrapOutput({

--- a/packages/cli/src/bootstrap/Bootstrap.ts
+++ b/packages/cli/src/bootstrap/Bootstrap.ts
@@ -21,6 +21,8 @@ import { type BootstrapStepStatus, formatBootstrapOutput } from './completion-ou
 import { detectProjectState, getModelNames, getSeedCommand } from './project-state'
 import { emitFlowCompleted, emitFlowStarted, emitStepCompleted, emitStepFailed, emitStepSkipped } from './telemetry'
 import {
+  addDevDependencies,
+  detectPackageManager,
   downloadAndExtractTemplate,
   installDependencies,
   isValidTemplateName,
@@ -210,7 +212,12 @@ ${bold('Examples')}
             stepsCompleted.push('template')
             await emitStepCompleted(telemetryCtx, 'template', performance.now() - stepStart)
           } catch (err) {
-            const msg = err instanceof Error ? err.message : String(err)
+            const isTimeout = err instanceof DOMException && err.name === 'TimeoutError'
+            const msg = isTimeout
+              ? 'Download timed out — check your network connection and try again'
+              : err instanceof Error
+                ? err.message
+                : String(err)
             spinner.fail(`Template download failed: ${sanitizeErrorMessage(msg)}`)
 
             if (isEmptyProject) {
@@ -240,12 +247,10 @@ ${bold('Examples')}
 
       // --- Step 2: Link ---
       if (!force && isAlreadyLinked(baseDir)) {
-        if (databaseId) {
-          return new HelpError(
-            `\n${bold(red('!'))} This project is already linked to Prisma Postgres. Re-run with ${bold('--force')} to relink to a different database.`,
-          )
-        }
         console.log(`\n${green('✔')} Already linked to Prisma Postgres`)
+        if (databaseId) {
+          console.log(`  ${dim('Skipping link — use --force to relink to a different database')}`)
+        }
         steps.link = 'skipped'
         await emitStepSkipped(telemetryCtx, 'link')
       } else {
@@ -327,7 +332,6 @@ ${bold('Examples')}
       // The generated prisma.config.ts imports dotenv/config, and migrate/generate
       // shell out to the local prisma binary when a schema file exists. Both must
       // be installed for subsequent steps to work.
-      // Bootstrap doesn't install deps — that's the user's responsibility.
       const missingDeps: string[] = []
       if (!templateScaffolded) {
         for (const pkg of ['dotenv', 'prisma']) {
@@ -336,20 +340,50 @@ ${bold('Examples')}
           }
         }
       }
-      const needsDepsInstall = missingDeps.length > 0
 
-      if (needsDepsInstall) {
-        console.log(`\n${yellow('!')} Missing dependencies required by Prisma: ${bold(missingDeps.join(', '))}`)
-        console.log(`  Install them as dev dependencies with your package manager, then re-run:`)
-        console.log(`  ${dim('$')} npx prisma@latest bootstrap`)
-
-        return formatBootstrapOutput({
-          databaseId: telemetryCtx.linkResult?.databaseId ?? databaseId ?? 'unknown',
-          isNewProject: !initialState.hasPackageJson,
-          steps,
-          hasModels: updatedState.hasModels,
-          pendingDepsInstall: true,
+      if (missingDeps.length > 0) {
+        const pm = detectPackageManager(baseDir)
+        const depsLabel = bold(missingDeps.join(', '))
+        const shouldInstall = await confirm({
+          message: `Install missing Prisma dependencies (${missingDeps.join(', ')}) with ${pm}?`,
+          default: true,
         })
+
+        if (shouldInstall) {
+          const installSpinner = ora(`Installing ${depsLabel}...`).start()
+          try {
+            await addDevDependencies(baseDir, missingDeps)
+            installSpinner.succeed(`Prisma dependencies installed`)
+            stepsCompleted.push('deps')
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err)
+            installSpinner.fail(`Failed to install dependencies: ${sanitizeErrorMessage(msg)}`)
+            console.log(`\n  Install them manually, then re-run:`)
+            console.log(`  ${dim('$')} ${pm} add -D ${missingDeps.join(' ')}`)
+            console.log(`  ${dim('$')} npx prisma@latest bootstrap`)
+
+            return formatBootstrapOutput({
+              databaseId: telemetryCtx.linkResult?.databaseId ?? databaseId ?? 'unknown',
+              isNewProject: !initialState.hasPackageJson,
+              steps,
+              hasModels: updatedState.hasModels,
+              pendingDepsInstall: true,
+            })
+          }
+        } else {
+          const pm = detectPackageManager(baseDir)
+          console.log(`\n  Install them manually, then re-run:`)
+          console.log(`  ${dim('$')} ${pm} add -D ${missingDeps.join(' ')}`)
+          console.log(`  ${dim('$')} npx prisma@latest bootstrap`)
+
+          return formatBootstrapOutput({
+            databaseId: telemetryCtx.linkResult?.databaseId ?? databaseId ?? 'unknown',
+            isNewProject: !initialState.hasPackageJson,
+            steps,
+            hasModels: updatedState.hasModels,
+            pendingDepsInstall: true,
+          })
+        }
       }
 
       // --- Step 4: Migrate (if schema has models) ---

--- a/packages/cli/src/bootstrap/__tests__/Bootstrap.vitest.ts
+++ b/packages/cli/src/bootstrap/__tests__/Bootstrap.vitest.ts
@@ -330,6 +330,7 @@ describe('Bootstrap command — deps gate', () => {
     vi.mocked(addDevDependencies).mockImplementation((_baseDir, _pkgs) => {
       fs.mkdirSync(path.join(tmpDir, 'node_modules', 'dotenv'), { recursive: true })
       fs.mkdirSync(path.join(tmpDir, 'node_modules', 'prisma'), { recursive: true })
+      return Promise.resolve()
     })
 
     setupMockApiSuccess()
@@ -358,8 +359,8 @@ describe('Bootstrap command — deps gate', () => {
 
     const { confirm } = await import('@inquirer/prompts')
     vi.mocked(confirm)
-      .mockResolvedValueOnce(true) // migrate confirm (asked before deps gate)
-      .mockResolvedValueOnce(false) // deps install — decline
+      .mockResolvedValueOnce(true) // deps install — approve
+      .mockResolvedValueOnce(false) // migrate confirm — decline
 
     setupMockApiSuccess()
 

--- a/packages/cli/src/bootstrap/__tests__/Bootstrap.vitest.ts
+++ b/packages/cli/src/bootstrap/__tests__/Bootstrap.vitest.ts
@@ -77,6 +77,8 @@ vi.mock('../../Init', () => ({
 }))
 
 vi.mock('../template-scaffold', () => ({
+  addDevDependencies: vi.fn(() => Promise.resolve()),
+  detectPackageManager: vi.fn(() => 'npm'),
   downloadAndExtractTemplate: vi.fn(() => Promise.resolve()),
   installDependencies: vi.fn(),
   isValidTemplateName: vi.fn((name: string) => ['nextjs', 'express'].includes(name)),
@@ -154,6 +156,8 @@ describe('Bootstrap command — help and validation', () => {
 describe('Bootstrap command — new project flow', () => {
   test('runs init when user declines template, then links', async () => {
     fs.writeFileSync(path.join(tmpDir, 'package.json'), '{"name":"test"}', 'utf-8')
+    fs.mkdirSync(path.join(tmpDir, 'node_modules', 'dotenv'), { recursive: true })
+    fs.mkdirSync(path.join(tmpDir, 'node_modules', 'prisma'), { recursive: true })
 
     const { confirm } = await import('@inquirer/prompts')
     vi.mocked(confirm).mockResolvedValue(false)
@@ -197,6 +201,8 @@ describe('Bootstrap command — new project flow', () => {
 
   test('falls back to init when template download fails', async () => {
     fs.writeFileSync(path.join(tmpDir, 'package.json'), '{"name":"test"}', 'utf-8')
+    fs.mkdirSync(path.join(tmpDir, 'node_modules', 'dotenv'), { recursive: true })
+    fs.mkdirSync(path.join(tmpDir, 'node_modules', 'prisma'), { recursive: true })
 
     const { confirm } = await import('@inquirer/prompts')
     vi.mocked(confirm).mockResolvedValue(false)
@@ -226,6 +232,8 @@ describe('Bootstrap command — existing project flow', () => {
     const prismaDir = path.join(tmpDir, 'prisma')
     fs.mkdirSync(prismaDir, { recursive: true })
     fs.writeFileSync(path.join(prismaDir, 'schema.prisma'), 'datasource db { provider = "postgresql" }', 'utf-8')
+    fs.mkdirSync(path.join(tmpDir, 'node_modules', 'dotenv'), { recursive: true })
+    fs.mkdirSync(path.join(tmpDir, 'node_modules', 'prisma'), { recursive: true })
 
     const { confirm } = await import('@inquirer/prompts')
     vi.mocked(confirm).mockResolvedValue(false)
@@ -257,6 +265,8 @@ model User { id Int @id }
 `,
       'utf-8',
     )
+    fs.mkdirSync(path.join(tmpDir, 'node_modules', 'dotenv'), { recursive: true })
+    fs.mkdirSync(path.join(tmpDir, 'node_modules', 'prisma'), { recursive: true })
 
     const { confirm } = await import('@inquirer/prompts')
     vi.mocked(confirm).mockResolvedValue(false)
@@ -276,7 +286,7 @@ model User { id Int @id }
 })
 
 describe('Bootstrap command — deps gate', () => {
-  test('pauses with pending deps message when dotenv and prisma are missing', async () => {
+  test('prompts to install missing deps and continues when accepted', async () => {
     fs.writeFileSync(path.join(tmpDir, 'package.json'), '{"name":"test"}', 'utf-8')
     const prismaDir = path.join(tmpDir, 'prisma')
     fs.mkdirSync(prismaDir, { recursive: true })
@@ -289,6 +299,12 @@ describe('Bootstrap command — deps gate', () => {
     const { confirm } = await import('@inquirer/prompts')
     vi.mocked(confirm).mockResolvedValue(true)
 
+    const { addDevDependencies } = await import('../template-scaffold')
+    vi.mocked(addDevDependencies).mockImplementation(async (_baseDir, _pkgs) => {
+      fs.mkdirSync(path.join(tmpDir, 'node_modules', 'dotenv'), { recursive: true })
+      fs.mkdirSync(path.join(tmpDir, 'node_modules', 'prisma'), { recursive: true })
+    })
+
     setupMockApiSuccess()
 
     const result = await Bootstrap.new().parse(
@@ -300,9 +316,35 @@ describe('Bootstrap command — deps gate', () => {
     expect(result).not.toBeInstanceOf(Error)
     const output = result as string
     expect(output).toContain('Bootstrap completed')
-    expect(output).toContain('Install')
-    expect(output).toContain('dotenv')
-    expect(output).toContain('Re-run')
+    expect(addDevDependencies).toHaveBeenCalledWith(tmpDir, ['dotenv', 'prisma'])
+  })
+
+  test('stops with install instructions when user declines deps install', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), '{"name":"test"}', 'utf-8')
+    const prismaDir = path.join(tmpDir, 'prisma')
+    fs.mkdirSync(prismaDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(prismaDir, 'schema.prisma'),
+      'datasource db { provider = "postgresql" }\nmodel User { id Int @id }',
+      'utf-8',
+    )
+
+    const { confirm } = await import('@inquirer/prompts')
+    vi.mocked(confirm)
+      .mockResolvedValueOnce(true) // migrate confirm (asked before deps gate)
+      .mockResolvedValueOnce(false) // deps install — decline
+
+    setupMockApiSuccess()
+
+    const result = await Bootstrap.new().parse(
+      ['--api-key', 'test_key', '--database', 'db_abc123'],
+      defaultTestConfig(),
+      tmpDir,
+    )
+
+    expect(result).not.toBeInstanceOf(Error)
+    const output = result as string
+    expect(output).toContain('Bootstrap completed')
   })
 
   test('skips deps gate when deps are installed', async () => {

--- a/packages/cli/src/bootstrap/__tests__/Bootstrap.vitest.ts
+++ b/packages/cli/src/bootstrap/__tests__/Bootstrap.vitest.ts
@@ -327,7 +327,7 @@ describe('Bootstrap command — deps gate', () => {
     vi.mocked(confirm).mockResolvedValue(true)
 
     const { addDevDependencies } = await import('../template-scaffold')
-    vi.mocked(addDevDependencies).mockImplementation(async (_baseDir, _pkgs) => {
+    vi.mocked(addDevDependencies).mockImplementation((_baseDir, _pkgs) => {
       fs.mkdirSync(path.join(tmpDir, 'node_modules', 'dotenv'), { recursive: true })
       fs.mkdirSync(path.join(tmpDir, 'node_modules', 'prisma'), { recursive: true })
     })

--- a/packages/cli/src/bootstrap/__tests__/Bootstrap.vitest.ts
+++ b/packages/cli/src/bootstrap/__tests__/Bootstrap.vitest.ts
@@ -225,6 +225,33 @@ describe('Bootstrap command — new project flow', () => {
     expect(output).toContain('failed')
     expect(output).toContain('Init')
   })
+
+  test('shows user-friendly message on template download timeout', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), '{"name":"test"}', 'utf-8')
+    fs.mkdirSync(path.join(tmpDir, 'node_modules', 'dotenv'), { recursive: true })
+    fs.mkdirSync(path.join(tmpDir, 'node_modules', 'prisma'), { recursive: true })
+
+    const { confirm } = await import('@inquirer/prompts')
+    vi.mocked(confirm).mockResolvedValue(false)
+
+    const { downloadAndExtractTemplate } = await import('../template-scaffold')
+    const timeoutError = new DOMException('The operation was aborted due to timeout', 'TimeoutError')
+    vi.mocked(downloadAndExtractTemplate).mockRejectedValueOnce(timeoutError)
+
+    setupMockApiSuccess()
+
+    const result = await Bootstrap.new().parse(
+      ['--api-key', 'test_key', '--database', 'db_abc123', '--template', 'nextjs'],
+      defaultTestConfig(),
+      tmpDir,
+    )
+
+    expect(result).not.toBeInstanceOf(Error)
+    const output = result as string
+    expect(output).toContain('Bootstrap completed')
+    expect(output).toContain('Template')
+    expect(output).toContain('failed')
+  })
 })
 
 describe('Bootstrap command — existing project flow', () => {

--- a/packages/cli/src/bootstrap/__tests__/Bootstrap.vitest.ts
+++ b/packages/cli/src/bootstrap/__tests__/Bootstrap.vitest.ts
@@ -358,9 +358,11 @@ describe('Bootstrap command — deps gate', () => {
     )
 
     const { confirm } = await import('@inquirer/prompts')
-    vi.mocked(confirm)
-      .mockResolvedValueOnce(true) // deps install — approve
-      .mockResolvedValueOnce(false) // migrate confirm — decline
+    vi.mocked(confirm).mockReset()
+    vi.mocked(confirm).mockResolvedValueOnce(false) // deps install — decline
+
+    const { addDevDependencies } = await import('../template-scaffold')
+    vi.mocked(addDevDependencies).mockReset()
 
     setupMockApiSuccess()
 
@@ -373,6 +375,7 @@ describe('Bootstrap command — deps gate', () => {
     expect(result).not.toBeInstanceOf(Error)
     const output = result as string
     expect(output).toContain('Bootstrap completed')
+    expect(addDevDependencies).not.toHaveBeenCalled()
   })
 
   test('skips deps gate when deps are installed', async () => {

--- a/packages/cli/src/bootstrap/__tests__/template-scaffold.vitest.ts
+++ b/packages/cli/src/bootstrap/__tests__/template-scaffold.vitest.ts
@@ -51,4 +51,25 @@ describe('detectPackageManager', () => {
     fs.writeFileSync(path.join(tmpDir, 'yarn.lock'), '', 'utf-8')
     expect(detectPackageManager(tmpDir)).toBe('pnpm')
   })
+
+  test('detects pnpm from packageManager field', () => {
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), '{"packageManager":"pnpm@10.15.1"}', 'utf-8')
+    expect(detectPackageManager(tmpDir)).toBe('pnpm')
+  })
+
+  test('detects yarn from packageManager field', () => {
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), '{"packageManager":"yarn@4.0.0"}', 'utf-8')
+    expect(detectPackageManager(tmpDir)).toBe('yarn')
+  })
+
+  test('detects bun from packageManager field', () => {
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), '{"packageManager":"bun@1.3.11"}', 'utf-8')
+    expect(detectPackageManager(tmpDir)).toBe('bun')
+  })
+
+  test('lockfile takes priority over packageManager field', () => {
+    fs.writeFileSync(path.join(tmpDir, 'yarn.lock'), '', 'utf-8')
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), '{"packageManager":"pnpm@10.0.0"}', 'utf-8')
+    expect(detectPackageManager(tmpDir)).toBe('yarn')
+  })
 })

--- a/packages/cli/src/bootstrap/template-scaffold.ts
+++ b/packages/cli/src/bootstrap/template-scaffold.ts
@@ -189,11 +189,16 @@ export async function addDevDependencies(baseDir: string, packages: string[]): P
   if (pm === 'deno') {
     throw new Error('Deno projects require manual dependency management. Please add dependencies to your deno.json.')
   }
-  const addArgs = pm === 'yarn' ? ['add', '--dev', ...packages] : ['add', '-D', ...packages]
-  if (pm === 'npm') {
-    addArgs[0] = 'install'
-    addArgs[1] = '--save-dev'
-  }
+  const addArgs = (() => {
+    switch (pm) {
+      case 'npm':
+        return ['install', '--save-dev', ...packages]
+      case 'yarn':
+        return ['add', '--dev', ...packages]
+      default:
+        return ['add', '-D', ...packages]
+    }
+  })()
   await execFileAsync(pm, addArgs, {
     cwd: baseDir,
     env: { ...process.env },

--- a/packages/cli/src/bootstrap/template-scaffold.ts
+++ b/packages/cli/src/bootstrap/template-scaffold.ts
@@ -54,7 +54,7 @@ export async function downloadAndExtractTemplate(templateName: string, targetDir
   const response = await fetch(PRISMA_EXAMPLES_TARBALL_URL, {
     headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'prisma-cli' },
     redirect: 'follow',
-    signal: AbortSignal.timeout(30_000),
+    signal: AbortSignal.timeout(120_000),
   })
 
   if (!response.ok || !response.body) {
@@ -105,6 +105,7 @@ async function decompressGzip(body: import('node:stream/web').ReadableStream): P
   const chunks: Buffer[] = []
 
   return new Promise<Buffer>((resolve, reject) => {
+    nodeStream.on('error', reject)
     nodeStream
       .pipe(gunzip)
       .on('data', (chunk: Buffer) => chunks.push(chunk))
@@ -161,6 +162,21 @@ const execFileAsync = promisify(execFile)
 export async function installDependencies(baseDir: string): Promise<void> {
   const pm = detectPackageManager(baseDir)
   await execFileAsync(pm, ['install'], {
+    cwd: baseDir,
+    env: { ...process.env },
+    shell: process.platform === 'win32',
+    timeout: 300_000,
+  })
+}
+
+export async function addDevDependencies(baseDir: string, packages: string[]): Promise<void> {
+  const pm = detectPackageManager(baseDir)
+  const addArgs = pm === 'yarn' ? ['add', '--dev', ...packages] : ['add', '-D', ...packages]
+  if (pm === 'npm') {
+    addArgs[0] = 'install'
+    addArgs[1] = '--save-dev'
+  }
+  await execFileAsync(pm, addArgs, {
     cwd: baseDir,
     env: { ...process.env },
     shell: process.platform === 'win32',

--- a/packages/cli/src/bootstrap/template-scaffold.ts
+++ b/packages/cli/src/bootstrap/template-scaffold.ts
@@ -164,6 +164,7 @@ export function detectPackageManager(baseDir: string): PackageManager {
         if (pm.startsWith('pnpm')) return 'pnpm'
         if (pm.startsWith('yarn')) return 'yarn'
         if (pm.startsWith('bun')) return 'bun'
+        if (pm.startsWith('deno')) return 'deno'
       }
     } catch {}
   }
@@ -185,6 +186,9 @@ export async function installDependencies(baseDir: string): Promise<void> {
 
 export async function addDevDependencies(baseDir: string, packages: string[]): Promise<void> {
   const pm = detectPackageManager(baseDir)
+  if (pm === 'deno') {
+    throw new Error('Deno projects require manual dependency management. Please add dependencies to your deno.json.')
+  }
   const addArgs = pm === 'yarn' ? ['add', '--dev', ...packages] : ['add', '-D', ...packages]
   if (pm === 'npm') {
     addArgs[0] = 'install'

--- a/packages/cli/src/bootstrap/template-scaffold.ts
+++ b/packages/cli/src/bootstrap/template-scaffold.ts
@@ -154,6 +154,20 @@ export function detectPackageManager(baseDir: string): PackageManager {
   if (fs.existsSync(path.join(baseDir, 'yarn.lock'))) return 'yarn'
   if (fs.existsSync(path.join(baseDir, 'bun.lock')) || fs.existsSync(path.join(baseDir, 'bun.lockb'))) return 'bun'
   if (fs.existsSync(path.join(baseDir, 'deno.lock'))) return 'deno'
+
+  const pkgPath = path.join(baseDir, 'package.json')
+  if (fs.existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'))
+      const pm = pkg.packageManager as string | undefined
+      if (pm) {
+        if (pm.startsWith('pnpm')) return 'pnpm'
+        if (pm.startsWith('yarn')) return 'yarn'
+        if (pm.startsWith('bun')) return 'bun'
+      }
+    } catch {}
+  }
+
   return 'npm'
 }
 


### PR DESCRIPTION
/integration

## Summary

Addresses product testing feedback ([PTL-1372](https://linear.app/prisma-company/issue/PTL-1372)) for `prisma bootstrap`:

- **Template download timeout** — increased from 30s to 120s. Added proper error handling on `nodeStream` in `decompressGzip` to prevent unhandled `DOMException` crashes on Node 25. Timeout errors now show a user-friendly message.
- **Auto-install missing deps** — instead of dead-ending with "install manually and re-run", the command now prompts to install missing `dotenv`/`prisma` via the detected package manager (`npm`, `pnpm`, `yarn`, `bun`).
- **Resumable re-run** — when `--database` is passed on an already-linked project, bootstrap now skips the link step and continues to migrate/generate/seed instead of blocking with "already linked, use --force".
- **Partial deps accuracy** — only lists actually missing dependencies in the prompt, not all checked deps.

## Test plan

- [x] All existing bootstrap unit tests pass (43/43)
- [x] All link unit tests pass (48/48)
- [x] Lint/format clean (`biome check`)
- [x] No new type errors (pre-existing errors in Studio/sortModels only)