### PR TITLE
fix(docker): make MongoDB replica set init idempotent

### DIFF
--- a/docker/mongodb_replica/Dockerfile
+++ b/docker/mongodb_replica/Dockerfile
@@ -4,9 +4,12 @@ FROM mongo:${MONGO_VERSION}
 
 # we take over the default & start mongo in replica set mode in a background task
 ENTRYPOINT mongod --port $MONGO_REPLICA_PORT --replSet rs0 --bind_ip 0.0.0.0 & MONGOD_PID=$!; \
-# we prepare the replica set with a single node and prepare the root user config
-INIT_REPL_CMD="rs.initiate({ _id: 'rs0', members: [{ _id: 0, host: '$MONGO_REPLICA_HOST:$MONGO_REPLICA_PORT' }] })"; \
-# we wait for the replica set to be ready and then submit the command just above
+# we prepare the replica set with a single node and prepare the root user config.
+# the initiate call is wrapped in try/catch so that a restart with a pre-existing
+# replica set state (AlreadyInitialized / code 23) is treated as success instead
+# of causing the `until` loop below to spin forever, spawning a mongosh every second.
+INIT_REPL_CMD="try { rs.initiate({ _id: 'rs0', members: [{ _id: 0, host: '$MONGO_REPLICA_HOST:$MONGO_REPLICA_PORT' }] }) } catch (e) { if (e.codeName !== 'AlreadyInitialized' && e.code !== 23) { throw e } }"; \
+# we wait for mongod to accept connections and then submit the command just above
 until ($MONGO_COMMAND admin --port $MONGO_REPLICA_PORT --eval "$INIT_REPL_CMD"); do sleep 1; done; \
 # we are done but we keep the container by waiting on signals from the mongo task
 echo "REPLICA SET ONLINE"; wait $MONGOD_PID;


### PR DESCRIPTION
## Problem

The replica-set init script in the shared MongoDB Dockerfile (`docker/mongodb_replica/Dockerfile`, used by both the `mongo` v4 and `mongo6` services in `docker/docker-compose.yml`) uses the following loop to wait for mongod to become ready before seeding the replica set:

```sh
until ($MONGO_COMMAND admin --port $MONGO_REPLICA_PORT --eval "rs.initiate(...)"); do sleep 1; done
```

On first boot this works correctly: `rs.initiate()` succeeds, mongosh exits 0, and the loop terminates.

However, when the container is restarted (`docker restart`, `docker compose up -d` after a stop, host reboot, etc.) with its writable layer still intact — which is the default, since neither service declares a named/bind volume for `/data/db` — the replica set config already exists in the data directory. `rs.initiate()` then returns an `AlreadyInitialized` error (code 23) with a non-zero exit status. The `until` loop treats that as "not ready yet" and retries every second, **forever**.

Each iteration:
- Spawns a fresh mongosh process (heavy V8/JS startup, especially on arm64).
- Opens ~5 TCP connections to mongod for topology discovery.

In a local workspace that had been running for ~19 hours, this had accumulated **~309,000 connections** and was steady-state pinning ~32% of a single CPU core (visible at the host level as the Colima/Lima VM sitting at load average ~1.0).

## Fix

Wrap the `rs.initiate(...)` call in a JS `try`/`catch` that swallows only the `AlreadyInitialized` case (matched by either `codeName` or numeric code `23`). The expression then exits 0 and the `until` loop terminates after a single successful attempt.

Real startup errors (connection refused while mongod is still booting, etc.) still surface as shell failures from mongo/mongosh itself and are retried exactly as before. Any *other* MongoDB error is re-thrown and remains visible in the logs.

Applies to both `mongo` (v4) and `mongo6` services since they share this Dockerfile via the `MONGO_VERSION` build arg. Both `mongo` and `mongosh` support `try`/`catch` with `throw`, so the same JS expression works for either value of `MONGO_COMMAND`.

## Verification

Rebuilt both images and exercised the failure mode locally:

1. **Fresh boot (`mongo6`)**: single `replSetInitiate` attempt, `REPLICA SET ONLINE` printed once, container reports `healthy`, steady-state CPU ~1% (with healthcheck-driven mongosh spawns every 5 s).
2. **Restart with existing replica-set state (`mongo6`)**: this is the bug scenario. After the fix, a single `replSetInitiate` attempt is made, the `AlreadyInitialized` error is caught, `REPLICA SET ONLINE` is printed once, and the loop exits immediately. PID count stays steady (no process leak). Connection IDs grow only at the expected healthcheck rate.
3. **`mongo` (v4)**: same behavior — the v4 shell prints the error object to stdout as text but the `throw` is still caught, so the script exits 0 and the loop terminates. Container reports `healthy`.

Without this fix, step 2 continues spawning a mongosh every second indefinitely.

## Risk

Minimal: the only behavioral change is that an `AlreadyInitialized` error no longer triggers a retry. Every other code path (successful init, transient connection failure during mongod startup, unexpected MongoDB error) is preserved.