### PR TITLE
fix: output path of current Prisma binary in -v (closes #7771)

### DIFF
--- a/packages/cli/src/Version.ts
+++ b/packages/cli/src/Version.ts
@@ -17,6 +17,7 @@ import {
 } from '@prisma/internals'
 import { bold, dim, red } from 'kleur/colors'
 import os from 'os'
+import path from 'path'
 
 import { getInstalledPrismaClientVersion } from './utils/getClientVersion'
 
@@ -81,6 +82,7 @@ export class Version implements Command {
 
     const rows = [
       [packageJson.name, packageJson.version],
+      ['CLI Path', path.resolve(process.argv[1])],
       ['@prisma/client', prismaClientVersion ?? 'Not found'],
       ['Operating System', os.platform()],
       ['Architecture', os.arch()],

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -13,6 +13,7 @@ describe('version', () => {
     expect(data.exitCode).toBe(0)
     expect(cleanSnapshot(data.stdout)).toMatchInlineSnapshot(`
       "prisma               : 0.0.0
+      CLI Path             : sanitized_path
       @prisma/client       : 0.0.0
       Operating System     : OS
       Architecture         : ARCHITECTURE
@@ -33,6 +34,9 @@ describe('version', () => {
 })
 
 function cleanSnapshot(str: string, versionOverride?: string): string {
+  // sanitize CLI path
+  str = str.replace(new RegExp('(CLI Path\\s+:).*', 'g'), '$1 sanitized_path')
+
   // sanitize engine path
   // Schema Engine : schema-engine e996df5d66a2314d1da15d31047f9777fc2fbdd9 (at ../../home/runner/work/prisma/prisma/node_modules/.pnpm/@prisma+engines@3.11.0-41.e996df5d66a2314d1da15d31047f9777fc2fbdd9/node_modules/@prisma/engines/schema-engine-TEST_PLATFORM)
   // +


### PR DESCRIPTION
## Summary
- Adds `CLI Path` to the `prisma -v` / `prisma version` output
- Uses `path.resolve(process.argv[1])` to show the absolute path of the executed Prisma binary
- Updates the `Version.test.ts` snapshot and adds path sanitization for cross-platform test stability

Closes #7771

/claim #7771