### PR TITLE
fix(client-generator-ts): add explicit :object type annotation to DbNull/JsonNull/AnyNull exports to fix TS4094 with native #private fields

### DIFF
--- a/packages/client-generator-ts/src/TSClient/NullTypes.ts
+++ b/packages/client-generator-ts/src/TSClient/NullTypes.ts
@@ -9,19 +9,19 @@ export const NullTypes = {
  *
  * @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-on-a-json-field
  */
-export const DbNull = runtime.DbNull
+export const DbNull: object = runtime.DbNull
 
 /**
  * Helper for filtering JSON entries that have JSON \`null\` values (not empty on the db)
  *
  * @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-on-a-json-field
  */
-export const JsonNull = runtime.JsonNull
+export const JsonNull: object = runtime.JsonNull
 
 /**
  * Helper for filtering JSON entries that are \`Prisma.DbNull\` or \`Prisma.JsonNull\`
  *
  * @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-on-a-json-field
  */
-export const AnyNull = runtime.AnyNull
+export const AnyNull: object = runtime.AnyNull
 `


### PR DESCRIPTION
PR #26867 fixed TS4094 errors for the `private` keyword form of branded null types, but TypeScript 6 with `declaration: true` still fails when the brand field uses native `#private` syntax. Because `DbNullClass`, `JsonNullClass`, and `AnyNullClass` each carry a native private brand field (`#_brand_DbNull`, etc.), TypeScript cannot represent the inferred type in `.d.ts` output without a direct reference to the class — which isn't available in the generated `prismaNamespace.ts` file — resulting in TS4094.

The fix adds an explicit `: object` type annotation to the `DbNull`, `JsonNull`, and `AnyNull` constant exports in the `nullTypes` generator template (`packages/client-generator-ts/src/TSClient/NullTypes.ts`). Since this template is shared by both `PrismaNamespaceFile.ts` and `PrismaNamespaceBrowserFile.ts`, the single change covers both generated files. TypeScript now emits `const DbNull: object` in the declaration output instead of attempting to resolve the full class type.

Fixes: #29549