### PR TITLE
fix(adapter-pg): preserve error.constraint on 23505 unique violations

### DIFF
--- a/packages/adapter-pg/src/__tests__/errors.test.ts
+++ b/packages/adapter-pg/src/__tests__/errors.test.ts
@@ -33,11 +33,41 @@ describe('convertDriverError', () => {
     })
   })
 
-  it('should handle UniqueConstraintViolation (23505)', () => {
+  it('should handle UniqueConstraintViolation (23505) with detail only', () => {
     const error = { code: '23505', message: 'msg', severity: 'ERROR', detail: 'Key (id)' }
     expect(convertDriverError(error)).toEqual({
       kind: 'UniqueConstraintViolation',
       constraint: { fields: ['id'] },
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle UniqueConstraintViolation (23505) with constraint', () => {
+    const error = { code: '23505', message: 'msg', severity: 'ERROR', constraint: 'users_email_partial_idx' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'UniqueConstraintViolation',
+      constraint: { index: 'users_email_partial_idx' },
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle UniqueConstraintViolation (23505) with both constraint and detail (constraint wins)', () => {
+    // Two unique constraints can share key columns (e.g. a full unique on
+    // `(user_id, account_id)` and a partial unique on `(account_id)
+    // WHERE role = 'owner'`); the constraint name is the only signal that
+    // disambiguates which one fired, so we prefer it over the parsed columns.
+    const error = {
+      code: '23505',
+      message: 'msg',
+      severity: 'ERROR',
+      constraint: 'users_email_partial_idx',
+      detail: 'Key (email)',
+    }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'UniqueConstraintViolation',
+      constraint: { index: 'users_email_partial_idx' },
       originalCode: error.code,
       originalMessage: error.message,
     })

--- a/packages/adapter-pg/src/errors.ts
+++ b/packages/adapter-pg/src/errors.ts
@@ -75,13 +75,23 @@ function mapDriverError(error: DatabaseError): MappedError {
         message: error.message,
       }
     case '23505': {
-      const fields = error.detail
-        ?.match(/Key \(([^)]+)\)/)
-        ?.at(1)
-        ?.split(', ')
+      let constraint: { fields: string[] } | { index: string } | undefined
+
+      if (error.constraint) {
+        constraint = { index: error.constraint }
+      } else {
+        const fields = error.detail
+          ?.match(/Key \(([^)]+)\)/)
+          ?.at(1)
+          ?.split(', ')
+        if (fields !== undefined) {
+          constraint = { fields }
+        }
+      }
+
       return {
         kind: 'UniqueConstraintViolation',
-        constraint: fields !== undefined ? { fields } : undefined,
+        constraint,
       }
     }
     case '23502': {

--- a/packages/adapter-pg/src/errors.ts
+++ b/packages/adapter-pg/src/errors.ts
@@ -57,6 +57,13 @@ export function convertDriverError(error: unknown): DriverAdapterErrorObject {
   throw error
 }
 
+function parseKeyFields(detail: string | undefined): string[] | undefined {
+  return detail
+    ?.match(/Key \(([^)]+)\)/)
+    ?.at(1)
+    ?.split(', ')
+}
+
 function mapDriverError(error: DatabaseError): MappedError {
   switch (error.code) {
     case '22001':
@@ -80,10 +87,7 @@ function mapDriverError(error: DatabaseError): MappedError {
       if (error.constraint) {
         constraint = { index: error.constraint }
       } else {
-        const fields = error.detail
-          ?.match(/Key \(([^)]+)\)/)
-          ?.at(1)
-          ?.split(', ')
+        const fields = parseKeyFields(error.detail)
         if (fields !== undefined) {
           constraint = { fields }
         }
@@ -95,10 +99,7 @@ function mapDriverError(error: DatabaseError): MappedError {
       }
     }
     case '23502': {
-      const fields = error.detail
-        ?.match(/Key \(([^)]+)\)/)
-        ?.at(1)
-        ?.split(', ')
+      const fields = parseKeyFields(error.detail)
       return {
         kind: 'NullConstraintViolation',
         constraint: fields !== undefined ? { fields } : undefined,


### PR DESCRIPTION
Closes #29495.

## Summary

`@prisma/adapter-pg`'s `mapDriverError` treated `error.constraint` (populated by node-postgres from `PG_DIAG_CONSTRAINT_NAME`) asymmetrically between unique-violation (23505) and foreign-key-violation (23503) branches:

- `case '23503'` already falls back to `{ index: error.constraint }` when `error.column` isn't populated.
- `case '23505'` ignored `error.constraint` entirely and only emitted `{ fields }` parsed out of `error.detail`.

`@prisma/adapter-mysql` already preserves the constraint name as `constraint.index` on 1062 (see #29344), so Postgres was the outlier here.

## Why it matters

For **partial unique indexes**, the parsed column list is ambiguous — two unique constraints on the same table can share key columns. For example, a full unique on `(user_id, account_id)` and a partial unique on `(account_id) WHERE role = 'owner'` both surface as 23505 with the same parsed `fields`. The constraint name is the only signal that disambiguates which one fired, and callers shouldn't have to regex-match `originalMessage` (not public API per #28281) to know.

## Fix

Prefer `error.constraint` (mapped to `{ index }`, matching the 23503 shape) when it's set, falling back to the existing `{ fields }` parse when it isn't:

```ts
case '23505': {
  let constraint: { fields: string[] } | { index: string } | undefined
  if (error.constraint) {
    constraint = { index: error.constraint }
  } else {
    const fields = error.detail?.match(/Key \(([^)]+)\)/)?.at(1)?.split(', ')
    if (fields !== undefined) {
      constraint = { fields }
    }
  }
  return { kind: 'UniqueConstraintViolation', constraint }
}
```

`MappedError.UniqueConstraintViolation` already accepts `{ index: string }` in `@prisma/driver-adapter-utils`, so this is a non-breaking widening of what callers may already see from the MySQL adapter.

## Tests

Three tests under `src/__tests__/errors.test.ts`:

- `should handle UniqueConstraintViolation (23505) with detail only` — existing behaviour, unchanged.
- `should handle UniqueConstraintViolation (23505) with constraint` — new branch.
- `should handle UniqueConstraintViolation (23505) with both constraint and detail (constraint wins)` — pins the precedence rule.

All 35 tests in `errors.test.ts` pass.