### PR TITLE
fix(adapter-mariadb): release pooled connections and harden transaction cleanup

### DIFF
--- a/packages/adapter-mariadb/src/mariadb.test.ts
+++ b/packages/adapter-mariadb/src/mariadb.test.ts
@@ -329,3 +329,106 @@ describe('PrismaMariaDbAdapterFactory', () => {
     expect(mockPool.end).toHaveBeenCalledTimes(2)
   })
 })
+
+describe('transaction connection management', () => {
+  function makePoolConn() {
+    const listeners = new Map<string, Set<(...args: unknown[]) => void>>()
+    const conn = {
+      query: vi.fn().mockResolvedValue([]),
+      execute: vi.fn().mockResolvedValue({ meta: [], affectedRows: 1 }),
+      release: vi.fn().mockResolvedValue(undefined),
+      end: vi.fn().mockResolvedValue(undefined),
+      on(event: string, cb: (...args: unknown[]) => void) {
+        if (!listeners.has(event)) listeners.set(event, new Set())
+        listeners.get(event)!.add(cb)
+        return this
+      },
+      off(event: string, cb: (...args: unknown[]) => void) {
+        listeners.get(event)?.delete(cb)
+        return this
+      },
+      listenerCount(event: string) {
+        return listeners.get(event)?.size ?? 0
+      },
+    }
+    return conn
+  }
+
+  test('commit returns connection to the pool via release() (not end())', async () => {
+    const conn = makePoolConn()
+    const pool = {
+      getConnection: vi.fn().mockResolvedValue(conn),
+      query: vi.fn().mockResolvedValue([['8.0.13']]),
+    } as unknown as mariadb.Pool
+
+    const adapter = new PrismaMariaDbAdapter(pool, { supportsRelationJoins: false })
+    const tx = await adapter.startTransaction()
+    await tx.commit()
+
+    expect(conn.release).toHaveBeenCalledTimes(1)
+    expect(conn.end).not.toHaveBeenCalled()
+  })
+
+  test('rollback returns connection to the pool via release() (not end())', async () => {
+    const conn = makePoolConn()
+    const pool = {
+      getConnection: vi.fn().mockResolvedValue(conn),
+      query: vi.fn().mockResolvedValue([['8.0.13']]),
+    } as unknown as mariadb.Pool
+
+    const adapter = new PrismaMariaDbAdapter(pool, { supportsRelationJoins: false })
+    const tx = await adapter.startTransaction()
+    await tx.rollback()
+
+    expect(conn.release).toHaveBeenCalledTimes(1)
+    expect(conn.end).not.toHaveBeenCalled()
+  })
+
+  test('error listener is removed after commit so it does not leak to the next user of the pooled connection', async () => {
+    const conn = makePoolConn()
+    const pool = {
+      getConnection: vi.fn().mockResolvedValue(conn),
+      query: vi.fn().mockResolvedValue([['8.0.13']]),
+    } as unknown as mariadb.Pool
+
+    const adapter = new PrismaMariaDbAdapter(pool, { supportsRelationJoins: false })
+    const tx = await adapter.startTransaction()
+    expect(conn.listenerCount('error')).toBe(1)
+    await tx.commit()
+    expect(conn.listenerCount('error')).toBe(0)
+  })
+
+  test('startTransaction releases the connection AND removes the listener when BEGIN fails', async () => {
+    const conn = makePoolConn()
+    conn.query.mockImplementation(({ sql }: { sql: string }) => {
+      if (sql === 'BEGIN') return Promise.reject(new Error('boom'))
+      return Promise.resolve([])
+    })
+    const pool = {
+      getConnection: vi.fn().mockResolvedValue(conn),
+      query: vi.fn().mockResolvedValue([['8.0.13']]),
+    } as unknown as mariadb.Pool
+
+    const adapter = new PrismaMariaDbAdapter(pool, { supportsRelationJoins: false })
+    await expect(adapter.startTransaction()).rejects.toBeDefined()
+
+    expect(conn.release).toHaveBeenCalledTimes(1)
+    expect(conn.end).not.toHaveBeenCalled()
+    expect(conn.listenerCount('error')).toBe(0)
+  })
+
+  test('falls back to end() for non-pool connections (no release method)', async () => {
+    const conn = makePoolConn()
+    const connNoRelease = { ...conn, release: undefined as unknown as typeof conn.release }
+    const pool = {
+      getConnection: vi.fn().mockResolvedValue(connNoRelease),
+      query: vi.fn().mockResolvedValue([['8.0.13']]),
+    } as unknown as mariadb.Pool
+
+    const adapter = new PrismaMariaDbAdapter(pool, { supportsRelationJoins: false })
+    const tx = await adapter.startTransaction()
+    await tx.commit()
+
+    expect(connNoRelease.end).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/adapter-mariadb/src/mariadb.ts
+++ b/packages/adapter-mariadb/src/mariadb.ts
@@ -397,8 +397,6 @@ type ArrayModeResult = unknown[][] & { meta?: mariadb.FieldInfo[]; affectedRows?
  * which breaks pool reuse and the `idleTimeout` / `minimumIdle` lifecycle.
  * Falls back to `end()` when `release` is not available (e.g. unit tests with
  * a non-pool connection).
- *
- * See https://github.com/prisma/prisma/issues/28964
  */
 async function releaseConnection(conn: mariadb.Connection): Promise<void> {
   const poolConn = conn as mariadb.PoolConnection

--- a/packages/adapter-mariadb/src/mariadb.ts
+++ b/packages/adapter-mariadb/src/mariadb.ts
@@ -103,7 +103,7 @@ class MariaDbTransaction extends MariaDbQueryable<mariadb.Connection> implements
       this.onError(err)
     } finally {
       this.cleanup?.()
-      await this.client.end()
+      await releaseConnection(this.client)
     }
   }
 
@@ -116,7 +116,7 @@ class MariaDbTransaction extends MariaDbQueryable<mariadb.Connection> implements
       this.onError(err)
     } finally {
       this.cleanup?.()
-      await this.client.end()
+      await releaseConnection(this.client)
     }
   }
 
@@ -188,7 +188,7 @@ export class PrismaMariaDbAdapter extends MariaDbQueryable<mariadb.Pool> impleme
     conn.on('error', onError)
 
     const cleanup = () => {
-      conn.removeListener('error', onError)
+      conn.off('error', onError)
     }
 
     try {
@@ -204,8 +204,14 @@ export class PrismaMariaDbAdapter extends MariaDbQueryable<mariadb.Pool> impleme
       await tx.conn.query({ sql: 'BEGIN' }).catch(this.onError.bind(this))
       return tx
     } catch (error) {
-      await conn.end()
-      cleanup()
+      // Detach the error listener before releasing the connection so it is not
+      // reused by the pool with our handler still attached. The release is
+      // wrapped in try/finally so the connection always returns to the pool.
+      try {
+        cleanup()
+      } finally {
+        await releaseConnection(conn)
+      }
       this.onError(error)
     }
   }
@@ -384,3 +390,21 @@ export function rewriteConnectionString(url: URL): URL {
 }
 
 type ArrayModeResult = unknown[][] & { meta?: mariadb.FieldInfo[]; affectedRows?: number; insertId?: BigInt }
+
+/**
+ * Returns a pool connection back to its pool via `PoolConnection#release()`.
+ * Using `end()` instead would permanently close a plain `mariadb.Connection`,
+ * which breaks pool reuse and the `idleTimeout` / `minimumIdle` lifecycle.
+ * Falls back to `end()` when `release` is not available (e.g. unit tests with
+ * a non-pool connection).
+ *
+ * See https://github.com/prisma/prisma/issues/28964
+ */
+async function releaseConnection(conn: mariadb.Connection): Promise<void> {
+  const poolConn = conn as mariadb.PoolConnection
+  if (typeof poolConn.release === 'function') {
+    await poolConn.release()
+  } else {
+    await conn.end()
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #28964.

The MariaDB adapter previously called `mariadb.Connection#end()` to dispose of a transaction connection. For a `PoolConnection` `end()` happens to be aliased to `release()`, so in practice it does return the connection to the pool — but the intent is ambiguous, and the same code path is reachable with a plain `mariadb.Connection` (e.g. in tests), where `end()` permanently closes the connection. The transaction failure path also removed the connection's `error` listener *after* releasing the connection and without a `try/finally`, so a throw during teardown would leak the listener onto the next caller.

## Changes

- Introduce a small `releaseConnection()` helper that prefers `PoolConnection#release()` and falls back to `Connection#end()`.
- Use it from `MariaDbTransaction#commit` and `#rollback`.
- In `startTransaction`'s catch path, detach the `error` listener **before** releasing the connection and wrap the release in `try/finally` so the connection is always returned to the pool, even if cleanup throws.

## Tests

Added unit tests in `packages/adapter-mariadb/src/mariadb.test.ts`:

- `release()` is used for pool connections; `end()` fallback for non-pool connections.
- The transaction `error` listener is detached on `commit`.
- The transaction `error` listener is detached and the connection is released on `startTransaction` failure.

All 26 adapter unit tests pass (`pnpm --filter @prisma/adapter-mariadb test`).

## Out-of-band verification

I also ran an end-to-end harness with Docker (`mariadb:10.11`) covering:

1. `connectionLimit=100`, 100 concurrent transactions → 100 idle conns after release ✅
2. Two sequential rounds of 100 → pool reuses, stays at 100 ✅
3. 200 concurrent vs `connectionLimit=100` → capped at 100, no leak ✅
4. `idleTimeout=10s` → pool drains to `minimumIdle` after the window ✅
5. After drain, a new burst grows the pool again ✅

Closes #28964
