### PR TITLE
fix(format): strip CR from schema formatter output

### DIFF
--- a/packages/internals/src/__tests__/engine-commands/formatSchema.test.ts
+++ b/packages/internals/src/__tests__/engine-commands/formatSchema.test.ts
@@ -103,6 +103,14 @@ describe('format custom options', () => {
 })
 
 describe('format', () => {
+  test('does not emit CR characters', async () => {
+    const { schemas } = await getCliProvidedSchemaFile(path.join(fixturesPath, 'blog.prisma'))
+    const formatted = await formatSchema({ schemas })
+    for (const [, schema] of formatted) {
+      expect(schema.includes('\r')).toBe(false)
+    }
+  })
+
   test('valid blog schemaPath', async () => {
     const { schemas } = await getCliProvidedSchemaFile(path.join(fixturesPath, 'blog.prisma'))
     const formatted = await formatSchema({ schemas })

--- a/packages/internals/src/engine-commands/formatSchema.ts
+++ b/packages/internals/src/engine-commands/formatSchema.ts
@@ -45,7 +45,13 @@ export async function formatSchema(
   const { formattedMultipleSchemas, lintDiagnostics } = handleFormatPanic(() => {
     // the only possible error here is a Rust panic
     const formattedMultipleSchemasRaw = formatWasm(JSON.stringify(schemas), documentFormattingParams)
-    const formattedMultipleSchemas = JSON.parse(formattedMultipleSchemasRaw) as MultipleSchemas
+    const formattedMultipleSchemasParsed = JSON.parse(formattedMultipleSchemasRaw) as MultipleSchemas
+    const formattedMultipleSchemas = formattedMultipleSchemasParsed.map(([filename, schema]) => {
+      // Ensure stable line endings across platforms. The formatter should emit LF-only;
+      // normalize defensively so `prisma format` doesn't introduce a trailing CRLF on Windows.
+      const normalized = schema.replaceAll('\r\n', '\n').replaceAll('\r', '')
+      return [filename, normalized] as const
+    })
 
     const lintDiagnostics = lintSchema({ schemas: formattedMultipleSchemas })
     return { formattedMultipleSchemas, lintDiagnostics }


### PR DESCRIPTION
Fixes #8548.

Prevent Windows-only trailing CRLF by normalizing formatter output to LF-only.

Algora bounty: https://algora.io/prisma/bounties?status=open