### PR TITLE
fix: fix stack trace capture in PrismaClientInitializationError

### DIFF
--- a/packages/client-runtime-utils/src/errors/PrismaClientInitializationError.ts
+++ b/packages/client-runtime-utils/src/errors/PrismaClientInitializationError.ts
@@ -11,7 +11,7 @@ export class PrismaClientInitializationError extends Error {
 
     this.clientVersion = clientVersion
     this.errorCode = errorCode
-    Error.captureStackTrace(PrismaClientInitializationError)
+    Error.captureStackTrace(this, PrismaClientInitializationError)
   }
   get [Symbol.toStringTag]() {
     return 'PrismaClientInitializationError'


### PR DESCRIPTION
It passed the constructor function instead of `this` as the first argument, setting the `.stack` property on the class itself rather than on the error instance

That said, I'm unsure what that served for, apparently it wasn't needed as it was unnoticed

This is how it behaved:
```console
> x = new PrismaClientInitializationError()
...
> x.stack
'PrismaClientInitializationError\n' +
  '    at REPL31:1:3\n' +
...
> PrismaClientInitializationError.stack
'PrismaClientInitializationError\n' +
  '    at new PrismaClientInitializationError (REPL29:8:11)\n' +
  '    at REPL31:1:3\n' +
...
```