### PR TITLE
fix: normalize line endings in prisma format output

### DIFF
--- a/packages/internals/src/__tests__/engine-commands/formatSchema.test.ts
+++ b/packages/internals/src/__tests__/engine-commands/formatSchema.test.ts
@@ -102,6 +102,21 @@ describe('format custom options', () => {
   })
 })
 
+describe('line ending normalization', () => {
+  test('should normalize CRLF to LF in formatted output', async () => {
+    const schemaWithCRLF =
+      'datasource db {\r\n  provider = "sqlite"\r\n}\r\n\r\nmodel User {\r\n  id String @default(cuid()) @id\r\n  email String @unique\r\n}\r\n'
+    const schemas: MultipleSchemas = [['/* schemaPath */', schemaWithCRLF]]
+
+    const formatted = await formatSchema({ schemas })
+    const formattedContent: string[] = extractSchemaContent(formatted)
+
+    expect(formattedContent.length).toBe(1)
+    expect(formattedContent[0]).not.toContain('\r\n')
+    expect(formattedContent[0]).toContain('\n')
+  })
+})
+
 describe('format', () => {
   test('valid blog schemaPath', async () => {
     const { schemas } = await getCliProvidedSchemaFile(path.join(fixturesPath, 'blog.prisma'))

--- a/packages/internals/src/engine-commands/formatSchema.ts
+++ b/packages/internals/src/engine-commands/formatSchema.ts
@@ -45,7 +45,9 @@ export async function formatSchema(
   const { formattedMultipleSchemas, lintDiagnostics } = handleFormatPanic(() => {
     // the only possible error here is a Rust panic
     const formattedMultipleSchemasRaw = formatWasm(JSON.stringify(schemas), documentFormattingParams)
-    const formattedMultipleSchemas = JSON.parse(formattedMultipleSchemasRaw) as MultipleSchemas
+    const formattedMultipleSchemas: MultipleSchemas = (JSON.parse(formattedMultipleSchemasRaw) as MultipleSchemas).map(
+      ([filename, content]) => [filename, content.replace(/\r\n/g, '\n')],
+    )
 
     const lintDiagnostics = lintSchema({ schemas: formattedMultipleSchemas })
     return { formattedMultipleSchemas, lintDiagnostics }


### PR DESCRIPTION
## Summary

- Normalizes CRLF (`
`) line endings to LF (`
`) in the output of `formatSchema`, which powers the `prisma format` command.
- On Windows, the Wasm formatter can produce a trailing CRLF at the end of the file even when all other lines use LF. This causes spurious diffs when the same file is formatted on Linux CI.
- Adds a test to verify that CRLF input is normalized to LF in the formatted output.

Fixes #8548

## Test plan

- [x] Added unit test: `should normalize CRLF to LF in formatted output` in `packages/internals/src/__tests__/engine-commands/formatSchema.test.ts`
- [x] All existing `formatSchema` tests pass (12/12)
- [x] Verify on Windows that `prisma format` no longer produces CRLF at end of file