### PR TITLE
fix(cli): normalize formatted schema line endings

### DIFF
--- a/packages/cli/src/Format.ts
+++ b/packages/cli/src/Format.ts
@@ -16,6 +16,10 @@ import {
 } from '@prisma/internals'
 import { bold, dim, red, underline } from 'kleur/colors'
 
+export function normalizeFormattedSchemaLineEndings(schema: string): string {
+  return schema.replace(/\r\n/g, '\n')
+}
+
 /**
  * $ prisma format
  */
@@ -88,12 +92,13 @@ Or specify a Prisma schema path
 
     if (args['--check']) {
       for (const [filename, formattedSchema] of formattedDatamodel) {
+        const normalizedFormattedSchema = normalizeFormattedSchemaLineEndings(formattedSchema)
         const originalSchemaTuple = schemas.find((s) => s[0] === filename)
         if (!originalSchemaTuple) {
           return new HelpError(`${bold(red(`!`))} The schema ${underline(filename)} is not found in the schema list.`)
         }
         const [, originalSchema] = originalSchemaTuple
-        if (originalSchema !== formattedSchema) {
+        if (originalSchema !== normalizedFormattedSchema) {
           return new HelpError(
             `${bold(red(`!`))} There are unformatted files. Run ${underline('prisma format')} to format them.`,
           )
@@ -103,7 +108,7 @@ Or specify a Prisma schema path
     }
 
     for (const [filename, data] of formattedDatamodel) {
-      await fs.writeFile(filename, data)
+      await fs.writeFile(filename, normalizeFormattedSchemaLineEndings(data))
     }
 
     const after = Math.round(performance.now())

--- a/packages/cli/src/Format.ts
+++ b/packages/cli/src/Format.ts
@@ -16,8 +16,11 @@ import {
 } from '@prisma/internals'
 import { bold, dim, red, underline } from 'kleur/colors'
 
+/**
+ * Prisma schema formatting should write LF-only files on every platform.
+ */
 export function normalizeFormattedSchemaLineEndings(schema: string): string {
-  return schema.replace(/\r\n/g, '\n')
+  return schema.replace(/\r\n?/g, '\n')
 }
 
 /**

--- a/packages/cli/src/__tests__/commands/Format.test.ts
+++ b/packages/cli/src/__tests__/commands/Format.test.ts
@@ -270,8 +270,8 @@ describe('format', () => {
       'generator client {\r\n',
       '  provider = "prisma-client-js"\r\n',
       '}\r\n',
-      '\r\n',
-      'model User {\r\n',
+      '\r',
+      'model User {\n',
       '  id String @id\r\n',
       '}\r\n',
     ].join('')

--- a/packages/cli/src/__tests__/commands/Format.test.ts
+++ b/packages/cli/src/__tests__/commands/Format.test.ts
@@ -6,7 +6,7 @@ import { defaultTestConfig } from '@prisma/config'
 import { jestConsoleContext, jestContext } from '@prisma/get-platform'
 import { extractSchemaContent, getSchemaWithPath } from '@prisma/internals'
 
-import { Format } from '../../Format'
+import { Format, normalizeFormattedSchemaLineEndings } from '../../Format'
 import { Validate } from '../../Validate'
 
 const ctx = jestContext.new().add(jestConsoleContext()).assemble()
@@ -263,6 +263,29 @@ describe('format', () => {
     ctx.fixture('example-project/prisma')
     await Format.new().parse([], defaultTestConfig())
     expect(fs.readFileSync('schema.prisma', { encoding: 'utf-8' })).toMatchSnapshot()
+  })
+
+  it('normalizes formatter CRLF output before comparing or writing', () => {
+    const formattedSchema = [
+      'generator client {\r\n',
+      '  provider = "prisma-client-js"\r\n',
+      '}\r\n',
+      '\r\n',
+      'model User {\r\n',
+      '  id String @id\r\n',
+      '}\r\n',
+    ].join('')
+
+    expect(normalizeFormattedSchemaLineEndings(formattedSchema)).toMatchInlineSnapshot(`
+      "generator client {
+        provider = "prisma-client-js"
+      }
+
+      model User {
+        id String @id
+      }
+      "
+    `)
   })
 
   it('should add missing backrelation', async () => {


### PR DESCRIPTION
/claim #8548

## Summary
- normalize formatted schema output to LF before `prisma format` writes files
- use the same normalized formatter output for `prisma format --check`
- add coverage for CRLF and lone CR output normalization

## Why
On Windows the formatter can hand the CLI CRLF output, which leaves `schema.prisma` with carriage returns even though Prisma schema formatting should produce LF-only output. This keeps the write path and `--check` path consistent.

I noticed there are other open attempts for this issue, so I kept this version narrowly scoped to the CLI format output normalization and added explicit coverage for both CRLF and stray CR input.

## Validation
- Verified the branch diff via GitHub compare API.
- Ran a local Node check for the normalization helper behavior: CR count went from 6 to 0.
- Local full Jest/PNPM tests were not run in this workspace because the Prisma monorepo dependencies are not installed here.