### PR TITLE
fix(adapter-neon): map args through mapArg in PrismaNeonHttpAdapter

### DIFF
--- a/packages/adapter-neon/src/__tests__/neon.test.ts
+++ b/packages/adapter-neon/src/__tests__/neon.test.ts
@@ -1,8 +1,9 @@
 import * as neon from '@neondatabase/serverless'
 import { getLogs } from '@prisma/debug'
+import type { SqlQuery } from '@prisma/driver-adapter-utils'
 import { describe, expect, it, vi } from 'vitest'
 
-import { PrismaNeonAdapterFactory } from '../neon'
+import { PrismaNeonAdapterFactory, PrismaNeonHttpAdapter } from '../neon'
 
 describe('PrismaNeonAdapterFactory', () => {
   it('should subscribe to pool error events', async () => {
@@ -74,5 +75,29 @@ describe('PrismaNeonAdapterFactory', () => {
     expect(mockConnection.removeListener).toHaveBeenCalledWith('error', expect.any(Function))
 
     await adapter.dispose()
+  })
+})
+
+describe('PrismaNeonHttpAdapter', () => {
+  it('maps args through mapArg before passing them to the HTTP client', async () => {
+    const mockClient = vi.fn().mockResolvedValue({ fields: [], rows: [], rowCount: 0 })
+    const adapter = new PrismaNeonHttpAdapter(mockClient as unknown as neon.NeonQueryFunction<any, any>)
+
+    // a base64-encoded `Bytes` arg, as the query engine hands it to the adapter
+    const bytesBase64 = Buffer.from('hello-raw-bytes').toString('base64')
+
+    const query: SqlQuery = {
+      sql: 'INSERT INTO "Thing" ("blob") VALUES ($1)',
+      args: [bytesBase64],
+      argTypes: [{ scalarType: 'bytes', arity: 'scalar' }],
+    }
+
+    await adapter.performIO(query)
+
+    const [, values] = mockClient.mock.calls[0]
+    expect(values[0]).toBeInstanceOf(Buffer)
+    expect((values[0] as Buffer).toString('utf-8')).toBe('hello-raw-bytes')
+    // the unmapped base64 string must not be what's sent to the driver
+    expect(values[0]).not.toBe(bytesBase64)
   })
 })

--- a/packages/adapter-neon/src/__tests__/neon.test.ts
+++ b/packages/adapter-neon/src/__tests__/neon.test.ts
@@ -100,4 +100,25 @@ describe('PrismaNeonHttpAdapter', () => {
     // the unmapped base64 string must not be what's sent to the driver
     expect(values[0]).not.toBe(bytesBase64)
   })
+
+  it('maps a DateTime arg to a UTC timestamp string, not the process-local offset', async () => {
+    const mockClient = vi.fn().mockResolvedValue({ fields: [], rows: [], rowCount: 0 })
+    const adapter = new PrismaNeonHttpAdapter(mockClient as unknown as neon.NeonQueryFunction<any, any>)
+
+    // the query engine hands DateTime args over as ISO strings
+    const isoDate = '2023-01-01T12:00:00.000Z'
+
+    const query: SqlQuery = {
+      sql: 'INSERT INTO "Thing" ("date") VALUES ($1)',
+      args: [isoDate],
+      argTypes: [{ scalarType: 'datetime', arity: 'scalar' }],
+    }
+
+    await adapter.performIO(query)
+
+    const [, values] = mockClient.mock.calls[0]
+    // formatDateTime renders the UTC wall-clock value with no offset suffix, unlike the
+    // driver's default `Date#toISOString`/`prepareValue`-style local-offset serialization
+    expect(values[0]).toBe('2023-01-01 12:00:00')
+  })
 })

--- a/packages/adapter-neon/src/neon.ts
+++ b/packages/adapter-neon/src/neon.ts
@@ -288,7 +288,8 @@ export class PrismaNeonHttpAdapter extends NeonQueryable implements SqlDriverAda
   }
 
   override async performIO(query: SqlQuery): Promise<PerformIOResult> {
-    const { sql, args: values } = query
+    const { sql, args } = query
+    const values = args.map((arg, i) => mapArg(arg, query.argTypes[i]))
     return await this.client(sql, values, {
       arrayMode: true,
       fullResults: true,


### PR DESCRIPTION
## Description

`PrismaNeonHttpAdapter.performIO` passes query arguments to the Neon HTTP client without running them through `mapArg`, while `NeonWsQueryable.performIO` (used by the WebSocket adapter, same file) maps every argument:

```ts
// NeonWsQueryable.performIO (WebSocket) — correct
args.map((arg, i) => mapArg(arg, query.argTypes[i]))

// PrismaNeonHttpAdapter.performIO (HTTP) — args passed through raw, before this PR
const { sql, args: values } = query
```

`mapArg` is what converts the engine's wire representation of arguments into driver-ready values — e.g. `Bytes` arguments arrive as base64 strings and need decoding to a `Buffer`, and `Date` arguments need to be formatted in UTC rather than left to the driver's default (local-timezone) serialization. Skipping it on the HTTP path caused two silent data-corruption bugs, with no error raised anywhere:

1. **`Bytes` values are stored/compared as literal base64 text** instead of raw bytes — writes are corrupted, and filters on `Bytes` columns never match rows written by anything other than the HTTP adapter itself.
2. **`Date` values are serialized with the process's local timezone offset** instead of UTC, so a `timestamp` (without time zone) column silently stores skewed wall-clock time.

This applies the same `mapArg` call the WebSocket path already uses, in `PrismaNeonHttpAdapter.performIO`.

Closes #29743

## Test plan

- Added a regression test in `packages/adapter-neon/src/__tests__/neon.test.ts` (there were no existing tests for `PrismaNeonHttpAdapter`) that constructs the adapter with a mocked query function and asserts a base64-encoded `Bytes` argument is decoded to a `Buffer` before being passed to the client, rather than passed through as the raw base64 string.
- Confirmed the new test fails on the pre-fix code with the exact corruption described in the issue (`expected 'aGVsbG8tcmF3LWJ5dGVz' to be an instance of Buffer`), and passes with the fix.
- `pnpm run test` in `packages/adapter-neon` — 5/5 tests passing.
- `eslint` on the changed files — no new errors (3 pre-existing warnings elsewhere in the file, unrelated to this change).