### PR TITLE
Fix prisma/prisma#7771

### DIFF
--- a/packages/cli/src/Version.ts
+++ b/packages/cli/src/Version.ts
@@ -17,10 +17,13 @@ import {
 } from '@prisma/internals'
 import { bold, dim, red } from 'kleur/colors'
 import os from 'os'
+import path from 'path'
 
 import { getInstalledPrismaClientVersion } from './utils/getClientVersion'
 
 const packageJson = require('../package.json')
+// Resolves to the package root in both source (`src/..`) and bundled (`build/..`) layouts.
+const prismaCliPath = path.resolve(__dirname, '..')
 
 /**
  * $ prisma version
@@ -92,6 +95,7 @@ export class Version implements Command {
 
       ['Default Engines Hash', enginesVersion],
       ['Studio', packageJson.dependencies['@prisma/studio-core']],
+      ['Prisma CLI Path', prismaCliPath],
     ]
 
     /**

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -22,7 +22,8 @@ describe('version', () => {
       PSL                  : @prisma/prisma-schema-wasm CLI_VERSION.ENGINE_VERSION
       Schema Engine        : schema-engine-cli ENGINE_VERSION (at sanitized_path/schema-engine-TEST_PLATFORM)
       Default Engines Hash : ENGINE_VERSION
-      Studio               : STUDIO_VERSION"
+      Studio               : STUDIO_VERSION
+      Prisma CLI Path      : sanitized_cli_path"
     `)
     expect(cleanSnapshot(data.stderr)).toMatchInlineSnapshot(`
       "Loaded Prisma config from prisma.config.ts.
@@ -63,6 +64,7 @@ function cleanSnapshot(str: string, versionOverride?: string): string {
   str = str.replace(new RegExp(defaultEngineVersion, 'g'), 'ENGINE_VERSION')
   str = str.replace(new RegExp('(Operating System\\s+:).*', 'g'), '$1 OS')
   str = str.replace(new RegExp('(Architecture\\s+:).*', 'g'), '$1 ARCHITECTURE')
+  str = str.replace(new RegExp('(Prisma CLI Path\\s+:).*', 'g'), '$1 sanitized_cli_path')
   str = str.replace(new RegExp('workspace:\\*', 'g'), 'ENGINE_VERSION')
   str = str.replace(new RegExp(process.version, 'g'), 'NODEJS_VERSION')
   str = str.replace(new RegExp(`(TypeScript\\s+:) ${typeScriptVersion}`, 'g'), '$1 TYPESCRIPT_VERSION')


### PR DESCRIPTION
## Summary

Adds an installed-path row to `prisma -v` / `prisma version` so users can see *which* `prisma` package the running CLI was loaded from.

This is the exact debugging information requested in #7771: in the original report, `yarn prisma -v` told the user that engines came from `node_modules/@prisma/engines`, but that directory did not exist in the project - because the executed CLI actually lived in a parent project's `node_modules`. Today the `-v` output gives no way to tell that the running CLI is outside the local install.

Closes #7771

## Changes

**`packages/cli/src/Version.ts`** (+4)

- Imports `path`.
- Computes `prismaCliPath = path.resolve(__dirname, '..')`. This resolves to the package root in both source layout (`src/..`) and bundled layout (`build/..`), so it points at the directory containing the `package.json` that defines the running CLI - matching the issue author's suggested solution.
- Appends a `['Prisma CLI Path', prismaCliPath]` row at the end of the `rows` array. Putting it last avoids reflowing any existing snapshot order above it, and it shows up automatically in `--json` output as the `prisma-cli-path` key (since `formatTable` slugifies row labels for JSON mode).

**`packages/cli/src/__tests__/commands/Version.test.ts`** (+3/-1)

- Adds the new `Prisma CLI Path      : sanitized_cli_path` line to the inline snapshot. Padding (6 chars between `Path` and `:`) matches `formatTable`'s `padEnd(maxPad)` where `maxPad` stays at 20 (`Default Engines Hash` is still the longest label, `Prisma CLI Path` is 15 chars, so 5 spaces of padding plus ` : `).
- Adds a sanitizer line to `cleanSnapshot`:

  ```ts
  str = str.replace(new RegExp('(Prisma CLI Path\\s+:).*', 'g'), '$1 sanitized_cli_path')
  ```

  The double-escaped `\\s+` (two backslashes in the TS source, one in the resulting regex) mirrors the existing `Operating System` / `Architecture` sanitizers two lines above it. A single-escaped `\s+` inside a string-form `RegExp` would be parsed as the literal characters `s+`, which is the bug that prevented snapshots from stabilising in the prior attempt at this issue (PR #29275).

## How tested

- Verified the snapshot alignment by reading `packages/internals/src/utils/formatTable.ts`: `maxPad = max(label.length)`, then each row renders as `${label.padEnd(maxPad)} : ${value}`. With `Default Engines Hash` (20) still the longest label and `Prisma CLI Path` being 15 characters, the row formats to `Prisma CLI Path` plus 5 spaces, then ` : value` - which is exactly what the updated inline snapshot shows.
- Verified the sanitizer regex by mirroring the exact form used for `Operating System` and `Architecture` two lines above it in the same `cleanSnapshot` function (string-form `RegExp` with double-escaped `\\s+`).
- Did **not** run `pnpm --filter prisma test -- Version.test.ts` locally. The fork was a shallow clone without `node_modules`, and a full `pnpm install` on this monorepo would not have finished in the time I had. If the inline snapshot drifts for an unrelated reason (e.g. row order changes elsewhere), regenerating with `pnpm jest -u` should produce a one-line diff. Happy to push a follow-up commit with the regenerated snapshot once CI surfaces any drift.
- Cross-checked prior attempts on this issue: PR #29275 (currently the lead, but stale since 2026-02-28) uses the same `path.resolve(__dirname, '..')` approach and got `CHANGES_REQUESTED` from @jacek-prisma for snapshot failures - the root cause being the single-escaped `\s+` in their sanitizer. This PR uses the correctly escaped `\\s+` form.

## Notes for reviewers

- No behavioural change to the rest of the version command - only an additional row.
- `--json` output gains a `prisma-cli-path` key without any extra plumbing (handled by `formatTable`'s existing slugify).
- The path value is absolute. On Windows it will be backslash-separated, on POSIX forward-slash - same as Node's `path.resolve` everywhere else in the CLI.
