### PR TITLE
feat(cli): show current prisma install path

### DIFF
--- a/packages/cli/src/Version.ts
+++ b/packages/cli/src/Version.ts
@@ -119,8 +119,8 @@ export class Version implements Command {
   }
 
   private async getPrismaInstallPath(): Promise<string> {
-    const prismaEntryPoint = process.argv[1] ? fs.realpathSync(process.argv[1]) : undefined
-    const basedir = prismaEntryPoint ? path.dirname(prismaEntryPoint) : fs.realpathSync(process.cwd())
+    const prismaEntryPoint = process.argv[1] ? this.safeRealpath(process.argv[1]) : undefined
+    const basedir = prismaEntryPoint ? path.dirname(prismaEntryPoint) : this.safeRealpath(process.cwd())
     const packageRoot = prismaEntryPoint ? this.getPackageRootFromFile(prismaEntryPoint) ?? basedir : basedir
 
     return (
@@ -128,6 +128,14 @@ export class Version implements Command {
       (await resolvePkg('prisma', { basedir: packageRoot })) ??
       packageRoot
     )
+  }
+
+  private safeRealpath(filePath: string): string {
+    try {
+      return fs.realpathSync(filePath)
+    } catch {
+      return path.resolve(filePath)
+    }
   }
 
   private getPackageRootFromFile(filePath: string): string | undefined {

--- a/packages/cli/src/Version.ts
+++ b/packages/cli/src/Version.ts
@@ -1,3 +1,4 @@
+import fs from 'fs'
 import type { PrismaConfigInternal } from '@prisma/config'
 import { enginesVersion } from '@prisma/engines'
 import {
@@ -13,9 +14,11 @@ import {
   isError,
   loadSchemaContext,
   resolveEngine,
+  resolvePkg,
   wasm,
 } from '@prisma/internals'
 import { bold, dim, red } from 'kleur/colors'
+import path from 'path'
 import os from 'os'
 
 import { getInstalledPrismaClientVersion } from './utils/getClientVersion'
@@ -78,9 +81,11 @@ export class Version implements Command {
 
     const prismaClientVersion = await getInstalledPrismaClientVersion()
     const typescriptVersion = await getTypescriptVersion()
+    const prismaInstallPath = await this.getPrismaInstallPath()
 
     const rows = [
       [packageJson.name, packageJson.version],
+      ['Current Prisma Path', prismaInstallPath],
       ['@prisma/client', prismaClientVersion ?? 'Not found'],
       ['Operating System', os.platform()],
       ['Architecture', os.arch()],
@@ -111,6 +116,17 @@ export class Version implements Command {
 
     // @ts-ignore TODO @jkomyno, as affects the type of rows
     return formatTable(rows, { json: args['--json'] })
+  }
+
+  private async getPrismaInstallPath(): Promise<string> {
+    const prismaEntryPoint = fs.realpathSync(process.argv[1] ?? process.cwd())
+    const basedir = path.dirname(prismaEntryPoint)
+
+    return (
+      (await resolvePkg('prisma', { basedir })) ??
+      (await resolvePkg('prisma', { basedir: process.cwd() })) ??
+      basedir
+    )
   }
 
   private async getFeatureFlags(schemaPath: string | undefined, baseDir: string): Promise<string[]> {

--- a/packages/cli/src/Version.ts
+++ b/packages/cli/src/Version.ts
@@ -121,12 +121,35 @@ export class Version implements Command {
   private async getPrismaInstallPath(): Promise<string> {
     const prismaEntryPoint = fs.realpathSync(process.argv[1] ?? process.cwd())
     const basedir = path.dirname(prismaEntryPoint)
+    const packageRoot = this.getPackageRootFromFile(prismaEntryPoint) ?? basedir
 
     return (
       (await resolvePkg('prisma', { basedir })) ??
-      (await resolvePkg('prisma', { basedir: process.cwd() })) ??
-      basedir
+      (await resolvePkg('prisma', { basedir: packageRoot })) ??
+      packageRoot
     )
+  }
+
+  private getPackageRootFromFile(filePath: string): string | undefined {
+    let currentDir = path.dirname(filePath)
+
+    while (currentDir !== path.dirname(currentDir)) {
+      const packageJsonPath = path.join(currentDir, 'package.json')
+      if (fs.existsSync(packageJsonPath)) {
+        try {
+          const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
+          if (packageJson.name === 'prisma') {
+            return currentDir
+          }
+        } catch {
+          return undefined
+        }
+      }
+
+      currentDir = path.dirname(currentDir)
+    }
+
+    return undefined
   }
 
   private async getFeatureFlags(schemaPath: string | undefined, baseDir: string): Promise<string[]> {

--- a/packages/cli/src/Version.ts
+++ b/packages/cli/src/Version.ts
@@ -119,9 +119,9 @@ export class Version implements Command {
   }
 
   private async getPrismaInstallPath(): Promise<string> {
-    const prismaEntryPoint = fs.realpathSync(process.argv[1] ?? process.cwd())
-    const basedir = path.dirname(prismaEntryPoint)
-    const packageRoot = this.getPackageRootFromFile(prismaEntryPoint) ?? basedir
+    const prismaEntryPoint = process.argv[1] ? fs.realpathSync(process.argv[1]) : undefined
+    const basedir = prismaEntryPoint ? path.dirname(prismaEntryPoint) : fs.realpathSync(process.cwd())
+    const packageRoot = prismaEntryPoint ? this.getPackageRootFromFile(prismaEntryPoint) ?? basedir : basedir
 
     return (
       (await resolvePkg('prisma', { basedir })) ??

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -13,6 +13,7 @@ describe('version', () => {
     expect(data.exitCode).toBe(0)
     expect(cleanSnapshot(data.stdout)).toMatchInlineSnapshot(`
       "prisma               : 0.0.0
+      Current Prisma Path  : PRISMA_INSTALL_PATH
       @prisma/client       : 0.0.0
       Operating System     : OS
       Architecture         : ARCHITECTURE
@@ -48,6 +49,7 @@ function cleanSnapshot(str: string, versionOverride?: string): string {
     /Loaded Prisma config from ".*(\/|\\)prisma\.config\.ts"/g,
     'Loaded Prisma config from "sanitized prisma.config.ts path"',
   )
+  str = str.replace(/(Current Prisma Path\s+:).*/g, '$1 PRISMA_INSTALL_PATH')
 
   // TODO: replace '[a-z0-9]{40}' with 'ENGINE_VERSION'.
   // Currently, the engine version of @prisma/prisma-schema-wasm isn't necessarily the same as the enginesVersion


### PR DESCRIPTION
/claim #7771

Adds the current Prisma install path to `prisma -v` output and covers it with a regression snapshot.

Verification: `corepack pnpm --filter prisma test -- Version.test.ts` was blocked locally because this checkout has no `node_modules`, and Corepack could not fetch `pnpm` until TLS was relaxed.