### PR TITLE
feat(cli): show prisma cli path in version output

### DIFF
--- a/packages/cli/src/Version.ts
+++ b/packages/cli/src/Version.ts
@@ -15,8 +15,10 @@ import {
   resolveEngine,
   wasm,
 } from '@prisma/internals'
+import fs from 'fs'
 import { bold, dim, red } from 'kleur/colors'
 import os from 'os'
+import path from 'path'
 
 import { getInstalledPrismaClientVersion } from './utils/getClientVersion'
 
@@ -78,6 +80,7 @@ export class Version implements Command {
 
     const prismaClientVersion = await getInstalledPrismaClientVersion()
     const typescriptVersion = await getTypescriptVersion()
+    const prismaCliPath = getPrismaCliPath()
 
     const rows = [
       [packageJson.name, packageJson.version],
@@ -92,6 +95,7 @@ export class Version implements Command {
 
       ['Default Engines Hash', enginesVersion],
       ['Studio', packageJson.dependencies['@prisma/studio-core']],
+      ['Prisma CLI Path', prismaCliPath],
     ]
 
     /**
@@ -126,5 +130,50 @@ export class Version implements Command {
       // console.error(e)
     }
     return []
+  }
+}
+
+export function getPrismaCliPath(entryPoint: string | undefined = process.argv[1]): string {
+  if (!entryPoint) {
+    return 'Not found'
+  }
+
+  const realEntryPoint = getRealPath(path.resolve(entryPoint))
+
+  return findPrismaPackageRoot(realEntryPoint) ?? path.dirname(realEntryPoint)
+}
+
+function getRealPath(entryPoint: string): string {
+  try {
+    return fs.realpathSync(entryPoint)
+  } catch {
+    return entryPoint
+  }
+}
+
+function findPrismaPackageRoot(entryPoint: string): string | null {
+  let currentDir = path.dirname(entryPoint)
+
+  while (true) {
+    const packageJsonPath = path.join(currentDir, 'package.json')
+
+    if (isPrismaPackage(packageJsonPath)) {
+      return currentDir
+    }
+
+    const parentDir = path.dirname(currentDir)
+    if (parentDir === currentDir) {
+      return null
+    }
+
+    currentDir = parentDir
+  }
+}
+
+function isPrismaPackage(packageJsonPath: string): boolean {
+  try {
+    return JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')).name === 'prisma'
+  } catch {
+    return false
   }
 }

--- a/packages/cli/src/Version.ts
+++ b/packages/cli/src/Version.ts
@@ -15,7 +15,6 @@ import {
   resolveEngine,
   wasm,
 } from '@prisma/internals'
-import fs from 'fs'
 import { bold, dim, red } from 'kleur/colors'
 import os from 'os'
 import path from 'path'
@@ -80,7 +79,7 @@ export class Version implements Command {
 
     const prismaClientVersion = await getInstalledPrismaClientVersion()
     const typescriptVersion = await getTypescriptVersion()
-    const prismaCliPath = getPrismaCliPath()
+    const prismaCliPath = path.dirname(require.resolve('../package.json'))
 
     const rows = [
       [packageJson.name, packageJson.version],
@@ -130,50 +129,5 @@ export class Version implements Command {
       // console.error(e)
     }
     return []
-  }
-}
-
-export function getPrismaCliPath(entryPoint: string | undefined = process.argv[1]): string {
-  if (!entryPoint) {
-    return 'Not found'
-  }
-
-  const realEntryPoint = getRealPath(path.resolve(entryPoint))
-
-  return findPrismaPackageRoot(realEntryPoint) ?? path.dirname(realEntryPoint)
-}
-
-function getRealPath(entryPoint: string): string {
-  try {
-    return fs.realpathSync(entryPoint)
-  } catch {
-    return entryPoint
-  }
-}
-
-function findPrismaPackageRoot(entryPoint: string): string | null {
-  let currentDir = path.dirname(entryPoint)
-
-  while (true) {
-    const packageJsonPath = path.join(currentDir, 'package.json')
-
-    if (isPrismaPackage(packageJsonPath)) {
-      return currentDir
-    }
-
-    const parentDir = path.dirname(currentDir)
-    if (parentDir === currentDir) {
-      return null
-    }
-
-    currentDir = parentDir
-  }
-}
-
-function isPrismaPackage(packageJsonPath: string): boolean {
-  try {
-    return JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')).name === 'prisma'
-  } catch {
-    return false
   }
 }

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -1,8 +1,12 @@
 import { enginesVersion } from '@prisma/engines'
 import { jestConsoleContext, jestContext } from '@prisma/get-platform'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
 import { version as typeScriptVersion } from 'typescript'
 
 import packageJson from '../../../package.json'
+import { getPrismaCliPath } from '../../Version'
 
 const ctx = jestContext.new().add(jestConsoleContext()).assemble()
 
@@ -22,13 +26,75 @@ describe('version', () => {
       PSL                  : @prisma/prisma-schema-wasm CLI_VERSION.ENGINE_VERSION
       Schema Engine        : schema-engine-cli ENGINE_VERSION (at sanitized_path/schema-engine-TEST_PLATFORM)
       Default Engines Hash : ENGINE_VERSION
-      Studio               : STUDIO_VERSION"
+      Studio               : STUDIO_VERSION
+      Prisma CLI Path      : sanitized_cli_path"
     `)
     expect(cleanSnapshot(data.stderr)).toMatchInlineSnapshot(`
       "Loaded Prisma config from prisma.config.ts.
 
       Prisma schema loaded from schema.prisma."
     `)
+  })
+
+  test('includes the Prisma CLI path in JSON output', async () => {
+    ctx.fixture('version')
+    const data = await ctx.cli('version', '--json')
+    const output = JSON.parse(data.stdout)
+
+    expect(data.exitCode).toBe(0)
+    expect(output['prisma-cli-path']).toEqual(expect.any(String))
+  })
+})
+
+describe('getPrismaCliPath', () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'prisma-cli-path-'))
+  })
+
+  afterEach(async () => {
+    await fs.promises.rm(tempDir, { force: true, recursive: true })
+  })
+
+  test('returns the package root for a Prisma CLI entry point', async () => {
+    const packageRoot = path.join(tempDir, 'node_modules', 'prisma')
+    const entryPoint = path.join(packageRoot, 'build', 'index.js')
+    await fs.promises.mkdir(path.dirname(entryPoint), { recursive: true })
+    await fs.promises.writeFile(path.join(packageRoot, 'package.json'), JSON.stringify({ name: 'prisma' }), 'utf-8')
+    await fs.promises.writeFile(entryPoint, '', 'utf-8')
+
+    expect(getPrismaCliPath(entryPoint)).toBe(await fs.promises.realpath(packageRoot))
+  })
+
+  test('follows a package-manager shim back to the Prisma package root when possible', async () => {
+    const packageRoot = path.join(tempDir, 'node_modules', 'prisma')
+    const entryPoint = path.join(packageRoot, 'build', 'index.js')
+    const binPath = path.join(tempDir, 'node_modules', '.bin', process.platform === 'win32' ? 'prisma.cmd' : 'prisma')
+
+    await fs.promises.mkdir(path.dirname(entryPoint), { recursive: true })
+    await fs.promises.mkdir(path.dirname(binPath), { recursive: true })
+    await fs.promises.writeFile(path.join(packageRoot, 'package.json'), JSON.stringify({ name: 'prisma' }), 'utf-8')
+    await fs.promises.writeFile(entryPoint, '', 'utf-8')
+
+    let cliEntryPoint = entryPoint
+    try {
+      await fs.promises.symlink(entryPoint, binPath)
+      cliEntryPoint = binPath
+    } catch {
+      // Symlink creation can be unavailable on some Windows setups.
+    }
+
+    expect(getPrismaCliPath(cliEntryPoint)).toBe(await fs.promises.realpath(packageRoot))
+  })
+
+  test('falls back to the entry point directory when the Prisma package root cannot be found', async () => {
+    const entryPoint = path.join(tempDir, 'node_modules', '.bin', 'prisma')
+    await fs.promises.mkdir(path.dirname(entryPoint), { recursive: true })
+    await fs.promises.writeFile(path.join(tempDir, 'package.json'), JSON.stringify({ name: 'app' }), 'utf-8')
+    await fs.promises.writeFile(entryPoint, '', 'utf-8')
+
+    expect(getPrismaCliPath(entryPoint)).toBe(await fs.promises.realpath(path.dirname(entryPoint)))
   })
 })
 
@@ -63,6 +129,7 @@ function cleanSnapshot(str: string, versionOverride?: string): string {
   str = str.replace(new RegExp(defaultEngineVersion, 'g'), 'ENGINE_VERSION')
   str = str.replace(new RegExp('(Operating System\\s+:).*', 'g'), '$1 OS')
   str = str.replace(new RegExp('(Architecture\\s+:).*', 'g'), '$1 ARCHITECTURE')
+  str = str.replace(new RegExp('(Prisma CLI Path\\s+:).*', 'g'), '$1 sanitized_cli_path')
   str = str.replace(new RegExp('workspace:\\*', 'g'), 'ENGINE_VERSION')
   str = str.replace(new RegExp(process.version, 'g'), 'NODEJS_VERSION')
   str = str.replace(new RegExp(`(TypeScript\\s+:) ${typeScriptVersion}`, 'g'), '$1 TYPESCRIPT_VERSION')

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -1,12 +1,8 @@
 import { enginesVersion } from '@prisma/engines'
 import { jestConsoleContext, jestContext } from '@prisma/get-platform'
-import fs from 'fs'
-import os from 'os'
-import path from 'path'
 import { version as typeScriptVersion } from 'typescript'
 
 import packageJson from '../../../package.json'
-import { getPrismaCliPath } from '../../Version'
 
 const ctx = jestContext.new().add(jestConsoleContext()).assemble()
 
@@ -43,58 +39,6 @@ describe('version', () => {
 
     expect(data.exitCode).toBe(0)
     expect(output['prisma-cli-path']).toEqual(expect.any(String))
-  })
-})
-
-describe('getPrismaCliPath', () => {
-  let tempDir: string
-
-  beforeEach(async () => {
-    tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'prisma-cli-path-'))
-  })
-
-  afterEach(async () => {
-    await fs.promises.rm(tempDir, { force: true, recursive: true })
-  })
-
-  test('returns the package root for a Prisma CLI entry point', async () => {
-    const packageRoot = path.join(tempDir, 'node_modules', 'prisma')
-    const entryPoint = path.join(packageRoot, 'build', 'index.js')
-    await fs.promises.mkdir(path.dirname(entryPoint), { recursive: true })
-    await fs.promises.writeFile(path.join(packageRoot, 'package.json'), JSON.stringify({ name: 'prisma' }), 'utf-8')
-    await fs.promises.writeFile(entryPoint, '', 'utf-8')
-
-    expect(getPrismaCliPath(entryPoint)).toBe(await fs.promises.realpath(packageRoot))
-  })
-
-  test('follows a package-manager shim back to the Prisma package root when possible', async () => {
-    const packageRoot = path.join(tempDir, 'node_modules', 'prisma')
-    const entryPoint = path.join(packageRoot, 'build', 'index.js')
-    const binPath = path.join(tempDir, 'node_modules', '.bin', process.platform === 'win32' ? 'prisma.cmd' : 'prisma')
-
-    await fs.promises.mkdir(path.dirname(entryPoint), { recursive: true })
-    await fs.promises.mkdir(path.dirname(binPath), { recursive: true })
-    await fs.promises.writeFile(path.join(packageRoot, 'package.json'), JSON.stringify({ name: 'prisma' }), 'utf-8')
-    await fs.promises.writeFile(entryPoint, '', 'utf-8')
-
-    let cliEntryPoint = entryPoint
-    try {
-      await fs.promises.symlink(entryPoint, binPath)
-      cliEntryPoint = binPath
-    } catch {
-      // Symlink creation can be unavailable on some Windows setups.
-    }
-
-    expect(getPrismaCliPath(cliEntryPoint)).toBe(await fs.promises.realpath(packageRoot))
-  })
-
-  test('falls back to the entry point directory when the Prisma package root cannot be found', async () => {
-    const entryPoint = path.join(tempDir, 'node_modules', '.bin', 'prisma')
-    await fs.promises.mkdir(path.dirname(entryPoint), { recursive: true })
-    await fs.promises.writeFile(path.join(tempDir, 'package.json'), JSON.stringify({ name: 'app' }), 'utf-8')
-    await fs.promises.writeFile(entryPoint, '', 'utf-8')
-
-    expect(getPrismaCliPath(entryPoint)).toBe(await fs.promises.realpath(path.dirname(entryPoint)))
   })
 })
 


### PR DESCRIPTION
## Summary
- add `Prisma CLI Path` to `prisma -v` and `prisma version --json`
- resolve the Prisma CLI package root directly with `path.dirname(require.resolve('../package.json'))`
- keep JSON output coverage and snapshot sanitization for the machine-specific path

## Validation
- `pnpm --filter prisma... build`
- `pnpm --filter prisma test src/__tests__/commands/Version.test.ts`
- `pnpm exec prettier --check packages/cli/src/Version.ts packages/cli/src/__tests__/commands/Version.test.ts`
- `git diff --check`

/claim #7771
Fixes #7771
Algora payout: @jamilahmadzai via Algora platform.