### PR TITLE
chore(deps): bump `@bomb.sh/tab`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -106,7 +106,7 @@
     }
   },
   "devDependencies": {
-    "@bomb.sh/tab": "0.0.19",
+    "@bomb.sh/tab": "0.0.21",
     "@clack/prompts": "1.7.0",
     "@inquirer/prompts": "7.3.3",
     "@libsql/client": "0.8.1",

--- a/packages/cli/src/completions/completion-command.test.ts
+++ b/packages/cli/src/completions/completion-command.test.ts
@@ -47,7 +47,7 @@ describe('completion command', () => {
 
     expect(result).toBe('')
     expect(output).toHaveLength(1)
-    expect(output[0]).toContain('set -l requestComp "prisma complete --')
+    expect(output[0]).toContain('prisma complete -- $args[2..-1] "$lastArg"')
     expect(output[0]).toContain('complete -c prisma')
   })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -450,8 +450,8 @@ importers:
         version: 3.4.7
     devDependencies:
       '@bomb.sh/tab':
-        specifier: 0.0.19
-        version: 0.0.19(commander@13.1.0)
+        specifier: 0.0.21
+        version: 0.0.21(commander@13.1.0)
       '@clack/prompts':
         specifier: 1.7.0
         version: 1.7.0
@@ -2214,8 +2214,8 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@bomb.sh/tab@0.0.19':
-    resolution: {integrity: sha512-dTRfo9Q9B+lbLG3JCu8a/AGQSfD2XXcFcnakQzVjSOX+VvR/s9zpsH8TlqV3iHqazniRn1Ypwd1hcRlXcu/4BA==}
+  '@bomb.sh/tab@0.0.21':
+    resolution: {integrity: sha512-L9tqUOFS9GFJu+EWaoN6EvNAFKHtROJ3VmKP0AKGN4AnR/JXZbNPC9TXJhrNdTJISiUN7ZU0uJCq64fvyUVSvg==}
     hasBin: true
     peerDependencies:
       cac: ^6.7.14
@@ -9420,7 +9420,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@bomb.sh/tab@0.0.19(commander@13.1.0)':
+  '@bomb.sh/tab@0.0.21(commander@13.1.0)':
     optionalDependencies:
       commander: 13.1.0
 


### PR DESCRIPTION
`0.0.21` of the tab library ships performance improvements and a fish shell multi-segment bug fix.

Both fixes are upstream in tab.
Note: requires a cli rebuild so `build/completion.js` bundles the new template.


a small documentation:

for locally-installed clis like prisma via a package manager (pnpm/bun/yarn)
`pnpm prisma <TAB>` is completed by the *[package manager's](https://github.com/bombshell-dev/tab#for-package-manager-completions)* completion, which
delegates to prisma. Load the package manager completion (requires the `tab` cli: `npm i -g @bomb.sh/tab`):
    # zsh
    `source <(tab pnpm zsh)`
    # bash
    `eval "$(tab pnpm bash)"`
    # fish
    `tab pnpm fish | source`
    Or: (MUST be saved as pnpm.fish (fish autoloads by command name))
    `tab pnpm fish > ~/.config/fish/completions/pnpm.fish`
Now `pnpm prisma <TAB>` works.

