### PR TITLE
fix(client-engine-runtime): populate meta.target for P2002/P2011 in JS driver-adapter path

### DIFF
--- a/packages/client-engine-runtime/src/user-facing-error.ts
+++ b/packages/client-engine-runtime/src/user-facing-error.ts
@@ -50,34 +50,32 @@ function extractMeta(err: DriverAdapterError): Record<string, unknown> {
   const meta: Record<string, unknown> = {}
 
   switch (err.cause.kind) {
-    case 'UniqueConstraintViolation': {
-      const constraint = err.cause.constraint
-      if (constraint) {
-        if ('fields' in constraint && constraint.fields.length > 0) {
-          // Adapters that resolve field names (e.g. adapter-pg via the error detail)
-          meta.target = constraint.fields
-        } else if ('index' in constraint) {
-          // Adapters that only expose the index name (e.g. adapter-mariadb, adapter-mssql).
-          // Wrap in an array to match the expected string[] type.
-          meta.target = [constraint.index]
-        }
-      }
-      break
-    }
+    case 'UniqueConstraintViolation':
     case 'NullConstraintViolation': {
-      const constraint = err.cause.constraint
-      if (constraint) {
-        if ('fields' in constraint && constraint.fields.length > 0) {
-          meta.target = constraint.fields
-        } else if ('index' in constraint) {
-          meta.target = [constraint.index]
-        }
-      }
+      const target = constraintToTarget(err.cause.constraint)
+      if (target) meta.target = target
       break
     }
   }
 
   return meta
+}
+
+/**
+ * Maps a structured constraint object to the `string[]` value expected by
+ * `meta.target`.
+ *
+ * - Adapters that resolve field names (e.g. adapter-pg) supply `{ fields }`.
+ * - Adapters that only expose an index name (e.g. adapter-mariadb, adapter-mssql)
+ *   supply `{ index }`, which is wrapped in an array to match the expected type.
+ */
+function constraintToTarget(
+  constraint?: { fields: string[] } | { index: string } | { foreignKey: {} },
+): string[] | undefined {
+  if (!constraint) return undefined
+  if ('fields' in constraint && constraint.fields.length > 0) return constraint.fields
+  if ('index' in constraint) return [constraint.index]
+  return undefined
 }
 
 export function rethrowAsUserFacingRawError(error: any): never {

--- a/packages/client-engine-runtime/src/user-facing-error.ts
+++ b/packages/client-engine-runtime/src/user-facing-error.ts
@@ -36,7 +36,48 @@ export function rethrowAsUserFacing(error: any): never {
   if (!code || !message) {
     throw error
   }
-  throw new UserFacingError(message, code, { driverAdapterError: error })
+  throw new UserFacingError(message, code, { driverAdapterError: error, ...extractMeta(error) })
+}
+
+/**
+ * Extracts structured metadata from a DriverAdapterError to populate the well-known
+ * `meta` fields expected by Prisma Client (e.g. `meta.target` for P2002).
+ *
+ * The Rust query engine populates these fields automatically; this function provides
+ * equivalent behaviour for the JS driver-adapter runtime path.
+ */
+function extractMeta(err: DriverAdapterError): Record<string, unknown> {
+  const meta: Record<string, unknown> = {}
+
+  switch (err.cause.kind) {
+    case 'UniqueConstraintViolation': {
+      const constraint = err.cause.constraint
+      if (constraint) {
+        if ('fields' in constraint && constraint.fields.length > 0) {
+          // Adapters that resolve field names (e.g. adapter-pg via the error detail)
+          meta.target = constraint.fields
+        } else if ('index' in constraint) {
+          // Adapters that only expose the index name (e.g. adapter-mariadb, adapter-mssql).
+          // Wrap in an array to match the expected string[] type.
+          meta.target = [constraint.index]
+        }
+      }
+      break
+    }
+    case 'NullConstraintViolation': {
+      const constraint = err.cause.constraint
+      if (constraint) {
+        if ('fields' in constraint && constraint.fields.length > 0) {
+          meta.target = constraint.fields
+        } else if ('index' in constraint) {
+          meta.target = [constraint.index]
+        }
+      }
+      break
+    }
+  }
+
+  return meta
 }
 
 export function rethrowAsUserFacingRawError(error: any): never {

--- a/packages/client/tests/functional/driver-adapters/constraint-meta-target/_matrix.ts
+++ b/packages/client/tests/functional/driver-adapters/constraint-meta-target/_matrix.ts
@@ -3,7 +3,7 @@ import { Providers } from '../../_utils/providers'
 
 export default defineMatrix(() => [
   [
-    { provider: Providers.POSTGRESQL },
-    { provider: Providers.MYSQL },
+    { provider: Providers.POSTGRESQL, driverAdapter: 'js_pg' },
+    { provider: Providers.MYSQL, driverAdapter: 'js_mariadb' },
   ],
 ])

--- a/packages/client/tests/functional/driver-adapters/constraint-meta-target/_matrix.ts
+++ b/packages/client/tests/functional/driver-adapters/constraint-meta-target/_matrix.ts
@@ -1,0 +1,9 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+import { Providers } from '../../_utils/providers'
+
+export default defineMatrix(() => [
+  [
+    { provider: Providers.POSTGRESQL },
+    { provider: Providers.MYSQL },
+  ],
+])

--- a/packages/client/tests/functional/driver-adapters/constraint-meta-target/prisma/_schema.ts
+++ b/packages/client/tests/functional/driver-adapters/constraint-meta-target/prisma/_schema.ts
@@ -14,6 +14,7 @@ export default testMatrix.setupSchema(({ provider }) => {
     model Role {
       id        ${idForProvider(provider)}
       shortCode String @unique
+      name      String
     }
   `
 })

--- a/packages/client/tests/functional/driver-adapters/constraint-meta-target/prisma/_schema.ts
+++ b/packages/client/tests/functional/driver-adapters/constraint-meta-target/prisma/_schema.ts
@@ -1,0 +1,19 @@
+import { idForProvider } from '../../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+    generator client {
+      provider = "prisma-client-js"
+    }
+
+    datasource db {
+      provider = "${provider}"
+    }
+
+    model Role {
+      id        ${idForProvider(provider)}
+      shortCode String @unique
+    }
+  `
+})

--- a/packages/client/tests/functional/driver-adapters/constraint-meta-target/tests.ts
+++ b/packages/client/tests/functional/driver-adapters/constraint-meta-target/tests.ts
@@ -1,3 +1,4 @@
+import { Providers } from '../../_utils/providers'
 import { defaultTestSuiteOptions } from '../_utils/test-suite-options'
 import testMatrix from './_matrix'
 // @ts-ignore
@@ -41,5 +42,9 @@ testMatrix.setupTestSuite(
   },
   {
     ...defaultTestSuiteOptions,
+    optOut: {
+      from: [Providers.COCKROACHDB, Providers.SQLSERVER, Providers.MONGODB, Providers.SQLITE],
+      reason: 'SQLite does not surface constraint metadata via driver adapters',
+    },
   },
 )

--- a/packages/client/tests/functional/driver-adapters/constraint-meta-target/tests.ts
+++ b/packages/client/tests/functional/driver-adapters/constraint-meta-target/tests.ts
@@ -7,35 +7,33 @@ declare let prisma: PrismaClient
 
 testMatrix.setupTestSuite(
   () => {
-    test('P2002: meta.target is populated via driver-adapter path', async () => {
-      await prisma.role.create({ data: { shortCode: 'ADMIN' } })
+    test('P2002: meta.target is populated and meta.driverAdapterError is preserved', async () => {
+      await prisma.role.create({ data: { shortCode: 'ADMIN', name: 'Administrator' } })
 
-      // Duplicate insert should trigger a unique constraint violation.
-      const result = prisma.role.create({ data: { shortCode: 'ADMIN' } })
-
-      await expect(result).rejects.toMatchObject({
-        name: 'PrismaClientKnownRequestError',
-        code: 'P2002',
-        meta: {
-          // Adapters that resolve field names (e.g. js_pg) return the actual
-          // field name(s); adapters that only expose the index name
-          // (e.g. js_mariadb) return the index name. Either way target must
-          // be a non-empty array.
-          target: expect.arrayContaining([expect.any(String)]),
-        },
-      })
-    })
-
-    test('P2002: meta.driverAdapterError is still present alongside meta.target', async () => {
-      await prisma.role.create({ data: { shortCode: 'EDITOR' } })
-
-      const result = prisma.role.create({ data: { shortCode: 'EDITOR' } })
+      // Duplicate insert triggers a unique constraint violation (P2002).
+      const result = prisma.role.create({ data: { shortCode: 'ADMIN', name: 'Duplicate' } })
 
       await expect(result).rejects.toMatchObject({
         name: 'PrismaClientKnownRequestError',
         code: 'P2002',
         meta: expect.objectContaining({
+          // js_pg resolves field names; js_mariadb exposes the index name.
+          // Either way target must be a non-empty string[].
+          target: expect.arrayContaining([expect.any(String)]),
+          // Preserved for backward compatibility.
           driverAdapterError: expect.anything(),
+        }),
+      })
+    })
+
+    test('P2011: meta.target is populated for null constraint violation', async () => {
+      // Bypass TypeScript's required-field check to force a null into a NOT NULL column.
+      const result = (prisma.role as any).create({ data: { shortCode: 'VIEWER' } })
+
+      await expect(result).rejects.toMatchObject({
+        name: 'PrismaClientKnownRequestError',
+        code: 'P2011',
+        meta: expect.objectContaining({
           target: expect.arrayContaining([expect.any(String)]),
         }),
       })

--- a/packages/client/tests/functional/driver-adapters/constraint-meta-target/tests.ts
+++ b/packages/client/tests/functional/driver-adapters/constraint-meta-target/tests.ts
@@ -42,6 +42,7 @@ testMatrix.setupTestSuite(
   },
   {
     ...defaultTestSuiteOptions,
+    skipDefaultClientInstance: false,
     optOut: {
       from: [Providers.COCKROACHDB, Providers.SQLSERVER, Providers.MONGODB, Providers.SQLITE],
       reason: 'SQLite does not surface constraint metadata via driver adapters',

--- a/packages/client/tests/functional/driver-adapters/constraint-meta-target/tests.ts
+++ b/packages/client/tests/functional/driver-adapters/constraint-meta-target/tests.ts
@@ -1,0 +1,47 @@
+import { defaultTestSuiteOptions } from '../_utils/test-suite-options'
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(
+  () => {
+    test('P2002: meta.target is populated via driver-adapter path', async () => {
+      await prisma.role.create({ data: { shortCode: 'ADMIN' } })
+
+      // Duplicate insert should trigger a unique constraint violation.
+      const result = prisma.role.create({ data: { shortCode: 'ADMIN' } })
+
+      await expect(result).rejects.toMatchObject({
+        name: 'PrismaClientKnownRequestError',
+        code: 'P2002',
+        meta: {
+          // Adapters that resolve field names (e.g. js_pg) return the actual
+          // field name(s); adapters that only expose the index name
+          // (e.g. js_mariadb) return the index name. Either way target must
+          // be a non-empty array.
+          target: expect.arrayContaining([expect.any(String)]),
+        },
+      })
+    })
+
+    test('P2002: meta.driverAdapterError is still present alongside meta.target', async () => {
+      await prisma.role.create({ data: { shortCode: 'EDITOR' } })
+
+      const result = prisma.role.create({ data: { shortCode: 'EDITOR' } })
+
+      await expect(result).rejects.toMatchObject({
+        name: 'PrismaClientKnownRequestError',
+        code: 'P2002',
+        meta: expect.objectContaining({
+          driverAdapterError: expect.anything(),
+          target: expect.arrayContaining([expect.any(String)]),
+        }),
+      })
+    })
+  },
+  {
+    ...defaultTestSuiteOptions,
+  },
+)

--- a/packages/client/tests/functional/driver-adapters/constraint-meta-target/tests.ts
+++ b/packages/client/tests/functional/driver-adapters/constraint-meta-target/tests.ts
@@ -44,8 +44,14 @@ testMatrix.setupTestSuite(
     ...defaultTestSuiteOptions,
     skipDefaultClientInstance: false,
     optOut: {
-      from: [Providers.COCKROACHDB, Providers.SQLSERVER, Providers.MONGODB, Providers.SQLITE],
-      reason: 'SQLite does not surface constraint metadata via driver adapters',
+      from: [
+        Providers.COCKROACHDB,
+        Providers.SQLSERVER,
+        Providers.MONGODB,
+        Providers.SQLITE,
+        Providers.MARIADB,
+      ],
+      reason: 'Only PostgreSQL (js_pg) and MySQL (js_mariadb) are in the test matrix',
     },
   },
 )


### PR DESCRIPTION
## Problem

Fixes #29344 — a confirmed bug where `err.meta.target` is `undefined` for `P2002` (Unique Constraint Violation) and `P2011` (Null Constraint Violation) errors thrown by the JS driver-adapter query-engine path.

The Rust query engine has always populated `meta.target` with the violating field name(s). The JS adapter runtime throws these errors with:

```ts
throw new UserFacingError(message, code, { driverAdapterError: error })
```

…which means `meta.target` is always missing, forcing users to dig into `meta.driverAdapterError.cause.constraint` to identify the offending field.

## Root cause

`rethrowAsUserFacing` did not extract structured constraint metadata from the `DriverAdapterError` before constructing `UserFacingError`. The information was already available in `err.cause.constraint`.

## Fix

`extractMeta` reads the structured `constraint` info from the `DriverAdapterError` and maps it to `meta.target`:

| Constraint shape | Source adapter (examples) | `meta.target` value |
|-----------------|--------------------------|---------------------|
| `{ fields: string[] }` | adapter-pg (parses PG error detail) | `["short_code"]` |
| `{ index: string }` | adapter-mariadb, adapter-mssql | `["roles_short_code_key"]` |

The existing `meta.driverAdapterError` key is kept for backward compatibility.

Both `UniqueConstraintViolation` (P2002) and `NullConstraintViolation` (P2011) are handled since both have the same constraint shape and the same user expectation.

## Test plan

- [ ] Create a model with a `@unique` field in MySQL / PostgreSQL
- [ ] Trigger a unique constraint violation
- [ ] Verify `err.meta.target` is now populated (e.g. `["shortCode"]` for pg, `["roles_short_code_key"]` for MySQL)
- [ ] Verify `err.meta.driverAdapterError` is still present

## Checklist

- [x] `packages/client-engine-runtime/src/user-facing-error.ts` — `extractMeta` helper + `rethrowAsUserFacing` updated