### PR TITLE
fix(client): reject non-object values in XOR type helper

### DIFF
--- a/packages/client-generator-js/src/TSClient/common.ts
+++ b/packages/client-generator-js/src/TSClient/common.ts
@@ -329,7 +329,7 @@ type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
 type XOR<T, U> =
   T extends object ?
   U extends object ?
-    (Without<T, U> & U) | (Without<U, T> & T)
+    ((Without<T, U> & U) | (Without<U, T> & T)) & object
   : U : T
 
 

--- a/packages/client-generator-ts/src/TSClient/common.ts
+++ b/packages/client-generator-ts/src/TSClient/common.ts
@@ -155,7 +155,7 @@ type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
 export type XOR<T, U> =
   T extends object ?
   U extends object ?
-    (Without<T, U> & U) | (Without<U, T> & T)
+    ((Without<T, U> & U) | (Without<U, T> & T)) & object
   : U : T
 
 


### PR DESCRIPTION
## Problem

Passing a primitive to an XOR-typed argument such as `update({ data: 5 })` is accepted at compile time even though the runtime rejects it. Only `null` and `undefined` are caught today. Reported in #22445 (duplicate of #9988).

```ts
prisma.user.update({
  where: { id: 1 },
  data: 5, // no type error, but there should be one
})
```

## Cause

`XOR<T, U>` expands to `(Without<T, U> & U) | (Without<U, T> & T)`. For update inputs the checked type's keys are a subset of the unchecked type's keys, so `Without<T, U>` reduces to `{}`. The member `{} & U` then loses the weak-type check that would otherwise reject a primitive against an all-optional object, so the union accepts numbers and strings.

## Change

Intersect the union with `object` once:

```ts
type XOR<T, U> =
  T extends object ?
  U extends object ?
    ((Without<T, U> & U) | (Without<U, T> & T)) & object
  : U : T
```

`object` excludes primitives, `null` and `undefined` while keeping every object shape, including empty objects, index signatures, branded objects, arrays and `Date`. Mutual exclusivity between the two sides is unchanged.

Applying `& object` to the whole union rather than to each member matters for type performance. Intersecting each member raised type instantiations by 4 to 9.5% on the type benchmarks, while the single outer intersection leaves them effectively unchanged (basic +0.002%, huge-schema +0.003%, lots-of-relations 0%).

The helper is emitted by both the TypeScript and JavaScript client generators, so both `common.ts` files are updated.

## Verification

- Generated a client with both generators and confirmed `update({ data: 5 })` now fails to type-check, while normal create/update/where and nested `connectOrCreate` still compile.
- Unit tests for `@prisma/client-generator-ts` and `@prisma/client-generator-js` pass.
- Ran the type benchmarks (basic, huge-schema, lots-of-relations) with the original and updated helper on the same generated output; instantiation counts are unchanged.

Closes #22445
