### PR TITLE
fix(cli): confirm global Prisma usage

### DIFF
--- a/packages/cli/src/CLI.ts
+++ b/packages/cli/src/CLI.ts
@@ -6,6 +6,7 @@ import { arg, drawBox, format, HelpError, isError, link, unknownCommand } from '
 import { bold, dim, green, red } from 'kleur/colors'
 
 import { runCheckpointClientCheck } from './utils/checkpoint'
+import { confirmUsingGlobalPrisma } from './utils/localPrisma'
 import { printUpdateMessage } from './utils/printUpdateMessage'
 import { Version } from './Version'
 
@@ -72,6 +73,13 @@ export class CLI implements Command {
           /* noop */
         },
       )
+
+      const shouldUseGlobalPrisma = await confirmUsingGlobalPrisma(cmdName, baseDir)
+      if (!shouldUseGlobalPrisma) {
+        return new HelpError(
+          `\n${bold(red('!'))} Use the local Prisma CLI instead, for example \`npx prisma ${cmdName}\`.\n`,
+        )
+      }
 
       // if we have that subcommand, let's ensure that the binary is there in case the command needs it
       if (this.ensureBinaries.includes(cmdName)) {

--- a/packages/cli/src/CLI.ts
+++ b/packages/cli/src/CLI.ts
@@ -67,19 +67,19 @@ export class CLI implements Command {
 
     const cmd = this.cmds[cmdName]
     if (cmd) {
-      // Only track if the command actually exists
-      const checkResultPromise = runCheckpointClientCheck({ schemaPathFromConfig: config.schema, baseDir }).catch(
-        () => {
-          /* noop */
-        },
-      )
-
       const shouldUseGlobalPrisma = await confirmUsingGlobalPrisma(cmdName, baseDir)
       if (!shouldUseGlobalPrisma) {
         return new HelpError(
           `\n${bold(red('!'))} Use the local Prisma CLI instead, for example \`npx prisma ${cmdName}\`.\n`,
         )
       }
+
+      // Only track if the command actually exists and will run.
+      const checkResultPromise = runCheckpointClientCheck({ schemaPathFromConfig: config.schema, baseDir }).catch(
+        () => {
+          /* noop */
+        },
+      )
 
       // if we have that subcommand, let's ensure that the binary is there in case the command needs it
       if (this.ensureBinaries.includes(cmdName)) {

--- a/packages/cli/src/__tests__/commands/CLI.test.ts
+++ b/packages/cli/src/__tests__/commands/CLI.test.ts
@@ -1,8 +1,18 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { confirm } from '@inquirer/prompts'
 import { defaultTestConfig } from '@prisma/config'
 import { jestConsoleContext, jestContext } from '@prisma/get-platform'
+import { HelpError } from '@prisma/internals'
 
 import { CLI } from '../../CLI'
 import { Validate } from '../../Validate'
+
+jest.mock('@inquirer/prompts', () => ({
+  confirm: jest.fn(),
+}))
 
 const ctx = jestContext.new().add(jestConsoleContext()).assemble()
 
@@ -36,16 +46,28 @@ function createCLI(download = jest.fn()) {
   )
 }
 
+function createTempProjectWithLocalPrismaBin(): string {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prisma-cli-local-'))
+  fs.mkdirSync(path.join(tmpDir, 'node_modules', '.bin'), { recursive: true })
+  fs.writeFileSync(path.join(tmpDir, 'node_modules', '.bin', 'prisma'), '', 'utf-8')
+  return tmpDir
+}
+
 describe('CLI', () => {
   const download = jest.fn()
   let cliInstance: CLI
+  const stdin = process.stdin as NodeJS.ReadStream & { isTTY?: boolean }
+  const originalIsTTY = stdin.isTTY
 
   beforeEach(() => {
     cliInstance = createCLI(download)
+    stdin.isTTY = true
+    jest.mocked(confirm).mockReset()
   })
 
   afterEach(() => {
     download.mockClear()
+    stdin.isTTY = originalIsTTY
   })
 
   describe('ensureNeededBinariesExist', () => {
@@ -89,5 +111,37 @@ describe('CLI', () => {
 
   it('unknown command', async () => {
     await expect(cliInstance.parse(['doesnotexist'], defaultTestConfig())).resolves.toThrow()
+  })
+
+  it('requires confirmation before running the global CLI when a local Prisma binary exists', async () => {
+    const tmpDir = createTempProjectWithLocalPrismaBin()
+    jest.mocked(confirm).mockResolvedValueOnce(false)
+
+    try {
+      const result = await cliInstance.parse(['validate'], defaultTestConfig(), tmpDir)
+
+      expect(result).toBeInstanceOf(HelpError)
+      expect((result as HelpError).message).toContain('Use the local Prisma CLI instead')
+      expect(confirm).toHaveBeenCalledTimes(1)
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it('continues when the user explicitly confirms the global CLI', async () => {
+    const tmpDir = createTempProjectWithLocalPrismaBin()
+    const validateParse = jest.fn(async () => 'validated')
+    const localCli = CLI.new({ validate: { parse: validateParse } as any }, [], download)
+    jest.mocked(confirm).mockResolvedValueOnce(true)
+
+    try {
+      const result = await localCli.parse(['validate'], defaultTestConfig(), tmpDir)
+
+      expect(result).toBe('validated')
+      expect(validateParse).toHaveBeenCalledTimes(1)
+      expect(confirm).toHaveBeenCalledTimes(1)
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/cli/src/bootstrap/Bootstrap.ts
+++ b/packages/cli/src/bootstrap/Bootstrap.ts
@@ -19,6 +19,7 @@ import { isAlreadyLinked } from '../postgres/link/local-setup'
 import { LinkApiError, sanitizeErrorMessage } from '../postgres/link/management-api'
 import { type BootstrapStepStatus, formatBootstrapOutput } from './completion-output'
 import { detectProjectState, getModelNames, getSeedCommand } from './project-state'
+import { findLocalPrismaBin } from '../utils/localPrisma'
 import { emitFlowCompleted, emitFlowStarted, emitStepCompleted, emitStepFailed, emitStepSkipped } from './telemetry'
 import {
   addDependencies,
@@ -29,15 +30,6 @@ import {
   isValidTemplateName,
   promptTemplateSelection,
 } from './template-scaffold'
-
-/**
- * Locates the user's locally installed `prisma` binary in node_modules.
- * Returns the absolute path if found, null otherwise.
- */
-function findLocalPrismaBin(baseDir: string): string | null {
-  const candidate = path.join(baseDir, 'node_modules', '.bin', 'prisma')
-  return fs.existsSync(candidate) ? candidate : null
-}
 
 /**
  * Runs a Prisma CLI command using the user's locally installed binary.

--- a/packages/cli/src/utils/localPrisma.ts
+++ b/packages/cli/src/utils/localPrisma.ts
@@ -1,0 +1,46 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { confirm } from '@inquirer/prompts'
+import { bold, yellow } from 'kleur/colors'
+
+import { canPrompt } from '@prisma/internals'
+
+export function findLocalPrismaBin(baseDir: string): string | null {
+  const candidates = [
+    path.join(baseDir, 'node_modules', '.bin', 'prisma'),
+    path.join(baseDir, 'node_modules', '.bin', 'prisma.cmd'),
+    path.join(baseDir, 'node_modules', '.bin', 'prisma.ps1'),
+  ]
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate
+    }
+  }
+
+  return null
+}
+
+export async function confirmUsingGlobalPrisma(commandName: string, baseDir: string): Promise<boolean> {
+  const localPrismaBin = findLocalPrismaBin(baseDir)
+
+  if (!localPrismaBin) {
+    return true
+  }
+
+  console.warn(
+    `${yellow(bold('warn'))} Found a local Prisma CLI at ${localPrismaBin}. ` +
+      `This command is running the global Prisma CLI for \`prisma ${commandName}\`.`,
+  )
+
+  if (!canPrompt()) {
+    console.warn(`${yellow(bold('warn'))} Re-run this command with the local Prisma CLI, for example \`npx prisma ${commandName}\`.`)
+    return false
+  }
+
+  return confirm({
+    message: 'Use the global Prisma CLI anyway?',
+    default: false,
+  })
+}


### PR DESCRIPTION
/claim #1911

Implement a confirmation flow when the global Prisma CLI detects a local Prisma install.

Issue: https://github.com/prisma/prisma/issues/2738
Amount: $150

Verification:
- git diff --check
- Focused pnpm test could not be executed here because Corepack cannot fetch pnpm from npm registry on this machine (certificate chain failure)

Changed paths:
- packages/cli/src/CLI.ts
- packages/cli/src/bootstrap/Bootstrap.ts
- packages/cli/src/utils/localPrisma.ts
- packages/cli/src/__tests__/commands/CLI.test.ts