### PR TITLE
fix(adapters): preserve constraint name in UniqueConstraintViolation error mapping for Postgres-based adapters

### DIFF
--- a/packages/adapter-neon/src/errors.ts
+++ b/packages/adapter-neon/src/errors.ts
@@ -35,9 +35,17 @@ function mapDriverError(error: DatabaseError): MappedError {
         ?.match(/Key \(([^)]+)\)/)
         ?.at(1)
         ?.split(', ')
+      let constraint: { fields: string[] } | { index: string } | undefined
+
+      if (error.constraint) {
+        constraint = { index: error.constraint }
+      } else if (fields) {
+        constraint = { fields }
+      }
+
       return {
         kind: 'UniqueConstraintViolation',
-        constraint: fields !== undefined ? { fields } : undefined,
+        constraint,
       }
     }
     case '23502': {

--- a/packages/adapter-pg/src/__tests__/errors.test.ts
+++ b/packages/adapter-pg/src/__tests__/errors.test.ts
@@ -33,11 +33,37 @@ describe('convertDriverError', () => {
     })
   })
 
-  it('should handle UniqueConstraintViolation (23505)', () => {
+  it('should handle UniqueConstraintViolation (23505) with detail fields', () => {
     const error = { code: '23505', message: 'msg', severity: 'ERROR', detail: 'Key (id)' }
     expect(convertDriverError(error)).toEqual({
       kind: 'UniqueConstraintViolation',
       constraint: { fields: ['id'] },
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle UniqueConstraintViolation (23505) with constraint name', () => {
+    const error = { code: '23505', message: 'msg', severity: 'ERROR', constraint: 'my_unique_idx' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'UniqueConstraintViolation',
+      constraint: { index: 'my_unique_idx' },
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle UniqueConstraintViolation (23505) with both constraint and detail', () => {
+    const error = {
+      code: '23505',
+      message: 'msg',
+      severity: 'ERROR',
+      detail: 'Key (user_id, account_id)',
+      constraint: 'partial_unique_idx',
+    }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'UniqueConstraintViolation',
+      constraint: { index: 'partial_unique_idx' },
       originalCode: error.code,
       originalMessage: error.message,
     })

--- a/packages/adapter-pg/src/errors.ts
+++ b/packages/adapter-pg/src/errors.ts
@@ -79,9 +79,17 @@ function mapDriverError(error: DatabaseError): MappedError {
         ?.match(/Key \(([^)]+)\)/)
         ?.at(1)
         ?.split(', ')
+      let constraint: { fields: string[] } | { index: string } | undefined
+
+      if (error.constraint) {
+        constraint = { index: error.constraint }
+      } else if (fields) {
+        constraint = { fields }
+      }
+
       return {
         kind: 'UniqueConstraintViolation',
-        constraint: fields !== undefined ? { fields } : undefined,
+        constraint,
       }
     }
     case '23502': {

--- a/packages/adapter-ppg/src/errors.ts
+++ b/packages/adapter-ppg/src/errors.ts
@@ -35,9 +35,17 @@ function mapDriverError(error: DatabaseError): MappedError {
         ?.match(/Key \(([^)]+)\)/)
         ?.at(1)
         ?.split(', ')
+      let constraint: { fields: string[] } | { index: string } | undefined
+
+      if (error.details.constraint) {
+        constraint = { index: error.details.constraint }
+      } else if (fields) {
+        constraint = { fields }
+      }
+
       return {
         kind: 'UniqueConstraintViolation',
-        constraint: fields !== undefined ? { fields } : undefined,
+        constraint,
       }
     }
     case '23502': {


### PR DESCRIPTION
## Summary
- Fixes #29495 by preserving the constraint name (`error.constraint`) in the `UniqueConstraintViolation` error mapping for PostgreSQL-based driver adapters
- Previously, the 23505 case in `adapter-pg`, `adapter-neon`, and `adapter-ppg` only extracted fields from the detail message, dropping the constraint name
- This is problematic for partial unique indexes where multiple constraints share the same key columns — callers couldn't distinguish which constraint was violated

## Changes
- **adapter-pg**: `packages/adapter-pg/src/errors.ts` — 23505 case now uses `error.constraint` as `{ index: constraint_name }` when available, falling back to fields-based extraction
- **adapter-neon**: `packages/adapter-neon/src/errors.ts` — same fix applied
- **adapter-ppg**: `packages/adapter-ppg/src/errors.ts` — same fix applied (using `error.details.constraint`)
- **adapter-pg tests**: Added 2 new unit tests for 23505 with constraint name and with both constraint + detail

## Notes
- The pattern already existed for `ForeignKeyConstraintViolation` (23503) in all three adapters
- `adapter-mariadb` already uses `{ index }` for unique constraint violations (1062)
- No breaking changes — the `MappedError` type already supports `{ index: string }` in the constraint, and `renderConstraint` in the client runtime handles both `fields` and `index`