### PR TITLE
fix(client): keep fluent relation fields named select or include when unpacking results

### DIFF
--- a/packages/client/src/runtime/RequestHandler.ts
+++ b/packages/client/src/runtime/RequestHandler.ts
@@ -278,7 +278,7 @@ export class RequestHandler {
     }
     const operation = Object.keys(data)[0]
     const response = Object.values(data)[0]
-    const pathForGet = dataPath.filter((key) => key !== 'select' && key !== 'include')
+    const pathForGet = dataPathToGetPath(dataPath)
     const extractedResponse = deepGet(response, pathForGet)
     const deserializedResponse =
       operation === 'queryRaw'
@@ -366,4 +366,20 @@ function convertValidationError(error: EngineValidationError): EngineValidationE
   }
 
   return error
+}
+
+/**
+ * Converts a fluent-API dataPath into the path used to read the result out of
+ * the response. dataPath is a sequence of [selector, relationField] pairs where
+ * the selector is always 'select' or 'include'. The relation field names (the
+ * odd positions) form the path. Filtering by the literal values 'select' or
+ * 'include' would also drop a relation field that happens to be named that way,
+ * so the path is derived positionally instead.
+ */
+export function dataPathToGetPath(dataPath: string[]): string[] {
+  const getPath: string[] = []
+  for (let index = 1; index < dataPath.length; index += 2) {
+    getPath.push(dataPath[index])
+  }
+  return getPath
 }

--- a/packages/client/src/runtime/dataPathToGetPath.test.ts
+++ b/packages/client/src/runtime/dataPathToGetPath.test.ts
@@ -1,0 +1,18 @@
+import { dataPathToGetPath } from './RequestHandler'
+
+describe('dataPathToGetPath', () => {
+  test('returns the relation field names from a fluent dataPath', () => {
+    expect(dataPathToGetPath(['select', 'posts'])).toEqual(['posts'])
+    expect(dataPathToGetPath(['select', 'posts', 'include', 'comments'])).toEqual(['posts', 'comments'])
+  })
+
+  test('keeps a relation field named "select" or "include"', () => {
+    expect(dataPathToGetPath(['select', 'select'])).toEqual(['select'])
+    expect(dataPathToGetPath(['select', 'include'])).toEqual(['include'])
+    expect(dataPathToGetPath(['select', 'posts', 'select', 'select'])).toEqual(['posts', 'select'])
+  })
+
+  test('returns an empty path for the root result', () => {
+    expect(dataPathToGetPath([])).toEqual([])
+  })
+})


### PR DESCRIPTION
`RequestHandler.unpack` derives the path to read a fluent-API result out of the
response with:

    const pathForGet = dataPath.filter((key) => key !== 'select' && key !== 'include')

`dataPath` is a sequence of `[selector, relationField]` pairs, where the selector
is always `select` or `include` and the relation field names are at the odd
positions. Filtering by the literal string value also strips any relation field
that is itself named `select` or `include`, so `deepGet` receives the wrong path
and returns the wrong slice of the response (often the whole response object).

Both `select` and `include` are valid Prisma relation field names. For example a
dataPath of `['select', 'select']` produced `[]` and returned the entire object
instead of `response.select`. The sibling module `resolve-result-extension-context`
already reads the same dataPath positionally (`index += 2`) and ships tests for
fields named `select` and `include`; only `unpack` was left on the naive filter.

The fix derives the path positionally through a small `dataPathToGetPath` helper,
keeping the odd-position field names. Behavior is identical for every field name
except `select` and `include`.
