### PR TITLE
chore(adapter-pg): remove duplicate values parameter

### DIFF
--- a/packages/adapter-pg/src/__tests__/pg.test.ts
+++ b/packages/adapter-pg/src/__tests__/pg.test.ts
@@ -129,7 +129,7 @@ describe('PrismaPgAdapterFactory', () => {
     await adapter.queryRaw(query)
 
     expect(mockGenerator).toHaveBeenCalledWith(query)
-    expect(mockQuery).toHaveBeenCalledWith(expect.objectContaining({ name: 'test-name' }), [])
+    expect(mockQuery).toHaveBeenCalledWith(expect.objectContaining({ name: 'test-name' }))
 
     await adapter.dispose()
   })
@@ -148,7 +148,7 @@ describe('PrismaPgAdapterFactory', () => {
     const query: SqlQuery = { sql: 'SELECT 1', args: [], argTypes: [] }
     await adapter.queryRaw(query)
 
-    expect(mockQuery).toHaveBeenCalledWith(expect.objectContaining({ name: undefined }), [])
+    expect(mockQuery).toHaveBeenCalledWith(expect.objectContaining({ name: undefined }))
 
     await adapter.dispose()
   })

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -103,24 +103,21 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements SqlQ
     const values = args.map((arg, i) => mapArg(arg, query.argTypes[i]))
 
     try {
-      const result = await this.client.query(
-        {
-          name: this.pgOptions?.statementNameGenerator?.(query),
-          text: sql,
-          values,
-          rowMode: 'array',
-          types: {
-            getTypeParser: (oid: number, format?) => {
-              if (format === 'text' && customParsers[oid]) {
-                return customParsers[oid]
-              }
+      const result = await this.client.query({
+        name: this.pgOptions?.statementNameGenerator?.(query),
+        text: sql,
+        values,
+        rowMode: 'array',
+        types: {
+          getTypeParser: (oid: number, format?) => {
+            if (format === 'text' && customParsers[oid]) {
+              return customParsers[oid]
+            }
 
-              return types.getTypeParser(oid, format)
-            },
+            return types.getTypeParser(oid, format)
           },
         },
-        // Removed the duplicate `values` argument here!
-      )
+      })
 
       return result
     } catch (e) {

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -119,7 +119,7 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements SqlQ
             },
           },
         },
-        values,
+        // Removed the duplicate `values` argument here!
       )
 
       return result


### PR DESCRIPTION
## What

Removes the redundant second `values` argument from the `this.client.query(...)` call in `PgQueryable.performIO`. The `values` array is already provided inside the query config object, so passing it again as the second positional argument was a no-op. Also updates the corresponding unit tests to match the single-argument call signature.

## Why

Small cleanup. The duplicate argument has no runtime effect: `pg`'s `normalizeQueryConfig` simply reassigns the same array onto `config.values`, so removing it changes no behavior.
