### PR TITLE
fix(client-generator-js): do not emit undefined for schemas without models

### DIFF
--- a/packages/client-generator-js/src/TSClient/TSClient.ts
+++ b/packages/client-generator-js/src/TSClient/TSClient.ts
@@ -232,8 +232,8 @@ ${fieldRefs.join('\n\n')}`
  * Deep Input Types
  */
 
-${this.dmmf.inputObjectTypes.prisma
-  ?.reduce((acc, inputType) => {
+${(this.dmmf.inputObjectTypes.prisma ?? [])
+  .reduce((acc, inputType) => {
     if (inputType.name.includes('Json') && inputType.name.includes('Filter')) {
       const needsGeneric = this.genericsInfo.typeNeedsGenericModelArg(inputType)
       const innerName = needsGeneric ? `${inputType.name}Base<$PrismaModel>` : `${inputType.name}Base`

--- a/packages/client-generator-js/tests/.gitignore
+++ b/packages/client-generator-js/tests/.gitignore
@@ -1,1 +1,2 @@
 /generated
+/generated-no-models

--- a/packages/client-generator-js/tests/generator.test.ts
+++ b/packages/client-generator-js/tests/generator.test.ts
@@ -222,6 +222,28 @@ describe('generator', () => {
     expect(warn).not.toHaveBeenCalled()
   })
 
+  test('schema without models', async () => {
+    const prismaClientTarget = path.join(__dirname, './node_modules/@prisma/client')
+    await fsPromises.rm(prismaClientTarget, { recursive: true, force: true })
+    await getPackedPackage('@prisma/client', prismaClientTarget)
+    await fsPromises.cp(path.join(__dirname, '../../client/runtime'), path.join(prismaClientTarget, 'runtime'), {
+      recursive: true,
+    })
+
+    const generator = await getGenerator({
+      schemaPath: path.join(__dirname, 'no-models.prisma'),
+      printDownloadProgress: false,
+      skipDownload: true,
+      registry,
+    })
+
+    await generator.generate()
+    generator.stop()
+
+    const declarations = await fsPromises.readFile(path.join(__dirname, 'generated-no-models', 'index.d.ts'), 'utf8')
+    expect(declarations).not.toMatch(/^\s*undefined\s*$/m)
+  })
+
   test('denylist from engine validation', async () => {
     expect.assertions(1)
     const prismaClientTarget = path.join(__dirname, './node_modules/@prisma/client')

--- a/packages/client-generator-js/tests/no-models.prisma
+++ b/packages/client-generator-js/tests/no-models.prisma
@@ -1,0 +1,8 @@
+datasource db {
+  provider = "sqlite"
+}
+
+generator client {
+  provider = "prisma-client-js"
+  output   = "./generated-no-models"
+}


### PR DESCRIPTION
A schema without models generates declarations containing a bare
`undefined` statement:

```ts
  /**
   * Deep Input Types
   */

  undefined
```

`inputObjectTypes.prisma` is undefined when there are no models, and the
optional chain result is interpolated into the template as is. The
interpolation for `inputObjectTypes.model` two lines below already
handles this.

Generating without models needs no flag since `--allow-no-models` was
replaced by `--require-models`, so any schema that only declares enums or
types hits this.

The added test generates from a model-less schema and asserts the
declarations contain no such statement.
