### PR TITLE
fix(client-engine-runtime): serialize unknown driver adapter error cause as JSON

### DIFF
--- a/packages/client-engine-runtime/src/user-facing-error.test.ts
+++ b/packages/client-engine-runtime/src/user-facing-error.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from 'vitest'
+
+import { rethrowAsUserFacing } from './user-facing-error'
+
+function makeDriverAdapterError(cause: object) {
+  // Minimal shape that satisfies isDriverAdapterError + rethrowAsUserFacing
+  return {
+    name: 'DriverAdapterError',
+    message: 'driver adapter error',
+    cause,
+  }
+}
+
+test('rethrowAsUserFacing re-throws the original error for unknown cause kinds', () => {
+  // An unknown `kind` value simulates a driver-adapter version that is ahead
+  // of the client (new error variant not yet handled by getErrorCode /
+  // renderErrorMessage). Before the fix the thrown message contained
+  // "[object Object]"; after the fix it contains a JSON-serialised snapshot.
+  const error = makeDriverAdapterError({ kind: 'SomeNewUnknownErrorKind', detail: 'more info' })
+
+  expect(() => rethrowAsUserFacing(error)).toThrowError(
+    /Unknown error: .*SomeNewUnknownErrorKind/,
+  )
+
+  // Crucially the message must NOT degrade to the useless "[object Object]"
+  expect(() => rethrowAsUserFacing(error)).not.toThrowError('[object Object]')
+})

--- a/packages/client-engine-runtime/src/user-facing-error.ts
+++ b/packages/client-engine-runtime/src/user-facing-error.ts
@@ -1,6 +1,6 @@
 import { DriverAdapterError, isDriverAdapterError } from '@prisma/driver-adapter-utils'
 
-import { assertNever } from './utils'
+import { assertNever, safeJsonStringify } from './utils'
 
 export class UserFacingError extends Error {
   name = 'UserFacingError'
@@ -108,7 +108,7 @@ function getErrorCode(err: DriverAdapterError): string | undefined {
     case 'mssql':
       return
     default:
-      assertNever(err.cause, `Unknown error: ${err.cause}`)
+      assertNever(err.cause, `Unknown error: ${safeJsonStringify(err.cause)}`)
   }
 }
 
@@ -186,7 +186,7 @@ function renderErrorMessage(err: DriverAdapterError): string | undefined {
     case 'mssql':
       return
     default:
-      assertNever(err.cause, `Unknown error: ${err.cause}`)
+      assertNever(err.cause, `Unknown error: ${safeJsonStringify(err.cause)}`)
   }
 }
 


### PR DESCRIPTION
## Problem

When a driver adapter throws an error with an unrecognised `cause.kind` — for example, when a newer adapter is paired with an older Prisma Client that doesn't yet handle a new error variant — the `assertNever` call in `getErrorCode` and `renderErrorMessage` builds its error message using a template literal:

```ts
assertNever(err.cause, `Unknown error: ${err.cause}`)
```

Because `err.cause` is a plain object, JavaScript coerces it to the string `[object Object]`, producing:

```
Unknown error: [object Object]
```

This makes debugging essentially impossible — the user has no idea which `kind` was encountered.

Fixes #29310.

## Fix

Replace the bare interpolation with the `safeJsonStringify` utility that is already present in `./utils`. It handles `BigInt` and `Uint8Array` values, so it won't throw on any valid cause shape:

```ts
assertNever(err.cause, `Unknown error: ${safeJsonStringify(err.cause)}`)
```

The message now looks like:

```
Unknown error: {"kind":"SomeNewUnknownErrorKind","detail":"more info"}
```

Both occurrences are fixed — in `getErrorCode` and `renderErrorMessage`.

## Test

Added `user-facing-error.test.ts` with a vitest test that:
- Verifies the thrown message contains the serialised `kind` value (regex `/Unknown error: .*SomeNewUnknownErrorKind/`)
- Asserts the message does **not** contain `[object Object]`