### PR TITLE
fix(client): handle null/undefined as property keys in StrictEnum proxy

### DIFF
--- a/packages/client/src/runtime/strictEnum.test.ts
+++ b/packages/client/src/runtime/strictEnum.test.ts
@@ -49,3 +49,11 @@ test('iterator', () => {
 test('toPrimitive', () => {
   expect(+StrictEnum).toBeNaN()
 })
+
+test('handles null as property key', () => {
+  expect(StrictEnum[null as any]).toBeUndefined()
+})
+
+test('handles undefined as property key', () => {
+  expect(StrictEnum[undefined as any]).toBeUndefined()
+})

--- a/packages/client/src/runtime/strictEnum.ts
+++ b/packages/client/src/runtime/strictEnum.ts
@@ -35,6 +35,9 @@ export function makeStrictEnum<T extends Record<PropertyKey, string | number>>(d
       if (allowList.has(property)) {
         return undefined
       }
+      if (property === 'null' || property === 'undefined') {
+        return undefined
+      }
       throw new TypeError(`Invalid enum value: ${String(property)}`)
     },
   })


### PR DESCRIPTION
## Summary

Fixes the StrictEnum Proxy get trap that stringifies null as 'null' and throws TypeError
instead of returning undefined for non-existent property keys.

When `StrictEnum[null]` or `StrictEnum[undefined]` was accessed, JavaScript's
String(null) coercion produced 'null' which didn't exist in the enum field map, 
triggering a TypeError. This fix returns undefined instead.

## Changes

- `packages/client/src/runtime/strictEnum.ts`: Added guard for 'null' and 'undefined' 
  string keys in the Proxy get trap before throwing
- `packages/client/src/runtime/strictEnum.test.ts`: Added tests for null/undefined property access

## Testing

- StrictEnum proxy tests: ✅ pass (strictEnum.test.ts with 12 tests)
- Regression: all strictEnum tests pass
- closes #29728 