### PR TITLE
fix(client-engine-runtime): send ROLLBACK when discarding a timed-out transaction start

### DIFF
--- a/packages/client-engine-runtime/src/transaction-manager/transaction-manager.test.ts
+++ b/packages/client-engine-runtime/src/transaction-manager/transaction-manager.test.ts
@@ -610,6 +610,7 @@ test('transaction start timeout cleans up connection if transaction eventually s
   const REMAINING_TIME_FOR_START = SLOW_START_TRANSACTION_TIME - TIME_PAST_MAX_WAIT
 
   const rollbackMock = vi.fn().mockResolvedValue(undefined)
+  const executeRawMock = vi.fn().mockResolvedValue(1)
 
   const driverAdapter = {
     adapterName: 'slow-adapter',
@@ -628,7 +629,7 @@ test('transaction start timeout cleans up connection if transaction eventually s
                 provider: 'postgres',
                 options: { usePhantomQuery: false },
                 queryRaw: vi.fn(),
-                executeRaw: vi.fn(),
+                executeRaw: executeRawMock,
                 commit: vi.fn(),
                 rollback: rollbackMock,
               }),
@@ -660,8 +661,10 @@ test('transaction start timeout cleans up connection if transaction eventually s
   // Now advance time to let the startTransaction promise resolve
   await vi.advanceTimersByTimeAsync(REMAINING_TIME_FOR_START)
 
-  // After the background startTransaction completes, rollback should be called
-  // to release the connection and avoid pool exhaustion
+  // After the background startTransaction completes, the discarded transaction must send an
+  // explicit ROLLBACK before releasing the connection. Without it, a non-phantom-query adapter
+  // (e.g. pg/neon) returns a connection to the pool while it is still mid-transaction.
+  expect(executeRawMock).toHaveBeenCalledWith(expect.objectContaining({ sql: 'ROLLBACK' }))
   expect(rollbackMock).toHaveBeenCalled()
 })
 

--- a/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
+++ b/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts
@@ -172,12 +172,25 @@ export class TransactionManager {
       case 'waiting':
         if (abortController.signal.aborted) {
           // The startTransaction promise may still be running in the background.
-          // If it eventually succeeds, we need to release the connection to avoid
-          // leaking it and exhausting the connection pool. We ignore any errors
-          // that happen during startup or rollback here because we will have
-          // already returned our own `TransactionStartTimeoutError` error to the user.
+          // If it eventually succeeds, we need to roll back and release the connection to
+          // avoid leaking it and exhausting the connection pool. For adapters that don't use
+          // phantom queries (e.g. pg/neon), `rollback()` only releases the connection without
+          // sending SQL, so we send an explicit ROLLBACK first; otherwise the connection returns
+          // to the pool mid-transaction because `BEGIN` already ran on the wire during startup.
+          // We ignore any errors here because we will have already returned our own
+          // `TransactionStartTimeoutError` error to the user.
           void startTransactionPromise
-            .then((tx) => tx.rollback())
+            .then(async (tx) => {
+              if (tx.options.usePhantomQuery) {
+                await tx.rollback()
+              } else {
+                try {
+                  await tx.executeRaw(ROLLBACK_QUERY())
+                } finally {
+                  await tx.rollback()
+                }
+              }
+            })
             .catch((e) => debug('error in discarded transaction:', e))
 
           // Call `#closeTransaction` to update internal state. It won't actually attempt


### PR DESCRIPTION
## Description

When an interactive transaction's `maxWait` expires while `adapter.startTransaction()` is still in flight, `TransactionManager` discards the transaction once it eventually resolves. It did this with a bare `tx.rollback()`, but for adapters that don't use phantom queries (`@prisma/adapter-pg`, `@prisma/adapter-neon`) `rollback()` only releases the connection back to the pool without sending any SQL. `BEGIN` has already run on the wire at that point, so the connection goes back into the pool mid-transaction. The next query that picks it up then hits `there is already a transaction in progress`, or worse, commits the leaked transaction's work along with its own.

`#closeTransaction` already handles this correctly: for non-phantom-query adapters it sends an explicit `ROLLBACK` before calling `rollback()`. This applies the same branch to the discard path, so the connection is always rolled back before it's released.

Closes #29719

## Test plan

The existing `transaction start timeout cleans up connection if transaction eventually starts` test already used a `usePhantomQuery: false` adapter, but only checked that `rollback()` ran, not that `ROLLBACK` was actually sent on the discarded transaction. I captured its transaction's `executeRaw` mock and asserted the discarded transaction executes `ROLLBACK`; it fails on `main` and passes with the fix.

`pnpm --filter @prisma/client-engine-runtime test` passes (202 tests).
