### PR TITLE
fix(cli): force LF line endings on Windows

### DIFF
--- a/packages/cli/src/Format.ts
+++ b/packages/cli/src/Format.ts
@@ -103,7 +103,7 @@ Or specify a Prisma schema path
     }
 
     for (const [filename, data] of formattedDatamodel) {
-      await fs.writeFile(filename, data)
+           await fs.writeFile(filename, data.replace(/\r\n/g, "\n"))
     }
 
     const after = Math.round(performance.now())


### PR DESCRIPTION
This PR ensures that `prisma format` uses LF line endings on Windows, preventing CRLF inconsistencies.