### PR TITLE
fix(client): restore OmitOpts default type to improve type-checking performance

### DIFF
--- a/packages/client-generator-ts/src/TSClient/PrismaClient.ts
+++ b/packages/client-generator-ts/src/TSClient/PrismaClient.ts
@@ -280,7 +280,7 @@ export interface PrismaClientConstructor {
 ${this.jsDoc}
 export interface PrismaClient<
   in LogOpts extends Prisma.LogLevel = never,
-  in out OmitOpts extends Prisma.PrismaClientOptions['omit'] = undefined,
+  in out OmitOpts extends Prisma.PrismaClientOptions['omit'] = Prisma.PrismaClientOptions['omit'],
   in out ExtArgs extends runtime.Types.Extensions.InternalArgs = runtime.Types.Extensions.DefaultArgs
 > {
   [K: symbol]: { types: Prisma.TypeMap<ExtArgs>['other'] }


### PR DESCRIPTION
Fixes #29011

<br/>

## Problem

After upgrading from Prisma 6 to 7, type checking on our production codebase (406 models, ~9,300-line schema) became effectively unusable — `tsc --noEmit` ran for over 2 minutes and `tsgo` timed out at 3 minutes, whereas it completed in ~9 seconds on v6.

I traced this down to a single line change.

<br/>

## Root Cause

In #28375, the default value of the `OmitOpts` generic parameter on the `PrismaClient` interface was changed from `Prisma.PrismaClientOptions['omit']` to `undefined`:

```diff
 export interface PrismaClient<
   in LogOpts extends Prisma.LogLevel = never,
-  in out OmitOpts extends Prisma.PrismaClientOptions['omit'] = Prisma.PrismaClientOptions['omit'],
+  in out OmitOpts extends Prisma.PrismaClientOptions['omit'] = undefined,
   in out ExtArgs extends runtime.Types.Extensions.InternalArgs = runtime.Types.Extensions.DefaultArgs
 > {
```

This reverts the optimization from #27777 (ORM-850). The change looks unintentional — #28375 was focused on removing the library engine and doesn't mention any reason for touching the `OmitOpts` default.

<br/>

## Why this causes the regression

When `OmitOpts` defaults to `undefined`, every model delegate gets instantiated with `{ omit: undefined }`. Since `undefined` is structurally distinct from the constraint type (`GlobalOmitConfig | undefined`), TypeScript can't reuse cached type instantiations — it re-evaluates the full generic chain for every model x every operation.

When the default matches the constraint (`= Prisma.PrismaClientOptions['omit']`), TypeScript can short-circuit the structural comparison and reuse a single cached instantiation. This is exactly how #27777 was designed to work.

<br/>

## Benchmark

406 models, ~9,300-line schema. Using `tsgo --extendedDiagnostics`:

| Metric              | `= undefined` (current) | `= PrismaClientOptions['omit']` (this fix) | Improvement |
| ------------------- | ----------------------- | ------------------------------------------ | ----------- |
| Type Instantiations | 32,823,262              | 2,650,891                                  | **12.4x**   |
| Types               | 6,385,830               | 1,162,723                                  | **5.5x**    |
| Memory              | 4,610 MB                | 2,193 MB                                   | **2.1x**    |
| Check time          | 16.97s                  | 2.47s                                      | **6.9x**    |

Full project type check (`pnpm check:type`):

| Tool         | Before          | After    |
| ------------ | --------------- | -------- |
| `tsgo`       | >3min (timeout) | **7.7s** |
| `tsc` v5.9.2 | OOM / >2min     | **9.0s** |

I can't share the production schema (proprietary), but the numbers in #29011 from other reporters are consistent with what I'm seeing — ~30M instantiations on v7 vs ~8M on v6.

<br/>

## Changes

One-line fix in `packages/client-generator-ts/src/TSClient/PrismaClient.ts` — restores the original default from #27777.

Note that `ClientFile.ts` already uses `Prisma.PrismaClientOptions['omit']` as the default for the public-facing export type, so this just aligns the internal interface with it.

<br/>

### Type safety

`PrismaClientOptions['omit']` resolves to `GlobalOmitConfig | undefined` (since `omit` is optional), which is a superset of `undefined` — so this is not a breaking change. The constructor's `OmitOpts` default is also unaffected. No runtime behavior changes.
