### PR TITLE
feat(cli): output binary path in prisma -v output

### DIFF
--- a/packages/cli/src/Version.ts
+++ b/packages/cli/src/Version.ts
@@ -17,6 +17,7 @@ import {
 } from '@prisma/internals'
 import { bold, dim, red } from 'kleur/colors'
 import os from 'os'
+import fs from 'fs'
 
 import { getInstalledPrismaClientVersion } from './utils/getClientVersion'
 
@@ -85,6 +86,7 @@ export class Version implements Command {
       ['Operating System', os.platform()],
       ['Architecture', os.arch()],
       ['Node.js', process.version],
+      ['Prisma CLI Path', process.argv[1] ? fs.realpathSync(process.argv[1]) : 'unknown'],
       ['TypeScript', typescriptVersion],
       ['Query Compiler', 'enabled'],
       ['PSL', `@prisma/prisma-schema-wasm ${wasm.prismaSchemaWasmVersion}`],

--- a/packages/cli/src/Version.ts
+++ b/packages/cli/src/Version.ts
@@ -80,18 +80,19 @@ export class Version implements Command {
     const prismaClientVersion = await getInstalledPrismaClientVersion()
     const typescriptVersion = await getTypescriptVersion()
 
+    // Try to resolve the actual binary path; if it doesn't exist (e.g. symlink to
+    // parent node_modules), use the unresolved argv[1] rather than throwing
+    let cliPath = 'unknown'
+    if (process.argv[1]) {
+      try { cliPath = fs.realpathSync(process.argv[1]) } catch { cliPath = process.argv[1] }
+    }
+
     const rows = [
       [packageJson.name, packageJson.version],
       ['@prisma/client', prismaClientVersion ?? 'Not found'],
       ['Operating System', os.platform()],
       ['Architecture', os.arch()],
       ['Node.js', process.version],
-      // Try to resolve the actual binary path; if it doesn't exist (e.g. symlink to
-      // parent node_modules), use the unresolved argv[1] rather than throwing
-      let cliPath = 'unknown'
-      if (process.argv[1]) {
-        try { cliPath = fs.realpathSync(process.argv[1]) } catch { cliPath = process.argv[1] }
-      }
       ['Prisma CLI Path', cliPath],
       ['TypeScript', typescriptVersion],
       ['Query Compiler', 'enabled'],

--- a/packages/cli/src/Version.ts
+++ b/packages/cli/src/Version.ts
@@ -86,7 +86,13 @@ export class Version implements Command {
       ['Operating System', os.platform()],
       ['Architecture', os.arch()],
       ['Node.js', process.version],
-      ['Prisma CLI Path', process.argv[1] ? fs.realpathSync(process.argv[1]) : 'unknown'],
+      // Try to resolve the actual binary path; if it doesn't exist (e.g. symlink to
+      // parent node_modules), use the unresolved argv[1] rather than throwing
+      let cliPath = 'unknown'
+      if (process.argv[1]) {
+        try { cliPath = fs.realpathSync(process.argv[1]) } catch { cliPath = process.argv[1] }
+      }
+      ['Prisma CLI Path', cliPath],
       ['TypeScript', typescriptVersion],
       ['Query Compiler', 'enabled'],
       ['PSL', `@prisma/prisma-schema-wasm ${wasm.prismaSchemaWasmVersion}`],

--- a/packages/cli/src/Version.ts
+++ b/packages/cli/src/Version.ts
@@ -15,9 +15,9 @@ import {
   resolveEngine,
   wasm,
 } from '@prisma/internals'
+import fs from 'fs'
 import { bold, dim, red } from 'kleur/colors'
 import os from 'os'
-import fs from 'fs'
 
 import { getInstalledPrismaClientVersion } from './utils/getClientVersion'
 
@@ -84,7 +84,11 @@ export class Version implements Command {
     // parent node_modules), use the unresolved argv[1] rather than throwing
     let cliPath = 'unknown'
     if (process.argv[1]) {
-      try { cliPath = fs.realpathSync(process.argv[1]) } catch { cliPath = process.argv[1] }
+      try {
+        cliPath = fs.realpathSync(process.argv[1])
+      } catch {
+        cliPath = process.argv[1]
+      }
     }
 
     const rows = [

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -17,6 +17,7 @@ describe('version', () => {
       Operating System     : OS
       Architecture         : ARCHITECTURE
       Node.js              : NODEJS_VERSION
+      Prisma CLI Path      : CLI_PATH
       TypeScript           : TYPESCRIPT_VERSION
       Query Compiler       : enabled
       PSL                  : @prisma/prisma-schema-wasm CLI_VERSION.ENGINE_VERSION

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -63,6 +63,9 @@ function cleanSnapshot(str: string, versionOverride?: string): string {
   str = str.replace(new RegExp(defaultEngineVersion, 'g'), 'ENGINE_VERSION')
   str = str.replace(new RegExp('(Operating System\\s+:).*', 'g'), '$1 OS')
   str = str.replace(new RegExp('(Architecture\\s+:).*', 'g'), '$1 ARCHITECTURE')
+
+  // sanitize Prisma CLI Path
+  str = str.replace(/Prisma CLI Path\s+:.*/g, 'Prisma CLI Path      : CLI_PATH')
   str = str.replace(new RegExp('workspace:\\*', 'g'), 'ENGINE_VERSION')
   str = str.replace(new RegExp(process.version, 'g'), 'NODEJS_VERSION')
   str = str.replace(new RegExp(`(TypeScript\\s+:) ${typeScriptVersion}`, 'g'), '$1 TYPESCRIPT_VERSION')


### PR DESCRIPTION
Fixes #7771.

`prisma -v` reports component versions and engine locations, but it does not show which CLI installation is executing. This change adds a `Prisma CLI Path` row using the resolved `process.argv[1]` path, with a graceful fallback if resolution fails.

Example output from Prisma 7.8.0 on Windows (paths shortened for readability):

```text
prisma               : 7.8.0
@prisma/client       : Not found
Operating System     : win32
Architecture         : x64
Node.js              : v26.5.0
Prisma CLI Path      : C:\...\node_modules\prisma\build\index.js
TypeScript           : unknown
Query Compiler       : enabled
PSL                  : @prisma/prisma-schema-wasm 7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a
Schema Engine        : schema-engine-cli 3c6e192761c0362d496ed980de936e2f3cebcd3a (at ...\@prisma\engines\schema-engine-windows.exe)
Default Engines Hash : 3c6e192761c0362d496ed980de936e2f3cebcd3a
Studio               : 0.27.3
```

Validation:

- `pnpm --filter prisma test src/__tests__/commands/Version.test.ts`
- targeted ESLint and Prettier checks