### PR TITLE
fix(cli): normalize prisma format line endings

### DIFF
--- a/packages/cli/src/Format.ts
+++ b/packages/cli/src/Format.ts
@@ -10,6 +10,7 @@ import {
   formatms,
   formatSchema,
   getSchemaWithPath,
+  type MultipleSchemas,
   HelpError,
   printSchemaLoadedMessage,
   validate,
@@ -79,7 +80,7 @@ Or specify a Prisma schema path
     })
     printSchemaLoadedMessage(schemaPath)
 
-    const formattedDatamodel = await formatSchema({ schemas })
+    const formattedDatamodel = normalizeLineEndings(await formatSchema({ schemas }))
 
     // Validate whether the formatted output is a valid schema
     validate({
@@ -118,4 +119,8 @@ Or specify a Prisma schema path
     }
     return Format.help
   }
+}
+
+function normalizeLineEndings(schemas: MultipleSchemas): MultipleSchemas {
+  return schemas.map(([filename, schema]) => [filename, schema.replace(/\r\n/g, '\n')])
 }

--- a/packages/cli/src/__tests__/commands/Format.test.ts
+++ b/packages/cli/src/__tests__/commands/Format.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 
 import { defaultTestConfig } from '@prisma/config'
 import { jestConsoleContext, jestContext } from '@prisma/get-platform'
-import { extractSchemaContent, getSchemaWithPath } from '@prisma/internals'
+import * as internals from '@prisma/internals'
 
 import { Format } from '../../Format'
 import { Validate } from '../../Validate'
@@ -219,10 +219,10 @@ describe('format', () => {
           Validate.new().parse(['--schema=prisma/schema'], defaultTestConfig()),
         ).resolves.toMatchInlineSnapshot(`"The schemas at prisma/schema are valid 🚀"`)
 
-        const { schemas } = (await getSchemaWithPath({ schemaPath: { cliProvidedPath: 'prisma/schema' } }))!
+        const { schemas } = (await internals.getSchemaWithPath({ schemaPath: { cliProvidedPath: 'prisma/schema' } }))!
 
         // notice how the `Link` backrelation was added in the first schema file:
-        expect(extractSchemaContent(schemas)).toMatchInlineSnapshot(`
+        expect(internals.extractSchemaContent(schemas)).toMatchInlineSnapshot(`
           [
             "generator client {
             provider = "prisma-client-js"
@@ -263,6 +263,23 @@ describe('format', () => {
     ctx.fixture('example-project/prisma')
     await Format.new().parse([], defaultTestConfig())
     expect(fs.readFileSync('schema.prisma', { encoding: 'utf-8' })).toMatchSnapshot()
+  })
+
+  it('normalizes CRLF from formatter output before writing', async () => {
+    ctx.fixture('example-project/prisma')
+    const schemaPath = path.join(process.cwd(), 'schema.prisma')
+    const schema = fs.readFileSync(schemaPath, { encoding: 'utf-8' }).replace(/\n/g, '\r\n')
+
+    const formatSchema = jest.spyOn(internals, 'formatSchema').mockResolvedValue([[schemaPath, schema]])
+    try {
+      await Format.new().parse([], defaultTestConfig())
+    } finally {
+      formatSchema.mockRestore()
+    }
+
+    const formatted = fs.readFileSync(schemaPath, { encoding: 'utf-8' })
+    expect(formatted).not.toContain('\r\n')
+    expect(formatted.endsWith('\n')).toBe(true)
   })
 
   it('should add missing backrelation', async () => {


### PR DESCRIPTION
Fixes #8548.

## Summary
- normalize CRLF sequences returned by the schema formatter before validating and writing formatted schema files
- add a CLI regression test that simulates CRLF formatter output and verifies the written schema stays LF-only

## Tests
- git diff --check