### PR TITLE
fix(cli): normalize trailing CRLF to LF in prisma format

### DIFF
--- a/packages/cli/src/Format.ts
+++ b/packages/cli/src/Format.ts
@@ -104,9 +104,10 @@ Or specify a Prisma schema path
 
     for (const [filename, data] of formattedDatamodel) {
       const normalizedData = data.endsWith('
-') ? data.replace(/\r
+') ? data.replace(/
 $/, '
-') : data; await fs.writeFile(filename, normalizedData)
+') : data
+      await fs.writeFile(filename, normalizedData)
     }
 
     const after = Math.round(performance.now())

--- a/packages/cli/src/Format.ts
+++ b/packages/cli/src/Format.ts
@@ -103,7 +103,10 @@ Or specify a Prisma schema path
     }
 
     for (const [filename, data] of formattedDatamodel) {
-      await fs.writeFile(filename, data)
+      const normalizedData = data.endsWith('
+') ? data.replace(/\r
+$/, '
+') : data; await fs.writeFile(filename, normalizedData)
     }
 
     const after = Math.round(performance.now())


### PR DESCRIPTION
Fixes #8548 — prisma format produces trailing CRLF instead of LF on Windows.

The Wasm formatter (Rust) preserves CRLF on Windows. The fix normalizes the trailing CRLF to LF in the TypeScript CLI layer before writing the file.

```typescript
for (const [filename, data] of formattedDatamodel) {
  const normalizedData = data.endsWith("\r\n") ? data.replace(/\\r\n$/, "\n") : data
  await fs.writeFile(filename, normalizedData)
}
```