### PR TITLE
fix: remove savepoint operations from the D1 adapter

### DIFF
--- a/packages/adapter-d1/src/d1-http.ts
+++ b/packages/adapter-d1/src/d1-http.ts
@@ -201,15 +201,15 @@ class D1HttpTransaction extends D1HttpQueryable implements Transaction {
   }
 
   async createSavepoint(name: string): Promise<void> {
-    await this.executeRaw({ sql: `SAVEPOINT ${name}`, args: [], argTypes: [] })
+    debug(`[js::createSavepoint] %s`, name)
   }
 
   async rollbackToSavepoint(name: string): Promise<void> {
-    await this.executeRaw({ sql: `ROLLBACK TO ${name}`, args: [], argTypes: [] })
+    debug(`[js::rollbackToSavepoint] %s`, name)
   }
 
   async releaseSavepoint(name: string): Promise<void> {
-    await this.executeRaw({ sql: `RELEASE SAVEPOINT ${name}`, args: [], argTypes: [] })
+    debug(`[js::releaseSavepoint] %s`, name)
   }
 }
 

--- a/packages/adapter-d1/src/d1-worker.ts
+++ b/packages/adapter-d1/src/d1-worker.ts
@@ -121,15 +121,15 @@ class D1WorkerTransaction extends D1WorkerQueryable<StdClient> implements Transa
   }
 
   async createSavepoint(name: string): Promise<void> {
-    await this.executeRaw({ sql: `SAVEPOINT ${name}`, args: [], argTypes: [] })
+    debug(`[js::createSavepoint] %s`, name)
   }
 
   async rollbackToSavepoint(name: string): Promise<void> {
-    await this.executeRaw({ sql: `ROLLBACK TO ${name}`, args: [], argTypes: [] })
+    debug(`[js::rollbackToSavepoint] %s`, name)
   }
 
   async releaseSavepoint(name: string): Promise<void> {
-    await this.executeRaw({ sql: `RELEASE SAVEPOINT ${name}`, args: [], argTypes: [] })
+    debug(`[js::releaseSavepoint] %s`, name)
   }
 }
 


### PR DESCRIPTION
As stated here: https://github.com/prisma/prisma/blob/830f75cd99d13d575c046c66f2dad60c8c86a10a/packages/adapter-d1/src/d1-worker.ts#L195
D1 transactional operations should be ignored. The same should apply to the savenpoints.

Related issue: https://github.com/prisma/prisma/issues/29477