### PR TITLE
fix(client): avoid literal DATABASE_URL in generated JSDoc examples

### DIFF
--- a/packages/client-generator-js/src/TSClient/PrismaClient.ts
+++ b/packages/client-generator-js/src/TSClient/PrismaClient.ts
@@ -410,7 +410,7 @@ export class PrismaClientClass implements Generable {
  * @example
  * \`\`\`
  * const prisma = new PrismaClient({
- *   adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL })
+ *   adapter: new PrismaPg({ connectionString: process.env.YOUR_DATABASE_URL_ENV_VAR })
  * })
  * // Fetch zero or more ${capitalize(example.plural)}
  * const ${uncapitalize(example.plural)} = await prisma.${uncapitalize(example.model)}.findMany()
@@ -632,7 +632,7 @@ export type TransactionClient = Omit<Prisma.DefaultPrismaClient, ${transactionCl
             import { PrismaPg } from '@prisma/adapter-pg'
             import { PrismaClient } from './generated/prisma/client'
 
-            const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL })
+            const adapter = new PrismaPg({ connectionString: process.env.YOUR_DATABASE_URL_ENV_VAR })
             const prisma = new PrismaClient({ adapter })
             \`\`\`
           `),

--- a/packages/client-generator-ts/src/TSClient/PrismaClient.ts
+++ b/packages/client-generator-ts/src/TSClient/PrismaClient.ts
@@ -240,7 +240,7 @@ export function getPrismaClientClassDocComment({ dmmf }: GenerateContext): ts.Do
     @example
     \`\`\`
     const prisma = new PrismaClient({
-      adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL })
+      adapter: new PrismaPg({ connectionString: process.env.YOUR_DATABASE_URL_ENV_VAR })
     })
     // Fetch zero or more ${capitalize(example.plural)}
     const ${uncapitalize(example.plural)} = await prisma.${uncapitalize(example.model)}.findMany()

--- a/packages/client-generator-ts/src/TSClient/file-generators/PrismaNamespaceFile.ts
+++ b/packages/client-generator-ts/src/TSClient/file-generators/PrismaNamespaceFile.ts
@@ -324,7 +324,7 @@ function buildClientOptions(context: GenerateContext) {
             import { PrismaPg } from '@prisma/adapter-pg'
             import { PrismaClient } from './generated/prisma/client'
 
-            const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL })
+            const adapter = new PrismaPg({ connectionString: process.env.YOUR_DATABASE_URL_ENV_VAR })
             const prisma = new PrismaClient({ adapter })
             \`\`\`
           `),


### PR DESCRIPTION
## Description

The generated client's JSDoc/comment usage examples hardcode `process.env.DATABASE_URL` as the connection string:

```ts
const prisma = new PrismaClient({
  adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL })
})
```

Combined with the single-line inlined schema in the current generator's output (`internal/class.ts`), this makes the generated file look like a minified bundle to heuristic secret-scanning tools, and the literal `process.env.DATABASE_URL` pattern trips false-positive "env leak" findings — even though nothing is actually leaked, since it's just referencing an env var by name.

This swaps the example to a clearly placeholder-style env var name (`YOUR_DATABASE_URL_ENV_VAR`) in both the current TS-based generator (`client-generator-ts`) and the legacy JS one (`client-generator-js`), since both produce the same kind of generated example.

Intentionally **not** changed:
- `packages/client/src/runtime/utils/validatePrismaClientOptions.ts` — this is a real runtime error message shown to users when client options are invalid, not generated example code.
- `packages/client/src/runtime/getPrismaClient.ts` — this is `@prisma/client`'s own shipped source/JSDoc, not per-project generated output.

Both show the real, correct `DATABASE_URL` convention, which is what users should actually see there.

Closes #29724

## Test plan

- `pnpm run test` in `packages/client-generator-ts` — 39 tests passing, including `tests/generator.test.ts` which generates a real client from several schemas and validates the resulting TypeScript.
- `pnpm run test` in `packages/client-generator-js` — 18 tests passing.
- `eslint` on the changed files — no errors.
- Confirmed via `grep` that no `.snap` files reference the changed string, and that all other `process.env.DATABASE_URL` occurrences in the codebase (outside the 3 changed files) are either the two files above or unrelated test usages, not generated example code.