### PR TITLE
fix(adapter-pg): map PostgreSQL deadlocks to P2034

### DIFF
--- a/packages/adapter-neon/src/__tests__/errors.test.ts
+++ b/packages/adapter-neon/src/__tests__/errors.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+
+import { convertDriverError } from '../errors'
+
+describe('convertDriverError', () => {
+  it.each(['40001', '40P01'])('should handle TransactionWriteConflict (%s)', (code) => {
+    const error = { code, message: 'msg', severity: 'ERROR' }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'TransactionWriteConflict',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+})

--- a/packages/adapter-neon/src/errors.ts
+++ b/packages/adapter-neon/src/errors.ts
@@ -98,6 +98,7 @@ function mapDriverError(error: DatabaseError): MappedError {
         user: error.message.split(' ').pop()?.split('"').at(1),
       }
     case '40001':
+    case '40P01':
       return {
         kind: 'TransactionWriteConflict',
       }

--- a/packages/adapter-pg/src/__tests__/errors.test.ts
+++ b/packages/adapter-pg/src/__tests__/errors.test.ts
@@ -127,8 +127,8 @@ describe('convertDriverError', () => {
     })
   })
 
-  it('should handle TransactionWriteConflict (40001)', () => {
-    const error = { code: '40001', message: 'msg', severity: 'ERROR' }
+  it.each(['40001', '40P01'])('should handle TransactionWriteConflict (%s)', (code) => {
+    const error = { code, message: 'msg', severity: 'ERROR' }
     expect(convertDriverError(error)).toEqual({
       kind: 'TransactionWriteConflict',
       originalCode: error.code,

--- a/packages/adapter-pg/src/errors.ts
+++ b/packages/adapter-pg/src/errors.ts
@@ -142,6 +142,7 @@ function mapDriverError(error: DatabaseError): MappedError {
         user: error.message.split(' ').pop()?.split('"').at(1),
       }
     case '40001':
+    case '40P01':
       return {
         kind: 'TransactionWriteConflict',
       }

--- a/packages/adapter-ppg/src/errors.test.ts
+++ b/packages/adapter-ppg/src/errors.test.ts
@@ -23,4 +23,13 @@ describe('convertDriverError', () => {
       originalMessage: error.message,
     })
   })
+
+  it.each(['40001', '40P01'])('should handle TransactionWriteConflict (%s)', (code) => {
+    const error = { code, message: 'msg', details: { severity: 'ERROR' } }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'TransactionWriteConflict',
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
 })

--- a/packages/adapter-ppg/src/errors.ts
+++ b/packages/adapter-ppg/src/errors.ts
@@ -98,6 +98,7 @@ function mapDriverError(error: DatabaseError): MappedError {
         user: error.message.split(' ').pop()?.split('"').at(1),
       }
     case '40001':
+    case '40P01':
       return {
         kind: 'TransactionWriteConflict',
       }


### PR DESCRIPTION
## Summary

- map PostgreSQL `40P01` (`deadlock_detected`) to `TransactionWriteConflict` in
  `@prisma/adapter-pg`
- extend the existing mapping test to cover both `40001` and `40P01`

PostgreSQL categorizes both codes as transaction-rollback conditions. Prisma
translates `TransactionWriteConflict` to `P2034`, its structured retry signal
for write conflicts and deadlocks. Before this change, `40P01` fell through to
the generic PostgreSQL error path.

Fixes #29716

## Verification

- `pnpm --filter @prisma/adapter-pg test src/__tests__/errors.test.ts -t 40P01`
- `pnpm -r --filter @prisma/adapter-pg... build`
- `pnpm --filter @prisma/adapter-pg test` (48 tests passed)
