### PR TITLE
fix(adapter-mariadb): return Uint8Array for binary rows

### DIFF
--- a/packages/adapter-mariadb/src/conversion.test.ts
+++ b/packages/adapter-mariadb/src/conversion.test.ts
@@ -26,10 +26,14 @@ describe('mapRow', () => {
     const row = { data: value }
 
     const result = mapRow(row, [{ type: 'BLOB' } as unknown as mariadb.FieldInfo])
+    const mapped = result[0] as Uint8Array
 
-    expect(Buffer.isBuffer(result[0])).toBe(false)
-    expect(result[0]).toBeInstanceOf(Uint8Array)
-    expect(result[0]).toEqual(Uint8Array.from([1, 2, 3]))
+    expect(Buffer.isBuffer(mapped)).toBe(false)
+    expect(mapped).toBeInstanceOf(Uint8Array)
+    expect(mapped.buffer).toBe(value.buffer)
+    expect(mapped.byteOffset).toBe(value.byteOffset)
+    expect(mapped.byteLength).toBe(value.byteLength)
+    expect(mapped).toEqual(Uint8Array.from([1, 2, 3]))
   })
 
   it('preserves property order for mixed object rows', () => {

--- a/packages/adapter-mariadb/src/conversion.test.ts
+++ b/packages/adapter-mariadb/src/conversion.test.ts
@@ -20,6 +20,18 @@ describe('mapRow', () => {
     expect(result).toEqual(['123'])
   })
 
+  it('maps buffer columns to Uint8Array views', () => {
+    const source = Buffer.from([0, 1, 2, 3, 4])
+    const value = source.subarray(1, 4)
+    const row = { data: value }
+
+    const result = mapRow(row, [{ type: 'BLOB' } as unknown as mariadb.FieldInfo])
+
+    expect(Buffer.isBuffer(result[0])).toBe(false)
+    expect(result[0]).toBeInstanceOf(Uint8Array)
+    expect(result[0]).toEqual(Uint8Array.from([1, 2, 3]))
+  })
+
   it('preserves property order for mixed object rows', () => {
     const row = {
       createdAt: '2024-01-02 03:04:05.123',

--- a/packages/adapter-mariadb/src/conversion.ts
+++ b/packages/adapter-mariadb/src/conversion.ts
@@ -166,6 +166,10 @@ export function mapRow<A>(row: A[] | Record<string, A>, fields?: mariadb.FieldIn
       return value.toString()
     }
 
+    if (Buffer.isBuffer(value)) {
+      return new Uint8Array(value.buffer, value.byteOffset, value.byteLength)
+    }
+
     return value
   })
 }


### PR DESCRIPTION
Fixes #29597.

MariaDB returns binary column values as Node Buffers, but the driver-adapter result contract uses Uint8Array for binary values. This normalizes Buffers in mapRow before they reach Prisma Client, preserving the original byte offset and length for sliced buffers.

Verification:
- pnpm --config.store-dir=/tmp/prisma-29597-pnpm-store --filter @prisma/adapter-mariadb test conversion.test.ts
- pnpm --config.store-dir=/tmp/prisma-29597-pnpm-store --filter @prisma/adapter-mariadb test
- pnpm --config.store-dir=/tmp/prisma-29597-pnpm-store --filter @prisma/adapter-mariadb build
- git diff --check