### PR TITLE
fix: remove duplicate words in test comments and descriptions

### DIFF
--- a/packages/client/src/runtime/core/extensions/visitQueryResult.test.ts
+++ b/packages/client/src/runtime/core/extensions/visitQueryResult.test.ts
@@ -165,7 +165,7 @@ test('visits nested relations when using select', () => {
   expect(visitor).toHaveBeenCalledWith(result.group, 'Group', {})
 })
 
-test('does not visit nested nested relations when include = false', () => {
+test('does not visit nested relations when include = false', () => {
   const result = {
     id: '1',
     name: 'Boaty McBoatface',
@@ -188,7 +188,7 @@ test('does not visit nested nested relations when include = false', () => {
   expect(visitor).not.toHaveBeenCalledWith(expect.anything(), GroupModel, expect.anything())
 })
 
-test('does not visit nested nested relations when corresponding field is null', () => {
+test('does not visit nested relations when corresponding field is null', () => {
   const result = {
     id: '1',
     name: 'Boaty McBoatface',

--- a/packages/client/tests/functional/_utils/checkMissingProviders.ts
+++ b/packages/client/tests/functional/_utils/checkMissingProviders.ts
@@ -31,7 +31,7 @@ export function checkMissingProviders({
     throw new Error(
       `Test: '${suiteMeta.testName}' is missing providers '${missingProviders
         .map((x) => `'${x}'`)
-        .join(', ')}' out out using options.optOut`,
+        .join(', ')}' out using options.optOut`,
     )
   }
 }

--- a/packages/debug/src/__tests__/debug.extended.test.ts
+++ b/packages/debug/src/__tests__/debug.extended.test.ts
@@ -277,7 +277,7 @@ test('regex characters do not mess with matching', async () => {
   expect(consoleWarnParams.length).toBe(0)
 })
 
-// utility to to map the calls to the stderr mock this makes it easier to read
+// utility to map the calls to the stderr mock this makes it easier to read
 // snapshots and separates time diffs from the message logs
 const mapper = (call: any[]) => {
   const [args, time] = call as [string, string]

--- a/packages/migrate/src/__tests__/DbPull/sqlserver.test.ts
+++ b/packages/migrate/src/__tests__/DbPull/sqlserver.test.ts
@@ -300,7 +300,7 @@ describeMatrix(sqlServerOnly, 'sqlserver-multischema', () => {
     expect(ctx.mocked['console.error'].mock.calls.join('\n')).toMatchInlineSnapshot(`""`)
   })
 
-  test('url with `?schema=does-not-exist` should error with with P4001, empty database', async () => {
+  test('url with `?schema=does-not-exist` should error with P4001, empty database', async () => {
     ctx.fixture('introspection/sqlserver')
     ctx.setDatasource({
       url: `${(await ctx.datasource())?.url}schema=does-not-exist`,


### PR DESCRIPTION
## Summary

Removes duplicate adjacent words found in test file comments, test names, and error message strings. No logic changes — comment and string cleanup only.

Similar to #29610 — scanning for repeated adjacent words that slipped through review.

## Changes

- `packages/migrate/src/__tests__/DbPull/sqlserver.test.ts`: `"error with with P4001"` → `"error with P4001"` in test name
- `packages/debug/src/__tests__/debug.extended.test.ts`: `"utility to to map"` → `"utility to map"` in comment
- `packages/client/tests/functional/_utils/checkMissingProviders.ts`: `"out out using"` → `"out using"` in error message string
- `packages/client/src/runtime/core/extensions/visitQueryResult.test.ts`: `"nested nested relations"` → `"nested relations"` in two test names

## Type

- [x] Chore (comment/string cleanup only, no logic changes)