### PR TITLE
fix(client): mask each quoted string in maskQuery independently

### DIFF
--- a/packages/client/src/runtime/core/engines/common/utils/maskQuery.test.ts
+++ b/packages/client/src/runtime/core/engines/common/utils/maskQuery.test.ts
@@ -101,3 +101,9 @@ test('aggregate', () => {
       }"
   `)
 })
+
+test('string with an escaped quote', () => {
+  const query = `email_endsWith: "safe\\"secret", next: "other"`
+
+  expect(maskQuery(query)).toMatchInlineSnapshot(`"email_endsWith: "X", next: "X""`)
+})

--- a/packages/client/src/runtime/core/engines/common/utils/maskQuery.test.ts
+++ b/packages/client/src/runtime/core/engines/common/utils/maskQuery.test.ts
@@ -48,7 +48,7 @@ test('big query', () => {
         where: {
           age_gt: 5
           age_in: [5, 5, 5]
-          name_in: ["X"]
+          name_in: ["X", "X", "X"]
           OR: [
             {
               age_gt: 5

--- a/packages/client/src/runtime/core/engines/common/utils/maskQuery.ts
+++ b/packages/client/src/runtime/core/engines/common/utils/maskQuery.ts
@@ -5,7 +5,7 @@ export function maskQuery(query?: string): string {
   return (
     query
       // replace all strings with X
-      .replace(/".*?"/g, '"X"')
+      .replace(/"(?:[^"\\]|\\.)*"/g, '"X"')
       // replace all numbers with 5
       .replace(/[\s:\[]([+-]?([0-9]*[.])?[0-9]+)/g, (substr) => {
         return `${substr[0]}5`

--- a/packages/client/src/runtime/core/engines/common/utils/maskQuery.ts
+++ b/packages/client/src/runtime/core/engines/common/utils/maskQuery.ts
@@ -5,7 +5,7 @@ export function maskQuery(query?: string): string {
   return (
     query
       // replace all strings with X
-      .replace(/".*"/g, '"X"')
+      .replace(/".*?"/g, '"X"')
       // replace all numbers with 5
       .replace(/[\s:\[]([+-]?([0-9]*[.])?[0-9]+)/g, (substr) => {
         return `${substr[0]}5`


### PR DESCRIPTION
## Description

`maskQuery` sanitizes string values in the engine query before it's included in panic/error reports. The regex used to strip strings (`/".*"/g`) is greedy, so on a line with more than one quoted string it matches from the first quote to the last quote and collapses everything in between into a single masked value.

For example:
```
name_in: ["hans", "peter", "schmidt"]
```
was masked to:
```
name_in: ["X"]
```
instead of:
```
name_in: ["X", "X", "X"]
```

This changes the regex to non-greedy (`/".*?"/g`) so each quoted string is matched and masked independently, and updates the existing snapshot test to reflect the corrected output.

Closes #17931

## Test plan

- Updated the `maskQuery.test.ts` snapshot; both existing test cases pass with the fix.
- `pnpm run test src/runtime/core/engines/common/utils/maskQuery.test.ts` in `packages/client` — passing.
- `eslint` on the changed files — no errors.