### PR TITLE
fix(cli): avoid CRLF in prisma format output

### DIFF
--- a/packages/cli/src/Format.ts
+++ b/packages/cli/src/Format.ts
@@ -79,7 +79,10 @@ Or specify a Prisma schema path
     })
     printSchemaLoadedMessage(schemaPath)
 
-    const formattedDatamodel = await formatSchema({ schemas })
+    const formattedDatamodelRaw = await formatSchema({ schemas })
+    const formattedDatamodel = formattedDatamodelRaw.map(
+      ([filename, data]) => [filename, normalizeSchemaNewlines(data)] as [string, string],
+    )
 
     // Validate whether the formatted output is a valid schema
     validate({
@@ -118,4 +121,8 @@ Or specify a Prisma schema path
     }
     return Format.help
   }
+}
+
+function normalizeSchemaNewlines(schema: string): string {
+  return schema.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
 }

--- a/packages/cli/src/__tests__/commands/Format.newlines.test.ts
+++ b/packages/cli/src/__tests__/commands/Format.newlines.test.ts
@@ -1,0 +1,32 @@
+import fs from 'node:fs'
+
+import { defaultTestConfig } from '@prisma/config'
+import { jestConsoleContext, jestContext } from '@prisma/get-platform'
+
+const mockFormatSchema = jest.fn(async () => [['schema.prisma', 'model A {\n  id Int @id\n}\r\n']])
+const mockValidate = jest.fn()
+
+jest.mock('@prisma/internals', () => {
+  const actual = jest.requireActual('@prisma/internals')
+  return {
+    ...actual,
+    formatSchema: (...args: unknown[]) => mockFormatSchema(...args),
+    validate: (...args: unknown[]) => mockValidate(...args),
+  }
+})
+
+import { Format } from '../../Format'
+
+const ctx = jestContext.new().add(jestConsoleContext()).assemble()
+
+describe('format (newline normalization)', () => {
+  it('writes LF-only even if formatter returns CRLF', async () => {
+    ctx.fixture('example-project/prisma')
+
+    await Format.new().parse([], defaultTestConfig())
+
+    const schema = fs.readFileSync('schema.prisma')
+    expect(schema.includes('\r')).toBe(false)
+  })
+})
+


### PR DESCRIPTION
Fixes #8548.

On Windows, prisma format could write a final CRLF even when all other lines are LF. This normalizes formatter output to LF before writing schema files, and adds a regression test.