### PR TITLE
fix(adapter-libsql): handle socket errors before isDriverError to prevent misclassification

### DIFF
--- a/packages/adapter-libsql/src/errors.test.ts
+++ b/packages/adapter-libsql/src/errors.test.ts
@@ -22,8 +22,12 @@ describe('LibSQL error handling', () => {
     // Socket errors have a string `code` and undefined `rawCode`, so without an
     // explicit guard they would pass isDriverError and be returned as
     // { kind: 'sqlite', extendedCode: 1 } — the wrong kind.
-    const error = { code, message, syscall: 'connect', errno: -1 }
-    expect(convertDriverError(error)).toEqual({ kind })
+    const error = { code, message, syscall: 'connect', errno: -1, address: '127.0.0.1', port: 8080, hostname: 'db.example.turso.io' }
+    const mapped = convertDriverError(error)
+    expect(mapped.kind).toBe(kind)
+    if (kind === 'DatabaseNotReachable') {
+      expect(mapped).toMatchObject({ host: '127.0.0.1', port: 8080 })
+    }
   })
 
   test.each([
@@ -40,13 +44,20 @@ describe('LibSQL error handling', () => {
         code: 'HRANA_WEBSOCKET_ERROR',
         message: causeMessage,
         rawCode: undefined,
-        cause: { code, message: causeMessage, syscall: 'connect', errno: -1 },
+        cause: { code, message: causeMessage, syscall: 'connect', errno: -1, address: '127.0.0.1', port: 1 },
       }
-      expect(convertDriverError(wrapped)).toEqual({ kind })
+      const mapped = convertDriverError(wrapped)
+      expect(mapped.kind).toBe(kind)
+      if (kind === 'DatabaseNotReachable') {
+        expect(mapped).toMatchObject({ host: '127.0.0.1', port: 1 })
+      }
     },
   )
 
-  test('non-driver, non-socket error is re-thrown', () => {
-    expect(() => convertDriverError({ message: 'Unknown driver message' })).toThrow()
+  test('non-driver, non-socket error is re-thrown unchanged', () => {
+    const input = { message: 'Unknown driver message' }
+    expect(() => convertDriverError(input)).toThrowError(
+      expect.objectContaining({ message: 'Unknown driver message' }),
+    )
   })
 })

--- a/packages/adapter-libsql/src/errors.test.ts
+++ b/packages/adapter-libsql/src/errors.test.ts
@@ -26,6 +26,26 @@ describe('LibSQL error handling', () => {
     expect(convertDriverError(error)).toEqual({ kind })
   })
 
+  test.each([
+    ['ENOTFOUND', 'DatabaseNotReachable', 'getaddrinfo ENOTFOUND db.example.turso.io'],
+    ['ECONNREFUSED', 'DatabaseNotReachable', 'connect ECONNREFUSED 127.0.0.1:1'],
+    ['ECONNRESET', 'ConnectionClosed', 'read ECONNRESET'],
+    ['ETIMEDOUT', 'SocketTimeout', 'connect ETIMEDOUT 127.0.0.1:1'],
+  ])(
+    'socket error %s wrapped in HRANA_WEBSOCKET_ERROR maps to %s',
+    (code, kind, causeMessage) => {
+      // @libsql/client wraps socket errors inside a LibsqlError with the raw
+      // socket error in `cause` (e.g. HRANA_WEBSOCKET_ERROR wrapping ECONNREFUSED).
+      const wrapped = {
+        code: 'HRANA_WEBSOCKET_ERROR',
+        message: causeMessage,
+        rawCode: undefined,
+        cause: { code, message: causeMessage, syscall: 'connect', errno: -1 },
+      }
+      expect(convertDriverError(wrapped)).toEqual({ kind })
+    },
+  )
+
   test('non-driver, non-socket error is re-thrown', () => {
     expect(() => convertDriverError({ message: 'Unknown driver message' })).toThrow()
   })

--- a/packages/adapter-libsql/src/errors.test.ts
+++ b/packages/adapter-libsql/src/errors.test.ts
@@ -12,4 +12,21 @@ describe('LibSQL error handling', () => {
       originalMessage: 'An error occurred',
     })
   })
