### PR TITLE
fix(ts-builders): escape comment terminator in doc comments

### DIFF
--- a/packages/ts-builders/src/DocComment.test.ts
+++ b/packages/ts-builders/src/DocComment.test.ts
@@ -42,6 +42,15 @@ test('multiple addText calls', () => {
   `)
 })
 
+test('escapes comment terminator', () => {
+  expect(stringify(docComment('before */ after'))).toMatchInlineSnapshot(`
+    "/**
+     * before *\\/ after
+     */
+    "
+  `)
+})
+
 test('tagged template - empty', () => {
   expect(stringify(docComment``)).toMatchInlineSnapshot(`
     "/**

--- a/packages/ts-builders/src/DocComment.ts
+++ b/packages/ts-builders/src/DocComment.ts
@@ -18,7 +18,7 @@ export class DocComment implements BasicBuilder {
   write(writer: Writer) {
     writer.writeLine('/**')
     for (const line of this.lines) {
-      writer.writeLine(` * ${line}`)
+      writer.writeLine(` * ${line.replace(/\*\//g, '*\\/')}`)
     }
     writer.writeLine(' */')
     return writer


### PR DESCRIPTION
A `///` documentation comment containing `*/` terminates the generated JSDoc
block early. Everything after it is emitted as top-level tokens, and the text
following the break gets lexed as a regular expression literal, so the damage
cascades through the rest of the file.

Schema:

```prisma
/// A model with */ inside it, then more text after the break
model User {
  id   Int    @id @default(autoincrement())
  name String
}
```

The PSL parser passes `*/` through into the DMMF `documentation` field
unchanged, so it reaches the emitter verbatim. Type checking the generated
output with `tsc --strict` gives:

```
error TS1434: Unexpected keyword or identifier.
error TS1005: ';' expected.
error TS1109: Expression expected.
error TS1161: Unterminated regular expression literal.
```

`DocComment.write()` is the single point where doc comment lines become
emitted text, so escaping there covers every caller in both generators
(model and field documentation, and typed SQL query/parameter docs).

`*\/` is the escape used by TypeDoc and graphql-code-generator for the same
problem.

Existing snapshots are unchanged: output without `*/` is byte identical.
