### PR TITLE
fix(schema-files-loader): keep track of visited directories

### DIFF
--- a/packages/schema-files-loader/src/loadSchemaFiles.test.ts
+++ b/packages/schema-files-loader/src/loadSchemaFiles.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { expect, test } from 'vitest'
 
 import { loadSchemaFiles } from './loadSchemaFiles'
-import { CompositeFilesResolver, InMemoryFilesResolver, realFsResolver } from './resolver'
+import { CompositeFilesResolver, FilesResolver, FsEntryType, InMemoryFilesResolver, realFsResolver } from './resolver'
 import { fixturePath, line, loadedFile } from './testUtils'
 
 test('simple list', async () => {
@@ -44,6 +44,43 @@ test('reads symlinks', async () => {
 test('ignores symlinks to directories', async () => {
   const files = await loadSchemaFiles(fixturePath('symlinks-to-dir'))
   expect(files).toEqual([])
+})
+
+test('does not get stuck on circular symlinks', async () => {
+  const rootDir = path.join('/', 'root')
+  const otherDir = path.join('/', 'other')
+  // the root can also be reached under a different path, like `/tmp` and `/private/tmp` on macOS
+  const rootAlias = path.join('/', 'alias-of-root')
+  const canonical = (entryPath: string) => (entryPath === rootAlias ? rootDir : entryPath)
+  // both directories contain a symlink to each other
+  const dirs: Record<string, Record<string, FsEntryType>> = {
+    [rootDir]: { 'a.prisma': { kind: 'file' }, link: { kind: 'symlink', realPath: otherDir } },
+    [otherDir]: { 'b.prisma': { kind: 'file' }, link: { kind: 'symlink', realPath: rootDir } },
+  }
+  let lookups = 0
+  const resolver: FilesResolver = {
+    listDirContents: (dirPath) => Promise.resolve(Object.keys(dirs[canonical(dirPath)] ?? {})),
+    getEntryType: (entryPath) => {
+      // fails the test instead of running out of memory if the cycle is not detected
+      if (++lookups > 20) {
+        throw new Error('too many lookups: traversal did not terminate')
+      }
+      const realPath = canonical(entryPath)
+      return Promise.resolve(
+        dirs[realPath]
+          ? { kind: 'directory', realPath }
+          : dirs[canonical(path.dirname(entryPath))]?.[path.basename(entryPath)],
+      )
+    },
+    getFileContents: (filePath) => Promise.resolve(`// this is ${path.basename(filePath)}`),
+  }
+
+  const files = await loadSchemaFiles(rootAlias, resolver)
+
+  expect(files).toEqual([
+    [path.join(rootAlias, 'a.prisma'), '// this is a.prisma'],
+    [path.join(otherDir, 'b.prisma'), '// this is b.prisma'],
+  ])
 })
 
 test('allows to use in-memory resolver', async () => {

--- a/packages/schema-files-loader/src/loadSchemaFiles.ts
+++ b/packages/schema-files-loader/src/loadSchemaFiles.ts
@@ -20,6 +20,7 @@ async function processEntry(
   entryPath: string,
   entryType: FsEntryType | undefined,
   filesResolver: FilesResolver,
+  visitedDirs: Set<string> = new Set(),
 ): Promise<LoadedFile[]> {
   if (!entryType) {
     return []
@@ -27,7 +28,7 @@ async function processEntry(
   if (entryType.kind === 'symlink') {
     const realPath = entryType.realPath
     const realType = await filesResolver.getEntryType(realPath)
-    return processEntry(realPath, realType, filesResolver)
+    return processEntry(realPath, realType, filesResolver, visitedDirs)
   }
 
   if (entryType.kind === 'file') {
@@ -42,12 +43,22 @@ async function processEntry(
   }
 
   if (entryType.kind === 'directory') {
+    // Symlinks pointing to directories are followed, so a directory that is
+    // reachable from itself would otherwise be traversed forever. The canonical
+    // path is used for tracking, since the same directory can be reached under
+    // different paths.
+    const dirId = entryType.realPath ?? entryPath
+    if (visitedDirs.has(dirId)) {
+      return []
+    }
+    visitedDirs.add(dirId)
+
     const dirEntries = await filesResolver.listDirContents(entryPath)
     const nested = await Promise.all(
       dirEntries.map(async (dirEntry) => {
         const fullPath = path.join(entryPath, dirEntry)
         const nestedEntryType = await filesResolver.getEntryType(fullPath)
-        return processEntry(fullPath, nestedEntryType, filesResolver)
+        return processEntry(fullPath, nestedEntryType, filesResolver, visitedDirs)
       }),
     )
     return nested.flat()

--- a/packages/schema-files-loader/src/resolver/realFsResolver.ts
+++ b/packages/schema-files-loader/src/resolver/realFsResolver.ts
@@ -13,7 +13,7 @@ export const realFsResolver: FilesResolver = {
     }
 
     if (stat.isDirectory()) {
-      return { kind: 'directory' }
+      return { kind: 'directory', realPath: await fs.realpath(path) }
     }
 
     if (stat.isSymbolicLink()) {

--- a/packages/schema-files-loader/src/resolver/types.ts
+++ b/packages/schema-files-loader/src/resolver/types.ts
@@ -4,6 +4,11 @@ export type FsEntryType =
     }
   | {
       kind: 'directory'
+      /**
+       * Canonical path of the directory, if the resolver is able to provide one.
+       * Used for detecting directories that are reachable from themselves through symlinks.
+       */
+      realPath?: string
     }
   | {
       kind: 'symlink'


### PR DESCRIPTION
### Problem

`loadSchemaFiles` follows symlinks that resolve to a directory, but it never records which directories it already walked into. Two directories that link to each other are enough to make it recurse forever:

```
schema/
  a.prisma
  nested/
    b.prisma
    link -> ..
```

Running `prisma validate --schema schema` on that layout never returns. Because the recursion is async, there is no stack overflow and no error, the command just sits there while memory keeps growing (136 MB to 303 MB over 20 seconds in my case). Directory symlinks used to be skipped entirely before #24378 reworked the traversal into a generic recursive function, and the cycle was never accounted for after that change.

### Fix

The traversal now carries a set of directories it has already entered and stops when it sees one again.

The set is keyed by the canonical path rather than the path the directory was reached through, otherwise the same directory can be entered twice under two different spellings. That is easy to hit on macOS, where `/tmp` is a symlink to `/private/tmp`: pointing the schema root at `/tmp/...` made the loader return `a.prisma` twice, once for each spelling, and validation then failed with

```
The model "A" cannot be defined because a model with that name already exists.
```

To get the canonical path, `getEntryType` now reports `realPath` for directories too. The field is optional, so resolvers that have no notion of symlinks (`InMemoryFilesResolver`) are unaffected and fall back to the entry path. The paths in the returned files are untouched, they are still reported the way the user spelled the schema root.

The same change also removes duplicates for a directory that is reachable twice without any cycle, which is a fix on its own: duplicated files are rejected later by validation.

### Test

The new test drives `loadSchemaFiles` with a resolver that describes two directories linking to each other, and reaches the root through a second path so both parts of the fix are covered. The resolver gives up after a fixed number of lookups, so a regression fails the test right away instead of taking the worker down with it.

### Note

`ignores symlinks to directories` does not test what its name says. Its fixture links to a directory that only contains `.gitkeep`, so the loader does walk into it and simply finds no `.prisma` files. I left it alone since it is unrelated to the cycle, but it is worth renaming at some point.
