### PR TITLE
fix(cli): update Studio to 0.33.0 and suppress aborted response errors

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -185,7 +185,7 @@
     "@prisma/config": "workspace:*",
     "@prisma/dev": "0.24.14",
     "@prisma/engines": "workspace:*",
-    "@prisma/studio-core": "0.27.3",
+    "@prisma/studio-core": "0.33.0",
     "mysql2": "3.15.3",
     "postgres": "3.4.7"
   },

--- a/packages/cli/src/Studio.ts
+++ b/packages/cli/src/Studio.ts
@@ -608,6 +608,10 @@ async function handleStudioBffRequest(payload: unknown, executor: Executor): Pro
     return jsonResponse([null, result])
   }
 
+  if (procedure === 'query-insights') {
+    return jsonResponse([serializeError(new Error('Executor does not support query insights'))])
+  }
+
   procedure satisfies undefined
 
   return textResponse('Unknown procedure', 500)

--- a/packages/cli/src/__tests__/Studio.vitest.ts
+++ b/packages/cli/src/__tests__/Studio.vitest.ts
@@ -345,6 +345,24 @@ describe('Studio BFF', () => {
     expect(await response.json()).toEqual([null, [[{ id: 1 }], [{ id: 2 }]]])
   })
 
+  test('returns an explicit error when query insights are unsupported', async () => {
+    await startStudioBff({
+      execute: vi.fn(),
+    })
+
+    const response = await getBffResponse({
+      procedure: 'query-insights',
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual([
+      {
+        message: 'Executor does not support query insights',
+        name: 'Error',
+      },
+    ])
+  })
+
   test('serves the Prisma logo as the favicon', async () => {
     await startStudioBff({
       execute: vi.fn(),

--- a/packages/cli/src/__tests__/studio-server.vitest.ts
+++ b/packages/cli/src/__tests__/studio-server.vitest.ts
@@ -46,6 +46,36 @@ test('logs server errors and returns the error message in the response body', as
   expect(consoleErrorSpy).toHaveBeenCalledWith('[Prisma Studio]', error)
 })
 
+test('does not log when the client disconnects before the response is written', async () => {
+  const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  let resolveHandlerStarted!: () => void
+  let resolveResponse!: () => void
+  const handlerStarted = new Promise<void>((resolve) => {
+    resolveHandlerStarted = resolve
+  })
+  const responseReady = new Promise<void>((resolve) => {
+    resolveResponse = resolve
+  })
+  const { port } = await startTestServer(async () => {
+    resolveHandlerStarted()
+    await responseReady
+    return new Response('late response')
+  })
+  const abortController = new AbortController()
+  const responsePromise = fetch(`http://127.0.0.1:${port}/`, {
+    signal: abortController.signal,
+  }).catch((error: unknown) => error)
+
+  await handlerStarted
+  abortController.abort()
+  await new Promise((resolve) => setTimeout(resolve, 25))
+  resolveResponse()
+
+  await expect(responsePromise).resolves.toMatchObject({ name: 'AbortError' })
+  await new Promise((resolve) => setTimeout(resolve, 25))
+  expect(consoleErrorSpy).not.toHaveBeenCalled()
+})
+
 async function startTestServer(handler: (request: Request) => Response | Promise<Response>): Promise<{ port: number }> {
   const port = await getPort({ host: '127.0.0.1' })
 

--- a/packages/cli/src/__tests__/studio-server.vitest.ts
+++ b/packages/cli/src/__tests__/studio-server.vitest.ts
@@ -49,18 +49,27 @@ test('logs server errors and returns the error message in the response body', as
 test('does not log when the client disconnects before the response is written', async () => {
   const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
   let resolveHandlerStarted!: () => void
+  let resolveRequestDestroyed!: () => void
+  let resolveRequestSettled!: () => void
   let resolveResponse!: () => void
   const handlerStarted = new Promise<void>((resolve) => {
     resolveHandlerStarted = resolve
   })
+  const requestDestroyed = new Promise<void>((resolve) => {
+    resolveRequestDestroyed = resolve
+  })
+  const requestSettled = new Promise<void>((resolve) => {
+    resolveRequestSettled = resolve
+  })
   const responseReady = new Promise<void>((resolve) => {
     resolveResponse = resolve
   })
-  const { port } = await startTestServer(async () => {
+  const { port } = await startTestServer(async (request) => {
     resolveHandlerStarted()
+    request.signal.addEventListener('abort', resolveRequestDestroyed, { once: true })
     await responseReady
     return new Response('late response')
-  })
+  }, resolveRequestSettled)
   const abortController = new AbortController()
   const responsePromise = fetch(`http://127.0.0.1:${port}/`, {
     signal: abortController.signal,
@@ -68,21 +77,25 @@ test('does not log when the client disconnects before the response is written', 
 
   await handlerStarted
   abortController.abort()
-  await new Promise((resolve) => setTimeout(resolve, 25))
+  await requestDestroyed
   resolveResponse()
 
   await expect(responsePromise).resolves.toMatchObject({ name: 'AbortError' })
-  await new Promise((resolve) => setTimeout(resolve, 25))
+  await requestSettled
   expect(consoleErrorSpy).not.toHaveBeenCalled()
 })
 
-async function startTestServer(handler: (request: Request) => Response | Promise<Response>): Promise<{ port: number }> {
+async function startTestServer(
+  handler: (request: Request) => Response | Promise<Response>,
+  onRequestSettled?: () => void,
+): Promise<{ port: number }> {
   const port = await getPort({ host: '127.0.0.1' })
 
   await new Promise<void>((resolve) => {
     const server = startStudioServer({
       handler,
       onListen: resolve,
+      onRequestSettled,
       port,
     })
 

--- a/packages/cli/src/__tests__/studio-server.vitest.ts
+++ b/packages/cli/src/__tests__/studio-server.vitest.ts
@@ -87,7 +87,7 @@ test('does not log when the client disconnects before the response is written', 
 
 async function startTestServer(
   handler: (request: Request) => Response | Promise<Response>,
-  onRequestSettled?: () => void,
+  onNodeRequestSettled?: () => void,
 ): Promise<{ port: number }> {
   const port = await getPort({ host: '127.0.0.1' })
 
@@ -95,7 +95,7 @@ async function startTestServer(
     const server = startStudioServer({
       handler,
       onListen: resolve,
-      onRequestSettled,
+      onNodeRequestSettled,
       port,
     })
 

--- a/packages/cli/src/studio-server.ts
+++ b/packages/cli/src/studio-server.ts
@@ -36,6 +36,10 @@ function startNodeStudioServer({ handler, onListen, port }: StartStudioServerOpt
       const response = await handler(request)
       await writeNodeResponse(nodeResponse, response, nodeRequest.method)
     } catch (error) {
+      if (nodeResponse.destroyed) {
+        return
+      }
+
       console.error('[Prisma Studio]', error)
 
       if (nodeResponse.headersSent || nodeResponse.writableEnded) {

--- a/packages/cli/src/studio-server.ts
+++ b/packages/cli/src/studio-server.ts
@@ -13,7 +13,7 @@ export interface StudioServer {
 type StartStudioServerOptions = {
   handler: StudioRequestHandler
   onListen(): void
-  onRequestSettled?(): void
+  onNodeRequestSettled?(): void
   port: number
 }
 
@@ -30,7 +30,12 @@ export function startStudioServer(options: StartStudioServerOptions): StudioServ
   }
 }
 
-function startNodeStudioServer({ handler, onListen, onRequestSettled, port }: StartStudioServerOptions): StudioServer {
+function startNodeStudioServer({
+  handler,
+  onListen,
+  onNodeRequestSettled,
+  port,
+}: StartStudioServerOptions): StudioServer {
   const server = createServer(async (nodeRequest, nodeResponse) => {
     try {
       const request = createNodeRequest(nodeRequest, nodeResponse, port)
@@ -52,7 +57,7 @@ function startNodeStudioServer({ handler, onListen, onRequestSettled, port }: St
       nodeResponse.setHeader('Access-Control-Allow-Origin', '*')
       nodeResponse.end(error instanceof Error ? error.message : 'Internal Server Error')
     } finally {
-      onRequestSettled?.()
+      onNodeRequestSettled?.()
     }
   })
 
@@ -117,7 +122,7 @@ async function writeNodeResponse(nodeResponse: ServerResponse, response: Respons
   await pipeline(Readable.fromWeb(response.body as never), nodeResponse)
 }
 
-function startBunStudioServer({ handler, onListen, onRequestSettled, port }: StartStudioServerOptions): StudioServer {
+function startBunStudioServer({ handler, onListen, port }: StartStudioServerOptions): StudioServer {
   const bun = (
     globalThis as typeof globalThis & {
       Bun?: {
@@ -131,7 +136,7 @@ function startBunStudioServer({ handler, onListen, onRequestSettled, port }: Sta
   }
 
   const server = bun.serve({
-    fetch: (request) => handleStudioRequest(handler, request, onRequestSettled),
+    fetch: handler,
     port,
   })
 
@@ -144,7 +149,7 @@ function startBunStudioServer({ handler, onListen, onRequestSettled, port }: Sta
   }
 }
 
-function startDenoStudioServer({ handler, onListen, onRequestSettled, port }: StartStudioServerOptions): StudioServer {
+function startDenoStudioServer({ handler, onListen, port }: StartStudioServerOptions): StudioServer {
   const abortController = new AbortController()
   const deno = (
     globalThis as typeof globalThis & {
@@ -161,27 +166,13 @@ function startDenoStudioServer({ handler, onListen, onRequestSettled, port }: St
     throw new Error('Deno runtime is not available.')
   }
 
-  deno.serve({ port, signal: abortController.signal }, (request) =>
-    handleStudioRequest(handler, request, onRequestSettled),
-  )
+  deno.serve({ port, signal: abortController.signal }, handler)
   onListen()
 
   return {
     close() {
       abortController.abort()
     },
-  }
-}
-
-async function handleStudioRequest(
-  handler: StudioRequestHandler,
-  request: Request,
-  onRequestSettled: (() => void) | undefined,
-): Promise<Response> {
-  try {
-    return await handler(request)
-  } finally {
-    onRequestSettled?.()
   }
 }
 

--- a/packages/cli/src/studio-server.ts
+++ b/packages/cli/src/studio-server.ts
@@ -13,6 +13,7 @@ export interface StudioServer {
 type StartStudioServerOptions = {
   handler: StudioRequestHandler
   onListen(): void
+  onRequestSettled?(): void
   port: number
 }
 
@@ -29,10 +30,10 @@ export function startStudioServer(options: StartStudioServerOptions): StudioServ
   }
 }
 
-function startNodeStudioServer({ handler, onListen, port }: StartStudioServerOptions): StudioServer {
+function startNodeStudioServer({ handler, onListen, onRequestSettled, port }: StartStudioServerOptions): StudioServer {
   const server = createServer(async (nodeRequest, nodeResponse) => {
     try {
-      const request = createNodeRequest(nodeRequest, port)
+      const request = createNodeRequest(nodeRequest, nodeResponse, port)
       const response = await handler(request)
       await writeNodeResponse(nodeResponse, response, nodeRequest.method)
     } catch (error) {
@@ -50,6 +51,8 @@ function startNodeStudioServer({ handler, onListen, port }: StartStudioServerOpt
       nodeResponse.statusCode = 500
       nodeResponse.setHeader('Access-Control-Allow-Origin', '*')
       nodeResponse.end(error instanceof Error ? error.message : 'Internal Server Error')
+    } finally {
+      onRequestSettled?.()
     }
   })
 
@@ -62,10 +65,17 @@ function startNodeStudioServer({ handler, onListen, port }: StartStudioServerOpt
   }
 }
 
-function createNodeRequest(nodeRequest: IncomingMessage, port: number): Request {
+function createNodeRequest(nodeRequest: IncomingMessage, nodeResponse: ServerResponse, port: number): Request {
   const origin = `http://${nodeRequest.headers.host ?? `localhost:${port}`}`
   const url = new URL(nodeRequest.url ?? '/', origin)
   const headers = new Headers()
+  const abortController = new AbortController()
+
+  nodeResponse.once('close', () => {
+    if (!nodeResponse.writableEnded) {
+      abortController.abort()
+    }
+  })
 
   for (const [key, value] of Object.entries(nodeRequest.headers)) {
     if (Array.isArray(value)) {
@@ -80,6 +90,7 @@ function createNodeRequest(nodeRequest: IncomingMessage, port: number): Request 
   const requestInit: RequestInit & { duplex?: 'half' } = {
     headers,
     method: nodeRequest.method,
+    signal: abortController.signal,
   }
 
   if (methodHasRequestBody(nodeRequest.method)) {
@@ -106,7 +117,7 @@ async function writeNodeResponse(nodeResponse: ServerResponse, response: Respons
   await pipeline(Readable.fromWeb(response.body as never), nodeResponse)
 }
 
-function startBunStudioServer({ handler, onListen, port }: StartStudioServerOptions): StudioServer {
+function startBunStudioServer({ handler, onListen, onRequestSettled, port }: StartStudioServerOptions): StudioServer {
   const bun = (
     globalThis as typeof globalThis & {
       Bun?: {
@@ -120,7 +131,7 @@ function startBunStudioServer({ handler, onListen, port }: StartStudioServerOpti
   }
 
   const server = bun.serve({
-    fetch: handler,
+    fetch: (request) => handleStudioRequest(handler, request, onRequestSettled),
     port,
   })
 
@@ -133,7 +144,7 @@ function startBunStudioServer({ handler, onListen, port }: StartStudioServerOpti
   }
 }
 
-function startDenoStudioServer({ handler, onListen, port }: StartStudioServerOptions): StudioServer {
+function startDenoStudioServer({ handler, onListen, onRequestSettled, port }: StartStudioServerOptions): StudioServer {
   const abortController = new AbortController()
   const deno = (
     globalThis as typeof globalThis & {
@@ -150,13 +161,27 @@ function startDenoStudioServer({ handler, onListen, port }: StartStudioServerOpt
     throw new Error('Deno runtime is not available.')
   }
 
-  deno.serve({ port, signal: abortController.signal }, handler)
+  deno.serve({ port, signal: abortController.signal }, (request) =>
+    handleStudioRequest(handler, request, onRequestSettled),
+  )
   onListen()
 
   return {
     close() {
       abortController.abort()
     },
+  }
+}
+
+async function handleStudioRequest(
+  handler: StudioRequestHandler,
+  request: Request,
+  onRequestSettled: (() => void) | undefined,
+): Promise<Response> {
+  try {
+    return await handler(request)
+  } finally {
+    onRequestSettled?.()
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -436,8 +436,8 @@ importers:
         specifier: workspace:*
         version: link:../engines
       '@prisma/studio-core':
-        specifier: 0.27.3
-        version: 0.27.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: 0.33.0
+        version: 0.33.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       mysql2:
         specifier: 3.15.3
         version: 3.15.3
@@ -3424,9 +3424,6 @@ packages:
     peerDependencies:
       tslib: '2'
 
-  '@kurkle/color@0.3.4':
-    resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
-
   '@libsql/client@0.17.0':
     resolution: {integrity: sha512-TLjSU9Otdpq0SpKHl1tD1Nc9MKhrsZbCFGot3EbCxRa8m1E5R1mMwoOjKMMM31IyF7fr+hPNHLpYfwbMKNusmg==}
 
@@ -3812,8 +3809,8 @@ packages:
     resolution: {integrity: sha512-0TcebL559MByKqTJ+SsrFIEg228iw8UCVRFckzgfRSiJqczhs+MuAgWOF9lnOIV/IVqvu+KMnFTH0eDeTQMpUg==}
     engines: {bun: '>=1.2.0', node: '>=22.0.0'}
 
-  '@prisma/studio-core@0.27.3':
-    resolution: {integrity: sha512-AADjNFPdsrglxHQVTmHFqv6DuKQZ5WY4p5/gVFY017twvNrSwpLJ9lqUbYYxEu2W7nbvVxTZA8deJ8LseNALsw==}
+  '@prisma/studio-core@0.33.0':
+    resolution: {integrity: sha512-V2fX/nKEymNTrHXwfP26PGjoLStO35Ogu+ex7CFJbLrMYEcZxxZpiSNOs7px23Hk5mzLWvM5RsqG6Ka+rha+wg==}
     engines: {node: ^20.19 || ^22.12 || >=24.0, pnpm: '8'}
     peerDependencies:
       '@types/react': ^18.0.0 || ^19.0.0
@@ -4264,6 +4261,39 @@ packages:
   '@types/cross-spawn@6.0.6':
     resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
 
+  '@types/d3-array@3.0.3':
+    resolution: {integrity: sha512-Reoy+pKnvsksN0lQUlcH6dOGjRZ/3WRwXR//m+/8lt1BXeI4xyaUZoqULNjyXXRuh0Mj4LNpkCvhUpQlY3X5xQ==}
+
+  '@types/d3-color@3.1.0':
+    resolution: {integrity: sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA==}
+
+  '@types/d3-delaunay@6.0.1':
+    resolution: {integrity: sha512-tLxQ2sfT0p6sxdG75c6f/ekqxjyYR0+LwPrsO1mbC9YDBzPJhs2HbJJRrn8Ez1DBoHRo2yx7YEATI+8V1nGMnQ==}
+
+  '@types/d3-format@3.0.1':
+    resolution: {integrity: sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-interpolate@3.0.1':
+    resolution: {integrity: sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.2':
+    resolution: {integrity: sha512-Yk4htunhPAwN0XGlIwArRomOjdoBFXC3+kCxK2Ubg7I9shQlVSJy/pG/Ht5ASN+gdMIalpk8TJ5xV74jFsetLA==}
+
+  '@types/d3-shape@3.1.7':
+    resolution: {integrity: sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==}
+
+  '@types/d3-time-format@2.1.0':
+    resolution: {integrity: sha512-/myT3I7EwlukNOX2xVdMzb8FRgNzRMpsZddwst9Ld/VFe6LyJyRp0s32l/V9XoUzk+Gqu56F/oGk6507+8BxrA==}
+
+  '@types/d3-time@3.0.0':
+    resolution: {integrity: sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -4317,6 +4347,9 @@ packages:
 
   '@types/jsonfile@6.1.4':
     resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
+
+  '@types/lodash@4.17.24':
+    resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
 
   '@types/minimist@1.2.2':
     resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
@@ -4505,6 +4538,41 @@ packages:
   '@typespec/ts-http-runtime@0.3.5':
     resolution: {integrity: sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==}
     engines: {node: '>=20.0.0'}
+
+  '@visx/curve@4.0.1-alpha.0':
+    resolution: {integrity: sha512-jRu61Uz274pV1zyioXmboyrLutYbnKsgjj4njSGCnhdXj5GkZvZbg+ThDb6oOzoAnJOBRLz4rzPlWvNJOzuVMg==}
+
+  '@visx/event@4.0.1-alpha.0':
+    resolution: {integrity: sha512-EQqCMSv/s8NbFjo+hz3FKsvvYfP+2QslsFJ/24/O5l/W+7UC6J6aAvO0ujVwrTwdYbuQ+vhxKi1xdPdKR/qj1g==}
+
+  '@visx/grid@4.0.1-alpha.0':
+    resolution: {integrity: sha512-rycutGmTHO+znNdPumheWMglm7YfpffvRwUkVy5zy4WoORIuKTMkDxwnOzHG2xMxU3EE/YCd37xFV5AxA30yeg==}
+    peerDependencies:
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+
+  '@visx/group@4.0.1-alpha.0':
+    resolution: {integrity: sha512-V19l7iQ7jccBv8kao/EByuI6o4xtxzzLV9nqVI1hRvmdzTVsuLpqlwzYCZUXJaTVvUWf8s4D2SQFjGkj/Nw+0w==}
+    peerDependencies:
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+
+  '@visx/point@4.0.1-alpha.0':
+    resolution: {integrity: sha512-ijTfr/Nx09f03vIj9nyTr3z4Xth4Y75427UaogJh6dnIRLMEFHQOwNu791sbfiNj0a+ZXuaE32h0vKrFe4/8Qg==}
+
+  '@visx/responsive@4.0.1-alpha.0':
+    resolution: {integrity: sha512-o+1zGywQZY0+yOx3Iw87wc4bbPJRr/HnIukTwfOz4UVyj9pB1OQNVHB7OORO1+LBHJceWpB31co/ZV9KHncKrA==}
+    peerDependencies:
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+
+  '@visx/scale@4.0.1-alpha.0':
+    resolution: {integrity: sha512-nzjeE87vFSAXGWFiiNfBpNLAf0Q8Qmf6syvKLjqNi4kGZkdhbUll3E/59YsgWXmjM8+llPLWzGsP+JPvo5eq1A==}
+
+  '@visx/shape@4.0.1-alpha.0':
+    resolution: {integrity: sha512-62QeiVNmPlterQGwhkEDcbq7M0MqY0lBsK5QKXtM9ZoPZWkuGV3aykA3+Xu20B2FAvyJq4LqJzBc7Sxr+EAdbA==}
+    peerDependencies:
+      react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
+
+  '@visx/vendor@4.0.0-alpha.0':
+    resolution: {integrity: sha512-6I+MuqXBcv9jnlcVowHoHKSdk9gXTWkHLKyqBwRWg7LY6A3Ei8SHfubpqGV5rBUSppxMq2RszPJUS6w+H0YgmQ==}
 
   '@vitest/coverage-v8@4.0.18':
     resolution: {integrity: sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==}
@@ -5026,10 +5094,6 @@ packages:
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
 
-  chart.js@4.5.1:
-    resolution: {integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==}
-    engines: {pnpm: '>=8'}
-
   checkpoint-client@1.1.33:
     resolution: {integrity: sha512-kiG9G/2K2lDkwd5q7TrzxN4IVqBSdwItLWXw6H+7+2N5jopjHRjD434OWvg/anuRvAnRlr5tflOuwbetsHQoZQ==}
 
@@ -5063,6 +5127,9 @@ packages:
 
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
+  classnames@2.5.1:
+    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
 
   clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
@@ -5217,6 +5284,54 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.1:
+    resolution: {integrity: sha512-gUY/qeHq/yNqqoCKNq4vtpFLdoCdvyNpWoC/KNjhGbhDuQpAM9sIQQKkXSNpXa9h5KySs/gzm7R88WkUutgwWQ==}
+    engines: {node: '>=12'}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.2:
+    resolution: {integrity: sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.0:
+    resolution: {integrity: sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.0:
+    resolution: {integrity: sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
   data-uri-to-buffer@2.0.2:
     resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
 
@@ -5314,6 +5429,9 @@ packages:
     resolution: {integrity: sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==}
     engines: {node: '>=10'}
 
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -5403,6 +5521,9 @@ packages:
 
   electron-to-chromium@1.4.645:
     resolution: {integrity: sha512-EeS1oQDCmnYsRDRy2zTeC336a/4LZ6WKqvSaM1jLocEk5ZuyszkQtCpsqvuvaIXGOUjwtvF6LTcS8WueibXvSw==}
+
+  elkjs@0.11.1:
+    resolution: {integrity: sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==}
 
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -6191,6 +6312,10 @@ packages:
   ini@4.1.1:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ip@2.0.0:
     resolution: {integrity: sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==}
@@ -7720,6 +7845,9 @@ packages:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
+
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
   rollup-plugin-inject@3.0.2:
     resolution: {integrity: sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==}
@@ -10204,8 +10332,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@kurkle/color@0.3.4': {}
-
   '@libsql/client@0.17.0(encoding@0.1.13)':
     dependencies:
       '@libsql/core': 0.17.0
@@ -10650,11 +10776,20 @@ snapshots:
       env-paths: 3.0.0
       proper-lockfile: 4.1.2
 
-  '@prisma/studio-core@0.27.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@prisma/studio-core@0.33.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@types/react': 19.2.14
-      chart.js: 4.5.1
+      '@visx/curve': 4.0.1-alpha.0
+      '@visx/event': 4.0.1-alpha.0
+      '@visx/grid': 4.0.1-alpha.0(react@19.2.0)
+      '@visx/group': 4.0.1-alpha.0(react@19.2.0)
+      '@visx/responsive': 4.0.1-alpha.0(react@19.2.0)
+      '@visx/scale': 4.0.1-alpha.0
+      '@visx/shape': 4.0.1-alpha.0(react@19.2.0)
+      d3-array: 3.2.4
+      d3-shape: 3.2.0
+      elkjs: 0.11.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     transitivePeerDependencies:
@@ -11053,6 +11188,36 @@ snapshots:
     dependencies:
       '@types/node': 20.19.25
 
+  '@types/d3-array@3.0.3': {}
+
+  '@types/d3-color@3.1.0': {}
+
+  '@types/d3-delaunay@6.0.1': {}
+
+  '@types/d3-format@3.0.1': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-interpolate@3.0.1':
+    dependencies:
+      '@types/d3-color': 3.1.0
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.2':
+    dependencies:
+      '@types/d3-time': 3.0.0
+
+  '@types/d3-shape@3.1.7':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@2.1.0': {}
+
+  '@types/d3-time@3.0.0': {}
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 0.7.31
@@ -11112,6 +11277,8 @@ snapshots:
   '@types/jsonfile@6.1.4':
     dependencies:
       '@types/node': 20.19.37
+
+  '@types/lodash@4.17.24': {}
 
   '@types/minimist@1.2.2': {}
 
@@ -11368,6 +11535,83 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
+
+  '@visx/curve@4.0.1-alpha.0':
+    dependencies:
+      '@visx/vendor': 4.0.0-alpha.0
+
+  '@visx/event@4.0.1-alpha.0':
+    dependencies:
+      '@types/react': 19.2.14
+      '@visx/point': 4.0.1-alpha.0
+
+  '@visx/grid@4.0.1-alpha.0(react@19.2.0)':
+    dependencies:
+      '@types/react': 19.2.14
+      '@visx/curve': 4.0.1-alpha.0
+      '@visx/group': 4.0.1-alpha.0(react@19.2.0)
+      '@visx/point': 4.0.1-alpha.0
+      '@visx/scale': 4.0.1-alpha.0
+      '@visx/shape': 4.0.1-alpha.0(react@19.2.0)
+      classnames: 2.5.1
+      react: 19.2.0
+
+  '@visx/group@4.0.1-alpha.0(react@19.2.0)':
+    dependencies:
+      '@types/react': 19.2.14
+      classnames: 2.5.1
+      react: 19.2.0
+
+  '@visx/point@4.0.1-alpha.0': {}
+
+  '@visx/responsive@4.0.1-alpha.0(react@19.2.0)':
+    dependencies:
+      '@types/lodash': 4.17.24
+      '@types/react': 19.2.14
+      lodash: 4.18.1
+      react: 19.2.0
+
+  '@visx/scale@4.0.1-alpha.0':
+    dependencies:
+      '@visx/vendor': 4.0.0-alpha.0
+
+  '@visx/shape@4.0.1-alpha.0(react@19.2.0)':
+    dependencies:
+      '@types/lodash': 4.17.24
+      '@types/react': 19.2.14
+      '@visx/curve': 4.0.1-alpha.0
+      '@visx/group': 4.0.1-alpha.0(react@19.2.0)
+      '@visx/scale': 4.0.1-alpha.0
+      '@visx/vendor': 4.0.0-alpha.0
+      classnames: 2.5.1
+      lodash: 4.18.1
+      react: 19.2.0
+
+  '@visx/vendor@4.0.0-alpha.0':
+    dependencies:
+      '@types/d3-array': 3.0.3
+      '@types/d3-color': 3.1.0
+      '@types/d3-delaunay': 6.0.1
+      '@types/d3-format': 3.0.1
+      '@types/d3-geo': 3.1.0
+      '@types/d3-interpolate': 3.0.1
+      '@types/d3-path': 3.1.1
+      '@types/d3-scale': 4.0.2
+      '@types/d3-shape': 3.1.7
+      '@types/d3-time': 3.0.0
+      '@types/d3-time-format': 2.1.0
+      d3-array: 3.2.1
+      d3-color: 3.1.0
+      d3-delaunay: 6.0.2
+      d3-format: 3.1.0
+      d3-geo: 3.1.0
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      internmap: 2.0.3
 
   '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.37)(jiti@2.6.1)(terser@5.27.0)(tsx@4.19.3)(yaml@2.8.3))':
     dependencies:
@@ -11993,10 +12237,6 @@ snapshots:
 
   chardet@0.7.0: {}
 
-  chart.js@4.5.1:
-    dependencies:
-      '@kurkle/color': 0.3.4
-
   checkpoint-client@1.1.33(encoding@0.1.13):
     dependencies:
       ci-info: 4.0.0
@@ -12027,6 +12267,8 @@ snapshots:
   ci-info@4.4.0: {}
 
   cjs-module-lexer@1.4.3: {}
+
+  classnames@2.5.1: {}
 
   clean-stack@2.2.0: {}
 
@@ -12185,6 +12427,52 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.1:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-delaunay@6.0.2:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-format@3.1.0: {}
+
+  d3-geo@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.0
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
   data-uri-to-buffer@2.0.2: {}
 
   data-uri-to-buffer@4.0.1: {}
@@ -12248,6 +12536,10 @@ snapshots:
       p-map: 4.0.0
       rimraf: 3.0.2
       slash: 3.0.0
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
 
   delayed-stream@1.0.0: {}
 
@@ -12316,6 +12608,8 @@ snapshots:
       fast-check: 3.23.2
 
   electron-to-chromium@1.4.645: {}
+
+  elkjs@0.11.1: {}
 
   emittery@0.13.1: {}
 
@@ -13239,6 +13533,8 @@ snapshots:
   ini@1.3.8: {}
 
   ini@4.1.1: {}
+
+  internmap@2.0.3: {}
 
   ip@2.0.0:
     optional: true
@@ -15020,6 +15316,8 @@ snapshots:
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
+
+  robust-predicates@3.0.3: {}
 
   rollup-plugin-inject@3.0.2:
     dependencies:


### PR DESCRIPTION
## Summary

- update the bundled `@prisma/studio-core` from 0.27.3 to 0.33.0
- stop logging response-stream failures after the browser has already disconnected
- handle the new optional `query-insights` BFF procedure with an explicit unsupported response
- add regressions for disconnected clients and the expanded Studio BFF contract

Studio Core 0.33.0 includes the Prisma Next Migrations viewer and the duplicate startup-introspection fix from prisma/studio#1539.

## Validation

- `pnpm --dir packages/cli exec vitest run src/__tests__/Studio.vitest.ts src/__tests__/studio-server.vitest.ts` (19 passed)
- `pnpm --filter prisma build`
- `pnpm --filter prisma tsc`
- ESLint and Prettier checks for all touched files
- frozen offline lockfile install
- PostgreSQL 17 end-to-end run with two migrations applied by Prisma Next: Studio listed both migrations, rendered schema deltas, and displayed their SQL operations
- real delayed BFF request aborted by the client: no server error was logged, and an immediate follow-up query succeeded

The broader CLI suite completed with 240 passing tests and three `incomplete-schemas` Wasm snapshot failures caused by the local schema engine returning `Schema engine error` instead of the expected P1013 detail. The same three failures reproduce on an unchanged `origin/main` checkout.