+
+  test.each([
+    ['ENOTFOUND', 'DatabaseNotReachable', 'getaddrinfo ENOTFOUND db.example.turso.io'],
+    ['ECONNREFUSED', 'DatabaseNotReachable', 'connect ECONNREFUSED 127.0.0.1:8080'],
+    ['ECONNRESET', 'ConnectionClosed', 'read ECONNRESET'],
+    ['ETIMEDOUT', 'SocketTimeout', 'connect ETIMEDOUT 127.0.0.1:8080'],
+  ])('socket error %s maps to %s and is not misclassified as a sqlite error', (code, kind, message) => {
+    // Socket errors have a string `code` and undefined `rawCode`, so without an
+    // explicit guard they would pass isDriverError and be returned as
+    // { kind: 'sqlite', extendedCode: 1 } — the wrong kind.
+    const error = { code, message, syscall: 'connect', errno: -1 }
+    expect(convertDriverError(error)).toEqual({ kind })
+  })
+
+  test('non-driver, non-socket error is re-thrown', () => {
+    expect(() => convertDriverError({ message: 'Unknown driver message' })).toThrow()
+  })
 })

--- a/packages/adapter-libsql/src/errors.ts
+++ b/packages/adapter-libsql/src/errors.ts
@@ -104,24 +104,34 @@ type SocketError = Error & {
   hostname?: string | undefined
 }
 
-// @libsql/client wraps raw socket errors inside a LibsqlError (e.g.
-// HRANA_WEBSOCKET_ERROR) with the original socket error as `cause`. We must
-// check both the error itself and its cause so neither path is missed.
-function isSocketError(error: any): boolean {
-  return isRawSocketError(error) || isRawSocketError(error?.cause)
-}
-
 function isRawSocketError(error: any): error is SocketError {
   return (
     typeof error?.code === 'string' &&
     typeof error?.syscall === 'string' &&
     typeof error?.errno === 'number' &&
-    SOCKET_ERRORS.has(error.code as string)
+    SOCKET_ERRORS.has(error.code)
   )
 }
 
