### PR TITLE
fix(client): deserialize `BigInt[]` / `Decimal[]` scalar lists under the `join` relation load strategy

### DIFF
--- a/packages/client-engine-runtime/src/interpreter/data-mapper.test.ts
+++ b/packages/client-engine-runtime/src/interpreter/data-mapper.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'vitest'
+
+import { ResultNode } from '../query-plan'
+import { applyDataMap } from './data-mapper'
+
+// A `findUnique` on a model with a to-many relation, loaded with the `join`
+// relation load strategy, deserializes to this shape: the relation is a single
+// JSON aggregate and each row is an object. Scalar list fields whose element
+// type cannot be represented in JSON without loss of precision (`BigInt[]`,
+// `Decimal[]`) are `::text`-cast into that aggregate by the query compiler, so
+// they arrive as a PostgreSQL array literal string (e.g. `"{1,2}"`) rather than
+// a JS array. See https://github.com/prisma/prisma/issues/28349.
+function listFieldStructure(type: 'bigint' | 'decimal' | 'string'): ResultNode {
+  return {
+    type: 'object',
+    serializedName: null,
+    skipNulls: false,
+    fields: {
+      values: { type: 'field', dbName: 'values', fieldType: { arity: 'list', type } },
+    },
+  }
+}
+
+const enums = {}
+
+describe('scalar list fields under the join relation load strategy', () => {
+  test('parses a BigInt[] PostgreSQL array literal string into an array', () => {
+    const result = applyDataMap({ values: '{1,2}' }, listFieldStructure('bigint'), enums)
+    expect(result).toEqual({
+      values: [
+        { $type: 'BigInt', value: '1' },
+        { $type: 'BigInt', value: '2' },
+      ],
+    })
+  })
+
+  test('parses a Decimal[] PostgreSQL array literal string into an array', () => {
+    const result = applyDataMap({ values: '{1.5,2.25}' }, listFieldStructure('decimal'), enums)
+    expect(result).toEqual({
+      values: [
+        { $type: 'Decimal', value: '1.5' },
+        { $type: 'Decimal', value: '2.25' },
+      ],
+    })
+  })
+
+  test('parses an empty PostgreSQL array literal into an empty array', () => {
+    const result = applyDataMap({ values: '{}' }, listFieldStructure('bigint'), enums)
+    expect(result).toEqual({ values: [] })
+  })
+
+  test('parses quoted elements, unescaping `\\"` and `\\\\`', () => {
+    const result = applyDataMap({ values: '{"a,b","c\\"d"}' }, listFieldStructure('string'), enums)
+    expect(result).toEqual({ values: ['a,b', 'c"d'] })
+  })
+
+  test('still maps a value that is already a JS array (query load strategy path)', () => {
+    const result = applyDataMap({ values: [1, 2] }, listFieldStructure('bigint'), enums)
+    expect(result).toEqual({
+      values: [
+        { $type: 'BigInt', value: 1 },
+        { $type: 'BigInt', value: 2 },
+      ],
+    })
+  })
+
+  test('a null list value maps to an empty array', () => {
+    const result = applyDataMap({ values: null }, listFieldStructure('bigint'), enums)
+    expect(result).toEqual({ values: [] })
+  })
+})

--- a/packages/client-engine-runtime/src/interpreter/data-mapper.ts
+++ b/packages/client-engine-runtime/src/interpreter/data-mapper.ts
@@ -142,11 +142,65 @@ function mapField(
   }
 
   if (fieldType.arity === 'list') {
-    const values = value as unknown[]
+    // Under the `join` relation load strategy the whole relation is returned as a
+    // single JSON aggregate. Scalar list fields whose element type cannot be
+    // represented in JSON without loss of precision (`BigInt[]`, `Decimal[]`) are
+    // `::text`-cast into that aggregate by the query compiler, so they arrive here
+    // as a Postgres array literal string (e.g. `"{1,2}"`) rather than a JS array.
+    // Parse it back into an array before mapping the elements, mirroring how the
+    // scalar `bigint`/`decimal` branches already accept the `::text`-cast string.
+    const values = typeof value === 'string' ? parsePostgresArrayLiteral(value) : (value as unknown[])
     return values.map((v, i) => mapValue(v, `${columnName}[${i}]`, fieldType, enums))
   }
 
   return mapValue(value, columnName, fieldType, enums)
