### PR TITLE
fix(client): copy Bytes values out of Node's shared Buffer pool on deserialization

### DIFF
--- a/packages/client-engine-runtime/src/json-protocol.test.ts
+++ b/packages/client-engine-runtime/src/json-protocol.test.ts
@@ -28,6 +28,14 @@ describe('deserializeJsonObject', () => {
     expect(value).toEqual(new Uint8Array(Buffer.from('hello world')))
   })
 
+  test('Bytes is backed by a standalone buffer', () => {
+    const value = deserializeJsonObject({ $type: 'Bytes', value: 'aGVsbG8gd29ybGQ=' }) as Uint8Array
+    // must not be a view into Node's shared Buffer pool, which would expose
+    // unrelated pool data through `value.buffer`
+    expect(value.byteOffset).toBe(0)
+    expect(value.buffer.byteLength).toBe(value.byteLength)
+  })
+
   test('Decimal', () => {
     const value = deserializeJsonObject({ $type: 'Decimal', value: '123.45' })
     expect(value).toBeInstanceOf(Decimal)

--- a/packages/client-engine-runtime/src/json-protocol.ts
+++ b/packages/client-engine-runtime/src/json-protocol.ts
@@ -153,10 +153,9 @@ function deserializeTaggedValue({ $type, value }: JsonInputTaggedValue | JsonOut
   switch ($type) {
     case 'BigInt':
       return BigInt(value)
-    case 'Bytes': {
-      const { buffer, byteOffset, byteLength } = Buffer.from(value, 'base64')
-      return new Uint8Array(buffer, byteOffset, byteLength)
-    }
+    case 'Bytes':
+      // copy instead of returning a view into Node's shared Buffer pool
+      return new Uint8Array(Buffer.from(value, 'base64'))
     case 'DateTime':
       return new Date(value)
     case 'Decimal':

--- a/packages/client/src/__tests__/deserializeRawResults.test.ts
+++ b/packages/client/src/__tests__/deserializeRawResults.test.ts
@@ -70,6 +70,15 @@ describe('deserializeRawResult', () => {
     ])
   })
 
+  test('bytes is backed by a standalone buffer', () => {
+    const [row] = deserializeRawResult({ columns: ['a'], types: ['bytes'], rows: [['Ynl0ZXM=']] })
+    const value = (row as { a: Uint8Array }).a
+    // must not be a view into Node's shared Buffer pool, which would expose
+    // unrelated pool data through `value.buffer`
+    expect(value.byteOffset).toBe(0)
+    expect(value.buffer.byteLength).toBe(value.byteLength)
+  })
+
   test('bool', () => {
     expect(deserializeRawResult({ columns: ['a', 'b'], types: ['bool', 'bool'], rows: [[true, false]] })).toEqual([
       {

--- a/packages/client/src/runtime/utils/deserializeRawResults.ts
+++ b/packages/client/src/runtime/utils/deserializeRawResults.ts
@@ -16,10 +16,9 @@ function deserializeValue(type: QueryIntrospectionBuiltinType, value: unknown): 
     case 'bigint':
       return BigInt(value as string)
 
-    case 'bytes': {
-      const { buffer, byteOffset, byteLength } = Buffer.from(value as string, 'base64')
-      return new Uint8Array(buffer, byteOffset, byteLength)
-    }
+    case 'bytes':
+      // copy instead of returning a view into Node's shared Buffer pool
+      return new Uint8Array(Buffer.from(value as string, 'base64'))
 
     case 'decimal':
       return new Decimal(value as string)


### PR DESCRIPTION
Fixes #29694

Bytes values come back as a Uint8Array that is a view into Node's shared 8 KB Buffer pool, so field.buffer is the whole pool — including bytes from other decoded values — and field.buffer.byteLength is 8192 instead of the value's real length. This changes both decode sites (structured results and $queryRaw) to copy into a standalone buffer instead of keeping the pool view. Added a test in each package asserting the returned array owns its buffer.