### PR TITLE
fix(client): handle batched findUniqueOrThrow misses

### DIFF
--- a/packages/client/src/runtime/core/engines/client/ClientEngine.ts
+++ b/packages/client/src/runtime/core/engines/client/ClientEngine.ts
@@ -601,6 +601,7 @@ export class ClientEngine implements Engine {
 
           const results: BatchQueryEngineResult<unknown>[] = []
           let rollback = false
+          let canContinueOnError: boolean | undefined
           for (const [batchIndex, plan] of batchResponse.plans.entries()) {
             try {
               const rows = await executor.execute({
@@ -620,9 +621,15 @@ export class ClientEngine implements Engine {
               })
               results.push({ data: { [queries[batchIndex].action]: rows } })
             } catch (err) {
+              canContinueOnError ??=
+                transaction?.kind !== 'batch' &&
+                queries.every((query) => query.action === 'findUnique' || query.action === 'findUniqueOrThrow')
+
               results.push(err as Error)
               rollback = true
-              break
+              if (!canContinueOnError) {
+                break
+              }
             }
           }
 

--- a/packages/client/tests/functional/issues/29638-concurrent-find-unique-or-throw/_matrix.ts
+++ b/packages/client/tests/functional/issues/29638-concurrent-find-unique-or-throw/_matrix.ts
@@ -1,0 +1,4 @@
+import { defineMatrix } from '../../_utils/defineMatrix'
+import { Providers } from '../../_utils/providers'
+
+export default defineMatrix(() => [[{ provider: Providers.POSTGRESQL }]])

--- a/packages/client/tests/functional/issues/29638-concurrent-find-unique-or-throw/_matrix.ts
+++ b/packages/client/tests/functional/issues/29638-concurrent-find-unique-or-throw/_matrix.ts
@@ -1,4 +1,4 @@
 import { defineMatrix } from '../../_utils/defineMatrix'
-import { Providers } from '../../_utils/providers'
+import { sqlProviders } from '../../_utils/providers'
 
-export default defineMatrix(() => [[{ provider: Providers.POSTGRESQL }]])
+export default defineMatrix(() => [sqlProviders])

--- a/packages/client/tests/functional/issues/29638-concurrent-find-unique-or-throw/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/29638-concurrent-find-unique-or-throw/prisma/_schema.ts
@@ -1,0 +1,33 @@
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(() => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+
+  datasource db {
+    provider = "postgresql"
+  }
+
+  model User {
+    id        String     @id
+    chatUsers ChatUser[]
+  }
+
+  model ChatUser {
+    chatId String
+    userId String
+
+    chat Chat @relation(fields: [chatId], references: [id])
+    user User @relation(fields: [userId], references: [id])
+
+    @@id([chatId, userId])
+  }
+
+  model Chat {
+    id        String     @id
+    chatUsers ChatUser[]
+  }
+  `
+})

--- a/packages/client/tests/functional/issues/29638-concurrent-find-unique-or-throw/prisma/_schema.ts
+++ b/packages/client/tests/functional/issues/29638-concurrent-find-unique-or-throw/prisma/_schema.ts
@@ -1,13 +1,13 @@
 import testMatrix from '../_matrix'
 
-export default testMatrix.setupSchema(() => {
+export default testMatrix.setupSchema(({ provider }) => {
   return /* Prisma */ `
   generator client {
     provider = "prisma-client-js"
   }
 
   datasource db {
-    provider = "postgresql"
+    provider = "${provider}"
   }
 
   model User {

--- a/packages/client/tests/functional/issues/29638-concurrent-find-unique-or-throw/tests.ts
+++ b/packages/client/tests/functional/issues/29638-concurrent-find-unique-or-throw/tests.ts
@@ -1,0 +1,59 @@
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite(
+  () => {
+    const chatId = 'chat-id'
+    const userIds = ['bob', 'eve', 'alice', 'david', 'charlie']
+
+    beforeEach(async () => {
+      await prisma.chatUser.deleteMany()
+      await prisma.chat.deleteMany()
+      await prisma.user.deleteMany()
+
+      await prisma.user.createMany({
+        data: userIds.map((id) => ({ id })),
+      })
+
+      await prisma.chat.create({
+        data: {
+          id: chatId,
+          chatUsers: {
+            create: [{ userId: 'bob' }, { userId: 'eve' }],
+          },
+        },
+      })
+    })
+
+    test('all missing records reject in concurrent findUniqueOrThrow batches', async () => {
+      const results = await Promise.allSettled(
+        userIds.map((userId) =>
+          prisma.chat.findUniqueOrThrow({
+            where: {
+              id: chatId,
+              chatUsers: { some: { userId } },
+            },
+          }),
+        ),
+      )
+
+      expect(results).not.toContainEqual({ status: 'fulfilled', value: undefined })
+      expect(results).toMatchObject([
+        { status: 'fulfilled', value: { id: chatId } },
+        { status: 'fulfilled', value: { id: chatId } },
+        { status: 'rejected', reason: expect.objectContaining({ code: 'P2025' }) },
+        { status: 'rejected', reason: expect.objectContaining({ code: 'P2025' }) },
+        { status: 'rejected', reason: expect.objectContaining({ code: 'P2025' }) },
+      ])
+    })
+  },
+  {
+    optOut: {
+      from: ['sqlite', 'mysql', 'mongodb', 'cockroachdb', 'sqlserver'],
+      reason: 'issue #29638 was reproduced on PostgreSQL and this regression stays focused on that path',
+    },
+  },
+)

--- a/packages/client/tests/functional/issues/29638-concurrent-find-unique-or-throw/tests.ts
+++ b/packages/client/tests/functional/issues/29638-concurrent-find-unique-or-throw/tests.ts
@@ -52,8 +52,8 @@ testMatrix.setupTestSuite(
   },
   {
     optOut: {
-      from: ['sqlite', 'mysql', 'mongodb', 'cockroachdb', 'sqlserver'],
-      reason: 'issue #29638 was reproduced on PostgreSQL and this regression stays focused on that path',
+      from: ['mongodb'],
+      reason: 'MongoDB does not support compound primary keys (@@id)',
     },
   },
 )


### PR DESCRIPTION
## Problem

Concurrent `findUniqueOrThrow()` calls can be auto-batched by Prisma Client. When multiple records are missing in the same batch, only the first missing query rejects with `P2025`. Later missing queries can incorrectly resolve with `undefined`.

This happens because the multi-batch path in `ClientEngine.requestBatch()` stops collecting results after the first thrown error. As a result, the returned result array can be shorter than the original request batch, and DataLoader resolves the remaining slots as `undefined`.

Fixes #29638

## Solution

Continue collecting results for auto-batched unique reads (`findUnique` / `findUniqueOrThrow`) outside explicit batch transactions. This preserves one result per request, so each missing `findUniqueOrThrow()` call rejects correctly with `P2025`.

## Tests

Added a functional regression test for concurrent `findUniqueOrThrow()` calls with multiple missing records.

```bash
pnpm --filter @prisma/client test:functional:code --adapter js_pg --runInBand 29638-concurrent-find-unique-or-throw