### PR TITLE
fix(config): add directUrl to datasource type definition for prisma.config.ts

### DIFF
--- a/packages/config/src/PrismaConfig.ts
+++ b/packages/config/src/PrismaConfig.ts
@@ -21,11 +21,13 @@ export type ExperimentalConfig = {
 const DatasourceShape = Shape.Struct({
   url: Shape.optional(Shape.String),
   shadowDatabaseUrl: Shape.optional(Shape.String),
+  directUrl: Shape.optional(Shape.String),
 })
 
 export type Datasource = {
   url?: string
   shadowDatabaseUrl?: string
+  directUrl?: string
 }
 
 export type SchemaEngineConfigInternal = {

--- a/packages/config/src/__tests__/defineConfig.test.ts
+++ b/packages/config/src/__tests__/defineConfig.test.ts
@@ -54,11 +54,13 @@ describe('defineConfig', () => {
         datasource: {
           url: 'postgresql://DATABASE_URL',
           shadowDatabaseUrl: 'postgresql://SHADOW_DATABASE_URL',
+          directUrl: 'postgresql://DIRECT_URL',
         },
       })
       expect(config.datasource).toMatchObject({
         url: 'postgresql://DATABASE_URL',
         shadowDatabaseUrl: 'postgresql://SHADOW_DATABASE_URL',
+        directUrl: 'postgresql://DIRECT_URL',
       })
     })
   })

--- a/packages/config/src/__tests__/fixtures/loadConfigFromFile/datasource/prisma.config.ts
+++ b/packages/config/src/__tests__/fixtures/loadConfigFromFile/datasource/prisma.config.ts
@@ -2,5 +2,6 @@ export default {
   datasource: {
     url: 'postgresql://DATABASE_URL',
     shadowDatabaseUrl: 'postgresql://SHADOW_DATABASE_URL',
+    directUrl: 'postgresql://DIRECT_URL',
   },
 }

--- a/packages/config/src/__tests__/loadConfigFromFile.test.ts
+++ b/packages/config/src/__tests__/loadConfigFromFile.test.ts
@@ -60,6 +60,7 @@ describe('loadConfigFromFile', () => {
       expect(config.datasource).toMatchObject({
         url: 'postgresql://DATABASE_URL',
         shadowDatabaseUrl: 'postgresql://SHADOW_DATABASE_URL',
+        directUrl: 'postgresql://DIRECT_URL',
       })
     })
   })
