### PR TITLE
fix(format): normalize schema line endings

### DIFF
--- a/packages/cli/src/Format.ts
+++ b/packages/cli/src/Format.ts
@@ -93,7 +93,7 @@ Or specify a Prisma schema path
           return new HelpError(`${bold(red(`!`))} The schema ${underline(filename)} is not found in the schema list.`)
         }
         const [, originalSchema] = originalSchemaTuple
-        if (originalSchema !== formattedSchema) {
+        if (originalSchema !== normalizeSchemaLineEndings(formattedSchema)) {
           return new HelpError(
             `${bold(red(`!`))} There are unformatted files. Run ${underline('prisma format')} to format them.`,
           )
@@ -103,7 +103,7 @@ Or specify a Prisma schema path
     }
 
     for (const [filename, data] of formattedDatamodel) {
-      await fs.writeFile(filename, data)
+      await fs.writeFile(filename, normalizeSchemaLineEndings(data))
     }
 
     const after = Math.round(performance.now())
@@ -118,4 +118,8 @@ Or specify a Prisma schema path
     }
     return Format.help
   }
+}
+
+function normalizeSchemaLineEndings(schema: string): string {
+  return schema.replace(/\r\n/g, '\n')
 }

--- a/packages/cli/src/__tests__/commands/Format.test.ts
+++ b/packages/cli/src/__tests__/commands/Format.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 
 import { defaultTestConfig } from '@prisma/config'
 import { jestConsoleContext, jestContext } from '@prisma/get-platform'
+import * as internals from '@prisma/internals'
 import { extractSchemaContent, getSchemaWithPath } from '@prisma/internals'
 
 import { Format } from '../../Format'
@@ -327,6 +328,20 @@ describe('format', () => {
     await expect(
       Format.new().parse(['--schema=unformatted.prisma', '--check'], defaultTestConfig()),
     ).resolves.toMatchInlineSnapshot(`"! There are unformatted files. Run prisma format to format them."`)
+  })
+
+  it('check should accept formatted output with CRLF line endings', async () => {
+    ctx.fixture('example-project/prisma')
+    const schema = fs.readFileSync('schema.prisma', { encoding: 'utf-8' })
+    const formatSchemaMock = jest
+      .spyOn(internals, 'formatSchema')
+      .mockResolvedValueOnce([['schema.prisma', schema.replace(/\n/g, '\r\n')]])
+
+    await expect(Format.new().parse(['--check'], defaultTestConfig())).resolves.toMatchInlineSnapshot(
+      `"All files are formatted correctly!"`,
+    )
+
+    formatSchemaMock.mockRestore()
   })
 
   it('should load and check schema located next to a nested config', async () => {

--- a/packages/cli/src/__tests__/commands/Format.test.ts
+++ b/packages/cli/src/__tests__/commands/Format.test.ts
@@ -262,7 +262,9 @@ describe('format', () => {
   it('should add a trailing EOL', async () => {
     ctx.fixture('example-project/prisma')
     await Format.new().parse([], defaultTestConfig())
-    expect(fs.readFileSync('schema.prisma', { encoding: 'utf-8' })).toMatchSnapshot()
+    const schema = fs.readFileSync('schema.prisma', { encoding: 'utf-8' })
+    expect(schema).toMatchSnapshot()
+    expect(schema).not.toContain('\r')
   })
 
   it('should add missing backrelation', async () => {


### PR DESCRIPTION
Fixes #8548.

This normalizes CRLF line endings returned by the formatter to LF before writing schema files and before comparing formatted output in --check mode.