### PR TITLE
feat(cli): show Prisma CLI path in version output

### DIFF
--- a/packages/cli/src/Version.ts
+++ b/packages/cli/src/Version.ts
@@ -1,3 +1,5 @@
+import path from 'node:path'
+
 import type { PrismaConfigInternal } from '@prisma/config'
 import { enginesVersion } from '@prisma/engines'
 import {
@@ -78,6 +80,7 @@ export class Version implements Command {
 
     const prismaClientVersion = await getInstalledPrismaClientVersion()
     const typescriptVersion = await getTypescriptVersion()
+    const prismaCliPath = path.dirname(require.resolve('../package.json'))
 
     const rows = [
       [packageJson.name, packageJson.version],
@@ -92,6 +95,7 @@ export class Version implements Command {
 
       ['Default Engines Hash', enginesVersion],
       ['Studio', packageJson.dependencies['@prisma/studio-core']],
+      ['Prisma CLI Path', prismaCliPath],
     ]
 
     /**

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -1,3 +1,5 @@
+import path from 'node:path'
+
 import { enginesVersion } from '@prisma/engines'
 import { jestConsoleContext, jestContext } from '@prisma/get-platform'
 import { version as typeScriptVersion } from 'typescript'
@@ -22,13 +24,22 @@ describe('version', () => {
       PSL                  : @prisma/prisma-schema-wasm CLI_VERSION.ENGINE_VERSION
       Schema Engine        : schema-engine-cli ENGINE_VERSION (at sanitized_path/schema-engine-TEST_PLATFORM)
       Default Engines Hash : ENGINE_VERSION
-      Studio               : STUDIO_VERSION"
+      Studio               : STUDIO_VERSION
+      Prisma CLI Path      : sanitized_prisma_cli_path"
     `)
     expect(cleanSnapshot(data.stderr)).toMatchInlineSnapshot(`
       "Loaded Prisma config from prisma.config.ts.
 
       Prisma schema loaded from schema.prisma."
     `)
+  })
+
+  test('includes the Prisma CLI path in JSON output', async () => {
+    ctx.fixture('version')
+    const data = await ctx.cli('version', '--json')
+
+    expect(data.exitCode).toBe(0)
+    expect(JSON.parse(data.stdout)['prisma-cli-path']).toBe(path.dirname(require.resolve('../../../package.json')))
   })
 })
 
@@ -72,6 +83,8 @@ function cleanSnapshot(str: string, versionOverride?: string): string {
 
   // sanitize windows specific engine names
   str = str.replace(/\.exe/g, '')
+
+  str = str.replace(new RegExp('(Prisma CLI Path\\s+:).*', 'g'), '$1 sanitized_prisma_cli_path')
 
   return str
 }


### PR DESCRIPTION
 /claim #7771
Fixes #7771

## Summary

- add the running Prisma CLI package path to `prisma -v` / `prisma version`
- resolve the path from the CLI package metadata so the reported location matches the CLI that is actually executing
- add test coverage for both the human-readable output and the JSON output

## Why

Issue #7771 asks for a way to tell which Prisma CLI installation is actually running. This helps when `prisma` resolves to a parent or otherwise unexpected install and the current version output does not reveal that.

## Implementation

- compute `prismaCliPath` from `path.dirname(require.resolve('../package.json'))`
- append a `Prisma CLI Path` row to the version output table
- update the inline snapshot for the version command
- add a JSON regression test asserting the `prisma-cli-path` field

## Verification

- `pnpm --filter "prisma..." build`
- `pnpm test src/__tests__/commands/Version.test.ts`
- `pnpm exec eslint packages/cli/src/Version.ts packages/cli/src/__tests__/commands/Version.test.ts`
- `pnpm exec prettier --check packages/cli/src/Version.ts packages/cli/src/__tests__/commands/Version.test.ts`
- `node packages/cli/build/index.js -v`
- `node packages/cli/build/index.js version --json`

This contribution was prepared with AI assistance under human direction and review. I inspected the change, verified the behavior described here, and am responsible for the submission.