### PR TITLE
feat(cli): warn on global local version mismatch

### DIFF
--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -32,6 +32,7 @@ import { Watcher } from './generate/Watcher'
 import { breakingChangesMessage } from './utils/breakingChanges'
 import { handleNpsSurvey } from './utils/nps/survey'
 import { simpleDebounce } from './utils/simpleDebounce'
+import { getVersionMismatchWarning, type VersionMismatchWarningOptions } from './utils/version-mismatch-warning'
 
 const pkg = eval(`require('../package.json')`)
 
@@ -40,9 +41,14 @@ const pkg = eval(`require('../package.json')`)
  */
 export class Generate implements Command {
   surveyHandler: () => Promise<void>
+  versionMismatchWarningOptions?: VersionMismatchWarningOptions
 
-  constructor(surveyHandler: () => Promise<void> = handleNpsSurvey) {
+  constructor(
+    surveyHandler: () => Promise<void> = handleNpsSurvey,
+    versionMismatchWarningOptions?: VersionMismatchWarningOptions,
+  ) {
     this.surveyHandler = surveyHandler
+    this.versionMismatchWarningOptions = versionMismatchWarningOptions
   }
 
   public static new(): Generate {
@@ -229,6 +235,15 @@ Please run \`prisma generate\` manually.`
     const hideHints = args['--no-hints'] ?? false
 
     if (!watchMode) {
+      const versionMismatchWarning = logger.should.warn()
+        ? await getVersionMismatchWarning({
+            cwd: baseDir,
+            globalVersion: pkg.version,
+            ...this.versionMismatchWarningOptions,
+          })
+        : null
+      const globalLocalVersionWarning = versionMismatchWarning ? `\n\n${versionMismatchWarning}` : ''
+
       const prismaClientJSGenerator = generators?.find(
         ({ options }) =>
           options?.generator.provider && parseEnvValue(options?.generator.provider) === BuiltInProvider.PrismaClientJs,
@@ -253,16 +268,18 @@ Please make sure they have the same version.`
             : ''
 
         if (hideHints) {
-          hint = `${breakingChangesStr}${versionsWarning}`
+          hint = `${breakingChangesStr}${versionsWarning}${globalLocalVersionWarning}`
         } else {
           hint = `
 Start by importing your Prisma Client (See: https://pris.ly/d/importing-client)
 
-${breakingChangesStr}${versionsWarning}`
+${breakingChangesStr}${versionsWarning}${globalLocalVersionWarning}`
         }
+      } else {
+        hint = globalLocalVersionWarning
       }
 
-      const message = '\n' + this.logText + (hasJsClient && !this.hasGeneratorErrored ? hint : '')
+      const message = '\n' + this.logText + (!this.hasGeneratorErrored ? hint : '')
 
       if (this.hasGeneratorErrored) {
         throw new Error(message)

--- a/packages/cli/src/__tests__/commands/Generate.test.ts
+++ b/packages/cli/src/__tests__/commands/Generate.test.ts
@@ -257,6 +257,34 @@ it('should hide hints with --no-hints', async () => {
   `)
 })
 
+it('should show a global/local version mismatch warning', async () => {
+  ctx.fixture('example-project')
+  const generate = new Generate(jest.fn(), {
+    isGlobalInstall: () => 'npm',
+    getPrismaClientVersion: () => Promise.resolve('5.0.0'),
+    getPackageJsonVersion: () => Promise.resolve('6.0.0'),
+  })
+
+  const result = await generate.parse([], await ctx.config())
+
+  expect(result).toContain('globally installed')
+  expect(result).toContain('@prisma/client@5.0.0')
+})
+
+it('should keep global/local version mismatch warnings with --no-hints', async () => {
+  ctx.fixture('example-project')
+  const generate = new Generate(jest.fn(), {
+    isGlobalInstall: () => 'npm',
+    getPrismaClientVersion: () => Promise.resolve(null),
+    getPackageJsonVersion: () => Promise.resolve('5.0.0'),
+  })
+
+  const result = await generate.parse(['--no-hints'], await ctx.config())
+
+  expect(result).toContain('prisma@5.0.0')
+  expect(result).not.toContain('Start by importing your Prisma Client')
+})
+
 it('should call the survey handler when hints are not disabled', async () => {
   ctx.fixture('example-project')
   const handler = jest.fn()

--- a/packages/cli/src/__tests__/version-mismatch-warning.test.ts
+++ b/packages/cli/src/__tests__/version-mismatch-warning.test.ts
@@ -1,0 +1,107 @@
+import {
+  formatVersionMismatchWarning,
+  getVersionMismatchWarning,
+  normalizeVersion,
+} from '../utils/version-mismatch-warning'
+
+describe('version mismatch warning', () => {
+  it('does not warn when Prisma is not running from a global install', async () => {
+    await expect(
+      getVersionMismatchWarning({
+        globalVersion: '6.0.0',
+        isGlobalInstall: () => false,
+      }),
+    ).resolves.toBeNull()
+  })
+
+  it('warns when global Prisma and local @prisma/client do not match', async () => {
+    await expect(
+      getVersionMismatchWarning({
+        cwd: process.cwd(),
+        globalVersion: '6.0.0',
+        isGlobalInstall: () => 'npm',
+        getPrismaClientVersion: () => Promise.resolve('5.0.0'),
+        getPackageJsonVersion: () => Promise.resolve(null),
+      }),
+    ).resolves.toContain('@prisma/client@5.0.0')
+  })
+
+  it('warns when global Prisma and local prisma do not match', async () => {
+    await expect(
+      getVersionMismatchWarning({
+        cwd: process.cwd(),
+        globalVersion: '6.0.0',
+        isGlobalInstall: () => 'npm',
+        getPrismaClientVersion: () => Promise.resolve(null),
+        getPackageJsonVersion: () => Promise.resolve('5.0.0'),
+      }),
+    ).resolves.toContain('prisma@5.0.0')
+  })
+
+  it('shows both mismatched local packages when both are out of sync', async () => {
+    const result = await getVersionMismatchWarning({
+      cwd: process.cwd(),
+      globalVersion: '6.0.0',
+      isGlobalInstall: () => 'npm',
+      getPrismaClientVersion: () => Promise.resolve('5.1.0'),
+      getPackageJsonVersion: () => Promise.resolve('5.0.0'),
+    })
+
+    expect(result).toContain('prisma@5.0.0')
+    expect(result).toContain('@prisma/client@5.1.0')
+  })
+
+  it('uses project package manager in the suggested command', async () => {
+    const result = await getVersionMismatchWarning({
+      cwd: process.cwd(),
+      globalVersion: '6.0.0',
+      isGlobalInstall: () => 'npm',
+      getPrismaClientVersion: () => Promise.resolve('5.0.0'),
+      getPackageJsonVersion: () => Promise.resolve(null),
+      detectPackageManager: () => 'pnpm',
+    })
+
+    expect(result).toContain('pnpm prisma generate')
+  })
+
+  it('does not warn for matching versions', async () => {
+    await expect(
+      getVersionMismatchWarning({
+        cwd: process.cwd(),
+        globalVersion: '6.0.0',
+        isGlobalInstall: () => 'npm',
+        getPrismaClientVersion: () => Promise.resolve('6.0.0'),
+        getPackageJsonVersion: () => Promise.resolve('^6.0.0'),
+      }),
+    ).resolves.toBeNull()
+  })
+
+  it('skips package specifiers that cannot be safely compared', async () => {
+    await expect(
+      getVersionMismatchWarning({
+        cwd: process.cwd(),
+        globalVersion: '6.0.0',
+        isGlobalInstall: () => 'npm',
+        getPrismaClientVersion: () => Promise.resolve('workspace:*'),
+        getPackageJsonVersion: () => Promise.resolve('latest'),
+      }),
+    ).resolves.toBeNull()
+  })
+
+  it('normalizes exact, caret, tilde, and prerelease versions', () => {
+    expect(normalizeVersion('6.0.0')).toBe('6.0.0')
+    expect(normalizeVersion('^6.0.0')).toBe('6.0.0')
+    expect(normalizeVersion('~6.0.0')).toBe('6.0.0')
+    expect(normalizeVersion('6.0.0-dev.1')).toBe('6.0.0-dev.1')
+  })
+
+  it('formats a clear warning', () => {
+    expect(
+      formatVersionMismatchWarning({
+        packageName: '@prisma/client',
+        globalVersion: '6.0.0',
+        localVersion: '5.0.0',
+      }),
+    ).toContain('npx prisma generate')
+  })
+})

--- a/packages/cli/src/utils/version-mismatch-warning.ts
+++ b/packages/cli/src/utils/version-mismatch-warning.ts
@@ -33,7 +33,7 @@ export async function getVersionMismatchWarning(options: VersionMismatchWarningO
   }
 
   const cwd = options.cwd ?? process.cwd()
-  const globalVersion = normalizeVersion(options.globalVersion ?? '')
+  const globalVersion = normalizeVersion(options.globalVersion)
 
   if (!globalVersion) {
     return null

--- a/packages/cli/src/utils/version-mismatch-warning.ts
+++ b/packages/cli/src/utils/version-mismatch-warning.ts
@@ -1,0 +1,162 @@
+import { isCurrentBinInstalledGlobally } from '@prisma/internals'
+import fs from 'fs'
+import { bold, yellow } from 'kleur/colors'
+import { packageUp } from 'package-up'
+import path from 'path'
+
+import { getInstalledPrismaClientVersion } from './getClientVersion'
+
+export type PackageName = 'prisma' | '@prisma/client'
+
+export type VersionMismatchWarningOptions = {
+  cwd?: string
+  globalVersion?: string
+  isGlobalInstall?: () => 'npm' | false
+  getPrismaClientVersion?: (cwd: string) => Promise<string | null>
+  getPackageJsonVersion?: (cwd: string, packageName: PackageName) => Promise<string | null>
+  detectPackageManager?: (cwd: string) => PackageManager
+}
+
+type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun'
+
+export type VersionMismatch = {
+  packageName: PackageName
+  globalVersion: string
+  localVersion: string
+}
+
+export async function getVersionMismatchWarning(options: VersionMismatchWarningOptions = {}): Promise<string | null> {
+  const isGlobalInstall = options.isGlobalInstall ?? isCurrentBinInstalledGlobally
+
+  if (!isGlobalInstall()) {
+    return null
+  }
+
+  const cwd = options.cwd ?? process.cwd()
+  const globalVersion = normalizeVersion(options.globalVersion ?? '')
+
+  if (!globalVersion) {
+    return null
+  }
+
+  const getClientVersion = options.getPrismaClientVersion ?? getInstalledPrismaClientVersion
+  const getPackageVersion = options.getPackageJsonVersion ?? getPackageJsonVersion
+  const detectPackageManager = options.detectPackageManager ?? detectPackageManagerFromProject
+
+  const localClientVersion = normalizeVersion(await getClientVersion(cwd))
+  const localPrismaVersion = normalizeVersion(await getPackageVersion(cwd, 'prisma'))
+  const packageManager = detectPackageManager(cwd)
+
+  const mismatches = [
+    findMismatch('prisma', globalVersion, localPrismaVersion),
+    findMismatch('@prisma/client', globalVersion, localClientVersion),
+  ].filter((mismatch): mismatch is VersionMismatch => Boolean(mismatch))
+
+  if (mismatches.length === 0) {
+    return null
+  }
+
+  return formatVersionMismatchWarning(mismatches, packageManager)
+}
+
+export function formatVersionMismatchWarning(
+  mismatch: VersionMismatch | VersionMismatch[],
+  packageManager: PackageManager = 'npm',
+): string {
+  const mismatches = Array.isArray(mismatch) ? mismatch : [mismatch]
+  const globalVersion = mismatches[0]?.globalVersion
+  const localVersions = mismatches
+    .map(({ packageName, localVersion }) => bold(`${packageName}@${localVersion}`))
+    .join(' and ')
+
+  return `${yellow(bold('warn'))} The globally installed ${bold(`prisma@${globalVersion}`)} does not match the local ${localVersions}.
+This can lead to unexpected behavior when running ${bold('prisma generate')}.
+Install matching versions locally and run ${bold(getPrismaGenerateCommand(packageManager))} to use the project version.`
+}
+
+function findMismatch(
+  packageName: PackageName,
+  globalVersion: string,
+  localVersion: string | null,
+): VersionMismatch | null {
+  if (!localVersion || localVersion === globalVersion) {
+    return null
+  }
+
+  return {
+    packageName,
+    globalVersion,
+    localVersion,
+  }
+}
+
+export async function getPackageJsonVersion(cwd: string, packageName: PackageName): Promise<string | null> {
+  try {
+    const packageJsonPath = await packageUp({ cwd })
+
+    if (!packageJsonPath) {
+      return null
+    }
+
+    const packageJsonString = await fs.promises.readFile(packageJsonPath, 'utf-8')
+    const packageJson = JSON.parse(packageJsonString)
+
+    return (
+      packageJson.dependencies?.[packageName] ??
+      packageJson.devDependencies?.[packageName] ??
+      packageJson.peerDependencies?.[packageName] ??
+      null
+    )
+  } catch {
+    return null
+  }
+}
+
+export function normalizeVersion(version: string | null | undefined): string | null {
+  if (!version) {
+    return null
+  }
+
+  const trimmed = version.trim()
+
+  if (trimmed.startsWith('workspace:') || /^[a-z]+$/i.test(trimmed)) {
+    return null
+  }
+
+  const match = trimmed.match(/^[~^]?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)/)
+
+  return match?.[1] ?? null
+}
+
+function detectPackageManagerFromProject(cwd: string): PackageManager {
+  if (fs.existsSync(path.join(cwd, 'pnpm-lock.yaml'))) return 'pnpm'
+  if (fs.existsSync(path.join(cwd, 'yarn.lock'))) return 'yarn'
+  if (fs.existsSync(path.join(cwd, 'bun.lock')) || fs.existsSync(path.join(cwd, 'bun.lockb'))) return 'bun'
+
+  const packageJsonPath = path.join(cwd, 'package.json')
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
+    const packageManager = packageJson.packageManager as string | undefined
+
+    if (packageManager?.startsWith('pnpm')) return 'pnpm'
+    if (packageManager?.startsWith('yarn')) return 'yarn'
+    if (packageManager?.startsWith('bun')) return 'bun'
+  } catch {
+    // Fall back to npm when the project package manager cannot be determined.
+  }
+
+  return 'npm'
+}
+
+function getPrismaGenerateCommand(packageManager: PackageManager): string {
+  switch (packageManager) {
+    case 'pnpm':
+      return 'pnpm prisma generate'
+    case 'yarn':
+      return 'yarn prisma generate'
+    case 'bun':
+      return 'bun prisma generate'
+    case 'npm':
+      return 'npx prisma generate'
+  }
+}


### PR DESCRIPTION
/claim #1911

## Summary
- add a global/local Prisma version mismatch warning to `prisma generate`
- compare the running global CLI version against local `prisma` and `@prisma/client` versions when the CLI is installed globally
- avoid noisy false positives for non-exact specifiers such as `workspace:*` or dist tags
- include project-package-manager-specific guidance (`npx`, `pnpm`, `yarn`, or `bun`) so users can run the local Prisma CLI

## Verification
- `nvm use 20.19.4; pnpm --filter prisma test -- src/__tests__/version-mismatch-warning.test.ts`
- `nvm use 20.19.4; pnpm exec turbo build --filter=prisma`
- `git diff --check HEAD~1 HEAD`

Note: I also added focused `Generate.test.ts` coverage for the user-facing `generate` output path, but the full `Generate.test.ts` fixture suite is blocked on this Windows environment by symlink permissions (`EPERM: operation not permitted, symlink ... node_modules/@prisma/client`). The helper suite and filtered CLI build pass locally.