### PR TITLE
fix: remove duplicate 'the the' in test comments

### DIFF
--- a/packages/client/tests/functional/extensions/query.ts
+++ b/packages/client/tests/functional/extensions/query.ts
@@ -1601,7 +1601,7 @@ testMatrix.setupTestSuite(
             },
             $allModels: {
               async $allOperations({ operation, args, query, model }) {
-                // same as above but also check the the model is User in the if condition
+                // same as above but also check the model is User in the if condition
                 if (model === 'User' && operation === 'aggregate') {
                   const data = await query(args)
 

--- a/packages/client/tests/functional/methods/upsert/native-atomic/tests.ts
+++ b/packages/client/tests/functional/methods/upsert/native-atomic/tests.ts
@@ -232,7 +232,7 @@ testMatrix.setupTestSuite(
           name,
         },
         create: {
-          // Because the the where 'name' is 'not' equal to the create 'name'
+          // Because the where 'name' is 'not' equal to the create 'name'
           name: name + '1',
         },
         update: {
@@ -248,7 +248,7 @@ testMatrix.setupTestSuite(
           name,
         },
         create: {
-          // Because the the where 'name' is 'equal' to the create 'name'
+          // Because the where 'name' is 'equal' to the create 'name'
           name,
         },
         update: {


### PR DESCRIPTION
## Summary

Removes duplicate "the the" → "the" in 3 test comments:

- `packages/client/tests/functional/extensions/query.ts:1604`
- `packages/client/tests/functional/methods/upsert/native-atomic/tests.ts:235`
- `packages/client/tests/functional/methods/upsert/native-atomic/tests.ts:251`

Comment-only changes, no functional impact.