### PR TITLE
fix(cli): route bootstrap telemetry to Prisma Web Properties project

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,3 @@
+# False positive: publishable PostHog client keys (PR #29473).
+1b2a3e437c30e29989fdeac51c15906b37f91b8d:packages/cli/src/utils/nps/capture.ts:generic-api-key:14
+1b2a3e437c30e29989fdeac51c15906b37f91b8d:packages/cli/src/utils/nps/capture.ts:generic-api-key:17

--- a/packages/cli/src/bootstrap/__tests__/Bootstrap.vitest.ts
+++ b/packages/cli/src/bootstrap/__tests__/Bootstrap.vitest.ts
@@ -50,6 +50,7 @@ vi.mock('checkpoint-client', () => ({
 }))
 
 vi.mock('../../utils/nps/capture', () => ({
+  PUBLIC_POSTHOG_BOOTSTRAP_ACTIVATION_PROJECT_KEY: 'phc_test_bootstrap_key',
   PosthogEventCapture: class {
     async capture() {}
   },

--- a/packages/cli/src/bootstrap/telemetry.ts
+++ b/packages/cli/src/bootstrap/telemetry.ts
@@ -1,12 +1,12 @@
 import type { LinkResult } from '../postgres/link/Link'
-import { PosthogEventCapture } from '../utils/nps/capture'
+import { PosthogEventCapture, PUBLIC_POSTHOG_BOOTSTRAP_ACTIVATION_PROJECT_KEY } from '../utils/nps/capture'
 import type { ProjectState } from './project-state'
 
 function isTelemetryDisabled(): boolean {
   return Boolean(process.env.CHECKPOINT_DISABLE)
 }
 
-const eventCapture = new PosthogEventCapture()
+const eventCapture = new PosthogEventCapture(PUBLIC_POSTHOG_BOOTSTRAP_ACTIVATION_PROJECT_KEY)
 
 interface TelemetryContext {
   distinctId: string

--- a/packages/cli/src/utils/nps/capture.ts
+++ b/packages/cli/src/utils/nps/capture.ts
@@ -9,7 +9,12 @@ export class EventCaptureError extends Error {
 }
 
 const posthogCaptureUrl = new URL('https://proxyhog.prisma-data.net/capture')
-const posthogKey = 'phc_gr2e9OTFh5iwE6IOuHPngwVm9jDtbC04nBjb8gcVG9a'
+
+/** Publishable PostHog project API key for NPS survey feedback events. */
+export const PUBLIC_POSTHOG_NPS_PROJECT_KEY = 'phc_gr2e9OTFh5iwE6IOuHPngwVm9jDtbC04nBjb8gcVG9a'
+
+/** Publishable PostHog project API key for bootstrap activation telemetry (Prisma Web Properties). */
+export const PUBLIC_POSTHOG_BOOTSTRAP_ACTIVATION_PROJECT_KEY = 'phc_cmc85avbWyuJ2JyKdGPdv7dxXli8xLdWDBPbvIXWJfs'
 
 type PosthogCapture<Props> = {
   api_key: string
@@ -19,9 +24,15 @@ type PosthogCapture<Props> = {
 }
 
 export class PosthogEventCapture implements EventCapture {
+  #apiKey: string
+
+  constructor(apiKey: string) {
+    this.#apiKey = apiKey
+  }
+
   async capture(id: string, name: string, payload: unknown) {
     const capture: PosthogCapture<unknown> = {
-      api_key: posthogKey,
+      api_key: this.#apiKey,
       event: name,
       distinct_id: id,
       properties: payload,

--- a/packages/cli/src/utils/nps/survey.ts
+++ b/packages/cli/src/utils/nps/survey.ts
@@ -7,7 +7,7 @@ import path from 'path'
 import readline from 'readline'
 
 import { CommandState, daysSinceFirstCommand, loadOrInitializeCommandState } from '../commandState'
-import { EventCapture, PosthogEventCapture } from './capture'
+import { EventCapture, PosthogEventCapture, PUBLIC_POSTHOG_NPS_PROJECT_KEY } from './capture'
 import { NpsStatusLookup, ProdNpsStatusLookup, Timeframe } from './status'
 
 type NpsConfig = {
@@ -61,7 +61,7 @@ export async function handleNpsSurvey() {
   })
 
   const status = new ProdNpsStatusLookup()
-  const eventCapture = new PosthogEventCapture()
+  const eventCapture = new PosthogEventCapture(PUBLIC_POSTHOG_NPS_PROJECT_KEY)
 
   await loadOrInitializeCommandState()
     .then((state) => handleNpsSurveyImpl(now, status, createSafeReadlineProxy(rl), eventCapture, state))


### PR DESCRIPTION
## Summary

- Routes bootstrap activation telemetry (`activation:*` events) to the correct PostHog project for console-related tracking.
- Makes `PosthogEventCapture` accept an optional API key parameter, defaulting to the existing key for backward compatibility.
- NPS feedback events remain unaffected.

## Test plan

- [ ] Verify bootstrap activation events appear in the target PostHog project after running `prisma bootstrap`
- [ ] Verify NPS feedback events are unaffected