+}
+
+/**
+ * Parses a one-dimensional PostgreSQL array literal, as produced by casting a
+ * scalar array to `text` (e.g. `"{1,2}"`, `"{}"`, `"{100,NULL,3}"`,
+ * `'{"a,b","x"}'`). Elements are either bare (up to the next `,`/`}`), with a
+ * bare `NULL` (case-sensitive, as emitted by Postgres) decoded to `null`, or
+ * double-quoted with `\"` and `\\` escapes. This only needs to cover the shapes
+ * the query compiler emits for `::text`-cast scalar lists, so multi-dimensional
+ * arrays are not supported.
+ */
+function parsePostgresArrayLiteral(literal: string): (string | null)[] {
+  if (literal.length < 2 || literal[0] !== '{' || literal[literal.length - 1] !== '}') {
+    throw new DataMapperError(`Expected a PostgreSQL array literal, got: ${literal}`)
+  }
+
+  const result: (string | null)[] = []
+  const end = literal.length - 1
+  let i = 1
+
+  if (i === end) return result // empty array: `{}`
+
+  while (i < end) {
+    let element: string | null
+    if (literal[i] === '"') {
+      i++ // opening quote
+      let buf = ''
+      while (i < end && literal[i] !== '"') {
+        if (literal[i] === '\\') i++
+        buf += literal[i]
+        i++
+      }
+      i++ // closing quote
+      element = buf
+    } else {
+      let buf = ''
+      while (i < end && literal[i] !== ',') {
+        buf += literal[i]
+        i++
+      }
+      element = buf === 'NULL' ? null : buf
+    }
+    result.push(element)
+    if (literal[i] === ',') i++ // element separator
+  }
+
+  return result
 }
 
 function mapValue(

--- a/packages/client/tests/functional/relation-load-strategy-scalar-list/_common.ts
+++ b/packages/client/tests/functional/relation-load-strategy-scalar-list/_common.ts
@@ -1,0 +1,1 @@
+export type RelationLoadStrategy = 'query' | 'join'

--- a/packages/client/tests/functional/relation-load-strategy-scalar-list/_matrix.ts
+++ b/packages/client/tests/functional/relation-load-strategy-scalar-list/_matrix.ts
@@ -1,0 +1,10 @@
+import { defineMatrix } from '../_utils/defineMatrix'
+import { Providers } from '../_utils/providers'
+import { RelationLoadStrategy } from './_common'
+
+// Scalar list (array) columns are only supported on PostgreSQL and CockroachDB,
+// which are also the relationJoins-capable providers relevant here.
+export default defineMatrix(() => [
+  [{ provider: Providers.POSTGRESQL }, { provider: Providers.COCKROACHDB }],
+  [{ strategy: 'query' as RelationLoadStrategy }, { strategy: 'join' as RelationLoadStrategy }],
+])

--- a/packages/client/tests/functional/relation-load-strategy-scalar-list/prisma/_schema.ts
+++ b/packages/client/tests/functional/relation-load-strategy-scalar-list/prisma/_schema.ts
@@ -1,0 +1,31 @@
+import { foreignKeyForProvider, idForProvider } from '../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+
+  datasource db {
+    provider = "${provider}"
+  }
+
+  model Author {
+    id    ${idForProvider(provider)}
+    name  String
+    books Book[]
+  }
+
+  model Book {
+    id       ${idForProvider(provider)}
+    title    String
+    tags     BigInt[]
+    prices   Decimal[]
+    strs     String[]
+    ints     Int[]
+    author   Author @relation(fields: [authorId], references: [id], onDelete: Cascade)
+    authorId ${foreignKeyForProvider(provider)}
+  }
+  `
+})

--- a/packages/client/tests/functional/relation-load-strategy-scalar-list/tests.ts
+++ b/packages/client/tests/functional/relation-load-strategy-scalar-list/tests.ts
@@ -1,0 +1,73 @@
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { Prisma as PrismaNamespace, PrismaClient } from './generated/prisma/client'
+
+declare let prisma: PrismaClient<'query'>
+
+// Regression test for https://github.com/prisma/prisma/issues/28349.
+//
+// Under `relationLoadStrategy: "join"` the query compiler `::text`-casts scalar
+// list columns whose element type can't be represented in JSON without loss of
+// precision (`BigInt[]`, `Decimal[]`) into the aggregated JSON object, so they
+// arrive at the client as a PostgreSQL array literal string (e.g. `"{1,2}"`).
+// The list deserializer used to call `.map` on that string and throw
+// `TypeError: <x>.map is not a function`. `strs` (`String[]`) and `ints`
+// (`Int[]`) are embedded natively and act as controls. The `query` strategy was
+// never affected, so running the whole suite under both strategies also asserts
+// parity between them.
+testMatrix.setupTestSuite(
+  (suiteConfig, _suiteMeta, _clientMeta, cliMeta) => {
+    const relationJoinsEnabled = cliMeta.previewFeatures.includes('relationJoins')
+
+    describeIf(relationJoinsEnabled)('scalar lists under relationLoadStrategy', () => {
+      const relationLoadStrategy = suiteConfig.strategy as PrismaNamespace.RelationLoadStrategy
+
+      beforeAll(async () => {
+        await prisma.author.create({
+          data: {
+            name: 'Ada',
+            books: {
+              create: {
+                title: 'b1',
+                tags: [1n, 2n],
+                prices: ['1.5', '2.25'],
+                strs: ['x', 'y'],
+                ints: [7, 8],
+              },
+            },
+          },
+        })
+      })
+
+      test('hydrates BigInt[] / Decimal[] child scalar lists when the relation is loaded via `include`', async () => {
+        const author = await prisma.author.findFirstOrThrow({
+          include: { books: true },
+          relationLoadStrategy,
+        })
+
+        expect(Array.isArray(author.books)).toBe(true)
+        const [book] = author.books
+        expect(book.tags).toEqual([1n, 2n])
+        expect(book.prices.map((p) => p.toString())).toEqual(['1.5', '2.25'])
+        expect(book.strs).toEqual(['x', 'y'])
+        expect(book.ints).toEqual([7, 8])
+      })
+
+      test('hydrates a BigInt[] child scalar list when selected via nested `select`', async () => {
+        const author = await prisma.author.findFirstOrThrow({
+          select: { books: { select: { id: true, tags: true } } },
+          relationLoadStrategy,
+        })
+
+        expect(Array.isArray(author.books)).toBe(true)
+        expect(author.books[0].tags).toEqual([1n, 2n])
+      })
+    })
+  },
+  {
+    optOut: {
+      from: ['sqlserver', 'mysql', 'sqlite', 'mongodb'],
+      reason: 'BigInt[] / Decimal[] scalar lists are only supported on PostgreSQL and CockroachDB',
+    },
+  },
+)


### PR DESCRIPTION

Relates to #28349 (same `mapField` gap: a scalar-list field arriving as a PostgreSQL
array-literal string). #28349 / #28941 cover extension-type (`citext`) arrays returned as
strings by the adapter; this change covers the sibling manifestation where the query
compiler `::text`-casts `BigInt[]` / `Decimal[]` into the `join` JSON aggregate, which the
adapter-level fix in #28941 cannot reach.

**Runnable reproduction:** https://github.com/pgtls/prisma-join-bigint-array-repro (Docker Postgres + `npm run setup && npm run repro`).

## Problem

With the `relationJoins` preview feature and a driver adapter (Rust-free
`queryCompiler` client), loading a relation whose model has a **`BigInt[]`** or
**`Decimal[]`** scalar list field via `relationLoadStrategy: "join"` throws:

```
TypeError: x.map is not a function
```

The same query works under `relationLoadStrategy: "query"`, which is why this
looks like a `join`-only bug. It also *appears* to be an `include`-vs-`select`
divergence — but that is a red herring: the trigger is simply whether the
precision-lossy scalar-list field is part of the selected payload. `select`ing
that field under `join` throws just the same; omitting it (even with `include`
of only safe fields) does not.

Reproduced on `prisma@7.8.0` / `@prisma/client@7.8.0` / `@prisma/adapter-pg@7.8.0`.

### Minimal schema

```prisma
model Author {
  id    Int    @id @default(autoincrement())
  name  String
  books Book[]
}

model Book {
  id       Int      @id @default(autoincrement())
  title    String
  tags     BigInt[]          // <-- the trigger
  authorId Int
  author   Author   @relation(fields: [authorId], references: [id])
}
```

```ts
await prisma.author.create({
  data: { name: "Ada", books: { create: { title: "b1", tags: [1n, 2n] } } },
})

// THROWS: TypeError: x.map is not a function
await prisma.author.findFirst({ include: { books: true }, relationLoadStrategy: "join" })

// THROWS too — proves it's the BigInt[] field, not include-vs-select
await prisma.author.findFirst({
  select: { books: { select: { id: true, tags: true } } },
  relationLoadStrategy: "join",
})

// OK — same query under the query strategy
await prisma.author.findFirst({ include: { books: true }, relationLoadStrategy: "query" })
```

## Root cause

Under the `join` strategy the whole relation is returned as one JSON aggregate.
For scalar-list fields whose element type cannot be represented in JSON without
loss of precision — `BigInt[]` (`int8[]`) and `Decimal[]` (`numeric[]`) — the
query compiler **`::text`-casts the entire array** into the aggregated JSON
object rather than embedding a native JSON array. The emitted SQL contains, for
the relation payload:

```sql
JSONB_BUILD_OBJECT('id', "t2"."id", 'title', "t2"."title", 'tags', "t2"."tags"::text, ...)
```

Note `"tags"::text`. `String[]` and `Int[]` in the *same* object are embedded
natively (no cast). Casting a `bigint[]` to `text` yields a **PostgreSQL array
literal string**, e.g. `{1,2}`. The driver adapter hands the aggregate back to
the engine as a string (`@prisma/adapter-pg` keeps JSON stringified —
`packages/adapter-pg/src/conversion.ts:354` `toJson`), so after the data mapper
JSON-parses the relation (`data-mapper.ts:68`), the `tags` field value is the
string `"{1,2}"`, not an array.

The data mapper then reaches `mapField`:

**`packages/client-engine-runtime/src/interpreter/data-mapper.ts:144-146`** (before)
```ts
if (fieldType.arity === 'list') {
  const values = value as unknown[]
  return values.map((v, i) => mapValue(v, `${columnName}[${i}]`, fieldType, enums))
}
```

`value` is the string `"{1,2}"`, so `values.map(...)` is `"{1,2}".map(...)` →
`TypeError: ... .map is not a function`.

The scalar (non-list) `bigint`/`decimal` branches already handle the
`::text`-cast string form (`mapValue`, `data-mapper.ts:193-198` and `:233-237`
accept a string); only the **list** branch assumed a JS array. Under the
`query` strategy `tags` comes back as a native `bigint[]` column (a real JS
array), so `.map` works there — hence the strategy-specific symptom.

Confirmed shape of the parsed relation value (from the driver adapter, this
repro):
```
[{"id": 1, "ints": [7, 8], "strs": ["x", "y"], "tags": "{1,2}", "title": "b1"}]
```
`tags` is the string `"{1,2}"`; `strs`/`ints` are native arrays.

## Fix

Parse the PostgreSQL array literal back into an array before mapping its
elements, in the one place that already owns list deserialization
(`mapField`). This mirrors the existing tolerance for the `::text`-cast scalar
form and requires no engine/compiler change:

```ts
if (fieldType.arity === 'list') {
  const values = typeof value === 'string' ? parsePostgresArrayLiteral(value) : (value as unknown[])
  return values.map((v, i) => mapValue(v, `${columnName}[${i}]`, fieldType, enums))
}
```

plus a small, self-contained one-dimensional array-literal parser
(`parsePostgresArrayLiteral`) that handles bare elements, bare `NULL`, empty
`{}`, and double-quoted elements with `\"` / `\\` escapes. Element values are
still fed through `mapValue`, so `BigInt`/`Decimal` wrapping is unchanged.

Files:
- `packages/client-engine-runtime/src/interpreter/data-mapper.ts` — the fix + parser.
- `packages/client-engine-runtime/src/interpreter/data-mapper.test.ts` — new unit tests.
- `packages/client/tests/functional/relation-load-strategy-scalar-list/**` — new
  functional/integration suite (PostgreSQL + CockroachDB): a to-many relation
  whose child has `BigInt[]` / `Decimal[]` columns, loaded via `include` and
  nested `select`, asserted under both `relationLoadStrategy: 'join'` and
  `'query'` (parity), with `String[]` / `Int[]` as controls.

## Verification

**End-to-end, against a real PostgreSQL 17** with `prisma@7.8.0` +
`@prisma/adapter-pg@7.8.0`, `relationJoins` on:

| query | before | after |
| --- | --- | --- |
| `include: { books: true }`, `join` | **THREW** `x.map is not a function` | `tags = [1n, 2n]` |
| `select: { books: { select: { id, tags } } }`, `join` | **THREW** | `tags = [1n, 2n]` |
| `include: { books: true }`, `query` | `[1n, 2n]` | `[1n, 2n]` (unchanged) |
| `select` without `tags`, `join` | OK | OK (unchanged) |

Runnable end-to-end reproduction: https://github.com/pgtls/prisma-join-bigint-array-repro

**Unit tests** (`data-mapper.test.ts`) — red/green verified against the real
source: without the fix the four array-literal-string cases fail with
`TypeError: values.map is not a function`; with the fix all pass. They cover
`BigInt[]` and `Decimal[]` literal strings → arrays, empty `{}` → `[]`,
quoted/escaped elements, an already-array value (the `query` path) still maps,
and `null` → `[]`.

The fix makes the `join` result match the `query` result exactly. Verified by
patching the fix into the installed client's bundled runtime and rerunning the
repro (`join`+`include` now returns `[1n, 2n]`).

**Unit tests** (`data-mapper.test.ts`) cover: `BigInt[]` and `Decimal[]` literal
strings → arrays, empty `{}` → `[]`, quoted/escaped elements, an already-array
value (the `query` path) still maps, and `null` → `[]`.

## Notes for maintainers

- An alternative fix lives in the query compiler (emit a native JSON array for
  precision-lossy scalar lists instead of a whole-array `::text` cast, e.g.
  `ARRAY(SELECT e::text FROM unnest(col) e)`). That change is in the Rust
  `query-compiler` (shipped as WASM), out of scope for this repo; the client-side
  fix here is correct regardless and unblocks users on current releases.
- Any other scalar-list type the compiler `::text`-casts into the join aggregate
  is covered by the same code path.