+// Walk the error.cause chain to find a raw socket error at any nesting depth.
+// @libsql/client wraps socket errors (e.g. ECONNREFUSED) inside a LibsqlError
+// (e.g. HRANA_WEBSOCKET_ERROR) with the original error as `cause`, so a single-
+// level check is insufficient when wrapping depth increases.
+function findSocketError(error: any): SocketError | undefined {
+  let err = error
+  while (err != null) {
+    if (isRawSocketError(err)) return err
+    err = err.cause
+  }
+  return undefined
+}
+
+function isSocketError(error: any): boolean {
+  return findSocketError(error) !== undefined
+}
+
 function mapSocketError(error: any): MappedError {
-  const e: SocketError = isRawSocketError(error) ? error : error.cause
+  const e = findSocketError(error)!
   switch (e.code) {
     case 'ENOTFOUND':
     case 'ECONNREFUSED':

--- a/packages/adapter-libsql/src/errors.ts
+++ b/packages/adapter-libsql/src/errors.ts
@@ -95,22 +95,16 @@ function isDriverError(error: any): error is LibsqlError {
   )
 }
 
-type SocketError = Error & {
+type SocketError = {
   code: 'ENOTFOUND' | 'ECONNREFUSED' | 'ECONNRESET' | 'ETIMEDOUT'
-  syscall: string
-  errno: number
+  message: string
   address?: string | undefined
   port?: number | undefined
   hostname?: string | undefined
 }
 
 function isRawSocketError(error: any): error is SocketError {
-  return (
-    typeof error?.code === 'string' &&
-    typeof error?.syscall === 'string' &&
-    typeof error?.errno === 'number' &&
-    SOCKET_ERRORS.has(error.code)
-  )
+  return typeof error?.code === 'string' && SOCKET_ERRORS.has(error.code)
 }
 
 // Walk the error.cause chain to find a raw socket error at any nesting depth.

--- a/packages/adapter-libsql/src/errors.ts
+++ b/packages/adapter-libsql/src/errors.ts
@@ -4,7 +4,16 @@ import { Error as DriverAdapterErrorObject, MappedError } from '@prisma/driver-a
 const SQLITE_BUSY = 5
 const PRIMARY_ERROR_CODE_MASK = 0xff
 
+const SOCKET_ERRORS = new Set(['ENOTFOUND', 'ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT'])
+
 export function convertDriverError(error: unknown): DriverAdapterErrorObject {
+  // Socket errors must be checked before isDriverError because they satisfy the
+  // LibsqlError type shape (string code, string message, undefined rawCode) and
+  // would otherwise be misclassified as SQLite errors with extendedCode 1.
+  if (isSocketError(error)) {
+    return mapSocketError(error)
+  }
+
   if (isDriverError(error)) {
     return {
       originalCode: error.rawCode?.toString(),
@@ -84,4 +93,42 @@ function isDriverError(error: any): error is LibsqlError {
     typeof error.message === 'string' &&
     (typeof error.rawCode === 'number' || error.rawCode === undefined)
   )
+}
+
+type SocketError = Error & {
+  code: 'ENOTFOUND' | 'ECONNREFUSED' | 'ECONNRESET' | 'ETIMEDOUT'
+  syscall: string
+  errno: number
+  address?: string | undefined
+  port?: number | undefined
+  hostname?: string | undefined
+}
+
+function isSocketError(error: any): error is SocketError {
+  return (
+    typeof error.code === 'string' &&
+    typeof error.syscall === 'string' &&
+    typeof error.errno === 'number' &&
+    SOCKET_ERRORS.has(error.code as string)
+  )
+}
+
+function mapSocketError(error: SocketError): MappedError {
+  switch (error.code) {
+    case 'ENOTFOUND':
+    case 'ECONNREFUSED':
+      return {
+        kind: 'DatabaseNotReachable',
+        host: error.address ?? error.hostname,
+        port: error.port,
+      }
+    case 'ECONNRESET':
+      return {
+        kind: 'ConnectionClosed',
+      }
+    case 'ETIMEDOUT':
+      return {
+        kind: 'SocketTimeout',
+      }
+  }
 }

--- a/packages/adapter-libsql/src/errors.ts
+++ b/packages/adapter-libsql/src/errors.ts
@@ -104,23 +104,31 @@ type SocketError = Error & {
   hostname?: string | undefined
 }
 
-function isSocketError(error: any): error is SocketError {
+// @libsql/client wraps raw socket errors inside a LibsqlError (e.g.
+// HRANA_WEBSOCKET_ERROR) with the original socket error as `cause`. We must
+// check both the error itself and its cause so neither path is missed.
+function isSocketError(error: any): boolean {
+  return isRawSocketError(error) || isRawSocketError(error?.cause)
+}
+
+function isRawSocketError(error: any): error is SocketError {
   return (
-    typeof error.code === 'string' &&
-    typeof error.syscall === 'string' &&
-    typeof error.errno === 'number' &&
+    typeof error?.code === 'string' &&
+    typeof error?.syscall === 'string' &&
+    typeof error?.errno === 'number' &&
     SOCKET_ERRORS.has(error.code as string)
   )
 }
 
-function mapSocketError(error: SocketError): MappedError {
-  switch (error.code) {
+function mapSocketError(error: any): MappedError {
+  const e: SocketError = isRawSocketError(error) ? error : error.cause
+  switch (e.code) {
     case 'ENOTFOUND':
     case 'ECONNREFUSED':
       return {
         kind: 'DatabaseNotReachable',
-        host: error.address ?? error.hostname,
-        port: error.port,
+        host: e.address ?? e.hostname,
+        port: e.port,
       }
     case 'ECONNRESET':
       return {

--- a/packages/client/tests/e2e/adapter-libsql-socket-error/_steps.ts
+++ b/packages/client/tests/e2e/adapter-libsql-socket-error/_steps.ts
@@ -1,0 +1,16 @@
+import { $ } from 'zx'
+
+import { executeSteps } from '../_utils/executeSteps'
+
+void executeSteps({
+  setup: async () => {
+    await $`pnpm install`
+    await $`pnpm prisma generate`
+  },
+  test: async () => {
+    await $`pnpm exec jest`
+  },
+  finish: async () => {
+    await $`echo "done"`
+  },
+})

--- a/packages/client/tests/e2e/adapter-libsql-socket-error/jest.config.js
+++ b/packages/client/tests/e2e/adapter-libsql-socket-error/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../jest.config')

--- a/packages/client/tests/e2e/adapter-libsql-socket-error/package.json
+++ b/packages/client/tests/e2e/adapter-libsql-socket-error/package.json
@@ -1,0 +1,17 @@
+{
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js",
+  "scripts": {},
+  "dependencies": {
+    "@libsql/client": "0.17.0",
+    "@prisma/adapter-libsql": "/tmp/prisma-adapter-libsql-0.0.0.tgz",
+    "@prisma/client": "/tmp/prisma-client-0.0.0.tgz",
+    "@prisma/client-runtime-utils": "/tmp/prisma-client-runtime-utils-0.0.0.tgz"
+  },
+  "devDependencies": {
+    "@types/jest": "29.5.12",
+    "@types/node": "~20.19.0",
+    "prisma": "/tmp/prisma-0.0.0.tgz"
+  }
+}

--- a/packages/client/tests/e2e/adapter-libsql-socket-error/prisma.config.ts
+++ b/packages/client/tests/e2e/adapter-libsql-socket-error/prisma.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'prisma/config'
+
+export default defineConfig({
+  datasource: {
+    url: 'file:./dev.db',
+  },
+})

--- a/packages/client/tests/e2e/adapter-libsql-socket-error/prisma/schema.prisma
+++ b/packages/client/tests/e2e/adapter-libsql-socket-error/prisma/schema.prisma
@@ -1,0 +1,13 @@
+generator client {
+  provider   = "prisma-client-js"
+  engineType = "client"
+}
+
+datasource db {
+  provider = "sqlite"
+}
+
+model User {
+  id    Int    @id @default(autoincrement())
+  email String @unique
+}

--- a/packages/client/tests/e2e/adapter-libsql-socket-error/tests/main.ts
+++ b/packages/client/tests/e2e/adapter-libsql-socket-error/tests/main.ts
@@ -1,0 +1,18 @@
+import { PrismaLibSql } from '@prisma/adapter-libsql'
+import { PrismaClient } from '@prisma/client'
+
+// ws:// (plain WebSocket) to localhost:1 triggers ECONNREFUSED at the TCP layer,
+// which the libsql adapter must map to DatabaseNotReachable (P1001).
+const adapter = new PrismaLibSql({ url: 'ws://localhost:1' })
+const prisma = new PrismaClient({ adapter, errorFormat: 'minimal' })
+
+test('maps ECONNREFUSED to P1001 DatabaseNotReachable', async () => {
+  await expect(prisma.user.findMany()).rejects.toMatchObject({
+    name: 'PrismaClientKnownRequestError',
+    code: 'P1001',
+  })
+})
+
+afterAll(async () => {
+  await prisma.$disconnect()
+})

--- a/packages/client/tests/e2e/adapter-libsql-socket-error/tsconfig.json
+++ b/packages/client/tests/e2e/adapter-libsql-socket-error/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.base.json",
+  "exclude": ["_steps.ts"]
+}


### PR DESCRIPTION
## Problem

Socket errors (`ENOTFOUND`, `ECONNREFUSED`, `ECONNRESET`, `ETIMEDOUT`) from the libsql client accidentally satisfy the `isDriverError` type guard:

```typescript
function isDriverError(error: any): error is LibsqlError {
  return (
    typeof error.code === 'string' &&      // ✓  e.g. 'ENOTFOUND'
    typeof error.message === 'string' &&   // ✓
    (typeof error.rawCode === 'number' || error.rawCode === undefined)  // ✓ undefined
  )
}
```

Because they pass the guard, they are routed to `mapDriverError` where:
```typescript
const rawCode: number = error.rawCode ?? error.cause?.['rawCode'] ?? 1
// rawCode = 1 (fallback)
```
`1 & 0xff = 1 ≠ SQLITE_BUSY (5)`, and none of the message-string checks match, so the error is returned as:
```typescript
{ kind: 'sqlite', extendedCode: 1, message: '...' }
```
…instead of `DatabaseNotReachable`, `ConnectionClosed`, or `SocketTimeout`. The wrong error kind reaches the Prisma client and surfaces as the wrong P-code.

## Fix

Add an `isSocketError` guard that is checked **before** `isDriverError`, mirroring the pattern already used in `adapter-pg` and `adapter-neon`:

```typescript
export function convertDriverError(error: unknown): DriverAdapterErrorObject {
  if (isSocketError(error)) {
    return mapSocketError(error)
  }
  if (isDriverError(error)) { ... }
  throw error
}
```

## Tests

Added 4 parameterized test cases — one per socket error code — verifying the correct `kind` is returned and the old `sqlite` misclassification does not occur. Existing default-code test preserved.

## Adapters affected

| Adapter | Status |
|---------|--------|
| adapter-pg | ✅ already handled |
| adapter-neon | ✅ fixed in PR #29489 |
| adapter-libsql | ✅ this PR |
| adapter-mssql | 🔜 separate PR (different failure mode: falls through to `throw error` rather than misclassifying) |
| adapter-planetscale / adapter-d1 / adapter-better-sqlite3 | N/A (HTTP/local — no socket errors) |