### PR TITLE
Show Prisma CLI path in version output

### DIFF
--- a/packages/cli/src/Version.ts
+++ b/packages/cli/src/Version.ts
@@ -16,6 +16,7 @@ import {
   wasm,
 } from '@prisma/internals'
 import { bold, dim, red } from 'kleur/colors'
+import path from 'node:path'
 import os from 'os'
 
 import { getInstalledPrismaClientVersion } from './utils/getClientVersion'
@@ -81,6 +82,7 @@ export class Version implements Command {
 
     const rows = [
       [packageJson.name, packageJson.version],
+      ['Prisma CLI path', process.argv[1] ? path.resolve(process.argv[1]) : 'Unknown'],
       ['@prisma/client', prismaClientVersion ?? 'Not found'],
       ['Operating System', os.platform()],
       ['Architecture', os.arch()],

--- a/packages/cli/src/__tests__/commands/Version.test.ts
+++ b/packages/cli/src/__tests__/commands/Version.test.ts
@@ -13,6 +13,7 @@ describe('version', () => {
     expect(data.exitCode).toBe(0)
     expect(cleanSnapshot(data.stdout)).toMatchInlineSnapshot(`
       "prisma               : 0.0.0
+      Prisma CLI path       : PRISMA_CLI_PATH
       @prisma/client       : 0.0.0
       Operating System     : OS
       Architecture         : ARCHITECTURE
@@ -61,6 +62,7 @@ function cleanSnapshot(str: string, versionOverride?: string): string {
   const currentEngineVersion = versionOverride ?? enginesVersion
   str = str.replace(new RegExp(currentEngineVersion, 'g'), 'ENGINE_VERSION')
   str = str.replace(new RegExp(defaultEngineVersion, 'g'), 'ENGINE_VERSION')
+  str = str.replace(new RegExp('(Prisma CLI path\\s+:).*', 'g'), '$1 PRISMA_CLI_PATH')
   str = str.replace(new RegExp('(Operating System\\s+:).*', 'g'), '$1 OS')
   str = str.replace(new RegExp('(Architecture\\s+:).*', 'g'), '$1 ARCHITECTURE')
   str = str.replace(new RegExp('workspace:\\*', 'g'), 'ENGINE_VERSION')


### PR DESCRIPTION
## Summary
- add the resolved Prisma CLI script path to `prisma -v` / `prisma version` output
- sanitize the path in the existing version command snapshot

## Tests
- `npx prettier --check packages/cli/src/Version.ts packages/cli/src/__tests__/commands/Version.test.ts`
- `git diff --check`

Note: I attempted `corepack pnpm --filter prisma test -- Version.test.ts`, but this local Windows checkout could not build/link workspace packages such as `@prisma/engines` after install. The changed snapshot covers the intended output shape.

Fixes #7771

@algora-pbc /claim #7771