### PR TITLE
fix(adapter-ppg): handle both quoted and unquoted column names in ColumnNotFound

### DIFF
--- a/packages/adapter-ppg/src/errors.test.ts
+++ b/packages/adapter-ppg/src/errors.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { convertDriverError } from './errors'
+
+describe('convertDriverError', () => {
+  it.each([
+    ['unquoted column name', 'column foo does not exist', 'foo'],
+    ['quoted column name', 'column "foo" does not exist', 'foo'],
+    ['unquoted qualified column name', 'column users.first_name does not exist', 'users.first_name'],
+    ['quoted qualified column name', 'column "users"."first name" does not exist', 'users.first name'],
+    ['partially quoted qualified column name (1)', 'column users."first name" does not exist', 'users.first name'],
+    ['partially quoted qualified column name (2)', 'column "users".first_name does not exist', 'users.first_name'],
+    ['quoted column name containing spaces', 'column "first name" does not exist', 'first name'],
+    ['quoted column name containing dots', 'column "first.name" does not exist', 'first.name'],
+    ['quoted qualified column name containing dots', 'column "users"."first.name" does not exist', 'users.first.name'],
+    ['quoted column name containing escaped quotes', 'column "a""b" does not exist', 'a"b'],
+  ])('should handle ColumnNotFound (42703) with %s', (_description, message, expectedColumn) => {
+    const error = { code: '42703', message, details: { severity: 'ERROR' } }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'ColumnNotFound',
+      column: expectedColumn,
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+})

--- a/packages/adapter-ppg/src/errors.ts
+++ b/packages/adapter-ppg/src/errors.ts
@@ -92,11 +92,13 @@ function mapDriverError(error: DatabaseError): MappedError {
         kind: 'TableDoesNotExist',
         table: error.message.split(' ').at(1)?.split('"').at(1),
       }
-    case '42703':
+    case '42703': {
+      const rawColumn = error.message.match(/^column (.+) does not exist$/)?.at(1)
       return {
         kind: 'ColumnNotFound',
-        column: error.message.split(' ').at(1)?.split('"').at(1),
+        column: rawColumn?.replace(/"((?:""|[^"])*)"/g, (_, id) => id.replaceAll('""', '"')),
       }
+    }
     case '42P04':
       return {
         kind: 'DatabaseAlreadyExists',


### PR DESCRIPTION
Postgres reports a missing column in more than one way. The identifier is
quoted only when it needs to be, and it can be qualified with the table
name:

```
column foo does not exist
column "foo" does not exist
column users.first_name does not exist
column "users"."first name" does not exist
```

`adapter-ppg` splits the message on double quotes, which only handles the
second form. The unquoted forms produce `undefined`, and an identifier
containing spaces is truncated at the first space, so `P2022` ends up
without a usable column name.

The same bug was fixed in `adapter-pg` in #29307. This applies the same
parsing to `adapter-ppg` and adds the test cases from that fix, which the
package did not have before.
