### PR TITLE
feat(cli): warn when global prisma CLI differs from locally installed version

### DIFF
--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -13,6 +13,7 @@ import {
   getGeneratorSuccessMessage,
   getSchemaWithPath,
   HelpError,
+  isCurrentBinInstalledGlobally,
   isError,
   logger,
   missingGeneratorMessage,
@@ -30,6 +31,7 @@ import { processSchemaResult } from '../../internals/src/cli/schemaContext'
 import { introspectSql, sqlDirPath } from './generate/introspectSql'
 import { Watcher } from './generate/Watcher'
 import { breakingChangesMessage } from './utils/breakingChanges'
+import { getInstalledPrismaCliVersion, shouldWarnGlobalLocalCliMismatch } from './utils/getClientVersion'
 import { handleNpsSurvey } from './utils/nps/survey'
 import { simpleDebounce } from './utils/simpleDebounce'
 
@@ -252,13 +254,27 @@ This might lead to unexpected behavior.
 Please make sure they have the same version.`
             : ''
 
+        const installedLocalPrismaCliVersion = await getInstalledPrismaCliVersion(baseDir)
+        const globalLocalCliMismatch = shouldWarnGlobalLocalCliMismatch({
+          isGlobalInstall: Boolean(isCurrentBinInstalledGlobally()),
+          globalCliVersion: pkg.version,
+          installedLocalPrismaCliVersion,
+        })
+        const globalLocalCliWarning =
+          globalLocalCliMismatch && logger.should.warn()
+            ? `\n\n${yellow(bold('warn'))} You're running ${bold(
+                `prisma@${pkg.version}`,
+              )} globally, but this project has ${bold(`prisma@${installedLocalPrismaCliVersion}`)} installed locally.
+Run \`npx prisma generate\` (or your package manager's equivalent) to use the local version.`
+            : ''
+
         if (hideHints) {
-          hint = `${breakingChangesStr}${versionsWarning}`
+          hint = `${breakingChangesStr}${versionsWarning}${globalLocalCliWarning}`
         } else {
           hint = `
 Start by importing your Prisma Client (See: https://pris.ly/d/importing-client)
 
-${breakingChangesStr}${versionsWarning}`
+${breakingChangesStr}${versionsWarning}${globalLocalCliWarning}`
         }
       }
 

--- a/packages/cli/src/Generate.ts
+++ b/packages/cli/src/Generate.ts
@@ -236,6 +236,26 @@ Please run \`prisma generate\` manually.`
           options?.generator.provider && parseEnvValue(options?.generator.provider) === BuiltInProvider.PrismaClientJs,
       )
 
