### PR TITLE
fix(client-generator-ts): remove ?module suffix for workerd target in wasm loader

### DIFF
--- a/packages/client-generator-ts/src/utils/wasm.ts
+++ b/packages/client-generator-ts/src/utils/wasm.ts
@@ -31,6 +31,7 @@ export function buildGetWasmModule({
   activeProvider,
   moduleFormat,
   compilerBuild,
+  target,
 }: BuildWasmModuleOptions) {
   const extension = match(moduleFormat)
     .with('esm', () => 'mjs')
@@ -94,6 +95,23 @@ config.compilerWasm = {
   }
 
   if (buildEdgeLoader) {
+    // For Cloudflare Workers (workerd), Vite 7 does not support the `?module` suffix.
+    // Use `import('#wasm-compiler-loader')` virtual module instead, which is resolved
+    // by the generated package.json `imports` field to a runtime-appropriate loader.
+    if (target === 'workerd') {
+      return `config.compilerWasm = {
+  getRuntime: async () => await import(${JSON.stringify(wasmBindingsPath)}),
+
+  getQueryCompilerWasmModule: async () => {
+    const loader = (await import('#wasm-compiler-loader')).default
+    const compiler = (await loader).default
+    return compiler
+  },
+
+  importName: ${JSON.stringify(`./${artifactName}.js`)}
+}`
+    }
+
     return `config.compilerWasm = {
   getRuntime: async () => await import(${JSON.stringify(wasmBindingsPath)}),
 

--- a/packages/client-generator-ts/tests/assert-typescript-is-valid.ts
+++ b/packages/client-generator-ts/tests/assert-typescript-is-valid.ts
@@ -90,6 +90,11 @@ declare module '*.wasm?module' {
   const wasmModule: WebAssembly.Module
   export default wasmModule
 }
+
+declare module '#wasm-compiler-loader' {
+  const loader: Promise<{ default: WebAssembly.Module }>
+  export default loader
+}
   `
 
   // Create the WASM declarations file

--- a/packages/client-generator-ts/tests/utils/__snapshots__/buildGetWasmModule.test.ts.snap
+++ b/packages/client-generator-ts/tests/utils/__snapshots__/buildGetWasmModule.test.ts.snap
@@ -191,8 +191,9 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-fast-wasm-co
   getRuntime: async () => await import("./query_compiler_fast_bg.js"),
 
   getQueryCompilerWasmModule: async () => {
-    const { default: module } = await import("./query_compiler_fast_bg.wasm?module")
-    return module
+    const loader = (await import('#wasm-compiler-loader')).default
+    const compiler = (await loader).default
+    return compiler
   },
 
   importName: "./query_compiler_fast_bg.js"
@@ -204,8 +205,9 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-fast-wasm-co
   getRuntime: async () => await import("./query_compiler_fast_bg.js"),
 
   getQueryCompilerWasmModule: async () => {
-    const { default: module } = await import("./query_compiler_fast_bg.wasm?module")
-    return module
+    const loader = (await import('#wasm-compiler-loader')).default
+    const compiler = (await loader).default
+    return compiler
   },
 
   importName: "./query_compiler_fast_bg.js"
@@ -403,8 +405,9 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-small-wasm-c
   getRuntime: async () => await import("./query_compiler_small_bg.js"),
 
   getQueryCompilerWasmModule: async () => {
-    const { default: module } = await import("./query_compiler_small_bg.wasm?module")
-    return module
+    const loader = (await import('#wasm-compiler-loader')).default
+    const compiler = (await loader).default
+    return compiler
   },
 
   importName: "./query_compiler_small_bg.js"
@@ -416,8 +419,9 @@ exports[`buildGetWasmModule > generates valid TypeScript > compiler-small-wasm-c
   getRuntime: async () => await import("./query_compiler_small_bg.js"),
 
   getQueryCompilerWasmModule: async () => {
-    const { default: module } = await import("./query_compiler_small_bg.wasm?module")
-    return module
+    const loader = (await import('#wasm-compiler-loader')).default
+    const compiler = (await loader).default
+    return compiler
   },
 
   importName: "./query_compiler_small_bg.js"


### PR DESCRIPTION
## Summary

Fixes **Issue #28105** — Vite 7 build failure when using Prisma Client with `engineType: 'client'` and `runtime: 'cloudflare'` (Cloudflare Workers / workerd).

## Problem

When generating a Prisma Client with Cloudflare Workers runtime support, the generated code used Vite's `?module` suffix for WASM module imports:

```js
const { default: module } = await import('./query_compiler_bg.wasm?module')
```

However, **workerd (Cloudflare Workers runtime) does not support the `?module` suffix** — it's a Vite-specific virtual module convention that workerd cannot parse, causing the build to fail with:

```
Unexpected character '?' at position 45
```

## Solution

For the **workerd** target, use the `#wasm-compiler-loader` virtual module import instead, which the generated `package.json` `imports` field resolves to a runtime-appropriate WASM loader. For **Vercel Edge**, the original `?module` suffix behavior is preserved.

## Files Changed

| File | Change |
|------|--------|
| `packages/client-generator-ts/src/utils/wasm.ts` | Added `target === 'workerd'` conditional that uses `import('#wasm-compiler-loader')` instead of `.wasm?module` |
| `packages/client-generator-ts/tests/assert-typescript-is-valid.ts` | Added TypeScript declaration for `'#wasm-compiler-loader'` virtual module |
| `packages/client-generator-ts/tests/utils/__snapshots__/buildGetWasmModule.test.ts.snap` | Updated snapshots to reflect the new generated code output |

## Testing

All 39 tests in `packages/client-generator-ts` pass, including 24 tests in `buildGetWasmModule.test.ts` covering all 4 workerd combinations and 4 vercel-edge combinations.

## Closes

Closes #28105
