### PR TITLE
fix(client,schema-files-loader): fix source slice and schema loader edge cases

### DIFF
--- a/packages/client/src/runtime/utils/SourceFileSlice.test.ts
+++ b/packages/client/src/runtime/utils/SourceFileSlice.test.ts
@@ -27,6 +27,11 @@ test('sliced toString', () => {
   expect(slice.toString()).toBe('2\n3')
 })
 
+test('sliced toString after slice', () => {
+  const slice = SourceFileSlice.fromContent('1\n2\n3\n4\n5').slice(2, 4).slice(3, 4)
+  expect(slice.toString()).toBe('3\n4')
+})
+
 test('lineAt', () => {
   const slice = SourceFileSlice.fromContent('1\n2\n3')
   expect(slice.lineAt(2)).toBe('2')
@@ -50,6 +55,18 @@ test('lineAt after slice outside of range', () => {
 test('mapLineAt', () => {
   const slice = SourceFileSlice.fromContent('1\n2\n3').mapLineAt(2, (line) => `mapped ${line}`)
   expect(slice.toString()).toBe('1\nmapped 2\n3')
+})
+
+test('mapLineAt outside of range', () => {
+  let called = false
+  const slice = SourceFileSlice.fromContent('1\n2\n3')
+  const mapped = slice.mapLineAt(4, () => {
+    called = true
+    return 'mapped'
+  })
+
+  expect(mapped).toBe(slice)
+  expect(called).toBe(false)
 })
 
 test('mapLines', () => {

--- a/packages/client/src/runtime/utils/SourceFileSlice.test.ts
+++ b/packages/client/src/runtime/utils/SourceFileSlice.test.ts
@@ -32,6 +32,18 @@ test('sliced toString after slice', () => {
   expect(slice.toString()).toBe('3\n4')
 })
 
+test('slice clamps lower bound after slice', () => {
+  const slice = SourceFileSlice.fromContent('1\n2\n3\n4\n5').slice(2, 4).slice(1, 3)
+  expect(slice.firstLineNumber).toBe(2)
+  expect(slice.toString()).toBe('2\n3')
+})
+
+test('slice clamps upper bound after slice', () => {
+  const slice = SourceFileSlice.fromContent('1\n2\n3\n4\n5').slice(2, 4).slice(3, 5)
+  expect(slice.firstLineNumber).toBe(3)
+  expect(slice.toString()).toBe('3\n4')
+})
+
 test('lineAt', () => {
   const slice = SourceFileSlice.fromContent('1\n2\n3')
   expect(slice.lineAt(2)).toBe('2')

--- a/packages/client/src/runtime/utils/SourceFileSlice.ts
+++ b/packages/client/src/runtime/utils/SourceFileSlice.ts
@@ -116,8 +116,17 @@ export class SourceFileSlice {
    * @returns
    */
   slice(fromLine: number, toLine: number): SourceFileSlice {
-    const slicedLines = this.lines.slice(fromLine - this.firstLineNumber, toLine - this.firstLineNumber + 1).join('\n')
-    return new SourceFileSlice(fromLine, dedent(slicedLines).split('\n'))
+    const clampedFrom = Math.max(fromLine, this.firstLineNumber)
+    const clampedTo = Math.min(toLine, this.lastLineNumber)
+
+    if (clampedFrom > clampedTo) {
+      return new SourceFileSlice(fromLine, [])
+    }
+
+    const slicedLines = this.lines
+      .slice(clampedFrom - this.firstLineNumber, clampedTo - this.firstLineNumber + 1)
+      .join('\n')
+    return new SourceFileSlice(clampedFrom, dedent(slicedLines).split('\n'))
   }
 
   /**

--- a/packages/client/src/runtime/utils/SourceFileSlice.ts
+++ b/packages/client/src/runtime/utils/SourceFileSlice.ts
@@ -53,7 +53,7 @@ export class SourceFileSlice {
    * @returns
    */
   mapLineAt(lineNumber: number, mapFn: (line: string) => string): SourceFileSlice {
-    if (lineNumber < this.firstLineNumber || lineNumber > this.lines.length + this.firstLineNumber) {
+    if (lineNumber < this.firstLineNumber || lineNumber > this.lastLineNumber) {
       return this
     }
     const idx = lineNumber - this.firstLineNumber
@@ -116,7 +116,7 @@ export class SourceFileSlice {
    * @returns
    */
   slice(fromLine: number, toLine: number): SourceFileSlice {
-    const slicedLines = this.lines.slice(fromLine - 1, toLine).join('\n')
+    const slicedLines = this.lines.slice(fromLine - this.firstLineNumber, toLine - this.firstLineNumber + 1).join('\n')
     return new SourceFileSlice(fromLine, dedent(slicedLines).split('\n'))
   }
 

--- a/packages/schema-files-loader/src/resolver/caseSensitivity.test.ts
+++ b/packages/schema-files-loader/src/resolver/caseSensitivity.test.ts
@@ -1,0 +1,19 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import { createFileNameToKeyMapper } from './caseSensitivity'
+
+describe('createFileNameToKeyMapper', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('uses locale-independent lowercase keys when case-insensitive', () => {
+    vi.spyOn(String.prototype, 'toLocaleLowerCase').mockImplementation(function () {
+      return String(this).replace(/I/g, 'ı').toLowerCase()
+    })
+
+    const mapFileName = createFileNameToKeyMapper({ caseSensitive: false })
+
+    expect(mapFileName('I.prisma')).toBe('i.prisma')
+  })
+})

--- a/packages/schema-files-loader/src/resolver/caseSensitivity.test.ts
+++ b/packages/schema-files-loader/src/resolver/caseSensitivity.test.ts
@@ -8,8 +8,8 @@ describe('createFileNameToKeyMapper', () => {
   })
 
   test('uses locale-independent lowercase keys when case-insensitive', () => {
-    vi.spyOn(String.prototype, 'toLocaleLowerCase').mockImplementation(function () {
-      return String(this).replace(/I/g, 'ı').toLowerCase()
+    vi.spyOn(String.prototype, 'toLocaleLowerCase').mockImplementation(function (this: string) {
+      return this.replace(/I/g, 'ı').toLowerCase()
     })
 
     const mapFileName = createFileNameToKeyMapper({ caseSensitive: false })

--- a/packages/schema-files-loader/src/resolver/caseSensitivity.ts
+++ b/packages/schema-files-loader/src/resolver/caseSensitivity.ts
@@ -6,5 +6,5 @@ export function createFileNameToKeyMapper(options: CaseSensitivityOptions): File
   if (options.caseSensitive) {
     return (fileName) => fileName
   }
-  return (fileName) => fileName.toLocaleLowerCase()
+  return (fileName) => fileName.toLowerCase()
 }


### PR DESCRIPTION
## Summary

- fix SourceFileSlice range checks so line transforms stop at the actual last line
- make slicing an existing SourceFileSlice use line numbers relative to that slice
- make schema file resolver case folding locale-independent

## Why

SourceFileSlice keeps original source line numbers after slicing. Two helpers still mixed original line numbers with array indexes, which allowed one line past the end in mapLineAt and produced incorrect results when slicing an already sliced source.

The schema files loader also used locale-sensitive lowercasing for case-insensitive file keys. That can produce unstable keys in locales with special casing rules, such as Turkish.

## Tests

- corepack pnpm --dir packages/client test -- src/runtime/utils/SourceFileSlice.test.ts
- corepack pnpm --dir packages/schema-files-loader exec vitest run src/resolver/caseSensitivity.test.ts src/resolver/InMemoryFilesResolver.test.ts src/resolver/CompositeFilesResolver.test.ts
- corepack pnpm exec prettier --check packages/client/src/runtime/utils/SourceFileSlice.ts packages/client/src/runtime/utils/SourceFileSlice.test.ts packages/schema-files-loader/src/resolver/caseSensitivity.ts packages/schema-files-loader/src/resolver/caseSensitivity.test.ts
- git diff --check