### PR TITLE
fix(adapter-pg): preserve constraint name on 23505 unique-violation

### DIFF
--- a/packages/adapter-pg/src/__tests__/errors.test.ts
+++ b/packages/adapter-pg/src/__tests__/errors.test.ts
@@ -33,11 +33,47 @@ describe('convertDriverError', () => {
     })
   })
 
-  it('should handle UniqueConstraintViolation (23505)', () => {
+  it('should handle UniqueConstraintViolation (23505) with detail only', () => {
     const error = { code: '23505', message: 'msg', severity: 'ERROR', detail: 'Key (id)' }
     expect(convertDriverError(error)).toEqual({
       kind: 'UniqueConstraintViolation',
       constraint: { fields: ['id'] },
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle UniqueConstraintViolation (23505) with constraint only', () => {
+    const error = { code: '23505', message: 'msg', severity: 'ERROR', constraint: 'users_email_partial_idx' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'UniqueConstraintViolation',
+      constraint: { index: 'users_email_partial_idx' },
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle UniqueConstraintViolation (23505) with both constraint and detail (constraint wins)', () => {
+    const error = {
+      code: '23505',
+      message: 'msg',
+      severity: 'ERROR',
+      detail: 'Key (account_id)=(1) already exists.',
+      constraint: 'accounts_owner_partial_idx',
+    }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'UniqueConstraintViolation',
+      constraint: { index: 'accounts_owner_partial_idx' },
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle UniqueConstraintViolation (23505) with neither constraint nor parseable detail', () => {
+    const error = { code: '23505', message: 'msg', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'UniqueConstraintViolation',
+      constraint: undefined,
       originalCode: error.code,
       originalMessage: error.message,
     })

--- a/packages/adapter-pg/src/errors.ts
+++ b/packages/adapter-pg/src/errors.ts
@@ -75,13 +75,23 @@ function mapDriverError(error: DatabaseError): MappedError {
         message: error.message,
       }
     case '23505': {
-      const fields = error.detail
-        ?.match(/Key \(([^)]+)\)/)
-        ?.at(1)
-        ?.split(', ')
+      let constraint: { fields: string[] } | { index: string } | undefined
+
+      if (error.constraint) {
+        constraint = { index: error.constraint }
+      } else {
+        const fields = error.detail
+          ?.match(/Key \(([^)]+)\)/)
+          ?.at(1)
+          ?.split(', ')
+        if (fields !== undefined) {
+          constraint = { fields }
+        }
+      }
+
       return {
         kind: 'UniqueConstraintViolation',
-        constraint: fields !== undefined ? { fields } : undefined,
+        constraint,
       }
     }
     case '23502': {


### PR DESCRIPTION
Fixes #29495.

`@prisma/adapter-pg`'s `mapDriverError` treats `error.constraint` asymmetrically between the unique-violation and foreign-key-violation branches: the 23503 branch already falls back to `{ index: error.constraint }`, but the 23505 branch only looks at `error.detail`. For partial unique indexes the column list from `error.detail` can match multiple constraints on the same table (e.g. one full unique on `(user_id, account_id)` and one partial unique on `(account_id) WHERE role = 'owner'`), and callers can't disambiguate without regex-matching `originalMessage`.

`@prisma/adapter-mariadb` already preserves this on 1062 (see #29344), so postgres was the outlier.

## What changed

In `packages/adapter-pg/src/errors.ts`, the 23505 branch now mirrors the 23503 pattern: if `error.constraint` is set, return `{ index: error.constraint }`; otherwise fall back to the existing `{ fields }` parse from `error.detail`; if neither is available, `constraint` stays `undefined` (unchanged from today).

Constraint precedence matches the reporter's suggested fix: `index` is a single unambiguous identifier for the violated constraint, whereas `fields` alone can be ambiguous for partial unique indexes. This also matches the union shape of `MappedError.UniqueConstraintViolation.constraint` in `@prisma/driver-adapter-utils` (`{ fields } | { index } | { foreignKey }` — one-of, not a combination).

## Before / After

Given `{ code: '23505', detail: 'Key (account_id)=(1) already exists.', constraint: 'accounts_owner_partial_idx' }`:

- Before:
  ```js
  { kind: 'UniqueConstraintViolation', constraint: { fields: ['account_id'] } }
  ```
- After:
  ```js
  { kind: 'UniqueConstraintViolation', constraint: { index: 'accounts_owner_partial_idx' } }
  ```

When `constraint` is absent, behavior is unchanged (still returns `{ fields }` or `undefined`).

## Tests

Added coverage in `packages/adapter-pg/src/__tests__/errors.test.ts` for all four input shapes of the 23505 branch: detail only, constraint only, both (constraint wins), and neither. The existing `adapter-pg` test suite still passes (`pnpm --filter @prisma/adapter-pg test` — 50 tests, all green).