### PR TITLE
fix(cli): install missing `@prisma/client` in `prisma bootstrap`

### DIFF
--- a/packages/cli/src/CLI.ts
+++ b/packages/cli/src/CLI.ts
@@ -130,6 +130,7 @@ Learn more at ${link('https://pris.ly/cli/pdp')}`
     ${bold('Commands')}
 
                 init   Set up Prisma for your app
+           bootstrap   Bootstrap a Prisma Postgres project
                  dev   Start a local Prisma Postgres server for development
             generate   Generate artifacts (e.g. Prisma Client)
                   db   Manage your database schema and lifecycle

--- a/packages/cli/src/bootstrap/Bootstrap.ts
+++ b/packages/cli/src/bootstrap/Bootstrap.ts
@@ -21,6 +21,7 @@ import { type BootstrapStepStatus, formatBootstrapOutput } from './completion-ou
 import { detectProjectState, getModelNames, getSeedCommand } from './project-state'
 import { emitFlowCompleted, emitFlowStarted, emitStepCompleted, emitStepFailed, emitStepSkipped } from './telemetry'
 import {
+  addDependencies,
   addDevDependencies,
   detectPackageManager,
   downloadAndExtractTemplate,
@@ -305,24 +306,39 @@ ${bold('Examples')}
       //
       // This runs BEFORE config reload — prisma.config.ts imports dotenv/config,
       // so dotenv must be installed first or the config load will fail.
+      const missingDevDeps: string[] = []
       const missingDeps: string[] = []
       if (!templateScaffolded) {
         for (const pkg of ['dotenv', 'prisma']) {
           if (!fs.existsSync(path.join(baseDir, 'node_modules', pkg))) {
-            missingDeps.push(pkg)
+            missingDevDeps.push(pkg)
           }
+        }
+        if (!fs.existsSync(path.join(baseDir, 'node_modules', '@prisma', 'client'))) {
+          missingDeps.push('@prisma/client')
         }
       }
 
-      if (missingDeps.length > 0) {
+      const allMissing = [...missingDevDeps, ...missingDeps]
+
+      if (allMissing.length > 0) {
         const pm = detectPackageManager(baseDir)
-        const depsLabel = bold(missingDeps.join(', '))
+        const depsLabel = bold(allMissing.join(', '))
 
         const manualInstallAndReturn = () => {
-          const installHint =
-            pm === 'npm' ? `npm install --save-dev ${missingDeps.join(' ')}` : `${pm} add -D ${missingDeps.join(' ')}`
           console.log(`\n  Install them manually, then re-run:`)
-          console.log(`  ${dim('$')} ${installHint}`)
+          if (missingDeps.length > 0) {
+            const installHint =
+              pm === 'npm' ? `npm install ${missingDeps.join(' ')}` : `${pm} add ${missingDeps.join(' ')}`
+            console.log(`  ${dim('$')} ${installHint}`)
+          }
+          if (missingDevDeps.length > 0) {
+            const installHint =
+              pm === 'npm'
+                ? `npm install --save-dev ${missingDevDeps.join(' ')}`
+                : `${pm} add -D ${missingDevDeps.join(' ')}`
+            console.log(`  ${dim('$')} ${installHint}`)
+          }
           console.log(`  ${dim('$')} npx prisma@latest bootstrap`)
 
           return formatBootstrapOutput({
@@ -339,14 +355,19 @@ ${bold('Examples')}
         }
 
         const shouldInstall = await confirm({
-          message: `Install missing Prisma dependencies (${missingDeps.join(', ')}) with ${pm}?`,
+          message: `Install missing Prisma dependencies (${allMissing.join(', ')}) with ${pm}?`,
           default: true,
         })
 
         if (shouldInstall) {
           const installSpinner = ora(`Installing ${depsLabel}...`).start()
           try {
-            await addDevDependencies(baseDir, missingDeps)
+            if (missingDeps.length > 0) {
+              await addDependencies(baseDir, missingDeps)
+            }
+            if (missingDevDeps.length > 0) {
+              await addDevDependencies(baseDir, missingDevDeps)
+            }
             installSpinner.succeed(`Prisma dependencies installed`)
             stepsCompleted.push('deps')
           } catch (err) {

--- a/packages/cli/src/bootstrap/__tests__/Bootstrap.vitest.ts
+++ b/packages/cli/src/bootstrap/__tests__/Bootstrap.vitest.ts
@@ -77,6 +77,7 @@ vi.mock('../../Init', () => ({
 }))
 
 vi.mock('../template-scaffold', () => ({
+  addDependencies: vi.fn(() => Promise.resolve()),
   addDevDependencies: vi.fn(() => Promise.resolve()),
   detectPackageManager: vi.fn(() => 'npm'),
   downloadAndExtractTemplate: vi.fn(() => Promise.resolve()),
@@ -158,6 +159,7 @@ describe('Bootstrap command — new project flow', () => {
     fs.writeFileSync(path.join(tmpDir, 'package.json'), '{"name":"test"}', 'utf-8')
     fs.mkdirSync(path.join(tmpDir, 'node_modules', 'dotenv'), { recursive: true })
     fs.mkdirSync(path.join(tmpDir, 'node_modules', 'prisma'), { recursive: true })
+    fs.mkdirSync(path.join(tmpDir, 'node_modules', '@prisma', 'client'), { recursive: true })
 
     const { confirm } = await import('@inquirer/prompts')
     vi.mocked(confirm).mockResolvedValue(false)
@@ -203,6 +205,7 @@ describe('Bootstrap command — new project flow', () => {
     fs.writeFileSync(path.join(tmpDir, 'package.json'), '{"name":"test"}', 'utf-8')
     fs.mkdirSync(path.join(tmpDir, 'node_modules', 'dotenv'), { recursive: true })
     fs.mkdirSync(path.join(tmpDir, 'node_modules', 'prisma'), { recursive: true })
+    fs.mkdirSync(path.join(tmpDir, 'node_modules', '@prisma', 'client'), { recursive: true })
 
     const { confirm } = await import('@inquirer/prompts')
     vi.mocked(confirm).mockResolvedValue(false)
@@ -230,6 +233,7 @@ describe('Bootstrap command — new project flow', () => {
     fs.writeFileSync(path.join(tmpDir, 'package.json'), '{"name":"test"}', 'utf-8')
     fs.mkdirSync(path.join(tmpDir, 'node_modules', 'dotenv'), { recursive: true })
     fs.mkdirSync(path.join(tmpDir, 'node_modules', 'prisma'), { recursive: true })
+    fs.mkdirSync(path.join(tmpDir, 'node_modules', '@prisma', 'client'), { recursive: true })
 
     const { confirm } = await import('@inquirer/prompts')
     vi.mocked(confirm).mockResolvedValue(false)
@@ -261,6 +265,7 @@ describe('Bootstrap command — existing project flow', () => {
     fs.writeFileSync(path.join(prismaDir, 'schema.prisma'), 'datasource db { provider = "postgresql" }', 'utf-8')
     fs.mkdirSync(path.join(tmpDir, 'node_modules', 'dotenv'), { recursive: true })
     fs.mkdirSync(path.join(tmpDir, 'node_modules', 'prisma'), { recursive: true })
+    fs.mkdirSync(path.join(tmpDir, 'node_modules', '@prisma', 'client'), { recursive: true })
 
     const { confirm } = await import('@inquirer/prompts')
     vi.mocked(confirm).mockResolvedValue(false)
@@ -294,6 +299,7 @@ model User { id Int @id }
     )
     fs.mkdirSync(path.join(tmpDir, 'node_modules', 'dotenv'), { recursive: true })
     fs.mkdirSync(path.join(tmpDir, 'node_modules', 'prisma'), { recursive: true })
+    fs.mkdirSync(path.join(tmpDir, 'node_modules', '@prisma', 'client'), { recursive: true })
 
     const { confirm } = await import('@inquirer/prompts')
     vi.mocked(confirm).mockResolvedValue(false)
@@ -326,7 +332,11 @@ describe('Bootstrap command — deps gate', () => {
     const { confirm } = await import('@inquirer/prompts')
     vi.mocked(confirm).mockResolvedValue(true)
 
-    const { addDevDependencies } = await import('../template-scaffold')
+    const { addDependencies, addDevDependencies } = await import('../template-scaffold')
+    vi.mocked(addDependencies).mockImplementation((_baseDir, _pkgs) => {
+      fs.mkdirSync(path.join(tmpDir, 'node_modules', '@prisma', 'client'), { recursive: true })
+      return Promise.resolve()
+    })
     vi.mocked(addDevDependencies).mockImplementation((_baseDir, _pkgs) => {
       fs.mkdirSync(path.join(tmpDir, 'node_modules', 'dotenv'), { recursive: true })
       fs.mkdirSync(path.join(tmpDir, 'node_modules', 'prisma'), { recursive: true })
@@ -344,6 +354,7 @@ describe('Bootstrap command — deps gate', () => {
     expect(result).not.toBeInstanceOf(Error)
     const output = result as string
     expect(output).toContain('Bootstrap completed')
+    expect(addDependencies).toHaveBeenCalledWith(tmpDir, ['@prisma/client'])
     expect(addDevDependencies).toHaveBeenCalledWith(tmpDir, ['dotenv', 'prisma'])
   })
 
@@ -361,7 +372,8 @@ describe('Bootstrap command — deps gate', () => {
     vi.mocked(confirm).mockReset()
     vi.mocked(confirm).mockResolvedValueOnce(false) // deps install — decline
 
-    const { addDevDependencies } = await import('../template-scaffold')
+    const { addDependencies, addDevDependencies } = await import('../template-scaffold')
+    vi.mocked(addDependencies).mockReset()
     vi.mocked(addDevDependencies).mockReset()
 
     setupMockApiSuccess()
@@ -375,6 +387,7 @@ describe('Bootstrap command — deps gate', () => {
     expect(result).not.toBeInstanceOf(Error)
     const output = result as string
     expect(output).toContain('Bootstrap completed')
+    expect(addDependencies).not.toHaveBeenCalled()
     expect(addDevDependencies).not.toHaveBeenCalled()
   })
 
@@ -390,6 +403,7 @@ describe('Bootstrap command — deps gate', () => {
 
     fs.mkdirSync(path.join(tmpDir, 'node_modules', 'dotenv'), { recursive: true })
     fs.mkdirSync(path.join(tmpDir, 'node_modules', 'prisma'), { recursive: true })
+    fs.mkdirSync(path.join(tmpDir, 'node_modules', '@prisma', 'client'), { recursive: true })
 
     const { confirm } = await import('@inquirer/prompts')
     vi.mocked(confirm).mockResolvedValue(true)
@@ -427,6 +441,7 @@ describe('Bootstrap command — seed step', () => {
 
     fs.mkdirSync(path.join(tmpDir, 'node_modules', 'dotenv'), { recursive: true })
     fs.mkdirSync(path.join(tmpDir, 'node_modules', 'prisma'), { recursive: true })
+    fs.mkdirSync(path.join(tmpDir, 'node_modules', '@prisma', 'client'), { recursive: true })
 
     const { confirm } = await import('@inquirer/prompts')
     vi.mocked(confirm).mockResolvedValue(true)
@@ -460,6 +475,7 @@ describe('Bootstrap command — seed step', () => {
 
     fs.mkdirSync(path.join(tmpDir, 'node_modules', 'dotenv'), { recursive: true })
     fs.mkdirSync(path.join(tmpDir, 'node_modules', 'prisma'), { recursive: true })
+    fs.mkdirSync(path.join(tmpDir, 'node_modules', '@prisma', 'client'), { recursive: true })
 
     const { confirm } = await import('@inquirer/prompts')
     vi.mocked(confirm)
@@ -498,6 +514,7 @@ describe('Bootstrap command — mixed consent gates', () => {
 
     fs.mkdirSync(path.join(tmpDir, 'node_modules', 'dotenv'), { recursive: true })
     fs.mkdirSync(path.join(tmpDir, 'node_modules', 'prisma'), { recursive: true })
+    fs.mkdirSync(path.join(tmpDir, 'node_modules', '@prisma', 'client'), { recursive: true })
 
     const { confirm } = await import('@inquirer/prompts')
     vi.mocked(confirm)
@@ -536,6 +553,7 @@ describe('Bootstrap command — mixed consent gates', () => {
 
     fs.mkdirSync(path.join(tmpDir, 'node_modules', 'dotenv'), { recursive: true })
     fs.mkdirSync(path.join(tmpDir, 'node_modules', 'prisma'), { recursive: true })
+    fs.mkdirSync(path.join(tmpDir, 'node_modules', '@prisma', 'client'), { recursive: true })
 
     const { confirm } = await import('@inquirer/prompts')
     vi.mocked(confirm)

--- a/packages/cli/src/bootstrap/completion-output.ts
+++ b/packages/cli/src/bootstrap/completion-output.ts
@@ -59,7 +59,9 @@ export function formatBootstrapOutput(opts: {
 
   if (opts.pendingDepsInstall) {
     lines.push(bold('Next steps:'))
-    lines.push(`  1. Install ${bold('dotenv')} and ${bold('prisma')} as dev dependencies with your package manager`)
+    lines.push(
+      `  1. Install ${bold('@prisma/client')}, ${bold('dotenv')}, and ${bold('prisma')} with your package manager`,
+    )
     lines.push(`  2. Re-run ${green('npx prisma@latest bootstrap')} to finish setup`)
     lines.push('')
     return lines.join('\n')

--- a/packages/cli/src/bootstrap/template-scaffold.ts
+++ b/packages/cli/src/bootstrap/template-scaffold.ts
@@ -174,9 +174,9 @@ export function detectPackageManager(baseDir: string): PackageManager {
 
 const execFileAsync = promisify(execFile)
 
-export async function installDependencies(baseDir: string): Promise<void> {
+async function runPackageManager(baseDir: string, args: string[]): Promise<void> {
   const pm = detectPackageManager(baseDir)
-  await execFileAsync(pm, ['install'], {
+  await execFileAsync(pm, args, {
     cwd: baseDir,
     env: { ...process.env },
     shell: process.platform === 'win32',
@@ -184,25 +184,29 @@ export async function installDependencies(baseDir: string): Promise<void> {
   })
 }
 
-export async function addDevDependencies(baseDir: string, packages: string[]): Promise<void> {
+export function installDependencies(baseDir: string): Promise<void> {
+  return runPackageManager(baseDir, ['install'])
+}
+
+function addArgsForPackages(baseDir: string, packages: string[], dev: boolean): string[] {
   const pm = detectPackageManager(baseDir)
   if (pm === 'deno') {
     throw new Error('Deno projects require manual dependency management. Please add dependencies to your deno.json.')
   }
-  const addArgs = (() => {
-    switch (pm) {
-      case 'npm':
-        return ['install', '--save-dev', ...packages]
-      case 'yarn':
-        return ['add', '--dev', ...packages]
-      default:
-        return ['add', '-D', ...packages]
-    }
-  })()
-  await execFileAsync(pm, addArgs, {
-    cwd: baseDir,
-    env: { ...process.env },
-    shell: process.platform === 'win32',
-    timeout: 300_000,
-  })
+  switch (pm) {
+    case 'npm':
+      return dev ? ['install', '--save-dev', ...packages] : ['install', ...packages]
+    case 'yarn':
+      return dev ? ['add', '--dev', ...packages] : ['add', ...packages]
+    default:
+      return dev ? ['add', '-D', ...packages] : ['add', ...packages]
+  }
+}
+
+export function addDependencies(baseDir: string, packages: string[]): Promise<void> {
+  return runPackageManager(baseDir, addArgsForPackages(baseDir, packages, false))
+}
+
+export function addDevDependencies(baseDir: string, packages: string[]): Promise<void> {
+  return runPackageManager(baseDir, addArgsForPackages(baseDir, packages, true))
 }


### PR DESCRIPTION
When initializing a project from scratch, `prisma bootstrap` initialized a broken project that didn't have the required `@prisma/client` dependency.