@@ -351,7 +352,7 @@ describe('loadConfigFromFile', () => {
         expect(config).toBeUndefined()
         assertErrorConfigFileSyntaxError(error)
         expect(error.error.message.replaceAll(resolvedPath!, '<prisma-config>.ts')).toMatchInlineSnapshot(`
-          "{ readonly experimental?: { readonly externalTables?: boolean | undefined; readonly extensions?: boolean | undefined } | undefined; readonly datasource?: { readonly url: string; readonly shadowDatabaseUrl?: string | undefined } | undefined; readonly schema?: string | undefined; readonly migrations?: { readonly path?: string | undefined; readonly initShadowDb?: string | undefined; readonly seed?: NonEmptyString | undefined } | undefined; readonly tables?: { readonly external?: ReadonlyArray<string> | undefined } | undefined; readonly enums?: { readonly external?: ReadonlyArray<string> | undefined } | undefined; readonly views?: { readonly path?: string | undefined } | undefined; readonly typedSql?: { readonly path?: string | undefined } | undefined; readonly extensions?: any | undefined; readonly loadedFromFile: string | null }
+          "{ readonly experimental?: { readonly externalTables?: boolean | undefined; readonly extensions?: boolean | undefined } | undefined; readonly datasource?: { readonly url: string; readonly shadowDatabaseUrl?: string | undefined; readonly directUrl?: string | undefined } | undefined; readonly schema?: string | undefined; readonly migrations?: { readonly path?: string | undefined; readonly initShadowDb?: string | undefined; readonly seed?: NonEmptyString | undefined } | undefined; readonly tables?: { readonly external?: ReadonlyArray<string> | undefined } | undefined; readonly enums?: { readonly external?: ReadonlyArray<string> | undefined } | undefined; readonly views?: { readonly path?: string | undefined } | undefined; readonly typedSql?: { readonly path?: string | undefined } | undefined; readonly extensions?: any | undefined; readonly loadedFromFile: string | null }
           └─ ["__esModule"]
              └─ is unexpected, expected: "experimental" | "datasource" | "schema" | "migrations" | "tables" | "enums" | "views" | "typedSql" | "extensions" | "loadedFromFile""
         `)
@@ -366,7 +367,7 @@ describe('loadConfigFromFile', () => {
         expect(config).toBeUndefined()
         assertErrorConfigFileSyntaxError(error)
         expect(error.error.message.replaceAll(resolvedPath!, '<prisma-config>.ts')).toMatchInlineSnapshot(`
-          "{ readonly experimental?: { readonly externalTables?: boolean | undefined; readonly extensions?: boolean | undefined } | undefined; readonly datasource?: { readonly url: string; readonly shadowDatabaseUrl?: string | undefined } | undefined; readonly schema?: string | undefined; readonly migrations?: { readonly path?: string | undefined; readonly initShadowDb?: string | undefined; readonly seed?: NonEmptyString | undefined } | undefined; readonly tables?: { readonly external?: ReadonlyArray<string> | undefined } | undefined; readonly enums?: { readonly external?: ReadonlyArray<string> | undefined } | undefined; readonly views?: { readonly path?: string | undefined } | undefined; readonly typedSql?: { readonly path?: string | undefined } | undefined; readonly extensions?: any | undefined; readonly loadedFromFile: string | null }
+          "{ readonly experimental?: { readonly externalTables?: boolean | undefined; readonly extensions?: boolean | undefined } | undefined; readonly datasource?: { readonly url: string; readonly shadowDatabaseUrl?: string | undefined; readonly directUrl?: string | undefined } | undefined; readonly schema?: string | undefined; readonly migrations?: { readonly path?: string | undefined; readonly initShadowDb?: string | undefined; readonly seed?: NonEmptyString | undefined } | undefined; readonly tables?: { readonly external?: ReadonlyArray<string> | undefined } | undefined; readonly enums?: { readonly external?: ReadonlyArray<string> | undefined } | undefined; readonly views?: { readonly path?: string | undefined } | undefined; readonly typedSql?: { readonly path?: string | undefined } | undefined; readonly extensions?: any | undefined; readonly loadedFromFile: string | null }
           └─ ["thisShouldFail"]
              └─ is unexpected, expected: "experimental" | "datasource" | "schema" | "migrations" | "tables" | "enums" | "views" | "typedSql" | "extensions" | "loadedFromFile""
         `)


### PR DESCRIPTION
## Description

Closes #29726

### What was the issue

When using the `prisma.config.ts` configuration, passing a `directUrl` to the `datasource` object caused a TypeScript error because `directUrl` was missing from the `Datasource` type definition. Since `directUrl` is required when using connection poolers like Supabase, it should be a supported property inside `defineConfig` just as it is inside `schema.prisma`.

### Where was the issue

`packages/config/src/PrismaConfig.ts` — both the runtime validator (`DatasourceShape`) and the exported TypeScript type (`Datasource`) were missing `directUrl` as an optional property.

### How it was fixed

Added `directUrl` as an optional string (`directUrl?: string`) to both the `DatasourceShape` effect/Schema validator and the `Datasource` type. Updated the corresponding test fixtures and inline snapshots in `defineConfig.test.ts` and `loadConfigFromFile.test.ts`.

### Why this approach

- Follows the exact same pattern used for `shadowDatabaseUrl` — optional string, same level in both the Shape and the type
- No runtime or engine changes needed — the Rust schema engine already supports `directUrl` natively (it's a standard `schema.prisma` datasource field). The engine receives the datasource as raw JSON via `--datasource`, so only the TypeScript type needed updating
- Minimal diff: 4 files, +8/-2 lines

### How to test locally

```bash
cd packages/config
pnpm run test
```

All 71 tests pass. You can also verify manually with a `prisma.config.ts`:

```ts
import { defineConfig } from 'prisma/config'

export default defineConfig({
  datasource: {
    url: process.env['DATABASE_URL'],
    directUrl: process.env['DIRECT_URL'], // no more TypeScript error
  },
})
```