### PR TITLE
chore: disable scheduled CI; run on push/PR/manual dispatch

### DIFF
--- a/.github/workflows/daily-buildpulse.yml
+++ b/.github/workflows/daily-buildpulse.yml
@@ -2,9 +2,12 @@ name: Daily BuildPulse run
 
 on:
   workflow_dispatch:
-  schedule:
-    # https://crontab.guru - “At every 30th minute past every hour from 3 through 4.”
-    - cron: '*/30 3-4 * * *'
+  # Scheduled trigger disabled: ORM iteration is paused; flaky-test
+  # analytics uploads run on demand. Restore the `schedule:` block below
+  # to re-enable.
+  # schedule:
+  #   # https://crontab.guru - “At every 30th minute past every hour from 3 through 4.”
+  #   - cron: '*/30 3-4 * * *'
 
 jobs:
   run_tests:

--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -2,9 +2,10 @@ name: Daily Test
 
 on:
   workflow_dispatch:
-  schedule:
-    # 4am daily Mon-Fri
-    - cron: '0 4 * * 1-5'
+  # Scheduled trigger disabled: ORM iteration is paused; the daily matrix
+  # is run on demand. Restore the `schedule:` block below to re-enable.
+  # schedule:
+  #   - cron: '0 4 * * 1-5'
 
 jobs:
   run_tests:

--- a/README.md
+++ b/README.md
@@ -371,5 +371,5 @@ Refer to our [contribution guidelines](https://github.com/prisma/prisma/blob/mai
 
 - Prisma Tests Status:
   [![Prisma Tests Status](https://github.com/prisma/prisma/workflows/CI/badge.svg)](https://github.com/prisma/prisma/actions/workflows/test.yml?query=branch%3Amain)
-- Ecosystem Tests Status:
-  [![Ecosystem Tests Status](https://github.com/prisma/ecosystem-tests/workflows/test/badge.svg)](https://github.com/prisma/ecosystem-tests/actions/workflows/test.yaml?query=branch%3Adev)
+
+Scheduled CI is currently disabled across the ORM repos; test workflows run on push, pull request, and manual `workflow_dispatch`. See the [Actions tab](https://github.com/prisma/prisma/actions) for recent runs.


### PR DESCRIPTION
## Summary

Disables the `schedule:` triggers on the two scheduled test workflows in this repo so they stop spending CI minutes while ORM iteration is paused. They remain runnable on demand via `workflow_dispatch`. Also removes the cross-repo `Ecosystem Tests Status` badge from the README so it can't go stale-red after the corresponding schedule is disabled in `prisma/ecosystem-tests`.

Workflows affected:

- `.github/workflows/daily-test.yml` (was `0 4 * * 1-5`).
- `.github/workflows/daily-buildpulse.yml` (was `*/30 3-4 * * *`).

Not touched (intentionally):

- `test.yml` — push/PR-driven; keeps running normally on `main`.
- `codeql-analysis.yml` — security scans are cheap and stay.
- `auto-close-github-discussions.yml`, `label-stale-issues.yml` — community housekeeping; negligible spend, stays.

The `schedule:` blocks are commented out rather than deleted so re-enabling is a one-PR uncomment when ORM iteration resumes.

## Context

Part of a coordinated effort across the Prisma ORM repos. Other PRs in flight:

- `prisma/action-status-check#10` — pauses the daily Slack digest (deploys after merge).
- `prisma/ecosystem-tests#5996` — disables `check-for-update`, `cleanup-clouds`, `failing-weekly`; removes the CI status badge table.
- `prisma/language-tools` (next) — disables `1_check_for_updates`, `e2e_check_for_new_published_vsix`, `update-api-types`; removes the `e2e-vsix` badge.

`prisma/prisma-engines` and `prisma/engines-wrapper` have no scheduled workflows.

Full project spec: `projects/disable-scheduled-ci/spec.md` in this repo (transient — will be deleted at close-out).

## Verification

- No workflow files are deleted; both modified workflows retain `workflow_dispatch:`.
- README diff is limited to the two badge lines.

## To re-enable later

For each workflow, uncomment its `schedule:` block. To restore the README badge, revert the README hunk of this commit.

## Acceptance criteria covered (from project spec)

- AC1: no `schedule:` triggers remain on `daily-test.yml` or `daily-buildpulse.yml`.
- AC4: each modified workflow still has `workflow_dispatch:`.
- AC5: README no longer carries the `Ecosystem Tests Status` badge; `Prisma Tests Status` remains.
- AC10: diff is limited to `schedule:` removal and the listed badge.
- AC11: README sentence explains that scheduled CI is disabled and how it still runs.