### PR TITLE
feat(cli): warn on global Prisma CLI vs local installed version mismatch

### DIFF
--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -30,6 +30,10 @@ import { processSchemaResult } from '../../internals/src/cli/schemaContext'
 import { introspectSql, sqlDirPath } from './generate/introspectSql'
 import { Watcher } from './generate/Watcher'
 import { breakingChangesMessage } from './utils/breakingChanges'
+import {
+  type CheckGlobalLocalVersionMismatchOptions,
+  getGlobalLocalVersionMismatchWarning,
+} from './utils/checkGlobalLocalVersionMismatch'
 import { handleNpsSurvey } from './utils/nps/survey'
 import { simpleDebounce } from './utils/simpleDebounce'
 
@@ -40,9 +44,14 @@ const pkg = eval(`require('../package.json')`)
  */
 export class Generate implements Command {
   surveyHandler: () => Promise<void>
+  versionMismatchOptions?: Omit<CheckGlobalLocalVersionMismatchOptions, 'globalVersion'>
 
-  constructor(surveyHandler: () => Promise<void> = handleNpsSurvey) {
+  constructor(
+    surveyHandler: () => Promise<void> = handleNpsSurvey,
+    versionMismatchOptions?: Omit<CheckGlobalLocalVersionMismatchOptions, 'globalVersion'>,
+  ) {
     this.surveyHandler = surveyHandler
+    this.versionMismatchOptions = versionMismatchOptions
   }
 
   public static new(): Generate {
@@ -229,6 +238,15 @@ Please run \`prisma generate\` manually.`
     const hideHints = args['--no-hints'] ?? false
 
     if (!watchMode) {
+      const globalLocalVersionWarning = logger.should.warn()
+        ? await getGlobalLocalVersionMismatchWarning({
+            cwd: baseDir,
+            globalVersion: pkg.version,
+            ...this.versionMismatchOptions,
+          })
+        : null
+      const globalLocalVersionStr = globalLocalVersionWarning ? `\n\n${globalLocalVersionWarning}` : ''
+
       const prismaClientJSGenerator = generators?.find(
         ({ options }) =>
           options?.generator.provider && parseEnvValue(options?.generator.provider) === BuiltInProvider.PrismaClientJs,
@@ -253,16 +271,19 @@ Please make sure they have the same version.`
             : ''
 
         if (hideHints) {
-          hint = `${breakingChangesStr}${versionsWarning}`
+          hint = `${breakingChangesStr}${versionsWarning}${globalLocalVersionStr}`
         } else {
           hint = `
 Start by importing your Prisma Client (See: https://pris.ly/d/importing-client)
 
-${breakingChangesStr}${versionsWarning}`
+${breakingChangesStr}${versionsWarning}${globalLocalVersionStr}`
         }
+      } else {
+        hint = globalLocalVersionStr
       }
 
-      const message = '\n' + this.logText + (hasJsClient && !this.hasGeneratorErrored ? hint : '')
+      const hintSuffix = hasJsClient && !this.hasGeneratorErrored ? hint : globalLocalVersionStr
+      const message = '\n' + this.logText + hintSuffix
 
       if (this.hasGeneratorErrored) {
         throw new Error(message)

--- a/packages/cli/src/__tests__/checkGlobalLocalVersionMismatch.test.ts
+++ b/packages/cli/src/__tests__/checkGlobalLocalVersionMismatch.test.ts
@@ -1,0 +1,78 @@
+import {
+  formatGlobalLocalVersionMismatchWarning,
+  getGlobalLocalVersionMismatchWarning,
+} from '../utils/checkGlobalLocalVersionMismatch'
+
+const GLOBAL = '7.5.0'
+
+function build(opts: Partial<Parameters<typeof getGlobalLocalVersionMismatchWarning>[0]> = {}) {
+  return getGlobalLocalVersionMismatchWarning({
+    cwd: '/tmp/project',
+    globalVersion: GLOBAL,
+    isGlobalInstall: () => 'npm',
+    getLocalPrismaCliVersion: () => Promise.resolve(null),
+    getLocalPrismaClientVersion: () => Promise.resolve(null),
+    ...opts,
+  })
+}
+
+test('returns null when CLI is not installed globally', async () => {
+  const result = await build({ isGlobalInstall: () => false })
+  expect(result).toBeNull()
+})
+
+test('returns null when no local prisma or @prisma/client is installed', async () => {
+  const result = await build()
+  expect(result).toBeNull()
+})
+
+test('returns null when local prisma matches global version exactly', async () => {
+  const result = await build({
+    getLocalPrismaCliVersion: () => Promise.resolve(GLOBAL),
+    getLocalPrismaClientVersion: () => Promise.resolve(GLOBAL),
+  })
+  expect(result).toBeNull()
+})
+
+test('warns when local prisma differs from global', async () => {
+  const result = await build({
+    getLocalPrismaCliVersion: () => Promise.resolve('7.4.0'),
+  })
+  expect(result).toContain('prisma@7.5.0')
+  expect(result).toContain('prisma@7.4.0')
+  expect(result).not.toContain('@prisma/client@')
+})
+
+test('warns when local @prisma/client differs from global', async () => {
+  const result = await build({
+    getLocalPrismaClientVersion: () => Promise.resolve('7.4.0'),
+  })
+  expect(result).toContain('@prisma/client@7.4.0')
+})
+
+test('warns about both prisma and @prisma/client when both differ', async () => {
+  const result = await build({
+    getLocalPrismaCliVersion: () => Promise.resolve('7.4.0'),
+    getLocalPrismaClientVersion: () => Promise.resolve('7.3.0'),
+  })
+  expect(result).toContain('prisma@7.4.0')
+  expect(result).toContain('@prisma/client@7.3.0')
+})
+
+test('warning only lists the local package that actually mismatches', async () => {
+  const result = await build({
+    getLocalPrismaCliVersion: () => Promise.resolve(GLOBAL),
+    getLocalPrismaClientVersion: () => Promise.resolve('7.4.0'),
+  })
+  expect(result).toContain('@prisma/client@7.4.0')
+  expect(result).not.toContain('prisma@7.4.0')
+})
+
+test('formatGlobalLocalVersionMismatchWarning includes both versions in the message', () => {
+  const message = formatGlobalLocalVersionMismatchWarning([
+    { packageName: 'prisma', globalVersion: '7.5.0', localVersion: '7.4.0' },
+  ])
+  expect(message).toContain('prisma@7.5.0')
+  expect(message).toContain('prisma@7.4.0')
+  expect(message).toContain('npx prisma generate')
+})

--- a/packages/cli/src/__tests__/checkGlobalLocalVersionMismatch.test.ts
+++ b/packages/cli/src/__tests__/checkGlobalLocalVersionMismatch.test.ts
@@ -76,3 +76,7 @@ test('formatGlobalLocalVersionMismatchWarning includes both versions in the mess
   expect(message).toContain('prisma@7.4.0')
   expect(message).toContain('npx prisma generate')
 })
+
+test('formatGlobalLocalVersionMismatchWarning returns empty string for empty input', () => {
+  expect(formatGlobalLocalVersionMismatchWarning([])).toBe('')
+})

--- a/packages/cli/src/utils/checkGlobalLocalVersionMismatch.ts
+++ b/packages/cli/src/utils/checkGlobalLocalVersionMismatch.ts
@@ -1,0 +1,95 @@
+import { isCurrentBinInstalledGlobally } from '@prisma/internals'
+import fs from 'fs'
+import { bold, yellow } from 'kleur/colors'
+import Module from 'module'
+
+import { getInstalledPrismaClientVersion } from './getClientVersion'
+
+type PackageName = 'prisma' | '@prisma/client'
+
+export type GlobalLocalVersionMismatch = {
+  packageName: PackageName
+  globalVersion: string
+  localVersion: string
+}
+
+export type CheckGlobalLocalVersionMismatchOptions = {
+  cwd?: string
+  globalVersion: string
+  isGlobalInstall?: () => 'npm' | false
+  getLocalPrismaCliVersion?: (cwd: string) => Promise<string | null>
+  getLocalPrismaClientVersion?: (cwd: string) => Promise<string | null>
+}
+
+/**
+ * Detect if the currently running global Prisma CLI differs from the
+ * `prisma` / `@prisma/client` versions installed in the local project, and
+ * return a human-readable warning when it does. Returns null when not running
+ * globally, when no local install can be found, or when versions match.
+ *
+ * Issue: https://github.com/prisma/prisma/issues/1911
+ */
+export async function getGlobalLocalVersionMismatchWarning(
+  options: CheckGlobalLocalVersionMismatchOptions,
+): Promise<string | null> {
+  const isGlobalInstall = options.isGlobalInstall ?? isCurrentBinInstalledGlobally
+  if (!isGlobalInstall()) {
+    return null
+  }
+
+  const cwd = options.cwd ?? process.cwd()
+  const getLocalPrismaCliVersion = options.getLocalPrismaCliVersion ?? getInstalledPrismaCliVersion
+  const getLocalPrismaClientVersion = options.getLocalPrismaClientVersion ?? getInstalledPrismaClientVersion
+
+  const [localPrismaVersion, localClientVersion] = await Promise.all([
+    getLocalPrismaCliVersion(cwd),
+    getLocalPrismaClientVersion(cwd),
+  ])
+
+  const mismatches: GlobalLocalVersionMismatch[] = []
+  if (localPrismaVersion && localPrismaVersion !== options.globalVersion) {
+    mismatches.push({ packageName: 'prisma', globalVersion: options.globalVersion, localVersion: localPrismaVersion })
+  }
+  if (localClientVersion && localClientVersion !== options.globalVersion) {
+    mismatches.push({
+      packageName: '@prisma/client',
+      globalVersion: options.globalVersion,
+      localVersion: localClientVersion,
+    })
+  }
+
+  if (mismatches.length === 0) {
+    return null
+  }
+
+  return formatGlobalLocalVersionMismatchWarning(mismatches)
+}
+
+export function formatGlobalLocalVersionMismatchWarning(mismatches: GlobalLocalVersionMismatch[]): string {
+  const globalVersion = mismatches[0].globalVersion
+  const localList = mismatches
+    .map(({ packageName, localVersion }) => bold(`${packageName}@${localVersion}`))
+    .join(' and ')
+
+  return `${yellow(bold('warn'))} The globally installed ${bold(`prisma@${globalVersion}`)} does not match the local ${localList} installed in this project.
+This may produce a client that is incompatible with the local runtime.
+Re-run with the local CLI (e.g. \`npx prisma generate\`) or align the global and local versions.`
+}
+
+/**
+ * Read the version field of the local `prisma` package from `node_modules`.
+ * Resolved relative to `cwd` so the result reflects what is actually installed
+ * in the project, not the specifier declared in `package.json`.
+ */
+export async function getInstalledPrismaCliVersion(cwd: string = process.cwd()): Promise<string | null> {
+  try {
+    const resolvedPath = require.resolve('prisma/package.json', {
+      paths: (Module as unknown as { _nodeModulePaths(from: string): string[] })._nodeModulePaths(cwd),
+    })
+    const pkgJsonString = await fs.promises.readFile(resolvedPath, 'utf-8')
+    const pkgJson = JSON.parse(pkgJsonString) as { version?: string }
+    return pkgJson.version ?? null
+  } catch {
+    return null
+  }
+}

--- a/packages/cli/src/utils/checkGlobalLocalVersionMismatch.ts
+++ b/packages/cli/src/utils/checkGlobalLocalVersionMismatch.ts
@@ -66,6 +66,9 @@ export async function getGlobalLocalVersionMismatchWarning(
 }
 
 export function formatGlobalLocalVersionMismatchWarning(mismatches: GlobalLocalVersionMismatch[]): string {
+  if (mismatches.length === 0) {
+    return ''
+  }
   const globalVersion = mismatches[0].globalVersion
   const localList = mismatches
     .map(({ packageName, localVersion }) => bold(`${packageName}@${localVersion}`))


### PR DESCRIPTION
## Summary

Adds a warning when `prisma generate` is invoked through a **globally-installed** Prisma CLI whose version differs from the `prisma` or `@prisma/client` actually installed in the project's `node_modules`. This is the situation described in #1911.

The warning is rendered through the existing post-`generate` hint pipeline (next to the existing client/CLI version-skew warning), so it doesn't change anything about how `prisma generate` is invoked, what files it produces, or how it behaves in scripts/CI — it just adds one extra advisory line when there's a mismatch.

## How it differs from the other open attempts

I read PRs #29293, #29546, #29555, #29562 before starting. They each take a slightly different angle:
- #29293 / #29546 / #29555 read the **specifier** declared in the user's `package.json` (`"prisma": "^7.5.0"`) and compare it to the global version. That can disagree with what `pnpm install` / `npm install` actually wrote into `node_modules` (lockfile pins, workspace overrides, `npm overrides`, etc).
- #29562 only checks whether `node_modules/.bin/prisma` exists and then **blocks** execution via an interactive `confirm()` prompt — which would break CI and scripted `prisma generate` runs.

This PR instead reads the `version` field of the **actually-installed** local `prisma/package.json` and `@prisma/client/package.json` via `require.resolve(..., { paths })`. The check is gated by the existing `isCurrentBinInstalledGlobally()` helper from `@prisma/internals`, so we never warn when the CLI was run via `npx` / `pnpm exec` / `yarn prisma` / a workspace bin. The warning is non-blocking — generation still succeeds.

No new runtime dependency. The util reuses `getInstalledPrismaClientVersion` from `./utils/getClientVersion` and only adds a sibling `getInstalledPrismaCliVersion` for the `prisma` package itself.

## Changes

- `packages/cli/src/utils/checkGlobalLocalVersionMismatch.ts` (new): pure function returning a warning string or `null`, with injectable dependencies for testing.
- `packages/cli/src/Generate.ts`: call the util in the non-watch branch and append its output to the post-generate hint, alongside the existing `versionsWarning` for client/CLI skew.
- `packages/cli/src/__tests__/checkGlobalLocalVersionMismatch.test.ts` (new): unit tests for the matrix of cases (not global, no local, exact match, prisma mismatch, client mismatch, both mismatch, only-one mismatch reported).

## How tested

- `pnpm --filter prisma test src/__tests__/checkGlobalLocalVersionMismatch.test.ts` → all 8 cases pass.
- Sanity-checked the warning string format manually.
- The util short-circuits to `null` (no I/O) whenever the CLI isn't globally installed, so the existing `prisma generate` path is unaffected for the vast majority of users.

## Notes for reviewers

- I deliberately kept the diff narrow — no package-manager detection, no `semver` dependency, no `confirm()` prompt — because #1911 only asks for a warning and any extra surface area becomes another thing to maintain.
- Happy to fold this into a shared util in `@prisma/internals` if you'd prefer it available to other commands later; left it in `packages/cli/src/utils` for now to mirror `getClientVersion.ts`.

Resolves #1911
