### PR TITLE
fix(dev): bump @hono/node-server to ^1.19.13 to resolve GHSA-92pp-h63…

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -167,7 +167,7 @@
     "@codspeed/benchmark.js-plugin": "4.0.0",
     "@faker-js/faker": "9.6.0",
     "@fast-check/jest": "2.0.3",
-    "@hono/node-server": "1.19.0",
+    "@hono/node-server": "^1.19.13",
     "@inquirer/prompts": "7.3.3",
     "@jest/create-cache-key-function": "29.7.0",
     "@jest/globals": "29.7.0",

--- a/packages/query-plan-executor/package.json
+++ b/packages/query-plan-executor/package.json
@@ -11,7 +11,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@hono/node-server": "1.19.0",
+    "@hono/node-server": "^1.19.13",
     "@hono/zod-validator": "0.7.2",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/context-async-hooks": "2.1.0",


### PR DESCRIPTION
**Description:**
Bumps `@hono/node-server` to `^1.19.13` in `@prisma/client` and `@prisma/query-plan-executor` to patch the middleware bypass vulnerability (GHSA-92pp-h63x-v22m). This removes the need for downstream consumers to use npm overrides in Prisma 7.x.

**Testing:**
- Monorepo dependencies were updated using `pnpm install` and the lockfile was verified to resolve the secure version.
- The dev build (`pnpm -r run dev`) completed successfully with zero TypeScript compilation errors.
- Internal test suites (`vitest` for the query-plan-executor) passed locally.