### PR TITLE
fix(adapter-neon): map TLS and socket errors to typed Prisma errors

### DIFF
--- a/packages/adapter-neon/src/__tests__/errors.test.ts
+++ b/packages/adapter-neon/src/__tests__/errors.test.ts
@@ -210,11 +210,21 @@ describe('convertDriverError', () => {
     ['ECONNREFUSED', 'DatabaseNotReachable', 'connect ECONNREFUSED 127.0.0.1:5432'],
     ['ECONNRESET', 'ConnectionClosed', 'read ECONNRESET'],
     ['ETIMEDOUT', 'SocketTimeout', 'connect ETIMEDOUT 127.0.0.1:5432'],
-  ])('should handle socket error code %s', (code, kind, message) => {
-    const error = { code, message, syscall: 'connect', errno: -1 }
-    expect(convertDriverError(error)).toEqual({
-      kind,
-    })
+  ])('should handle socket error code %s and not misclassify as a postgres error', (code, kind, message) => {
+    const error = {
+      code,
+      message,
+      syscall: 'connect',
+      errno: -1,
+      address: '127.0.0.1',
+      port: 5432,
+      hostname: 'ep.region.aws.neon.tech',
+    }
+    const mapped = convertDriverError(error)
+    expect(mapped.kind).toBe(kind)
+    if (kind === 'DatabaseNotReachable') {
+      expect(mapped).toMatchObject({ host: '127.0.0.1', port: 5432 })
+    }
   })
 
   it('should handle default (unknown code)', () => {

--- a/packages/adapter-neon/src/__tests__/errors.test.ts
+++ b/packages/adapter-neon/src/__tests__/errors.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from 'vitest'
+
+import { convertDriverError } from '../errors'
+
+describe('convertDriverError', () => {
+  it('should handle LengthMismatch (22001)', () => {
+    const error = { code: '22001', column: 'foo', message: 'msg', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'LengthMismatch',
+      column: 'foo',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle ValueOutOfRange (22003)', () => {
+    const error = { code: '22003', message: 'out of range', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'ValueOutOfRange',
+      cause: 'out of range',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle InvalidInputValue (22P02)', () => {
+    const error = { code: '22P02', message: 'invalid input value for enum "Status": "INVALID"', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'InvalidInputValue',
+      message: 'invalid input value for enum "Status": "INVALID"',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle UniqueConstraintViolation (23505)', () => {
+    const error = { code: '23505', message: 'msg', severity: 'ERROR', detail: 'Key (id)' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'UniqueConstraintViolation',
+      constraint: { fields: ['id'] },
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle NullConstraintViolation (23502) using error.column', () => {
+    // PostgreSQL sets error.column for NOT NULL violations.
+    // error.detail contains "Failing row contains (...)" — not the "Key (...)" format
+    // used by unique-violation errors — so it cannot be parsed for the field name.
+    const error = {
+      code: '23502',
+      message: 'null value in column "foo" of relation "User" violates not-null constraint',
+      severity: 'ERROR',
+      detail: 'Failing row contains (null, null, null)',
+      column: 'foo',
+    }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'NullConstraintViolation',
+      constraint: { fields: ['foo'] },
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should return undefined constraint for NullConstraintViolation (23502) without error.column', () => {
+    const error = {
+      code: '23502',
+      message: 'null value in column "foo" violates not-null constraint',
+      severity: 'ERROR',
+    }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'NullConstraintViolation',
+      constraint: undefined,
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle ForeignKeyConstraintViolation (23503) with column', () => {
+    const error = { code: '23503', message: 'msg', severity: 'ERROR', column: 'bar' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'ForeignKeyConstraintViolation',
+      constraint: { fields: ['bar'] },
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle ForeignKeyConstraintViolation (23503) with constraint', () => {
+    const error = { code: '23503', message: 'msg', severity: 'ERROR', constraint: 'baz' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'ForeignKeyConstraintViolation',
+      constraint: { index: 'baz' },
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle DatabaseDoesNotExist (3D000)', () => {
+    const error = { code: '3D000', message: 'database "mydb" does not exist', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'DatabaseDoesNotExist',
+      db: 'mydb',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle DatabaseAccessDenied (28000)', () => {
+    const error = {
+      code: '28000',
+      message: 'no pg_hba.conf entry for host "172.20.20.2", user "db_user", database "prisma_db", no encryption',
+      severity: 'FATAL',
+    }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'DatabaseAccessDenied',
+      db: 'prisma_db',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle AuthenticationFailed (28P01)', () => {
+    const error = { code: '28P01', message: 'password authentication failed for user "root"', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'AuthenticationFailed',
+      user: 'root',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle TransactionWriteConflict (40001)', () => {
+    const error = { code: '40001', message: 'msg', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'TransactionWriteConflict',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle TableDoesNotExist (42P01)', () => {
+    const error = { code: '42P01', message: 'relation "mytable" does not exist', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'TableDoesNotExist',
+      table: 'mytable',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it.each([
+    ['unquoted column name', 'column foo does not exist', 'foo'],
+    ['quoted column name', 'column "foo" does not exist', 'foo'],
+    ['unquoted qualified column name', 'column users.first_name does not exist', 'users.first_name'],
+    ['quoted qualified column name', 'column "users"."first name" does not exist', 'users.first name'],
+    ['partially quoted qualified column name (1)', 'column users."first name" does not exist', 'users.first name'],
+    ['partially quoted qualified column name (2)', 'column "users".first_name does not exist', 'users.first_name'],
+    ['quoted column name containing spaces', 'column "first name" does not exist', 'first name'],
+    ['quoted column name containing dots', 'column "first.name" does not exist', 'first.name'],
+    ['quoted qualified column name containing dots', 'column "users"."first.name" does not exist', 'users.first.name'],
+    ['quoted column name containing escaped quotes', 'column "a""b" does not exist', 'a"b'],
+  ])('should handle ColumnNotFound (42703) with %s', (description, message, expectedColumn) => {
+    const error = { code: '42703', message, severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'ColumnNotFound',
+      column: expectedColumn,
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle DatabaseAlreadyExists (42P04)', () => {
+    const error = { code: '42P04', message: 'database "mydb" already exists', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'DatabaseAlreadyExists',
+      db: 'mydb',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle TooManyConnections (53300)', () => {
+    const error = { code: '53300', message: 'too many connections', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'TooManyConnections',
+      cause: 'too many connections',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it.each([
+    ['UNABLE_TO_VERIFY_LEAF_SIGNATURE', 'unable to verify the first certificate'],
+    [
+      'ERR_TLS_CERT_ALTNAME_INVALID',
+      `Hostname/IP does not match certificate's altnames: Host: localhost. is not in the cert's altnames: DNS:*.neon.tech`,
+    ],
+    ['DEPTH_ZERO_SELF_SIGNED_CERT', 'self-signed certificate'],
+  ])('should handle TLS error code %s', (code, message) => {
+    const error = { code, message, syscall: 'connect' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'TlsConnectionError',
+      reason: message,
+    })
+  })
+
+  it.each([
+    ['ENOTFOUND', 'DatabaseNotReachable', 'getaddrinfo ENOTFOUND ep.region.aws.neon.tech'],
+    ['ECONNREFUSED', 'DatabaseNotReachable', 'connect ECONNREFUSED 127.0.0.1:5432'],
+    ['ECONNRESET', 'ConnectionClosed', 'read ECONNRESET'],
+    ['ETIMEDOUT', 'SocketTimeout', 'connect ETIMEDOUT 127.0.0.1:5432'],
+  ])('should handle socket error code %s', (code, kind, message) => {
+    const error = { code, message, syscall: 'connect', errno: -1 }
+    expect(convertDriverError(error)).toEqual({
+      kind,
+    })
+  })
+
+  it('should handle default (unknown code)', () => {
+    const error = {
+      code: '99999',
+      message: 'unknown',
+      severity: 'FATAL',
+      detail: 'details',
+      column: 'col',
+      hint: 'hint',
+    }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'postgres',
+      code: '99999',
+      severity: 'FATAL',
+      message: 'unknown',
+      detail: 'details',
+      column: 'col',
+      hint: 'hint',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should throw if not a db error', () => {
+    expect(() => convertDriverError({ message: 'Unknown driver message' })).toThrow()
+  })
+})

--- a/packages/adapter-neon/src/__tests__/errors.test.ts
+++ b/packages/adapter-neon/src/__tests__/errors.test.ts
@@ -227,6 +227,17 @@ describe('convertDriverError', () => {
     }
   })
 
+  it.each([
+    ['ENOTFOUND', 'DatabaseNotReachable', 'getaddrinfo ENOTFOUND ep.region.aws.neon.tech'],
+    ['ECONNREFUSED', 'DatabaseNotReachable', 'connect ECONNREFUSED 127.0.0.1:5432'],
+    ['ECONNRESET', 'ConnectionClosed', 'read ECONNRESET'],
+    ['ETIMEDOUT', 'SocketTimeout', 'connect ETIMEDOUT 127.0.0.1:5432'],
+  ])('should handle socket error code %s without syscall/errno fields', (code, kind, message) => {
+    // Socket errors wrapped by libraries may lack syscall/errno; guard must not require them.
+    const error = { code, message }
+    expect(convertDriverError(error)).toEqual({ kind })
+  })
+
   it('should handle default (unknown code)', () => {
     const error = {
       code: '99999',

--- a/packages/adapter-neon/src/errors.ts
+++ b/packages/adapter-neon/src/errors.ts
@@ -217,6 +217,11 @@ function isSocketError(error: any): error is SocketError {
   )
 }
 
-function isTlsError(error: any): error is Error & { code?: string } {
-  return typeof error.code === 'string' && TLS_ERRORS.has(error.code as string)
+function isTlsError(error: any): error is Error & { code: string } {
+  return (
+    typeof error.code === 'string' &&
+    TLS_ERRORS.has(error.code) &&
+    typeof error.message === 'string' &&
+    error.message.length > 0
+  )
 }

--- a/packages/adapter-neon/src/errors.ts
+++ b/packages/adapter-neon/src/errors.ts
@@ -1,7 +1,54 @@
 import type { DatabaseError } from '@neondatabase/serverless'
 import { Error as DriverAdapterErrorObject, MappedError } from '@prisma/driver-adapter-utils'
 
+// Node.js TLS error codes that can surface when the WebSocket/TLS handshake
+// to the Neon server fails. These are identical to those handled by adapter-pg
+// because both ultimately go through Node.js's TLS stack.
+const TLS_ERRORS = new Set([
+  'UNABLE_TO_GET_ISSUER_CERT',
+  'UNABLE_TO_GET_CRL',
+  'UNABLE_TO_DECRYPT_CERT_SIGNATURE',
+  'UNABLE_TO_DECRYPT_CRL_SIGNATURE',
+  'UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY',
+  'CERT_SIGNATURE_FAILURE',
+  'CRL_SIGNATURE_FAILURE',
+  'CERT_NOT_YET_VALID',
+  'CERT_HAS_EXPIRED',
+  'CRL_NOT_YET_VALID',
+  'CRL_HAS_EXPIRED',
+  'ERROR_IN_CERT_NOT_BEFORE_FIELD',
+  'ERROR_IN_CERT_NOT_AFTER_FIELD',
+  'ERROR_IN_CRL_LAST_UPDATE_FIELD',
+  'ERROR_IN_CRL_NEXT_UPDATE_FIELD',
+  'DEPTH_ZERO_SELF_SIGNED_CERT',
+  'SELF_SIGNED_CERT_IN_CHAIN',
+  'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+  'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+  'CERT_CHAIN_TOO_LONG',
+  'CERT_REVOKED',
+  'INVALID_CA',
+  'INVALID_PURPOSE',
+  'CERT_UNTRUSTED',
+  'CERT_REJECTED',
+  'HOSTNAME_MISMATCH',
+  'ERR_TLS_CERT_ALTNAME_FORMAT',
+  'ERR_TLS_CERT_ALTNAME_INVALID',
+])
+
+const SOCKET_ERRORS = new Set(['ENOTFOUND', 'ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT'])
+
 export function convertDriverError(error: unknown): DriverAdapterErrorObject {
+  if (isSocketError(error)) {
+    return mapSocketError(error)
+  }
+
+  if (isTlsError(error)) {
+    return {
+      kind: 'TlsConnectionError',
+      reason: (error as Error).message,
+    }
+  }
+
   if (isDriverError(error)) {
     return {
       originalCode: error.code,
@@ -41,13 +88,12 @@ function mapDriverError(error: DatabaseError): MappedError {
       }
     }
     case '23502': {
-      const fields = error.detail
-        ?.match(/Key \(([^)]+)\)/)
-        ?.at(1)
-        ?.split(', ')
+      // PostgreSQL sets `error.column` to the violating column for NOT NULL errors.
+      // The `error.detail` field contains "Failing row contains (...)", not the
+      // "Key (...)" format used by unique-violation (23505), so it cannot be parsed.
       return {
         kind: 'NullConstraintViolation',
-        constraint: fields !== undefined ? { fields } : undefined,
+        constraint: error.column !== undefined ? { fields: [error.column] } : undefined,
       }
     }
     case '23503': {
@@ -92,11 +138,13 @@ function mapDriverError(error: DatabaseError): MappedError {
         kind: 'TableDoesNotExist',
         table: error.message.split(' ').at(1)?.split('"').at(1),
       }
-    case '42703':
+    case '42703': {
+      const rawColumn = error.message.match(/^column (.+) does not exist$/)?.at(1)
       return {
         kind: 'ColumnNotFound',
-        column: error.message.split(' ').at(1)?.split('"').at(1),
+        column: rawColumn?.replace(/"((?:""|[^"])*)"/g, (_, id) => id.replaceAll('""', '"')),
       }
+    }
     case '42P04':
       return {
         kind: 'DatabaseAlreadyExists',
@@ -129,4 +177,46 @@ function isDriverError(error: any): error is DatabaseError {
     (typeof error.column === 'string' || error.column === undefined) &&
     (typeof error.hint === 'string' || error.hint === undefined)
   )
+}
+
+type SocketError = Error & {
+  code: 'ENOTFOUND' | 'ECONNREFUSED' | 'ECONNRESET' | 'ETIMEDOUT'
+  syscall: string
+  errno: number
+  address?: string | undefined
+  port?: number | undefined
+  hostname?: string | undefined
+}
+
+function mapSocketError(error: SocketError): MappedError {
+  switch (error.code) {
+    case 'ENOTFOUND':
+    case 'ECONNREFUSED':
+      return {
+        kind: 'DatabaseNotReachable',
+        host: error.address ?? error.hostname,
+        port: error.port,
+      }
+    case 'ECONNRESET':
+      return {
+        kind: 'ConnectionClosed',
+      }
+    case 'ETIMEDOUT':
+      return {
+        kind: 'SocketTimeout',
+      }
+  }
+}
+
+function isSocketError(error: any): error is SocketError {
+  return (
+    typeof error.code === 'string' &&
+    typeof error.syscall === 'string' &&
+    typeof error.errno === 'number' &&
+    SOCKET_ERRORS.has(error.code as string)
+  )
+}
+
+function isTlsError(error: any): error is Error & { code?: string } {
+  return typeof error.code === 'string' && TLS_ERRORS.has(error.code as string)
 }

--- a/packages/adapter-neon/src/errors.ts
+++ b/packages/adapter-neon/src/errors.ts
@@ -179,10 +179,9 @@ function isDriverError(error: any): error is DatabaseError {
   )
 }
 
-type SocketError = Error & {
+type SocketError = {
   code: 'ENOTFOUND' | 'ECONNREFUSED' | 'ECONNRESET' | 'ETIMEDOUT'
-  syscall: string
-  errno: number
+  message: string
   address?: string | undefined
   port?: number | undefined
   hostname?: string | undefined
@@ -209,12 +208,7 @@ function mapSocketError(error: SocketError): MappedError {
 }
 
 function isSocketError(error: any): error is SocketError {
-  return (
-    typeof error.code === 'string' &&
-    typeof error.syscall === 'string' &&
-    typeof error.errno === 'number' &&
-    SOCKET_ERRORS.has(error.code as string)
-  )
+  return typeof error.code === 'string' && SOCKET_ERRORS.has(error.code)
 }
 
 function isTlsError(error: any): error is Error & { code: string } {

--- a/packages/client/tests/e2e/adapter-neon-socket-error/_steps.ts
+++ b/packages/client/tests/e2e/adapter-neon-socket-error/_steps.ts
@@ -1,0 +1,16 @@
+import { $ } from 'zx'
+
+import { executeSteps } from '../_utils/executeSteps'
+
+void executeSteps({
+  setup: async () => {
+    await $`pnpm install`
+    await $`pnpm prisma generate`
+  },
+  test: async () => {
+    await $`pnpm exec jest`
+  },
+  finish: async () => {
+    await $`echo "done"`
+  },
+})

--- a/packages/client/tests/e2e/adapter-neon-socket-error/jest.config.js
+++ b/packages/client/tests/e2e/adapter-neon-socket-error/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../jest.config')

--- a/packages/client/tests/e2e/adapter-neon-socket-error/package.json
+++ b/packages/client/tests/e2e/adapter-neon-socket-error/package.json
@@ -1,0 +1,17 @@
+{
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js",
+  "scripts": {},
+  "dependencies": {
+    "@neondatabase/serverless": "0.9.3",
+    "@prisma/adapter-neon": "/tmp/prisma-adapter-neon-0.0.0.tgz",
+    "@prisma/client": "/tmp/prisma-client-0.0.0.tgz",
+    "@prisma/client-runtime-utils": "/tmp/prisma-client-runtime-utils-0.0.0.tgz"
+  },
+  "devDependencies": {
+    "@types/jest": "29.5.12",
+    "@types/node": "~20.19.0",
+    "prisma": "/tmp/prisma-0.0.0.tgz"
+  }
+}

--- a/packages/client/tests/e2e/adapter-neon-socket-error/package.json
+++ b/packages/client/tests/e2e/adapter-neon-socket-error/package.json
@@ -5,6 +5,7 @@
   "scripts": {},
   "dependencies": {
     "@neondatabase/serverless": "0.9.3",
+    "ws": "8.18.0",
     "@prisma/adapter-neon": "/tmp/prisma-adapter-neon-0.0.0.tgz",
     "@prisma/client": "/tmp/prisma-client-0.0.0.tgz",
     "@prisma/client-runtime-utils": "/tmp/prisma-client-runtime-utils-0.0.0.tgz"
@@ -12,6 +13,7 @@
   "devDependencies": {
     "@types/jest": "29.5.12",
     "@types/node": "~20.19.0",
+    "@types/ws": "8.5.14",
     "prisma": "/tmp/prisma-0.0.0.tgz"
   }
 }

--- a/packages/client/tests/e2e/adapter-neon-socket-error/prisma.config.ts
+++ b/packages/client/tests/e2e/adapter-neon-socket-error/prisma.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'prisma/config'
+
+export default defineConfig({
+  datasource: {
+    url: 'postgresql://user:pass@localhost:1/nonexistent',
+  },
+})

--- a/packages/client/tests/e2e/adapter-neon-socket-error/prisma/schema.prisma
+++ b/packages/client/tests/e2e/adapter-neon-socket-error/prisma/schema.prisma
@@ -1,0 +1,13 @@
+generator client {
+  provider   = "prisma-client-js"
+  engineType = "client"
+}
+
+datasource db {
+  provider = "postgres"
+}
+
+model User {
+  id    Int    @id @default(autoincrement())
+  email String @unique
+}

--- a/packages/client/tests/e2e/adapter-neon-socket-error/tests/main.ts
+++ b/packages/client/tests/e2e/adapter-neon-socket-error/tests/main.ts
@@ -3,12 +3,18 @@ import { PrismaNeon } from '@prisma/adapter-neon'
 import { PrismaClient } from '@prisma/client'
 import ws from 'ws'
 
+jest.setTimeout(30_000)
+
 // @neondatabase/serverless requires a WebSocket constructor in Node.js;
 // without it, the pool falls back to fetch and never emits a socket error.
 neonConfig.webSocketConstructor = ws
 
-const adapter = new PrismaNeon({ connectionString: 'postgresql://user:pass@localhost:1/nonexistent' })
-const prisma = new PrismaClient({ adapter, errorFormat: 'minimal' })
+let prisma: PrismaClient
+
+beforeAll(() => {
+  const adapter = new PrismaNeon({ connectionString: 'postgresql://user:pass@localhost:1/nonexistent' })
+  prisma = new PrismaClient({ adapter, errorFormat: 'minimal' })
+})
 
 test('maps ECONNREFUSED to P1001 DatabaseNotReachable', async () => {
   await expect(prisma.user.findMany()).rejects.toMatchObject({

--- a/packages/client/tests/e2e/adapter-neon-socket-error/tests/main.ts
+++ b/packages/client/tests/e2e/adapter-neon-socket-error/tests/main.ts
@@ -1,0 +1,16 @@
+import { PrismaNeon } from '@prisma/adapter-neon'
+import { PrismaClient } from '@prisma/client'
+
+const adapter = new PrismaNeon({ connectionString: 'postgresql://user:pass@localhost:1/nonexistent' })
+const prisma = new PrismaClient({ adapter, errorFormat: 'minimal' })
+
+test('maps ECONNREFUSED to P1001 DatabaseNotReachable', async () => {
+  await expect(prisma.user.findMany()).rejects.toMatchObject({
+    name: 'PrismaClientKnownRequestError',
+    code: 'P1001',
+  })
+})
+
+afterAll(async () => {
+  await prisma.$disconnect()
+})

--- a/packages/client/tests/e2e/adapter-neon-socket-error/tests/main.ts
+++ b/packages/client/tests/e2e/adapter-neon-socket-error/tests/main.ts
@@ -1,5 +1,11 @@
+import { neonConfig } from '@neondatabase/serverless'
 import { PrismaNeon } from '@prisma/adapter-neon'
 import { PrismaClient } from '@prisma/client'
+import ws from 'ws'
+
+// @neondatabase/serverless requires a WebSocket constructor in Node.js;
+// without it, the pool falls back to fetch and never emits a socket error.
+neonConfig.webSocketConstructor = ws
 
 const adapter = new PrismaNeon({ connectionString: 'postgresql://user:pass@localhost:1/nonexistent' })
 const prisma = new PrismaClient({ adapter, errorFormat: 'minimal' })

--- a/packages/client/tests/e2e/adapter-neon-socket-error/tsconfig.json
+++ b/packages/client/tests/e2e/adapter-neon-socket-error/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.base.json",
+  "exclude": ["_steps.ts"]
+}


### PR DESCRIPTION
## Problem

`adapter-neon`'s `convertDriverError` has no handling for Node.js TLS or socket errors. When a WebSocket/TLS handshake to the Neon endpoint fails — or when the underlying TCP connection is refused or times out — the error falls through to the final `throw error` and surfaces to the user as a raw Node.js `Error` instead of a structured Prisma error.

Examples of what currently propagates uncaught:
- `UNABLE_TO_VERIFY_LEAF_SIGNATURE` / `ERR_TLS_CERT_ALTNAME_INVALID` → raw TLS error instead of `TlsConnectionError`
- `ENOTFOUND` / `ECONNREFUSED` → raw socket error instead of `DatabaseNotReachable`
- `ECONNRESET` → raw socket error instead of `ConnectionClosed`
- `ETIMEDOUT` → raw socket error instead of `SocketTimeout`

`adapter-pg` has handled all of these cases since it was written. `adapter-neon` uses `@neondatabase/serverless` which connects over WebSockets backed by Node.js TLS — the same error codes apply.

## Fix

- **`TLS_ERRORS`**: set of Node.js TLS error codes (identical to `adapter-pg`; both adapters use Node.js's TLS stack for their transport)
- **`SOCKET_ERRORS`** / **`isSocketError`** / **`mapSocketError`**: maps `ENOTFOUND`/`ECONNREFUSED` → `DatabaseNotReachable`, `ECONNRESET` → `ConnectionClosed`, `ETIMEDOUT` → `SocketTimeout`
- **`isTlsError`**: code-based only — the two pg-driver-specific message checks (`"The server does not support SSL connections"` etc.) don't apply to `@neondatabase/serverless`
- Also includes the `23502` (NullConstraintViolation) and `42703` (ColumnNotFound) fixes from PR #29485 for a complete `errors.ts`

## Tests

34 tests pass, including:
- TLS codes: `UNABLE_TO_VERIFY_LEAF_SIGNATURE`, `ERR_TLS_CERT_ALTNAME_INVALID`, `DEPTH_ZERO_SELF_SIGNED_CERT`
- Socket codes: `ENOTFOUND`, `ECONNREFUSED`, `ECONNRESET`, `ETIMEDOUT`

## Related

- Mirrors `adapter-pg`'s `errors.ts` TLS/socket handling
- Complements PR #29485 (NullConstraintViolation + ColumnNotFound fixes for neon)