### PR TITLE
fix: normalize line endings in prisma format output

### DIFF
--- a/packages/internals/src/__tests__/engine-commands/formatSchema.test.ts
+++ b/packages/internals/src/__tests__/engine-commands/formatSchema.test.ts
@@ -111,7 +111,18 @@ describe('line ending normalization', () => {
     const formattedContent: string[] = extractSchemaContent(formatted)
     expect(formattedContent.length).toBe(1)
     expect(formattedContent[0]).not.toContain('\r\n')
+    expect(formattedContent[0]).not.toContain('\r')
     expect(formattedContent[0]).toContain('\n')
+  })
+
+  test('standalone CR in input is also normalized to LF', async () => {
+    const schemaWithCr = "datasource db {\r  provider = \"sqlite\"\r}\r"
+    const schemas: MultipleSchemas = [['/* schemaPath */', schemaWithCr]]
+
+    const formatted = await formatSchema({ schemas })
+    const formattedContent: string[] = extractSchemaContent(formatted)
+    expect(formattedContent.length).toBe(1)
+    expect(formattedContent[0]).not.toMatch(/\r/)
   })
 })
 

--- a/packages/internals/src/__tests__/engine-commands/formatSchema.test.ts
+++ b/packages/internals/src/__tests__/engine-commands/formatSchema.test.ts
@@ -102,6 +102,19 @@ describe('format custom options', () => {
   })
 })
 
+describe('line ending normalization', () => {
+  test('CRLF in input schema is normalized to LF in output', async () => {
+    const schemaWithCrlf = "datasource db {\r\n  provider = \"sqlite\"\r\n}\r\n\r\nmodel User {\r\n  id String @default(cuid()) @id\r\n  email String @unique\r\n}\r\n"
+    const schemas: MultipleSchemas = [['/* schemaPath */', schemaWithCrlf]]
+
+    const formatted = await formatSchema({ schemas })
+    const formattedContent: string[] = extractSchemaContent(formatted)
+    expect(formattedContent.length).toBe(1)
+    expect(formattedContent[0]).not.toContain('\r\n')
+    expect(formattedContent[0]).toContain('\n')
+  })
+})
+
 describe('format', () => {
   test('valid blog schemaPath', async () => {
     const { schemas } = await getCliProvidedSchemaFile(path.join(fixturesPath, 'blog.prisma'))

--- a/packages/internals/src/__tests__/engine-commands/formatSchema.test.ts
+++ b/packages/internals/src/__tests__/engine-commands/formatSchema.test.ts
@@ -123,6 +123,7 @@ describe('line ending normalization', () => {
     const formattedContent: string[] = extractSchemaContent(formatted)
     expect(formattedContent.length).toBe(1)
     expect(formattedContent[0]).not.toMatch(/\r/)
+    expect(formattedContent[0]).toContain('\n')
   })
 })
 

--- a/packages/internals/src/engine-commands/formatSchema.ts
+++ b/packages/internals/src/engine-commands/formatSchema.ts
@@ -113,5 +113,5 @@ function formatWasm(schema: string, documentFormattingParams: DocumentFormatting
  * The Wasm formatter may produce CRLF on Windows (see https://github.com/prisma/prisma/issues/8548).
  */
 function normalizeCrlf(schemas: MultipleSchemas): MultipleSchemas {
-  return schemas.map(([filePath, content]) => [filePath, content.replace(/\r\n/g, '\n')]) as MultipleSchemas
+  return schemas.map(([filePath, content]) => [filePath, content.replace(/\r\n?/g, '\n')]) as MultipleSchemas
 }

--- a/packages/internals/src/engine-commands/formatSchema.ts
+++ b/packages/internals/src/engine-commands/formatSchema.ts
@@ -45,7 +45,7 @@ export async function formatSchema(
   const { formattedMultipleSchemas, lintDiagnostics } = handleFormatPanic(() => {
     // the only possible error here is a Rust panic
     const formattedMultipleSchemasRaw = formatWasm(JSON.stringify(schemas), documentFormattingParams)
-    const formattedMultipleSchemas = JSON.parse(formattedMultipleSchemasRaw) as MultipleSchemas
+    const formattedMultipleSchemas = normalizeCrlf(JSON.parse(formattedMultipleSchemasRaw) as MultipleSchemas)
 
     const lintDiagnostics = lintSchema({ schemas: formattedMultipleSchemas })
     return { formattedMultipleSchemas, lintDiagnostics }
@@ -106,4 +106,12 @@ type DocumentFormattingParams = {
 function formatWasm(schema: string, documentFormattingParams: DocumentFormattingParams): string {
   const formattedSchema = prismaSchemaWasm.format(schema, JSON.stringify(documentFormattingParams))
   return formattedSchema
+}
+
+/**
+ * Normalize CRLF line endings to LF in all schema contents.
+ * The Wasm formatter may produce CRLF on Windows (see https://github.com/prisma/prisma/issues/8548).
+ */
+function normalizeCrlf(schemas: MultipleSchemas): MultipleSchemas {
+  return schemas.map(([filePath, content]) => [filePath, content.replace(/\r\n/g, '\n')]) as MultipleSchemas
 }


### PR DESCRIPTION
On Windows, `prisma format` writes all lines with LF except the very last line which gets CRLF. This breaks CI on Linux where the formatted output differs.

Normalizes line endings to LF before writing. Includes a regression test.

Fixes #8548