+      // The global-vs-local prisma CLI mismatch concerns the CLI itself, not any
+      // particular client generator, so it must surface independent of which
+      // generator ran (e.g. the Prisma 7 default `prisma-client` generator) and
+      // of whether a JS client was produced. Anchor the local-install lookup at
+      // the schema's root dir so `--schema <other-dir>` invocations resolve the
+      // project's node_modules rather than the shell cwd.
+      const installedLocalPrismaCliVersion = await getInstalledPrismaCliVersion(schemaContext.schemaRootDir)
+      const globalLocalCliMismatch = shouldWarnGlobalLocalCliMismatch({
+        isGlobalInstall: Boolean(isCurrentBinInstalledGlobally()),
+        globalCliVersion: pkg.version,
+        installedLocalPrismaCliVersion,
+      })
+      const globalLocalCliWarning =
+        globalLocalCliMismatch && logger.should.warn()
+          ? `\n\n${yellow(bold('warn'))} You're running ${bold(
+              `prisma@${pkg.version}`,
+            )} globally, but this project has ${bold(`prisma@${installedLocalPrismaCliVersion}`)} installed locally.
+Run \`npx prisma generate\` (or your package manager's equivalent) to use the local version.`
+          : ''
+
       let hint = ''
       if (prismaClientJSGenerator) {
         const breakingChangesStr = printBreakingChangesMessage
@@ -254,31 +274,20 @@ This might lead to unexpected behavior.
 Please make sure they have the same version.`
             : ''
 
-        const installedLocalPrismaCliVersion = await getInstalledPrismaCliVersion(baseDir)
-        const globalLocalCliMismatch = shouldWarnGlobalLocalCliMismatch({
-          isGlobalInstall: Boolean(isCurrentBinInstalledGlobally()),
-          globalCliVersion: pkg.version,
-          installedLocalPrismaCliVersion,
-        })
-        const globalLocalCliWarning =
-          globalLocalCliMismatch && logger.should.warn()
-            ? `\n\n${yellow(bold('warn'))} You're running ${bold(
-                `prisma@${pkg.version}`,
-              )} globally, but this project has ${bold(`prisma@${installedLocalPrismaCliVersion}`)} installed locally.
-Run \`npx prisma generate\` (or your package manager's equivalent) to use the local version.`
-            : ''
-
         if (hideHints) {
-          hint = `${breakingChangesStr}${versionsWarning}${globalLocalCliWarning}`
+          hint = `${breakingChangesStr}${versionsWarning}`
         } else {
           hint = `
 Start by importing your Prisma Client (See: https://pris.ly/d/importing-client)
 
-${breakingChangesStr}${versionsWarning}${globalLocalCliWarning}`
+${breakingChangesStr}${versionsWarning}`
         }
       }
 
-      const message = '\n' + this.logText + (hasJsClient && !this.hasGeneratorErrored ? hint : '')
+      // Client-specific hint only renders when a JS client was generated; the CLI
+      // mismatch warning renders regardless, except on the thrown-error path below.
+      const clientHint = hasJsClient && !this.hasGeneratorErrored ? hint : ''
+      const message = '\n' + this.logText + clientHint + (this.hasGeneratorErrored ? '' : globalLocalCliWarning)
 
       if (this.hasGeneratorErrored) {
         throw new Error(message)

--- a/packages/cli/src/utils/getClientVersion.test.ts
+++ b/packages/cli/src/utils/getClientVersion.test.ts
@@ -45,26 +45,22 @@ describe('shouldWarnGlobalLocalCliMismatch', () => {
     ).toBe(false)
   })
 
+  // Defensive: `installedLocalPrismaCliVersion` is always read from an installed
+  // `node_modules/prisma/package.json` `version` field, so in practice it is a
+  // well-formed version. These cases lock in that a malformed / non-exact-semver
+  // `version` value never produces a (misleading) warning.
   test.each([
-    ['workspace:*', 'workspace:*'],
-    ['workspace alias', 'workspace:^7.0.0'],
-    ['dist-tag latest', 'latest'],
-    ['dist-tag next', 'next'],
-    ['caret range', '^7.0.0'],
-    ['tilde range', '~7.0.0'],
-    ['gte range', '>=7.0.0'],
-    ['file specifier', 'file:../prisma'],
-    ['link specifier', 'link:../prisma'],
-    ['npm alias', 'npm:prisma@7.0.0'],
+    ['empty string', ''],
     ['partial version', '7'],
     ['partial version with minor', '7.0'],
-    ['empty string', ''],
-  ])('does not warn for non-exact-semver local specifier (%s)', (_label, specifier) => {
+    ['leading v', 'v7.0.0'],
+    ['non-version string', 'not-a-version'],
+  ])('does not warn for a non-exact-semver installed version (%s)', (_label, version) => {
     expect(
       shouldWarnGlobalLocalCliMismatch({
         isGlobalInstall: true,
         globalCliVersion: '7.0.0',
-        installedLocalPrismaCliVersion: specifier,
+        installedLocalPrismaCliVersion: version,
       }),
     ).toBe(false)
   })
@@ -119,6 +115,15 @@ describe('getInstalledPrismaCliVersion', () => {
     const prismaDir = path.join(tmpDir, 'node_modules', 'prisma')
     fs.mkdirSync(prismaDir, { recursive: true })
     fs.writeFileSync(path.join(prismaDir, 'package.json'), JSON.stringify({ name: 'prisma' }))
+
+    const result = await getInstalledPrismaCliVersion(tmpDir)
+    expect(result).toBeNull()
+  })
+
+  test('returns null when the version field is not a string', async () => {
+    const prismaDir = path.join(tmpDir, 'node_modules', 'prisma')
+    fs.mkdirSync(prismaDir, { recursive: true })
+    fs.writeFileSync(path.join(prismaDir, 'package.json'), JSON.stringify({ name: 'prisma', version: 7 }))
 
     const result = await getInstalledPrismaCliVersion(tmpDir)
     expect(result).toBeNull()

--- a/packages/cli/src/utils/getClientVersion.test.ts
+++ b/packages/cli/src/utils/getClientVersion.test.ts
@@ -1,0 +1,126 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { getInstalledPrismaCliVersion, shouldWarnGlobalLocalCliMismatch } from './getClientVersion'
+
+describe('shouldWarnGlobalLocalCliMismatch', () => {
+  test('warns when global CLI version differs from locally installed prisma', () => {
+    expect(
+      shouldWarnGlobalLocalCliMismatch({
+        isGlobalInstall: true,
+        globalCliVersion: '7.0.0',
+        installedLocalPrismaCliVersion: '6.5.0',
+      }),
+    ).toBe(true)
+  })
+
+  test('does not warn when versions match', () => {
+    expect(
+      shouldWarnGlobalLocalCliMismatch({
+        isGlobalInstall: true,
+        globalCliVersion: '7.0.0',
+        installedLocalPrismaCliVersion: '7.0.0',
+      }),
+    ).toBe(false)
+  })
+
+  test('does not warn when CLI is not globally installed', () => {
+    expect(
+      shouldWarnGlobalLocalCliMismatch({
+        isGlobalInstall: false,
+        globalCliVersion: '7.0.0',
+        installedLocalPrismaCliVersion: '6.5.0',
+      }),
+    ).toBe(false)
+  })
+
+  test('does not warn when no local prisma is detected', () => {
+    expect(
+      shouldWarnGlobalLocalCliMismatch({
+        isGlobalInstall: true,
+        globalCliVersion: '7.0.0',
+        installedLocalPrismaCliVersion: null,
+      }),
+    ).toBe(false)
+  })
+
+  test.each([
+    ['workspace:*', 'workspace:*'],
+    ['workspace alias', 'workspace:^7.0.0'],
+    ['dist-tag latest', 'latest'],
+    ['dist-tag next', 'next'],
+    ['caret range', '^7.0.0'],
+    ['tilde range', '~7.0.0'],
+    ['gte range', '>=7.0.0'],
+    ['file specifier', 'file:../prisma'],
+    ['link specifier', 'link:../prisma'],
+    ['npm alias', 'npm:prisma@7.0.0'],
+    ['partial version', '7'],
+    ['partial version with minor', '7.0'],
+    ['empty string', ''],
+  ])('does not warn for non-exact-semver local specifier (%s)', (_label, specifier) => {
+    expect(
+      shouldWarnGlobalLocalCliMismatch({
+        isGlobalInstall: true,
+        globalCliVersion: '7.0.0',
+        installedLocalPrismaCliVersion: specifier,
+      }),
+    ).toBe(false)
+  })
+
+  test('accepts prerelease semver as exact comparable', () => {
+    expect(
+      shouldWarnGlobalLocalCliMismatch({
+        isGlobalInstall: true,
+        globalCliVersion: '7.0.0',
+        installedLocalPrismaCliVersion: '7.0.0-beta.1',
+      }),
+    ).toBe(true)
+  })
+
+  test('does not warn when global version itself is not exact semver', () => {
+    expect(
+      shouldWarnGlobalLocalCliMismatch({
+        isGlobalInstall: true,
+        globalCliVersion: 'placeholder-not-a-version',
+        installedLocalPrismaCliVersion: '7.0.0',
+      }),
+    ).toBe(false)
+  })
+})
+
+describe('getInstalledPrismaCliVersion', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prisma-cli-version-test-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  test('returns the installed prisma version from node_modules', async () => {
+    const prismaDir = path.join(tmpDir, 'node_modules', 'prisma')
+    fs.mkdirSync(prismaDir, { recursive: true })
+    fs.writeFileSync(path.join(prismaDir, 'package.json'), JSON.stringify({ name: 'prisma', version: '6.5.0' }))
+
+    const result = await getInstalledPrismaCliVersion(tmpDir)
+    expect(result).toBe('6.5.0')
+  })
+
+  test('returns null when prisma is not installed locally', async () => {
+    const result = await getInstalledPrismaCliVersion(tmpDir)
+    expect(result).toBeNull()
+  })
+
+  test('returns null when node_modules/prisma/package.json has no version', async () => {
+    const prismaDir = path.join(tmpDir, 'node_modules', 'prisma')
+    fs.mkdirSync(prismaDir, { recursive: true })
+    fs.writeFileSync(path.join(prismaDir, 'package.json'), JSON.stringify({ name: 'prisma' }))
+
+    const result = await getInstalledPrismaCliVersion(tmpDir)
+    expect(result).toBeNull()
+  })
+})

--- a/packages/cli/src/utils/getClientVersion.test.ts
+++ b/packages/cli/src/utils/getClientVersion.test.ts
@@ -123,4 +123,32 @@ describe('getInstalledPrismaCliVersion', () => {
     const result = await getInstalledPrismaCliVersion(tmpDir)
     expect(result).toBeNull()
   })
+
+  test('walks up from cwd and finds prisma in a parent directory', async () => {
+    const nestedCwd = path.join(tmpDir, 'apps', 'api')
+    fs.mkdirSync(nestedCwd, { recursive: true })
+
+    const prismaDir = path.join(tmpDir, 'node_modules', 'prisma')
+    fs.mkdirSync(prismaDir, { recursive: true })
+    fs.writeFileSync(path.join(prismaDir, 'package.json'), JSON.stringify({ name: 'prisma', version: '6.5.0' }))
+
+    const result = await getInstalledPrismaCliVersion(nestedCwd)
+    expect(result).toBe('6.5.0')
+  })
+
+  test('returns null on a malformed package.json without continuing to walk up', async () => {
+    // Inner node_modules/prisma/package.json is corrupt; outer one has a real version.
+    // The function must NOT silently fall through to the outer install.
+    const innerDir = path.join(tmpDir, 'inner')
+    const innerPrismaDir = path.join(innerDir, 'node_modules', 'prisma')
+    fs.mkdirSync(innerPrismaDir, { recursive: true })
+    fs.writeFileSync(path.join(innerPrismaDir, 'package.json'), 'not valid json{')
+
+    const outerPrismaDir = path.join(tmpDir, 'node_modules', 'prisma')
+    fs.mkdirSync(outerPrismaDir, { recursive: true })
+    fs.writeFileSync(path.join(outerPrismaDir, 'package.json'), JSON.stringify({ name: 'prisma', version: '9.9.9' }))
+
+    const result = await getInstalledPrismaCliVersion(innerDir)
+    expect(result).toBeNull()
+  })
 })

--- a/packages/cli/src/utils/getClientVersion.ts
+++ b/packages/cli/src/utils/getClientVersion.ts
@@ -1,12 +1,66 @@
 import fs from 'fs'
 import Module from 'module'
 import { packageUp } from 'package-up'
+import path from 'path'
 
 /**
  * Try reading the installed Prisma Client version
  */
 export async function getInstalledPrismaClientVersion(cwd: string = process.cwd()): Promise<string | null> {
   return (await getPrismaClientVersionFromNodeModules(cwd)) ?? (await getPrismaClientVersionFromLocalPackageJson(cwd))
+}
+
+/**
+ * Try reading the locally installed prisma CLI version by walking up from `cwd` looking
+ * for `node_modules/prisma/package.json`. Returns null when prisma is not installed locally.
+ *
+ * Uses explicit filesystem traversal rather than `require.resolve` because the prisma CLI
+ * is itself the `prisma` package — Node's resolver would otherwise find the CLI's own
+ * package.json instead of a locally installed one.
+ *
+ * Unlike `getInstalledPrismaClientVersion`, this does NOT fall back to the project's
+ * declared dependency specifier — only a real, installed version under node_modules is
+ * comparable to the globally running CLI version.
+ */
+export async function getInstalledPrismaCliVersion(cwd: string = process.cwd()): Promise<string | null> {
+  try {
+    let dir = path.resolve(cwd)
+    // walk up to filesystem root
+    while (true) {
+      const candidate = path.join(dir, 'node_modules', 'prisma', 'package.json')
+      try {
+        const pkgJson = JSON.parse(await fs.promises.readFile(candidate, 'utf-8'))
+        return pkgJson.version ?? null
+      } catch {
+        // not in this directory; keep walking up
+      }
+      const parent = path.dirname(dir)
+      if (parent === dir) return null
+      dir = parent
+    }
+  } catch {
+    return null
+  }
+}
+
+const exactSemverRegex = /^\d+\.\d+\.\d+(?:-[\w.-]+)?(?:\+[\w.-]+)?$/
+
+/**
+ * Decide whether to surface a "global prisma vs locally-installed prisma" mismatch warning.
+ * Only triggers on exact semver mismatches — workspace:*, dist-tags (latest/next),
+ * ranges (^x, ~x), and file:/link: specifiers are intentionally ignored to avoid false positives.
+ */
+export function shouldWarnGlobalLocalCliMismatch(args: {
+  isGlobalInstall: boolean
+  globalCliVersion: string | null | undefined
+  installedLocalPrismaCliVersion: string | null | undefined
+}): boolean {
+  const { isGlobalInstall, globalCliVersion, installedLocalPrismaCliVersion } = args
+  if (!isGlobalInstall) return false
+  if (!globalCliVersion || !installedLocalPrismaCliVersion) return false
+  if (!exactSemverRegex.test(globalCliVersion)) return false
+  if (!exactSemverRegex.test(installedLocalPrismaCliVersion)) return false
+  return globalCliVersion !== installedLocalPrismaCliVersion
 }
 
 /**

--- a/packages/cli/src/utils/getClientVersion.ts
+++ b/packages/cli/src/utils/getClientVersion.ts
@@ -30,7 +30,10 @@ export async function getInstalledPrismaCliVersion(cwd: string = process.cwd()):
       const candidate = path.join(dir, 'node_modules', 'prisma', 'package.json')
       try {
         const pkgJson = JSON.parse(await fs.promises.readFile(candidate, 'utf-8'))
-        return pkgJson.version ?? null
+        // Guard the type: a malformed package.json could carry a non-string
+        // `version` (e.g. a number), which must not leak through the
+        // `Promise<string | null>` contract.
+        return typeof pkgJson.version === 'string' ? pkgJson.version : null
       } catch (error: unknown) {
         // Only ENOENT means "not here, keep walking". Any other error
         // (EACCES, parse failure, etc.) on an existing candidate is terminal
@@ -53,8 +56,14 @@ const exactSemverRegex = /^\d+\.\d+\.\d+(?:-[\w.-]+)?(?:\+[\w.-]+)?$/
 
 /**
  * Decide whether to surface a "global prisma vs locally-installed prisma" mismatch warning.
- * Only triggers on exact semver mismatches — workspace:*, dist-tags (latest/next),
- * ranges (^x, ~x), and file:/link: specifiers are intentionally ignored to avoid false positives.
+ *
+ * Both inputs are concrete, installed versions: `globalCliVersion` is the running CLI's
+ * own `pkg.version` and `installedLocalPrismaCliVersion` is read from an installed
+ * `node_modules/prisma/package.json` (see `getInstalledPrismaCliVersion`). Neither is ever
+ * a dependency specifier. The exact-semver guard is therefore defensive — it only acts when
+ * both strings are concrete versions, so a malformed/non-version `version` field can never
+ * produce a misleading warning. Comparison is exact-string by design (an advisory about
+ * differing installed identities), so prerelease/build-metadata differences do surface.
  */
 export function shouldWarnGlobalLocalCliMismatch(args: {
   isGlobalInstall: boolean

--- a/packages/cli/src/utils/getClientVersion.ts
+++ b/packages/cli/src/utils/getClientVersion.ts
@@ -31,8 +31,14 @@ export async function getInstalledPrismaCliVersion(cwd: string = process.cwd()):
       try {
         const pkgJson = JSON.parse(await fs.promises.readFile(candidate, 'utf-8'))
         return pkgJson.version ?? null
-      } catch {
-        // not in this directory; keep walking up
+      } catch (error: unknown) {
+        // Only ENOENT means "not here, keep walking". Any other error
+        // (EACCES, parse failure, etc.) on an existing candidate is terminal
+        // — silently continuing could resolve a different prisma higher up
+        // and produce a misleading warning.
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+          return null
+        }
       }
       const parent = path.dirname(dir)
       if (parent === dir) return null


### PR DESCRIPTION
Closes #1911.

## What

When `prisma generate` runs from a globally-installed `prisma` CLI in a project
that has a different `prisma` version under `node_modules`, the CLI now emits
a single advisory line — same visual style as the existing
`prisma`/`@prisma/client` version-mismatch warning — pointing the user toward
running the local version (`npx prisma generate` or your package manager's
equivalent).

## How

- Add `getInstalledPrismaCliVersion(cwd)` in
  `packages/cli/src/utils/getClientVersion.ts` — walks up from `cwd` looking
  for `node_modules/prisma/package.json`. Explicit filesystem walk (not
  `require.resolve`) because the running prisma CLI is itself the `prisma`
  package, so Node's resolver would otherwise find the CLI's own
  `package.json`.
- Add `shouldWarnGlobalLocalCliMismatch({ ... })` — pure predicate. Only
  triggers when (a) `isCurrentBinInstalledGlobally()` is truthy, (b) a
  locally-installed prisma version is found under `node_modules`, and (c)
  both versions match exact semver and differ. Skips `workspace:*`, dist-tags
  (`latest`, `next`), ranges (`^x`, `~x`, `>=x`), `file:`/`link:` specifiers,
  and partial versions to avoid false positives.
- In `packages/cli/src/Generate.ts`, after the existing `versionsWarning`
  block, append a `globalLocalCliWarning` to the `hint` (same style; same
  `--no-hints` and `logger.should.warn()` gating as the existing warning).

## Diff size

74 lines of production code added, 2 lines modified across 2 files. No new
source files (helpers live in the existing `getClientVersion.ts`). 126 lines
of new tests in `src/utils/getClientVersion.test.ts` (22 cases), placed
alongside the source file, matching the convention of existing util tests
(`client-output-path.test.ts`, `loadConfig.test.ts`, `ppgInfo.test.ts`).

## Tests

22 unit tests on the two new helpers (`pnpm --filter prisma test src/utils/getClientVersion.test.ts`):

- exact-semver mismatch → warn
- exact-semver match → no warn
- not globally installed → no warn
- no local prisma installed → no warn
- 13 non-exact specifier cases (`workspace:*`, `latest`, `next`, `^7.0.0`,
  `~7.0.0`, `>=7.0.0`, `file:../prisma`, `link:../prisma`,
  `npm:prisma@7.0.0`, `7`, `7.0`, empty string, `workspace:^7.0.0`) → all
  no-warn
- prerelease semver `7.0.0-beta.1` → warn
- non-exact global version (e.g. placeholder strings) → no warn
- helper reads `node_modules/prisma/package.json` correctly
- returns null when prisma is not installed
- returns null when version field is absent

## Documentation

This change adds a runtime advisory line to the existing `prisma generate`
hint block; it does not introduce new commands, flags, or configuration. The
existing `prisma@x` ↔ `@prisma/client@x` mismatch warning is similarly
surfaced only as runtime output and is not documented in the CLI reference,
so I haven't filed a docs-update PR. Happy to open one if a maintainer would
prefer the warning behavior described in the reference.

## Disclosure

Patch drafted with AI assistance (Claude Code); reviewed line-by-line by the
author, locally tested, and CLA-signed by the author.

/claim #1911
