### PR TITLE
fix(format): normalize schema formatter line endings

### DIFF
--- a/packages/cli/src/Format.ts
+++ b/packages/cli/src/Format.ts
@@ -13,6 +13,7 @@ import {
   HelpError,
   printSchemaLoadedMessage,
   validate,
+  type MultipleSchemas,
 } from '@prisma/internals'
 import { bold, dim, red, underline } from 'kleur/colors'
 
@@ -79,7 +80,7 @@ Or specify a Prisma schema path
     })
     printSchemaLoadedMessage(schemaPath)
 
-    const formattedDatamodel = await formatSchema({ schemas })
+    const formattedDatamodel = normalizeFormattedSchemas(await formatSchema({ schemas }))
 
     // Validate whether the formatted output is a valid schema
     validate({
@@ -118,4 +119,12 @@ Or specify a Prisma schema path
     }
     return Format.help
   }
+}
+
+export function normalizeFormattedSchemaLineEndings(schema: string): string {
+  return schema.replace(/\r\n/g, '\n')
+}
+
+function normalizeFormattedSchemas(schemas: MultipleSchemas): MultipleSchemas {
+  return schemas.map(([filename, schema]) => [filename, normalizeFormattedSchemaLineEndings(schema)])
 }

--- a/packages/cli/src/__tests__/commands/Format.test.ts
+++ b/packages/cli/src/__tests__/commands/Format.test.ts
@@ -6,7 +6,7 @@ import { defaultTestConfig } from '@prisma/config'
 import { jestConsoleContext, jestContext } from '@prisma/get-platform'
 import { extractSchemaContent, getSchemaWithPath } from '@prisma/internals'
 
-import { Format } from '../../Format'
+import { Format, normalizeFormattedSchemaLineEndings } from '../../Format'
 import { Validate } from '../../Validate'
 
 const ctx = jestContext.new().add(jestConsoleContext()).assemble()
@@ -263,6 +263,12 @@ describe('format', () => {
     ctx.fixture('example-project/prisma')
     await Format.new().parse([], defaultTestConfig())
     expect(fs.readFileSync('schema.prisma', { encoding: 'utf-8' })).toMatchSnapshot()
+  })
+
+  it('normalizes CRLF line endings from formatter output', () => {
+    const formatted = 'model User {\r\n  id Int @id\r\n}\r\n'
+
+    expect(normalizeFormattedSchemaLineEndings(formatted)).toBe('model User {\n  id Int @id\n}\n')
   })
 
   it('should add missing backrelation', async () => {


### PR DESCRIPTION
## Summary
- Normalize formatted Prisma schemas to LF before validation, check, and write.
- Keep prisma format --check and written schema output stable if formatter output contains CRLF line endings.
- Add regression coverage for CRLF formatter output.

Fixes #8548.

## Test
- npx pnpm@10.15.1 --filter prisma... build
- npx pnpm@10.15.1 --filter prisma exec jest --silent src/__tests__/commands/Format.test.ts
- npx pnpm@10.15.1 exec prettier --check packages/cli/src/Format.ts packages/cli/src/__tests__/commands/Format.test.ts

Note: npx pnpm@10.15.1 --filter prisma test -- src/__tests__/commands/Format.test.ts ran the target Jest suite successfully, then failed in unrelated package-wide Vitest tests (studio-server/Init) due local environment behavior.