### PR TITLE
fix(adapters): serialize JSON args with Decimal-aware replacer to restore numeric type

### DIFF
--- a/packages/adapter-libsql/src/conversion.ts
+++ b/packages/adapter-libsql/src/conversion.ts
@@ -51,6 +51,7 @@ function mapDeclType(declType: string): ColumnType | null {
       return ColumnTypeEnum.Bytes
     case 'BOOLEAN':
       return ColumnTypeEnum.Boolean
+    case 'JSON':
     case 'JSONB':
       return ColumnTypeEnum.Json
     default:
@@ -169,9 +170,41 @@ export function mapRow(row: Row, columnTypes: ColumnType[]): ResultValue[] {
   return result
 }
 
+/**
+ * Serializes a value intended for a JSON column.
+ * See the equivalent in adapter-pg for a full explanation.
+ */
+function serializeJsonArg(value: unknown): string {
+  return JSON.stringify(value, (_key, val) => {
+    if (typeof val === 'bigint') {
+      return val.toString()
+    }
+    if (val instanceof ArrayBuffer) {
+      return Buffer.from(val).toString('base64')
+    }
+    if (ArrayBuffer.isView(val)) {
+      return Buffer.from((val as ArrayBufferView).buffer, (val as ArrayBufferView).byteOffset, (val as ArrayBufferView).byteLength).toString('base64')
+    }
+    if (
+      val !== null &&
+      typeof val === 'object' &&
+      (val as Record<string, unknown>).constructor?.name === 'Decimal' &&
+      typeof (val as Record<string, unknown>).toNumber === 'function'
+    ) {
+      return (val as { toNumber(): number }).toNumber()
+    }
+    return val
+  })
+}
+
 export function mapArg(arg: unknown, argType: ArgType, options?: PrismaLibSqlOptions): InValue {
   if (arg === null) {
     return null
+  }
+
+  // Pre-serialize JSON args so that special types (e.g. Decimal) are converted correctly.
+  if (argType.scalarType === 'json' && typeof arg !== 'string') {
+    return serializeJsonArg(arg)
   }
 
   if (typeof arg === 'string' && argType.scalarType === 'bigint') {

--- a/packages/adapter-libsql/src/conversion.ts
+++ b/packages/adapter-libsql/src/conversion.ts
@@ -175,7 +175,7 @@ export function mapRow(row: Row, columnTypes: ColumnType[]): ResultValue[] {
  * See the equivalent in adapter-pg for a full explanation.
  */
 function serializeJsonArg(value: unknown): string {
-  return JSON.stringify(value, (_key, val) => {
+  return JSON.stringify(value, function (this: Record<string, unknown>, key: string, val: unknown) {
     if (typeof val === 'bigint') {
       return val.toString()
     }
@@ -185,13 +185,16 @@ function serializeJsonArg(value: unknown): string {
     if (ArrayBuffer.isView(val)) {
       return Buffer.from((val as ArrayBufferView).buffer, (val as ArrayBufferView).byteOffset, (val as ArrayBufferView).byteLength).toString('base64')
     }
+    // See adapter-pg serializeJsonArg for a full explanation of why we inspect the
+    // original pre-toJSON value via this[key] / value instead of using val directly.
+    const original: unknown = key === '' ? value : this[key]
     if (
-      val !== null &&
-      typeof val === 'object' &&
-      (val as Record<string, unknown>).constructor?.name === 'Decimal' &&
-      typeof (val as Record<string, unknown>).toNumber === 'function'
+      original !== null &&
+      typeof original === 'object' &&
+      (original as Record<string, unknown>).constructor?.name === 'Decimal' &&
+      typeof (original as Record<string, unknown>).toNumber === 'function'
     ) {
-      return (val as { toNumber(): number }).toNumber()
+      return (original as { toNumber(): number }).toNumber()
     }
     return val
   })

--- a/packages/adapter-libsql/src/conversion.ts
+++ b/packages/adapter-libsql/src/conversion.ts
@@ -194,7 +194,8 @@ function serializeJsonArg(value: unknown): string {
       (original as Record<string, unknown>).constructor?.name === 'Decimal' &&
       typeof (original as Record<string, unknown>).toNumber === 'function'
     ) {
-      return (original as { toNumber(): number }).toNumber()
+      const num = (original as { toNumber(): number }).toNumber()
+      return Number.isFinite(num) ? num : String(original)
     }
     return val
   })

--- a/packages/adapter-mariadb/src/conversion.ts
+++ b/packages/adapter-mariadb/src/conversion.ts
@@ -107,9 +107,38 @@ export function mapColumnType(field: mariadb.FieldInfo): ColumnType {
   }
 }
 
+/**
+ * Serializes a value intended for a JSON column.
+ * See the equivalent in adapter-pg for a full explanation.
+ */
+function serializeJsonArg(value: unknown): string {
+  return JSON.stringify(value, (_key, val) => {
+    if (typeof val === 'bigint') {
+      return val.toString()
+    }
+    if (ArrayBuffer.isView(val)) {
+      return Buffer.from((val as ArrayBufferView).buffer, (val as ArrayBufferView).byteOffset, (val as ArrayBufferView).byteLength).toString('base64')
+    }
+    if (
+      val !== null &&
+      typeof val === 'object' &&
+      (val as Record<string, unknown>).constructor?.name === 'Decimal' &&
+      typeof (val as Record<string, unknown>).toNumber === 'function'
+    ) {
+      return (val as { toNumber(): number }).toNumber()
+    }
+    return val
+  })
+}
+
 export function mapArg<A>(arg: A | Date, argType: ArgType): null | BigInt | string | Buffer | A {
   if (arg === null) {
     return null
+  }
+
+  // Pre-serialize JSON args so that special types (e.g. Decimal) are converted correctly.
+  if (argType.scalarType === 'json' && typeof arg !== 'string') {
+    return serializeJsonArg(arg)
   }
 
   if (typeof arg === 'string' && argType.scalarType === 'bigint') {

--- a/packages/adapter-mariadb/src/conversion.ts
+++ b/packages/adapter-mariadb/src/conversion.ts
@@ -112,20 +112,23 @@ export function mapColumnType(field: mariadb.FieldInfo): ColumnType {
  * See the equivalent in adapter-pg for a full explanation.
  */
 function serializeJsonArg(value: unknown): string {
-  return JSON.stringify(value, (_key, val) => {
+  return JSON.stringify(value, function (this: Record<string, unknown>, key: string, val: unknown) {
     if (typeof val === 'bigint') {
       return val.toString()
     }
     if (ArrayBuffer.isView(val)) {
       return Buffer.from((val as ArrayBufferView).buffer, (val as ArrayBufferView).byteOffset, (val as ArrayBufferView).byteLength).toString('base64')
     }
+    // See adapter-pg serializeJsonArg for a full explanation of why we inspect the
+    // original pre-toJSON value via this[key] / value instead of using val directly.
+    const original: unknown = key === '' ? value : this[key]
     if (
-      val !== null &&
-      typeof val === 'object' &&
-      (val as Record<string, unknown>).constructor?.name === 'Decimal' &&
-      typeof (val as Record<string, unknown>).toNumber === 'function'
+      original !== null &&
+      typeof original === 'object' &&
+      (original as Record<string, unknown>).constructor?.name === 'Decimal' &&
+      typeof (original as Record<string, unknown>).toNumber === 'function'
     ) {
-      return (val as { toNumber(): number }).toNumber()
+      return (original as { toNumber(): number }).toNumber()
     }
     return val
   })

--- a/packages/adapter-mariadb/src/conversion.ts
+++ b/packages/adapter-mariadb/src/conversion.ts
@@ -128,7 +128,8 @@ function serializeJsonArg(value: unknown): string {
       (original as Record<string, unknown>).constructor?.name === 'Decimal' &&
       typeof (original as Record<string, unknown>).toNumber === 'function'
     ) {
-      return (original as { toNumber(): number }).toNumber()
+      const num = (original as { toNumber(): number }).toNumber()
+      return Number.isFinite(num) ? num : String(original)
     }
     return val
   })

--- a/packages/adapter-mssql/src/conversion.ts
+++ b/packages/adapter-mssql/src/conversion.ts
@@ -95,20 +95,23 @@ export function mapIsolationLevel(level: IsolationLevel): sql.IIsolationLevel {
  * See the equivalent in adapter-pg for a full explanation.
  */
 function serializeJsonArg(value: unknown): string {
-  return JSON.stringify(value, (_key, val) => {
+  return JSON.stringify(value, function (this: Record<string, unknown>, key: string, val: unknown) {
     if (typeof val === 'bigint') {
       return val.toString()
     }
     if (ArrayBuffer.isView(val)) {
       return Buffer.from((val as ArrayBufferView).buffer, (val as ArrayBufferView).byteOffset, (val as ArrayBufferView).byteLength).toString('base64')
     }
+    // See adapter-pg serializeJsonArg for a full explanation of why we inspect the
+    // original pre-toJSON value via this[key] / value instead of using val directly.
+    const original: unknown = key === '' ? value : this[key]
     if (
-      val !== null &&
-      typeof val === 'object' &&
-      (val as Record<string, unknown>).constructor?.name === 'Decimal' &&
-      typeof (val as Record<string, unknown>).toNumber === 'function'
+      original !== null &&
+      typeof original === 'object' &&
+      (original as Record<string, unknown>).constructor?.name === 'Decimal' &&
+      typeof (original as Record<string, unknown>).toNumber === 'function'
     ) {
-      return (val as { toNumber(): number }).toNumber()
+      return (original as { toNumber(): number }).toNumber()
     }
     return val
   })

--- a/packages/adapter-mssql/src/conversion.ts
+++ b/packages/adapter-mssql/src/conversion.ts
@@ -111,7 +111,8 @@ function serializeJsonArg(value: unknown): string {
       (original as Record<string, unknown>).constructor?.name === 'Decimal' &&
       typeof (original as Record<string, unknown>).toNumber === 'function'
     ) {
-      return (original as { toNumber(): number }).toNumber()
+      const num = (original as { toNumber(): number }).toNumber()
+      return Number.isFinite(num) ? num : String(original)
     }
     return val
   })

--- a/packages/adapter-mssql/src/conversion.ts
+++ b/packages/adapter-mssql/src/conversion.ts
@@ -90,9 +90,38 @@ export function mapIsolationLevel(level: IsolationLevel): sql.IIsolationLevel {
   }
 }
 
+/**
+ * Serializes a value intended for a JSON column.
+ * See the equivalent in adapter-pg for a full explanation.
+ */
+function serializeJsonArg(value: unknown): string {
+  return JSON.stringify(value, (_key, val) => {
+    if (typeof val === 'bigint') {
+      return val.toString()
+    }
+    if (ArrayBuffer.isView(val)) {
+      return Buffer.from((val as ArrayBufferView).buffer, (val as ArrayBufferView).byteOffset, (val as ArrayBufferView).byteLength).toString('base64')
+    }
+    if (
+      val !== null &&
+      typeof val === 'object' &&
+      (val as Record<string, unknown>).constructor?.name === 'Decimal' &&
+      typeof (val as Record<string, unknown>).toNumber === 'function'
+    ) {
+      return (val as { toNumber(): number }).toNumber()
+    }
+    return val
+  })
+}
+
 export function mapArg<A>(arg: A | BigInt | Date, argType: ArgType): null | number | BigInt | string | Buffer | A {
   if (arg === null) {
     return null
+  }
+
+  // Pre-serialize JSON args so that special types (e.g. Decimal) are converted correctly.
+  if (argType.scalarType === 'json' && typeof arg !== 'string') {
+    return serializeJsonArg(arg)
   }
 
   if (typeof arg === 'string' && argType.scalarType === 'bigint') {

--- a/packages/adapter-pg/src/conversion.ts
+++ b/packages/adapter-pg/src/conversion.ts
@@ -416,23 +416,27 @@ export const customParsers = {
  * before serialization.
  */
 function serializeJsonArg(value: unknown): string {
-  return JSON.stringify(value, (_key, val) => {
+  return JSON.stringify(value, function (this: Record<string, unknown>, key: string, val: unknown) {
     if (typeof val === 'bigint') {
       return val.toString()
     }
     if (ArrayBuffer.isView(val)) {
       return Buffer.from((val as ArrayBufferView).buffer, (val as ArrayBufferView).byteOffset, (val as ArrayBufferView).byteLength).toString('base64')
     }
-    // Decimal.js instances (and compatible Decimal classes) have `toNumber()` and an
-    // internal `toJSON()` that returns the string representation.  Convert to a JS number
-    // so the value is persisted as a JSON numeric literal, matching pre-7.4 behaviour.
+    // `JSON.stringify` calls `toJSON()` on objects *before* passing the value to the
+    // replacer.  Since `Decimal.prototype.toJSON === Decimal.prototype.toString`, the
+    // replacer would normally see a plain string and miss the Decimal instance.
+    // To work around this, we inspect the *original* pre-toJSON value:
+    //   - for root call (key === ''), `value` holds the original value we were given
+    //   - for nested properties, `this[key]` is the original property value on the parent
+    const original: unknown = key === '' ? value : this[key]
     if (
-      val !== null &&
-      typeof val === 'object' &&
-      (val as Record<string, unknown>).constructor?.name === 'Decimal' &&
-      typeof (val as Record<string, unknown>).toNumber === 'function'
+      original !== null &&
+      typeof original === 'object' &&
+      (original as Record<string, unknown>).constructor?.name === 'Decimal' &&
+      typeof (original as Record<string, unknown>).toNumber === 'function'
     ) {
-      return (val as { toNumber(): number }).toNumber()
+      return (original as { toNumber(): number }).toNumber()
     }
     return val
   })

--- a/packages/adapter-pg/src/conversion.ts
+++ b/packages/adapter-pg/src/conversion.ts
@@ -406,6 +406,38 @@ export const customParsers = {
   [ArrayColumnType.XML_ARRAY]: normalize_array(normalize_xml),
 }
 
+/**
+ * Serializes a value intended for a JSON/JSONB column.
+ *
+ * `JSON.stringify` calls `toJSON()` on objects, and `Decimal.prototype.toJSON`
+ * returns the decimal as a *string*. This causes values like `new Decimal("-11000")`
+ * to be stored as the JSON string `"-11000"` instead of the number `-11000`.
+ * We use a custom replacer to convert Decimal-like instances to their numeric value
+ * before serialization.
+ */
+function serializeJsonArg(value: unknown): string {
+  return JSON.stringify(value, (_key, val) => {
+    if (typeof val === 'bigint') {
+      return val.toString()
+    }
+    if (ArrayBuffer.isView(val)) {
+      return Buffer.from((val as ArrayBufferView).buffer, (val as ArrayBufferView).byteOffset, (val as ArrayBufferView).byteLength).toString('base64')
+    }
+    // Decimal.js instances (and compatible Decimal classes) have `toNumber()` and an
+    // internal `toJSON()` that returns the string representation.  Convert to a JS number
+    // so the value is persisted as a JSON numeric literal, matching pre-7.4 behaviour.
+    if (
+      val !== null &&
+      typeof val === 'object' &&
+      (val as Record<string, unknown>).constructor?.name === 'Decimal' &&
+      typeof (val as Record<string, unknown>).toNumber === 'function'
+    ) {
+      return (val as { toNumber(): number }).toNumber()
+    }
+    return val
+  })
+}
+
 export function mapArg<A>(arg: A | Date, argType: ArgType): null | unknown[] | string | Uint8Array | A {
   if (arg === null) {
     return null
@@ -413,6 +445,12 @@ export function mapArg<A>(arg: A | Date, argType: ArgType): null | unknown[] | s
 
   if (Array.isArray(arg) && argType.arity === 'list') {
     return arg.map((value) => mapArg(value, argType))
+  }
+
+  // Pre-serialize JSON args so that special types (e.g. Decimal) are converted correctly
+  // before the pg driver calls JSON.stringify internally on the value.
+  if (argType.scalarType === 'json' && typeof arg !== 'string') {
+    return serializeJsonArg(arg) as unknown as A
   }
 
   if (typeof arg === 'string' && argType.scalarType === 'datetime') {

--- a/packages/adapter-pg/src/conversion.ts
+++ b/packages/adapter-pg/src/conversion.ts
@@ -436,7 +436,8 @@ function serializeJsonArg(value: unknown): string {
       (original as Record<string, unknown>).constructor?.name === 'Decimal' &&
       typeof (original as Record<string, unknown>).toNumber === 'function'
     ) {
-      return (original as { toNumber(): number }).toNumber()
+      const num = (original as { toNumber(): number }).toNumber()
+      return Number.isFinite(num) ? num : String(original)
     }
     return val
   })
@@ -454,7 +455,7 @@ export function mapArg<A>(arg: A | Date, argType: ArgType): null | unknown[] | s
   // Pre-serialize JSON args so that special types (e.g. Decimal) are converted correctly
   // before the pg driver calls JSON.stringify internally on the value.
   if (argType.scalarType === 'json' && typeof arg !== 'string') {
-    return serializeJsonArg(arg) as unknown as A
+    return serializeJsonArg(arg)
   }
 
   if (typeof arg === 'string' && argType.scalarType === 'datetime') {


### PR DESCRIPTION
## Problem

Fixes #29387 — a regression introduced in Prisma 7.4.0 where `Decimal` values nested inside a JSON/JSONB field are persisted as a JSON *string* instead of a JSON *number*.

### Root cause

`Decimal.prototype.toJSON` is aliased to `Decimal.prototype.toString`, so when a driver library (e.g. `node-postgres`) calls `JSON.stringify` on the argument object, Decimal instances are serialized as quoted strings (`"-11000"`) rather than numeric literals (`-11000`).

**Example:**

```ts
// before 7.4.0 → stored as {"someDecimal": -11000}  ✅
// after  7.5.0 → stored as {"someDecimal": "-11000"} ❌
await prisma.modelWithJson.create({
  data: {
    id: '1',
    properties: { someDecimal: new Decimal('-11000') },
  },
})
```

## Fix

Each adapter's `mapArg` now pre-serialises JSON arguments using a custom `JSON.stringify` replacer that:

- Converts **Decimal-like instances** (detected via `constructor.name === 'Decimal'` + presence of `toNumber()`) to their numeric value, restoring the JSON number representation.
- Keeps the existing handling for `bigint` (→ string) and `ArrayBuffer`/`ArrayBufferView` (→ base64).

All four adapters (`adapter-pg`, `adapter-mariadb`, `adapter-mssql`, `adapter-libsql`) receive the same fix.

**Bonus:** also adds the missing `'JSON'` decltype mapping in `adapter-libsql` (`mapDeclType` only handled `'JSONB'`, not `'JSON'`).

## Test plan

- [ ] Create a model with a `Json` field in PostgreSQL/MariaDB/SQL Server/SQLite (libSQL)
- [ ] Write a record containing `new Decimal("-11000")` inside the JSON object
- [ ] Read it back and verify the stored value is the JSON number `-11000`, not the string `"-11000"`
- [ ] Verify existing JSON-field tests pass

## Checklist

- [x] `adapter-pg/src/conversion.ts` — `serializeJsonArg` + `mapArg` guard
- [x] `adapter-mariadb/src/conversion.ts` — same
- [x] `adapter-mssql/src/conversion.ts` — same
- [x] `adapter-libsql/src/conversion.ts` — same + `'JSON'` decltype case