### PR TITLE
fix(client): throw on invalid Date in raw query parameters instead of binding "null"

### DIFF
--- a/packages/client/src/__tests__/serializeRawParameters.test.ts
+++ b/packages/client/src/__tests__/serializeRawParameters.test.ts
@@ -27,6 +27,18 @@ describe('serializeRawParameters', () => {
     ])
   })
 
+  test('invalid date', () => {
+    const data = [new Date('not a date')]
+
+    expect(() => serialize(data)).toThrow('Provided Date object is invalid')
+  })
+
+  test('invalid date nested in array', () => {
+    const data = [[new Date('invalid')]]
+
+    expect(() => serialize(data)).toThrow('Provided Date object is invalid')
+  })
+
   test('BigInt', () => {
     const data = [BigInt('321804719213721')]
 

--- a/packages/client/src/runtime/utils/serializeRawParameters.ts
+++ b/packages/client/src/runtime/utils/serializeRawParameters.ts
@@ -1,6 +1,6 @@
 import { Decimal } from '@prisma/client-runtime-utils'
 
-import { isDate } from './date'
+import { isDate, isValidDate } from './date'
 
 export function serializeRawParameters(parameters: any[]): string {
   try {
@@ -28,6 +28,11 @@ function encodeParameter(parameter: any, objectSerialization: 'fast' | 'slow'): 
   }
 
   if (isDate(parameter)) {
+    if (!isValidDate(parameter)) {
+      // Invalid dates serialize to `null` via `toJSON()`, which would silently
+      // bind the string "null" as a datetime. Fail loudly like the non-raw path.
+      throw new Error('Provided Date object is invalid')
+    }
     return {
       prisma__type: 'date',
       prisma__value: parameter.toJSON(),


### PR DESCRIPTION
Fixes #29696

Passing an invalid Date to $queryRaw/$executeRaw currently does not fail — it quietly gets serialized as the string "null" and bound as a datetime, which can corrupt the value that ends up in the database. The regular query path already throws "Provided Date object is invalid" for the same input, so this makes the raw path throw the same error using the existing isValidDate helper. Added two unit tests, one for a top-level invalid date and one nested in an array.