### PR TITLE
feat(cli): warn when local Prisma installation exists

### DIFF
--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -55,6 +55,7 @@ import { redactCommandArray } from './utils/checkpoint'
 import { loadOrInitializeCommandState } from './utils/commandState'
 import { UserFacingError } from './utils/errors'
 import { loadConfig } from './utils/loadConfig'
+import { warnIfLocalInstallationShadowed } from './utils/warn-local-installation'
 import { Validate } from './Validate'
 import { Version } from './Version'
 
@@ -93,6 +94,9 @@ const args = arg(
  * Main function
  */
 async function main(): Promise<number> {
+  // https://github.com/prisma/prisma/issues/2738
+  warnIfLocalInstallationShadowed()
+
   // create a new CLI with our subcommands
 
   const cli = CLI.new(

--- a/packages/cli/src/utils/__tests__/warn-local-installation.vitest.ts
+++ b/packages/cli/src/utils/__tests__/warn-local-installation.vitest.ts
@@ -1,0 +1,117 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@prisma/internals', () => ({
+  isCurrentBinInstalledGlobally: vi.fn(() => false),
+}))
+
+let internals: typeof import('@prisma/internals')
+
+beforeEach(async () => {
+  internals = await import('@prisma/internals')
+})
+
+describe('findLocalPrismaInstallation', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prisma-test-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns undefined when no local installation exists', async () => {
+    const { findLocalPrismaInstallation } = await import('../warn-local-installation')
+    expect(findLocalPrismaInstallation(tmpDir)).toBeUndefined()
+  })
+
+  it('returns path when node_modules/.bin/prisma exists', async () => {
+    const binDir = path.join(tmpDir, 'node_modules', '.bin')
+    fs.mkdirSync(binDir, { recursive: true })
+    fs.writeFileSync(path.join(binDir, 'prisma'), '', { mode: 0o755 })
+
+    const { findLocalPrismaInstallation } = await import('../warn-local-installation')
+    const result = findLocalPrismaInstallation(tmpDir)
+    expect(result).toBe(path.join(tmpDir, 'node_modules', '.bin', 'prisma'))
+  })
+
+  it('returns path when node_modules/prisma directory exists', async () => {
+    const prismaDir = path.join(tmpDir, 'node_modules', 'prisma')
+    fs.mkdirSync(prismaDir, { recursive: true })
+
+    const { findLocalPrismaInstallation } = await import('../warn-local-installation')
+    const result = findLocalPrismaInstallation(tmpDir)
+    expect(result).toBe(prismaDir)
+  })
+})
+
+describe('warnIfLocalInstallationShadowed', () => {
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore()
+    vi.restoreAllMocks()
+  })
+
+  it('does not warn when running locally (not globally installed)', async () => {
+    vi.mocked(internals.isCurrentBinInstalledGlobally).mockReturnValue(false)
+
+    const { warnIfLocalInstallationShadowed } = await import('../warn-local-installation')
+    warnIfLocalInstallationShadowed()
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not warn when globally installed but no local installation exists', async () => {
+    vi.mocked(internals.isCurrentBinInstalledGlobally).mockReturnValue('npm')
+
+    // Use a temporary directory that has no node_modules
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prisma-test-'))
+    const originalCwd = process.cwd()
+    process.chdir(tmpDir)
+
+    try {
+      const { warnIfLocalInstallationShadowed } = await import('../warn-local-installation')
+      warnIfLocalInstallationShadowed()
+      expect(consoleWarnSpy).not.toHaveBeenCalled()
+    } finally {
+      process.chdir(originalCwd)
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it('warns when globally installed and a local installation exists', async () => {
+    vi.mocked(internals.isCurrentBinInstalledGlobally).mockReturnValue('npm')
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prisma-test-'))
+    const binDir = path.join(tmpDir, 'node_modules', '.bin')
+    fs.mkdirSync(binDir, { recursive: true })
+    fs.writeFileSync(path.join(binDir, 'prisma'), '', { mode: 0o755 })
+
+    const originalCwd = process.cwd()
+    process.chdir(tmpDir)
+
+    try {
+      const { warnIfLocalInstallationShadowed } = await import('../warn-local-installation')
+      warnIfLocalInstallationShadowed()
+
+      expect(consoleWarnSpy).toHaveBeenCalledOnce()
+      const message = consoleWarnSpy.mock.calls[0][0] as string
+      expect(message).toContain('global Prisma CLI')
+      expect(message).toContain('npx prisma')
+      expect(message).toContain('npm')
+    } finally {
+      process.chdir(originalCwd)
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/cli/src/utils/__tests__/warn-local-installation.vitest.ts
+++ b/packages/cli/src/utils/__tests__/warn-local-installation.vitest.ts
@@ -40,6 +40,16 @@ describe('findLocalPrismaInstallation', () => {
     expect(result).toBe(path.join(tmpDir, 'node_modules', '.bin', 'prisma'))
   })
 
+  it('returns path when Windows shim node_modules/.bin/prisma.cmd exists', async () => {
+    const binDir = path.join(tmpDir, 'node_modules', '.bin')
+    fs.mkdirSync(binDir, { recursive: true })
+    fs.writeFileSync(path.join(binDir, 'prisma.cmd'), '')
+
+    const { findLocalPrismaInstallation } = await import('../warn-local-installation')
+    const result = findLocalPrismaInstallation(tmpDir)
+    expect(result).toBe(path.join(tmpDir, 'node_modules', '.bin', 'prisma.cmd'))
+  })
+
   it('returns path when node_modules/prisma directory exists', async () => {
     const prismaDir = path.join(tmpDir, 'node_modules', 'prisma')
     fs.mkdirSync(prismaDir, { recursive: true })

--- a/packages/cli/src/utils/printUpdateMessage.ts
+++ b/packages/cli/src/utils/printUpdateMessage.ts
@@ -57,8 +57,8 @@ function makeInstallCommand(
   },
 ): string {
   let command = ''
-  if (isPrismaInstalledGlobally === 'npm' && options.canBeGlobal) {
-    command = `npm i -g ${packageName}`
+  if (isPrismaInstalledGlobally && options.canBeGlobal) {
+    command = globalInstallCommand(isPrismaInstalledGlobally, packageName)
   } else if (options.canBeDev) {
     command = `npm i --save-dev ${packageName}`
   } else {
@@ -71,4 +71,16 @@ function makeInstallCommand(
   command += `@${tag}`
 
   return command
+}
+
+function globalInstallCommand(manager: 'npm' | 'yarn' | 'pnpm', packageName: string): string {
+  switch (manager) {
+    case 'yarn':
+      return `yarn global add ${packageName}`
+    case 'pnpm':
+      return `pnpm add -g ${packageName}`
+    case 'npm':
+    default:
+      return `npm i -g ${packageName}`
+  }
 }

--- a/packages/cli/src/utils/warn-local-installation.ts
+++ b/packages/cli/src/utils/warn-local-installation.ts
@@ -9,9 +9,17 @@ import { bold, yellow } from 'kleur/colors'
  * Returns the resolved path if found, or `undefined` otherwise.
  */
 export function findLocalPrismaInstallation(cwd: string = process.cwd()): string | undefined {
-  const localBinPath = path.join(cwd, 'node_modules', '.bin', 'prisma')
-  if (fs.existsSync(localBinPath)) {
-    return localBinPath
+  // On Windows, npm/yarn/pnpm expose local bins as `prisma.cmd` (and sometimes `prisma.ps1`);
+  // on POSIX systems the shim is just `prisma`. Check all common variants so a valid local
+  // installation is not missed based on platform.
+  const localBinCandidates = [
+    path.join(cwd, 'node_modules', '.bin', 'prisma'),
+    path.join(cwd, 'node_modules', '.bin', 'prisma.cmd'),
+  ]
+  for (const candidate of localBinCandidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate
+    }
   }
 
   const localPackagePath = path.join(cwd, 'node_modules', 'prisma')

--- a/packages/cli/src/utils/warn-local-installation.ts
+++ b/packages/cli/src/utils/warn-local-installation.ts
@@ -1,0 +1,48 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { isCurrentBinInstalledGlobally } from '@prisma/internals'
+import { bold, yellow } from 'kleur/colors'
+
+/**
+ * Checks whether a local `prisma` package is installed in the project's `node_modules`.
+ * Returns the resolved path if found, or `undefined` otherwise.
+ */
+export function findLocalPrismaInstallation(cwd: string = process.cwd()): string | undefined {
+  const localBinPath = path.join(cwd, 'node_modules', '.bin', 'prisma')
+  if (fs.existsSync(localBinPath)) {
+    return localBinPath
+  }
+
+  const localPackagePath = path.join(cwd, 'node_modules', 'prisma')
+  if (fs.existsSync(localPackagePath)) {
+    return localPackagePath
+  }
+
+  return undefined
+}
+
+/**
+ * When the current binary is installed globally and a local installation exists in the
+ * project's `node_modules`, prints a warning to stderr advising the user to use `npx prisma`
+ * instead.
+ *
+ * See: https://github.com/prisma/prisma/issues/2738
+ */
+export function warnIfLocalInstallationShadowed(): void {
+  const globalManager = isCurrentBinInstalledGlobally()
+  if (!globalManager) {
+    return
+  }
+
+  const localPath = findLocalPrismaInstallation()
+  if (!localPath) {
+    return
+  }
+
+  const message = `${yellow(bold('warn'))} You are using the global Prisma CLI (installed via ${globalManager}), but a local installation was found in this project.
+To avoid version mismatches, use the local CLI instead:
+  ${bold('npx prisma <command>')}`
+
+  console.warn(message)
+}

--- a/packages/internals/src/utils/isCurrentBinInstalledGlobally.ts
+++ b/packages/internals/src/utils/isCurrentBinInstalledGlobally.ts
@@ -1,17 +1,49 @@
 import fs from 'fs'
 import globalDirectories from 'global-directory'
+import path from 'path'
 
-// returns if current prisma bin is installed globally
-export function isCurrentBinInstalledGlobally(): 'npm' | false {
+export type GlobalPackageManager = 'npm' | 'yarn' | 'pnpm'
+
+// returns which package manager installed the current prisma bin globally, or false if it is not global
+export function isCurrentBinInstalledGlobally(): GlobalPackageManager | false {
+  let realPrismaPath: string
   try {
-    const realPrismaPath = fs.realpathSync(process.argv[1])
-    const usingGlobalNpm = realPrismaPath.indexOf(fs.realpathSync(globalDirectories.npm.packages)) === 0
-
-    if (usingGlobalNpm) {
-      return 'npm'
-    }
-  } catch (e) {
-    //
+    realPrismaPath = fs.realpathSync(process.argv[1])
+  } catch {
+    return false
   }
+
+  const startsWith = (prefix: string): boolean => {
+    try {
+      return realPrismaPath.indexOf(fs.realpathSync(prefix)) === 0
+    } catch {
+      return false
+    }
+  }
+
+  if (startsWith(globalDirectories.npm.packages)) {
+    return 'npm'
+  }
+
+  if (startsWith(globalDirectories.yarn.packages)) {
+    return 'yarn'
+  }
+
+  // pnpm installs global bins under `$PNPM_HOME` (set by `pnpm setup`). Fall back to the
+  // default locations pnpm uses on macOS/Linux/Windows when `PNPM_HOME` is not exported.
+  const pnpmCandidates = [
+    process.env.PNPM_HOME,
+    process.env.XDG_DATA_HOME && path.join(process.env.XDG_DATA_HOME, 'pnpm'),
+    process.env.HOME && path.join(process.env.HOME, '.local', 'share', 'pnpm'),
+    process.env.HOME && path.join(process.env.HOME, 'Library', 'pnpm'),
+    process.env.LOCALAPPDATA && path.join(process.env.LOCALAPPDATA, 'pnpm'),
+  ].filter((candidate): candidate is string => Boolean(candidate))
+
+  for (const candidate of pnpmCandidates) {
+    if (startsWith(candidate)) {
+      return 'pnpm'
+    }
+  }
+
   return false
 }


### PR DESCRIPTION
## Summary

- When the global `prisma` CLI is invoked in a project that also has a local installation in `node_modules`, a warning is now printed to stderr advising the user to use `npx prisma` instead.
- Leverages the existing `isCurrentBinInstalledGlobally()` utility from `@prisma/internals` to detect global execution, and checks for `node_modules/.bin/prisma` or `node_modules/prisma` to detect a local installation.
- Includes vitest tests covering all branches: no warning when local, no warning when global without local, warning when global with local.

Closes #2738

## Test plan

- [x] `findLocalPrismaInstallation` returns `undefined` when no local installation exists
- [x] `findLocalPrismaInstallation` detects `node_modules/.bin/prisma`
- [x] `findLocalPrismaInstallation` detects `node_modules/prisma`
- [x] `warnIfLocalInstallationShadowed` does not warn when CLI is not globally installed
- [x] `warnIfLocalInstallationShadowed` does not warn when globally installed but no local installation
- [x] `warnIfLocalInstallationShadowed` warns with correct message when globally installed and local installation exists