### PR TITLE
fix(format): normalize schema line endings

### DIFF
--- a/packages/internals/src/__tests__/engine-commands/formatSchema.test.ts
+++ b/packages/internals/src/__tests__/engine-commands/formatSchema.test.ts
@@ -168,23 +168,35 @@ describe('format', () => {
         '/* schemaPath */',
         'datasource db {\r\n  provider = "sqlite"\r\n}\r\n\r\nmodel User {\r\n  id String @id\r\n}\r\n',
       ],
+      [
+        '/* legacySchemaPath */',
+        'datasource db {\r  provider = "sqlite"\r}\r\rmodel Post {\r  id String @id\r}\r',
+      ],
     ]
 
     const formatted = await formatSchema({ schemas })
     const formattedContent: string[] = extractSchemaContent(formatted)
 
-    expect(formattedContent).toHaveLength(1)
-    expect(formattedContent[0]).not.toContain('\r')
-    expect(formattedContent[0]).toMatchInlineSnapshot(`
-      "datasource db {
-        provider = "sqlite"
-      }
+    expect(formattedContent).toHaveLength(2)
+    expect(formattedContent).toEqual([
+      `datasource db {
+  provider = "sqlite"
+}
 
-      model User {
-        id String @id
-      }
-      "
-    `)
+model User {
+  id String @id
+}
+`,
+      `datasource db {
+  provider = "sqlite"
+}
+
+model Post {
+  id String @id
+}
+`,
+    ])
+    expect(formattedContent).toEqual(formattedContent.map((content) => content.replaceAll('\r', '')))
   })
 
   test('valid schema with 1 preview feature flag warning', async () => {

--- a/packages/internals/src/__tests__/engine-commands/formatSchema.test.ts
+++ b/packages/internals/src/__tests__/engine-commands/formatSchema.test.ts
@@ -162,6 +162,31 @@ describe('format', () => {
     expect(formattedContent[0]).toMatchSnapshot()
   })
 
+  test('normalizes formatted schema output to LF line endings', async () => {
+    const schemas: MultipleSchemas = [
+      [
+        '/* schemaPath */',
+        'datasource db {\r\n  provider = "sqlite"\r\n}\r\n\r\nmodel User {\r\n  id String @id\r\n}\r\n',
+      ],
+    ]
+
+    const formatted = await formatSchema({ schemas })
+    const formattedContent: string[] = extractSchemaContent(formatted)
+
+    expect(formattedContent).toHaveLength(1)
+    expect(formattedContent[0]).not.toContain('\r')
+    expect(formattedContent[0]).toMatchInlineSnapshot(`
+      "datasource db {
+        provider = "sqlite"
+      }
+
+      model User {
+        id String @id
+      }
+      "
+    `)
+  })
+
   test('valid schema with 1 preview feature flag warning', async () => {
     const schema = /* prisma */ `
       generator client {

--- a/packages/internals/src/engine-commands/formatSchema.ts
+++ b/packages/internals/src/engine-commands/formatSchema.ts
@@ -45,7 +45,7 @@ export async function formatSchema(
   const { formattedMultipleSchemas, lintDiagnostics } = handleFormatPanic(() => {
     // the only possible error here is a Rust panic
     const formattedMultipleSchemasRaw = formatWasm(JSON.stringify(schemas), documentFormattingParams)
-    const formattedMultipleSchemas = JSON.parse(formattedMultipleSchemasRaw) as MultipleSchemas
+    const formattedMultipleSchemas = normalizeLineEndings(JSON.parse(formattedMultipleSchemasRaw) as MultipleSchemas)
 
     const lintDiagnostics = lintSchema({ schemas: formattedMultipleSchemas })
     return { formattedMultipleSchemas, lintDiagnostics }
@@ -58,6 +58,10 @@ export async function formatSchema(
   }
 
   return Promise.resolve(formattedMultipleSchemas)
+}
+
+function normalizeLineEndings(schemas: MultipleSchemas): MultipleSchemas {
+  return schemas.map(([filename, schema]) => [filename, schema.replace(/\r\n?/g, '\n')])
 }
 
 function handleFormatPanic<T>(tryCb: () => T) {


### PR DESCRIPTION
Fixes #8548.\n\nThis normalizes formatter output to LF line endings in the shared formatSchema internals path before linting/returning formatted schemas. It also adds a regression test with CRLF input to assert formatted schema content contains no carriage returns.\n\nVerification: not run locally; Prisma requires pnpm >=10.15 <11, while the available installed pnpm is 11.0.8.