### PR TITLE
chore(deps): bump postgres-bytea to 1.0.1 to drop Buffer() deprecation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7434,8 +7434,8 @@ packages:
     resolution: {integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==}
     engines: {node: '>=12'}
 
-  postgres-bytea@1.0.0:
-    resolution: {integrity: sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==}
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
     engines: {node: '>=0.10.0'}
 
   postgres-bytea@3.0.0:
@@ -14676,7 +14676,7 @@ snapshots:
     dependencies:
       pg-int8: 1.0.1
       postgres-array: 2.0.0
-      postgres-bytea: 1.0.0
+      postgres-bytea: 1.0.1
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
 
@@ -14760,7 +14760,7 @@ snapshots:
 
   postgres-array@3.0.4: {}
 
-  postgres-bytea@1.0.0: {}
+  postgres-bytea@1.0.1: {}
 
   postgres-bytea@3.0.0:
     dependencies:


### PR DESCRIPTION
## Problem

Reading a `Bytes` column through `@prisma/adapter-neon`, `@prisma/adapter-pg`, or `@prisma/adapter-ppg` emits Node.js `DEP0005` because `pg-types`' `BYTEA` parser is [`postgres-bytea@1.0.0`](https://www.npmjs.com/package/postgres-bytea/v/1.0.0), which still uses the deprecated `new Buffer(...)` constructor.

## Fix

[`postgres-bytea@1.0.1`](https://www.npmjs.com/package/postgres-bytea/v/1.0.1) (released 2025-12-17) swaps `new Buffer(...)` for `Buffer.from || Buffer` and stays inside the `~1.0.0` range that `pg-types` declares, so a lockfile refresh is enough — no `package.json` or source changes are required.

This commit updates the three `pnpm-lock.yaml` references (resolution block, snapshot block, and the single consumer entry under `pg-types@2.x`) from `1.0.0` to `1.0.1`. `pnpm install --lockfile-only --frozen-lockfile` round-trips cleanly.

The previous version of this PR inlined a hand-written replacement parser across the three adapters. Thanks to @aqrln for [pointing out](https://github.com/prisma/prisma/pull/29538#issuecomment-4485884504) that the upstream fix had already landed and the change reduces to a transitive bump.

Refs [`brianc/node-postgres#2426`](https://github.com/brianc/node-postgres/issues/2426).