### PR TITLE
fix(config): add directUrl support to datasource config types

### DIFF
--- a/packages/config/src/PrismaConfig.ts
+++ b/packages/config/src/PrismaConfig.ts
@@ -20,11 +20,13 @@ export type ExperimentalConfig = {
 
 const DatasourceShape = Shape.Struct({
   url: Shape.optional(Shape.String),
+  directUrl: Shape.optional(Shape.String),
   shadowDatabaseUrl: Shape.optional(Shape.String),
 })
 
 export type Datasource = {
   url?: string
+  directUrl?: string
   shadowDatabaseUrl?: string
 }
 

--- a/packages/config/src/__tests__/defineConfig.test.ts
+++ b/packages/config/src/__tests__/defineConfig.test.ts
@@ -61,6 +61,18 @@ describe('defineConfig', () => {
         shadowDatabaseUrl: 'postgresql://SHADOW_DATABASE_URL',
       })
     })
+    test('when `directUrl` is provided in datasource, it should be set correctly', () => {
+      const config = defineConfig({
+        datasource: {
+          url: 'postgresql://DATABASE_URL',
+          directUrl: 'postgresql://DIRECT_URL',
+        },
+      })
+      expect(config.datasource).toMatchObject({
+        url: 'postgresql://DATABASE_URL',
+        directUrl: 'postgresql://DIRECT_URL',
+      })
+    })
   })
 
   describe('migrations', () => {


### PR DESCRIPTION
### What
Adds the missing `directUrl` field to the `Datasource` and `DatasourceShape` types in `PrismaConfig.ts`.

### Why
`directUrl` is fully supported in `schema.prisma` but was completely omitted from the `prisma.config.ts` type definitions. This caused strict TypeScript errors for users trying to use `defineConfig` with modern serverless database providers (like Supabase/Neon) that require both a pooled connection (`url`) and a direct connection (`directUrl`).

### Changes
- Added `directUrl?: string` to `DatasourceShape` in `packages/config/src/PrismaConfig.ts`
- Added `directUrl?: string` to the exported `Datasource` type in the same file.
- Added a test case in `packages/config/src/__tests__/defineConfig.test.ts` to ensure `directUrl` is correctly parsed and set.

### Testing
- [x] Added unit tests in `defineConfig.test.ts`.
- [x] Ran `pnpm run test` in `packages/config` (Tests targeting `defineConfig` pass successfully). 

*(Note to reviewers: Some unrelated tests in `loadConfigFromFile.test.ts` failed locally due to Windows OS restrictions on creating symlinks without admin privileges, but all code-related tests pass flawlessly).*

Fixes #29639