### PR TITLE
docs: fix typos in code comments

### DIFF
--- a/packages/client/src/runtime/core/compositeProxy/createCompositeProxy.ts
+++ b/packages/client/src/runtime/core/compositeProxy/createCompositeProxy.ts
@@ -14,8 +14,7 @@ export interface CompositeProxyLayer<KeyType extends string | symbol = string | 
   getPropertyValue(key: KeyType): unknown
 
   /**
-   * Gets a descriptor for given property. If not implemented or undefined is returned, { enumerable: true, writeable: true, configurable: true} is defaulted
-   * is used
+   * Gets a descriptor for given property. If not implemented or undefined is returned, { enumerable: true, writable: true, configurable: true } is used as the default.
    * @param key
    */
   getPropertyDescriptor?(key: KeyType): PropertyDescriptor | undefined

--- a/packages/client/tests/functional/extensions/query.ts
+++ b/packages/client/tests/functional/extensions/query.ts
@@ -1601,7 +1601,7 @@ testMatrix.setupTestSuite(
             },
             $allModels: {
               async $allOperations({ operation, args, query, model }) {
-                // same as above but also check the the model is User in the if condition
+                // same as above but also check the model is User in the if condition
                 if (model === 'User' && operation === 'aggregate') {
                   const data = await query(args)
 

--- a/packages/client/tests/functional/methods/upsert/native-atomic/tests.ts
+++ b/packages/client/tests/functional/methods/upsert/native-atomic/tests.ts
@@ -232,7 +232,7 @@ testMatrix.setupTestSuite(
           name,
         },
         create: {
-          // Because the the where 'name' is 'not' equal to the create 'name'
+          // Because the where 'name' is 'not' equal to the create 'name'
           name: name + '1',
         },
         update: {
@@ -248,7 +248,7 @@ testMatrix.setupTestSuite(
           name,
         },
         create: {
-          // Because the the where 'name' is 'equal' to the create 'name'
+          // Because the where 'name' is 'equal' to the create 'name'
           name,
         },
         update: {


### PR DESCRIPTION

**Repo:** prisma/prisma (⭐ 39000)
**Type:** docs
**Files changed:** 3
**Lines:** +4/-5

## What
Fixes small typos in inline code comments across the client runtime and
functional tests. In `createCompositeProxy.ts`, corrects `writeable` to
`writable` (the actual `PropertyDescriptor` field name in the JavaScript
spec) and removes a dangling "is used" fragment that left the doc comment
ungrammatical. Also removes duplicated "the the" wording in two test
comments under `packages/client/tests/functional/`.

## Why
The `writeable` typo in the `CompositeProxyLayer.getPropertyDescriptor`
doc comment is actively misleading: it documents a default that uses a
field name (`writeable`) which JavaScript's `Object.defineProperty`
silently ignores — the real key is `writable`. A reader following the
doc could write a layer that returns `{ writeable: false }` and be
surprised when the property is still mutable. The other duplicated-word
typos are minor readability fixes.

## Testing
Comment-only changes; no behavior is affected. Verified the original
`writable` field is what the surrounding code actually reads at
`createCompositeProxy.ts:83` (`layer?.getPropertyDescriptor?.(prop)?.writable`).
No build or test run required.

## Risk
Low — comment-only changes, no runtime or type impact.
