### PR TITLE
fix: print update-available notice to stdout instead of stderr

### DIFF
--- a/packages/cli/src/__tests__/printUpdateMessage.test.ts
+++ b/packages/cli/src/__tests__/printUpdateMessage.test.ts
@@ -24,7 +24,7 @@ function printUpdateMessageFromTo(from: string, to: string): void {
   })
 }
 
-const consoleErrorMock = jest.spyOn(console, 'error').mockImplementation()
+const consoleLogMock = jest.spyOn(console, 'log').mockImplementation()
 
 let originalPrismaHideUpdateMessageEnv: string | undefined
 
@@ -34,13 +34,13 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  consoleErrorMock.mockReset()
+  consoleLogMock.mockReset()
   process.env.PRISMA_HIDE_UPDATE_MESSAGE = originalPrismaHideUpdateMessageEnv
 })
 
 test('normal release', () => {
   printUpdateMessageFromTo('4.5.0', '4.6.0')
-  expect(consoleErrorMock.mock.calls[0][0]).toMatchInlineSnapshot(`
+  expect(consoleLogMock.mock.calls[0][0]).toMatchInlineSnapshot(`
     "┌─────────────────────────────────────────────────────────┐
     │  Update available 4.5.0 -> 4.6.0                        │
     │  Run the following to update                            │
@@ -52,7 +52,7 @@ test('normal release', () => {
 
 test('integration version with long name', () => {
   printUpdateMessageFromTo('4.5.0-integration-use-keep-alive-for-node-fetch.1', '4.6.0')
-  expect(consoleErrorMock.mock.calls[0][0]).toMatchInlineSnapshot(`
+  expect(consoleLogMock.mock.calls[0][0]).toMatchInlineSnapshot(`
     "┌───────────────────────────────────────────────────────────────────────────────┐
     │  Update available 4.5.0-integration-use-keep-alive-for-node-fetch.1 -> 4.6.0  │
     │  Run the following to update                                                  │

--- a/packages/cli/src/utils/printUpdateMessage.ts
+++ b/packages/cli/src/utils/printUpdateMessage.ts
@@ -45,7 +45,7 @@ export function printUpdateMessage(checkResult: Check.Result | 0 | void): void {
     horizontalPadding: 2,
   })
 
-  console.error(boxedMessage)
+  console.log(boxedMessage)
 }
 
 function makeInstallCommand(


### PR DESCRIPTION
## Summary

Fixes #29541

This PR fixes a logging issue where the "Update available" notice is printed to stderr instead of stdout, causing log aggregators to incorrectly classify it as an error.

## Problem

The "Update available" notice is printed to **stderr** via `console.error()`. In container/CI environments, log aggregators (Datadog, GCP Cloud Logging, AWS CloudWatch, Loki, etc.) classify any line on stderr as severity `error` by default. This means an *informational* update notice surfaces in observability tools as a recurring **error**, which is misleading and pollutes alerting/dashboards.

### Impact

- **Datadog Agent's docker log integration** marks every stderr line as `status:error` by default. Result: the box-drawing notice shows up in Datadog as a recurring `error`-severity event every time a new container starts and runs `prisma migrate deploy`.
- Similar behavior in Loki/Promtail (`level=error`), AWS CloudWatch (with default JSON parsers), and GCP Cloud Logging (`severity: ERROR` for stderr).
- Causes false-positive "errors" in dashboards, alerts, and monitor queries, even though Prisma is functioning normally.

### Current Workarounds

Users currently rely on:

1. Set `PRISMA_HIDE_UPDATE_MESSAGE=true` — works, but suppresses the notice entirely (defeats the purpose of having it).
2. Redirect stderr to stdout in the container entrypoint (`2>&1`) — works for the notice, but also collapses real errors to stdout, which is worse.
3. Add a custom log-pipeline rule in the aggregator that re-tags messages matching `/Update available .* -> .*/` to severity `info` — surgical, but lives outside the application repo and adds operational complexity per environment.

## Solution

Change `console.error()` to `console.log()` in `printUpdateMessage()`. The notice is informational by nature and doesn't reflect a failure of the user's command. It should be printed to **stdout** so log aggregators classify it as `info`.

This is a single-line fix that eliminates the need for any of the workarounds above.

## Changes

- `packages/cli/src/utils/printUpdateMessage.ts`
  - Change `console.error(boxedMessage)` to `console.log(boxedMessage)`
- `packages/cli/src/__tests__/printUpdateMessage.test.ts`
  - Update test mocks from `console.error` to `console.log`
  - Update all test assertions to use `consoleLogMock` instead of `consoleErrorMock`

## Testing

- Updated existing unit tests to verify the message is now printed to stdout
- All tests pass with the new behavior
- The notice content and formatting remain unchanged

## Before/After

**Before:**
```bash
prisma migrate deploy 2>&1 >/dev/null
# Output: Update available notice (proves it was on stderr)
```

**After:**
```bash
prisma migrate deploy 2>&1 >/dev/null
# Output: (empty - notice is now on stdout)
```

## Environment

- OS: Alpine Linux 3.22 (any container OS reproduces)
- Node.js: v24.14.0
- Prisma version: 6.19.2