### PR TITLE
fix(client): infer moduleFormat correctly for nodenext/node16 in CJS projects

### DIFF
--- a/packages/client-generator-ts/src/generator.ts
+++ b/packages/client-generator-ts/src/generator.ts
@@ -66,6 +66,7 @@ export class PrismaClientTsGenerator implements Generator {
             tsconfig,
             generatedFileExtension,
             importFileExtension,
+            outputDir,
           })
 
     await generateClient({

--- a/packages/client-generator-ts/src/module-format.ts
+++ b/packages/client-generator-ts/src/module-format.ts
@@ -1,4 +1,7 @@
+import fs from 'node:fs'
+
 import { TsConfigJson, TsConfigJsonResolved } from 'get-tsconfig'
+import { packageUpSync } from 'package-up'
 
 import { GeneratedFileExtension } from './file-extensions'
 
@@ -30,15 +33,17 @@ type InferModuleFormatOptions = {
   tsconfig: TsConfigJsonResolved | undefined
   generatedFileExtension: GeneratedFileExtension
   importFileExtension: GeneratedFileExtension
+  outputDir: string
 }
 
 export function inferModuleFormat({
   tsconfig,
   generatedFileExtension,
   importFileExtension,
+  outputDir,
 }: InferModuleFormatOptions): ModuleFormat {
   if (tsconfig?.compilerOptions?.module) {
-    return fromTsConfigModule(tsconfig.compilerOptions.module)
+    return fromTsConfigModule(tsconfig.compilerOptions.module, outputDir)
   }
 
   if (generatedFileExtension === 'cts' || importFileExtension === 'cjs') {
@@ -48,12 +53,36 @@ export function inferModuleFormat({
   return 'esm'
 }
 
-function fromTsConfigModule(module: TsConfigJson.CompilerOptions.Module) {
+// With these `module` settings, TypeScript does not treat the project as ESM or CommonJS
+// uniformly. Instead, it determines the format on a per-file basis by looking at the nearest
+// `package.json`'s `type` field, defaulting to CommonJS when it is absent or not `"module"`.
+const nodeNextModuleModes = new Set<TsConfigJson.CompilerOptions.Module>(['node16', 'nodenext'])
+
+function fromTsConfigModule(module: TsConfigJson.CompilerOptions.Module, outputDir: string): ModuleFormat {
   const normalizedModule = module.toLowerCase() as TsConfigJson.CompilerOptions.Module
 
   if (normalizedModule === 'commonjs') {
     return 'cjs'
   }
 
+  if (nodeNextModuleModes.has(normalizedModule)) {
+    return inferModuleFormatFromNearestPackageJson(outputDir)
+  }
+
   return 'esm'
+}
+
+function inferModuleFormatFromNearestPackageJson(outputDir: string): ModuleFormat {
+  const packageJsonPath = packageUpSync({ cwd: outputDir })
+
+  if (!packageJsonPath) {
+    return 'cjs'
+  }
+
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
+    return packageJson.type === 'module' ? 'esm' : 'cjs'
+  } catch {
+    return 'cjs'
+  }
 }

--- a/packages/client-generator-ts/tests/module-format.test.ts
+++ b/packages/client-generator-ts/tests/module-format.test.ts
@@ -1,0 +1,151 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import type { TsConfigJsonResolved } from 'get-tsconfig'
+import { packageUpSync } from 'package-up'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import { inferModuleFormat } from '../src/module-format'
+
+vi.mock('package-up', () => ({
+  packageUpSync: vi.fn(),
+}))
+
+function tsconfigWithModule(module: string): TsConfigJsonResolved {
+  return { compilerOptions: { module } } as TsConfigJsonResolved
+}
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  vi.mocked(packageUpSync).mockReset()
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function writeTempPackageJson(packageJson: Record<string, unknown>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'module-format-test-'))
+  tempDirs.push(dir)
+  const packageJsonPath = path.join(dir, 'package.json')
+  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson))
+  return packageJsonPath
+}
+
+describe('inferModuleFormat', () => {
+  test('module: commonjs is always cjs, regardless of package.json', () => {
+    vi.mocked(packageUpSync).mockReturnValue(writeTempPackageJson({ type: 'module' }))
+
+    expect(
+      inferModuleFormat({
+        tsconfig: tsconfigWithModule('commonjs'),
+        generatedFileExtension: 'ts',
+        importFileExtension: 'js',
+        outputDir: '/irrelevant',
+      }),
+    ).toBe('cjs')
+  })
+
+  test('module: esnext is always esm, regardless of package.json', () => {
+    vi.mocked(packageUpSync).mockReturnValue(writeTempPackageJson({}))
+
+    expect(
+      inferModuleFormat({
+        tsconfig: tsconfigWithModule('esnext'),
+        generatedFileExtension: 'ts',
+        importFileExtension: 'js',
+        outputDir: '/irrelevant',
+      }),
+    ).toBe('esm')
+  })
+
+  test.each(['node16', 'nodenext', 'NodeNext', 'Node16'])(
+    'module: %s infers esm when the nearest package.json has "type": "module"',
+    (module) => {
+      vi.mocked(packageUpSync).mockReturnValue(writeTempPackageJson({ type: 'module' }))
+
+      expect(
+        inferModuleFormat({
+          tsconfig: tsconfigWithModule(module),
+          generatedFileExtension: 'ts',
+          importFileExtension: 'js',
+          outputDir: '/irrelevant',
+        }),
+      ).toBe('esm')
+    },
+  )
+
+  test.each(['node16', 'nodenext'])(
+    'module: %s infers cjs when the nearest package.json has no "type" field',
+    (module) => {
+      vi.mocked(packageUpSync).mockReturnValue(writeTempPackageJson({}))
+
+      expect(
+        inferModuleFormat({
+          tsconfig: tsconfigWithModule(module),
+          generatedFileExtension: 'ts',
+          importFileExtension: 'js',
+          outputDir: '/irrelevant',
+        }),
+      ).toBe('cjs')
+    },
+  )
+
+  test('module: nodenext infers cjs when the nearest package.json has "type": "commonjs"', () => {
+    vi.mocked(packageUpSync).mockReturnValue(writeTempPackageJson({ type: 'commonjs' }))
+
+    expect(
+      inferModuleFormat({
+        tsconfig: tsconfigWithModule('nodenext'),
+        generatedFileExtension: 'ts',
+        importFileExtension: 'js',
+        outputDir: '/irrelevant',
+      }),
+    ).toBe('cjs')
+  })
+
+  test('module: nodenext infers cjs when no package.json can be found', () => {
+    vi.mocked(packageUpSync).mockReturnValue(undefined)
+
+    expect(
+      inferModuleFormat({
+        tsconfig: tsconfigWithModule('nodenext'),
+        generatedFileExtension: 'ts',
+        importFileExtension: 'js',
+        outputDir: '/irrelevant',
+      }),
+    ).toBe('cjs')
+  })
+
+  test('falls back to the extension-based heuristic when tsconfig has no "module" set', () => {
+    expect(
+      inferModuleFormat({
+        tsconfig: { compilerOptions: {} } as TsConfigJsonResolved,
+        generatedFileExtension: 'cts',
+        importFileExtension: 'js',
+        outputDir: '/irrelevant',
+      }),
+    ).toBe('cjs')
+
+    expect(
+      inferModuleFormat({
+        tsconfig: undefined,
+        generatedFileExtension: 'ts',
+        importFileExtension: 'cjs',
+        outputDir: '/irrelevant',
+      }),
+    ).toBe('cjs')
+
+    expect(
+      inferModuleFormat({
+        tsconfig: undefined,
+        generatedFileExtension: 'ts',
+        importFileExtension: 'js',
+        outputDir: '/irrelevant',
+      }),
+    ).toBe('esm')
+
+    expect(packageUpSync).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- The `prisma-client` generator inferred `moduleFormat` by checking whether `tsconfig.json`'s `compilerOptions.module` was literally `"commonjs"`, treating anything else (including `"nodenext"`/`"node16"`) as ESM.
- Under `nodenext`/`node16`, TypeScript actually decides CJS vs ESM per file based on the nearest `package.json`'s `"type"` field, not the `module` setting alone. A CJS project (no `"type": "module"`) using `nodenext` therefore got an ESM-only client containing `import.meta.url`, which crashes at runtime once `require()`'d (`ReferenceError: exports is not defined in ES module scope`).
- This PR makes `inferModuleFormat` mirror `tsc`'s own resolution for `nodenext`/`node16`: look up the nearest `package.json` to the generator's output directory and infer `"esm"` only when its `"type"` field is `"module"`, defaulting to `"cjs"` otherwise (including when no `package.json` is found). Other `module` settings (`commonjs`, `esnext`, etc.) are unaffected.

Closes #29710

## Test plan

- [x] Added `packages/client-generator-ts/tests/module-format.test.ts` — unit tests covering `commonjs`/`esnext` unconditional behavior, `node16`/`nodenext` (with casing variants) against `package.json` with `type: module`, `type: commonjs`, no `type` field, and no `package.json` found, plus the pre-existing extension-based fallback.
- [x] `pnpm run build` in `packages/client-generator-ts` — clean, no type errors.
- [x] Full package test suite (50 tests, including `generator.test.ts`) passes with no regressions.
- [x] Manually reproduced the exact bug report: CJS project (no `"type"` field) + `tsconfig.json` with `module: nodenext` + no explicit `moduleFormat` → generated client now has no `import.meta.url`, compiles cleanly with `tsc`, and runs under `node` without crashing.
- [x] Verified no regression for genuine ESM projects: `"type": "module"` + `module: nodenext` → generated client still correctly gets `import.meta.url` and runs under Node's ESM loader.