### PR TITLE
fix(adapter-neon): use error.column for NullConstraintViolation and fix ColumnNotFound for unquoted names

### DIFF
--- a/packages/adapter-neon/src/__tests__/errors.test.ts
+++ b/packages/adapter-neon/src/__tests__/errors.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from 'vitest'
+
+import { convertDriverError } from '../errors'
+
+describe('convertDriverError', () => {
+  it('should handle LengthMismatch (22001)', () => {
+    const error = { code: '22001', column: 'foo', message: 'msg', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'LengthMismatch',
+      column: 'foo',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle ValueOutOfRange (22003)', () => {
+    const error = { code: '22003', message: 'out of range', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'ValueOutOfRange',
+      cause: 'out of range',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle InvalidInputValue (22P02)', () => {
+    const error = { code: '22P02', message: 'invalid input value for enum "Status": "INVALID"', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'InvalidInputValue',
+      message: 'invalid input value for enum "Status": "INVALID"',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle UniqueConstraintViolation (23505)', () => {
+    const error = { code: '23505', message: 'msg', severity: 'ERROR', detail: 'Key (id)' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'UniqueConstraintViolation',
+      constraint: { fields: ['id'] },
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle NullConstraintViolation (23502) using error.column', () => {
+    // PostgreSQL sets error.column for NOT NULL violations.
+    // error.detail contains "Failing row contains (...)" — not the "Key (...)" format
+    // used by unique-violation errors — so it cannot be parsed for the field name.
+    const error = {
+      code: '23502',
+      message: 'null value in column "foo" of relation "User" violates not-null constraint',
+      severity: 'ERROR',
+      detail: 'Failing row contains (null, null, null)',
+      column: 'foo',
+    }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'NullConstraintViolation',
+      constraint: { fields: ['foo'] },
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should return undefined constraint for NullConstraintViolation (23502) without error.column', () => {
+    const error = {
+      code: '23502',
+      message: 'null value in column "foo" violates not-null constraint',
+      severity: 'ERROR',
+    }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'NullConstraintViolation',
+      constraint: undefined,
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle ForeignKeyConstraintViolation (23503) with column', () => {
+    const error = { code: '23503', message: 'msg', severity: 'ERROR', column: 'bar' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'ForeignKeyConstraintViolation',
+      constraint: { fields: ['bar'] },
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle ForeignKeyConstraintViolation (23503) with constraint', () => {
+    const error = { code: '23503', message: 'msg', severity: 'ERROR', constraint: 'baz' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'ForeignKeyConstraintViolation',
+      constraint: { index: 'baz' },
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle DatabaseDoesNotExist (3D000)', () => {
+    const error = { code: '3D000', message: 'database "mydb" does not exist', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'DatabaseDoesNotExist',
+      db: 'mydb',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle DatabaseAccessDenied (28000)', () => {
+    const error = {
+      code: '28000',
+      message: 'no pg_hba.conf entry for host "172.20.20.2", user "db_user", database "prisma_db", no encryption',
+      severity: 'FATAL',
+    }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'DatabaseAccessDenied',
+      db: 'prisma_db',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle AuthenticationFailed (28P01)', () => {
+    const error = { code: '28P01', message: 'password authentication failed for user "root"', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'AuthenticationFailed',
+      user: 'root',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle TransactionWriteConflict (40001)', () => {
+    const error = { code: '40001', message: 'msg', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'TransactionWriteConflict',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle TableDoesNotExist (42P01)', () => {
+    const error = { code: '42P01', message: 'relation "mytable" does not exist', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'TableDoesNotExist',
+      table: 'mytable',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it.each([
+    ['unquoted column name', 'column foo does not exist', 'foo'],
+    ['quoted column name', 'column "foo" does not exist', 'foo'],
+    ['unquoted qualified column name', 'column users.first_name does not exist', 'users.first_name'],
+    ['quoted qualified column name', 'column "users"."first name" does not exist', 'users.first name'],
+    ['partially quoted qualified column name (1)', 'column users."first name" does not exist', 'users.first name'],
+    ['partially quoted qualified column name (2)', 'column "users".first_name does not exist', 'users.first_name'],
+    ['quoted column name containing spaces', 'column "first name" does not exist', 'first name'],
+    ['quoted column name containing dots', 'column "first.name" does not exist', 'first.name'],
+    ['quoted qualified column name containing dots', 'column "users"."first.name" does not exist', 'users.first.name'],
+    ['quoted column name containing escaped quotes', 'column "a""b" does not exist', 'a"b'],
+  ])('should handle ColumnNotFound (42703) with %s', (description, message, expectedColumn) => {
+    const error = { code: '42703', message, severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'ColumnNotFound',
+      column: expectedColumn,
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle DatabaseAlreadyExists (42P04)', () => {
+    const error = { code: '42P04', message: 'database "mydb" already exists', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'DatabaseAlreadyExists',
+      db: 'mydb',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle TooManyConnections (53300)', () => {
+    const error = { code: '53300', message: 'too many connections', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'TooManyConnections',
+      cause: 'too many connections',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle default (unknown code)', () => {
+    const error = {
+      code: '99999',
+      message: 'unknown',
+      severity: 'FATAL',
+      detail: 'details',
+      column: 'col',
+      hint: 'hint',
+    }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'postgres',
+      code: '99999',
+      severity: 'FATAL',
+      message: 'unknown',
+      detail: 'details',
+      column: 'col',
+      hint: 'hint',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should throw if not a db error', () => {
+    expect(() => convertDriverError({ message: 'Unknown driver message' })).toThrow()
+  })
+})

--- a/packages/adapter-neon/src/errors.ts
+++ b/packages/adapter-neon/src/errors.ts
@@ -41,13 +41,12 @@ function mapDriverError(error: DatabaseError): MappedError {
       }
     }
     case '23502': {
-      const fields = error.detail
-        ?.match(/Key \(([^)]+)\)/)
-        ?.at(1)
-        ?.split(', ')
+      // PostgreSQL sets `error.column` to the violating column for NOT NULL errors.
+      // The `error.detail` field contains "Failing row contains (...)", not the
+      // "Key (...)" format used by unique-violation (23505), so it cannot be parsed.
       return {
         kind: 'NullConstraintViolation',
-        constraint: fields !== undefined ? { fields } : undefined,
+        constraint: error.column !== undefined ? { fields: [error.column] } : undefined,
       }
     }
     case '23503': {
@@ -92,11 +91,13 @@ function mapDriverError(error: DatabaseError): MappedError {
         kind: 'TableDoesNotExist',
         table: error.message.split(' ').at(1)?.split('"').at(1),
       }
-    case '42703':
+    case '42703': {
+      const rawColumn = error.message.match(/^column (.+) does not exist$/)?.at(1)
       return {
         kind: 'ColumnNotFound',
-        column: error.message.split(' ').at(1)?.split('"').at(1),
+        column: rawColumn?.replace(/"((?:""|[^"])*)"/g, (_, id) => id.replaceAll('""', '"')),
       }
+    }
     case '42P04':
       return {
         kind: 'DatabaseAlreadyExists',


### PR DESCRIPTION
## Problem

### P2011 always shows empty `meta.target`

When a PostgreSQL NOT NULL constraint is violated (error code `23502`), Prisma returns `P2011` with an empty `meta.target`:

```
PrismaClientKnownRequestError: Null constraint violation on the (not available)
  code: 'P2011',
  meta: { target: [] }
```

The root cause: `adapter-neon` applied the unique-constraint regex `/Key \(([^)]+)\)/` to `error.detail` for NOT NULL errors. PostgreSQL's `23502` errors always have `error.detail = "Failing row contains (...)"`, which never matches that pattern — so `fields` is always `undefined` and `meta.target` is always empty.

PostgreSQL correctly sets `error.column` to the violating column name for NOT NULL errors. The fix reads that field directly.

### ColumnNotFound misses unquoted column names (42703)

The previous implementation — `error.message.split(' ').at(1)?.split('"').at(1)` — only extracted column names surrounded by double-quotes. For unquoted names (`column foo does not exist`), qualified names (`column users.first_name does not exist`), and escaped-quote names (`column "a""b" does not exist`), it returned `undefined` or the wrong value.

The same fix was applied to `adapter-pg` in #29307. This PR brings parity to `adapter-neon`.

## Fix

**`errors.ts`**

- `23502`: use `error.column` directly instead of the wrong regex.
- `42703`: use the same improved regex (`/^column (.+) does not exist$/`) plus the de-quoting replacer already in `adapter-pg`.

## Tests

Added `src/__tests__/errors.test.ts` with full coverage of all error cases including:
- NullConstraintViolation with and without `error.column`
- ColumnNotFound with unquoted, quoted, qualified, spaced, and escaped-quote column names

All 27 tests pass.

## Related

- Fixes the same bugs as adapter-pg PR #29484 (NullConstraintViolation) and commit #29307 (ColumnNotFound).