### PR TITLE
Normalize formatted schema line endings to LF

### DIFF
--- a/packages/internals/src/__tests__/engine-commands/formatSchema.test.ts
+++ b/packages/internals/src/__tests__/engine-commands/formatSchema.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, test, vi } from 'vitest'
 import { getCliProvidedSchemaFile } from '../../cli/getSchema'
 import { formatSchema } from '../../engine-commands'
 import { extractSchemaContent, type MultipleSchemas } from '../../utils/schemaFileInput'
+import { prismaSchemaWasm } from '../../wasm'
 import { fixturesPath } from '../__utils__/fixtures'
 
 if (process.env.CI) {
@@ -103,6 +104,45 @@ describe('format custom options', () => {
 })
 
 describe('format', () => {
+  test('normalizes CRLF returned by wasm to LF', async () => {
+    const formattedSchemaWithCrLf = [
+      'datasource db {',
+      '  provider = "sqlite"',
+      '  url      = "file:dev.db"',
+      '}',
+      '',
+      'model User {',
+      '  id Int @id',
+      '}',
+      '',
+    ].join('\r\n')
+    const formattedSchemaWithLf = [
+      'datasource db {',
+      '  provider = "sqlite"',
+      '  url      = "file:dev.db"',
+      '}',
+      '',
+      'model User {',
+      '  id Int @id',
+      '}',
+      '',
+    ].join('\n')
+
+    const formatSpy = vi
+      .spyOn(prismaSchemaWasm, 'format')
+      .mockReturnValue(JSON.stringify([['schema.prisma', formattedSchemaWithCrLf]]))
+    const lintSpy = vi.spyOn(prismaSchemaWasm, 'lint').mockReturnValue('[]')
+
+    try {
+      await expect(formatSchema({ schemas: [['schema.prisma', 'model User { id Int @id }']] })).resolves.toEqual([
+        ['schema.prisma', formattedSchemaWithLf],
+      ])
+    } finally {
+      formatSpy.mockRestore()
+      lintSpy.mockRestore()
+    }
+  })
+
   test('valid blog schemaPath', async () => {
     const { schemas } = await getCliProvidedSchemaFile(path.join(fixturesPath, 'blog.prisma'))
     const formatted = await formatSchema({ schemas })

--- a/packages/internals/src/engine-commands/formatSchema.ts
+++ b/packages/internals/src/engine-commands/formatSchema.ts
@@ -45,7 +45,7 @@ export async function formatSchema(
   const { formattedMultipleSchemas, lintDiagnostics } = handleFormatPanic(() => {
     // the only possible error here is a Rust panic
     const formattedMultipleSchemasRaw = formatWasm(JSON.stringify(schemas), documentFormattingParams)
-    const formattedMultipleSchemas = JSON.parse(formattedMultipleSchemasRaw) as MultipleSchemas
+    const formattedMultipleSchemas = normalizeLineEndings(JSON.parse(formattedMultipleSchemasRaw) as MultipleSchemas)
 
     const lintDiagnostics = lintSchema({ schemas: formattedMultipleSchemas })
     return { formattedMultipleSchemas, lintDiagnostics }
@@ -106,4 +106,8 @@ type DocumentFormattingParams = {
 function formatWasm(schema: string, documentFormattingParams: DocumentFormattingParams): string {
   const formattedSchema = prismaSchemaWasm.format(schema, JSON.stringify(documentFormattingParams))
   return formattedSchema
+}
+
+function normalizeLineEndings(schemas: MultipleSchemas): MultipleSchemas {
+  return schemas.map(([filename, schema]) => [filename, schema.replace(/\r\n/g, '\n')])
 }


### PR DESCRIPTION
Fixes #8548

/claim #8548

## Summary

- Normalize formatted schema output from CRLF to LF at the shared `formatSchema()` boundary.
- Add a focused regression test that mocks the schema wasm formatter returning CRLF and verifies `formatSchema()` returns LF.

## Testing

- `pnpm --filter @prisma/internals exec vitest run --silent=true src/__tests__/engine-commands/formatSchema.test.ts`
- `pnpm exec prettier --check packages/internals/src/engine-commands/formatSchema.ts packages/internals/src/__tests__/engine-commands/formatSchema.test.ts`
- `pnpm exec eslint packages/internals/src/engine-commands/formatSchema.ts packages/internals/src/__tests__/engine-commands/formatSchema.test.ts`
- `git diff --check`
