### PR TITLE
fix(internals): use display width for drawBox title border

### DIFF
--- a/packages/internals/src/utils/drawBox.ts
+++ b/packages/internals/src/utils/drawBox.ts
@@ -38,7 +38,7 @@ export function drawBox({ title, width, height, str, horizontalPadding }: BoxOpt
       ' ' +
       reset(bold(title)) +
       ' ' +
-      grey(chars.horizontal.repeat(width - title.length - 2 - 3) + chars.topRight) +
+      grey(chars.horizontal.repeat(Math.max(width - stringWidth(title) - 2 - 3, 0)) + chars.topRight) +
       reset()
     : grey(chars.topLeft + chars.horizontal) + grey(chars.horizontal.repeat(width - 3) + chars.topRight)
 


### PR DESCRIPTION
`drawBox` already measures display width with `string-width`: once for the box width (`maxLineLength`) and once for the per-line right padding (`Math.min(stringWidth(l), width)` and `Math.max(width - lineWidth - 2, 0)`). The title border on the top line is the one spot that still counts with `title.length`:

```ts
grey(chars.horizontal.repeat(width - title.length - 2 - 3) + chars.topRight)
```

`title.length` is the number of UTF-16 code units, not terminal columns. When a title contains wide characters (CJK, full-width), the top border comes out too long, so the top-right corner no longer lines up with the bottom border (which uses `width - 2`) or with the content lines.

There is also a latent crash: when a title is wider than the box, `width - title.length - 2 - 3` is negative and `String.prototype.repeat` throws `RangeError: Invalid count value`.

This changes the count to `stringWidth(title)` so it matches the rest of the function, and wraps it in `Math.max(..., 0)`, the same guard already used for `paddingRight` a few lines below. `stringWidth` is already imported, so it stays a one-line change.

Verified against a standalone reproduction of `drawBox`:

- ASCII title: top border width equals bottom border width both before and after (no change).
- CJK title `設定の更新` in a width-40 box: before, the top border measures 45 columns against 40; after, it measures 40.
- Over-long title in a narrow box: before throws `RangeError: Invalid count value`, after does not.
