### PR TITLE
fix: fix condition check for log level precedence

### DIFF
--- a/packages/client/src/runtime/getLogLevel.ts
+++ b/packages/client/src/runtime/getLogLevel.ts
@@ -16,7 +16,7 @@ export function getLogLevel(log: LogLevel | Array<LogLevel | LogDefinition>): Lo
     if (!acc) {
       return currentLevel
     }
-    if (curr === 'info' || acc === 'info') {
+    if (currentLevel === 'info' || acc === 'info') {
       // info has precedence
       return 'info'
     }


### PR DESCRIPTION
From `const currentLevel = typeof curr === 'string' ? curr : curr.level`, curr could be an object `{ level: 'info' }`.

Comparing it to string seems like a mistake.