### PR TITLE
  fix(adapter-mariadb): preserve local timezone when serializing Date parameters to MySQL

### DIFF
--- a/packages/adapter-mariadb/src/conversion.test.ts
+++ b/packages/adapter-mariadb/src/conversion.test.ts
@@ -1,7 +1,7 @@
 import * as mariadb from 'mariadb'
 import { describe, expect, it } from 'vitest'
 
-import { formatDateTime, mapRow } from './conversion'
+import { mapArg, mapRow } from './conversion'
 
 describe('mapRow', () => {
   it('maps datetime columns from object rows to ISO strings', () => {
@@ -37,37 +37,42 @@ describe('mapRow', () => {
   })
 })
 
-describe('formatDateTime with local time', () => {
-  it('preserves local time: uses local-time methods not UTC methods', () => {
-    // Create a date representing 2026-07-16T16:39:36.363+08:00
-    // formatDateTime now uses local-time getters (getFullYear, getMonth, etc.)
-    // so the result should reflect local time, not UTC
-    // UTC equivalent would be 08:39:36.363, local time varies by timezone
-    const date = new Date('2026-07-16T16:39:36.363+08:00')
+describe('mapArg returns Date for datetime to let driver handle timezone', () => {
+  it('returns the original Date object for DATETIME columns (lets driver handle timezone)', () => {
+    const inputDate = new Date('2026-07-16T16:39:36.363+08:00')
 
-    const result = formatDateTime(date)
+    // @ts-ignore - testing with a mock argType
+    const result = mapArg(inputDate, { dbType: 'DATETIME' })
 
-    // Verify format is correct
-    expect(result).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\.\d{3})?$/)
-
-    // Verify it uses the date components — the year, month, and day come from
-    // the local-time interpretation of the input (not UTC)
-    expect(result.startsWith('2026-07-16')).toBe(true)
-
-    // Critical: ensure NOT using UTC hours (which would be 08 for +08:00 offset)
-    expect(result).not.toBe('2026-07-16 08:39:36.363')
+    expect(result).toBe(inputDate)
   })
 
-  it('produces correct output for a UTC-zoned date', () => {
-    // When input is UTC, local-time and UTC methods produce the same result
-    // only in UTC timezone. Use a clearly different offset to verify local time.
-    const date = new Date('2026-07-16T16:39:36.363+05:00')
+  it('returns the original Date object for TIMESTAMP columns', () => {
+    const inputDate = new Date('2026-07-16T16:39:36.363+05:00')
 
-    const result = formatDateTime(date)
+    // @ts-ignore - testing with a mock argType
+    const result = mapArg(inputDate, { dbType: 'TIMESTAMP' })
 
-    // UTC would be 11:39:36.363, local should be 16:39:36.363 if in +05:00
-    // Since we can't know the test runner's timezone, verify the general format
-    // and that the function doesn't produce UTC output
-    expect(result).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\.\d{3})?$/)
+    expect(result).toBe(inputDate)
+  })
+
+  it('still formats TIME columns to string', () => {
+    const inputDate = new Date('1970-01-01T14:30:00.000Z')
+
+    // @ts-ignore - testing with a mock argType
+    const result = mapArg(inputDate, { dbType: 'TIME' })
+
+    expect(typeof result).toBe('string')
+    expect(result).toMatch(/^\d{2}:\d{2}:\d{2}(\.\d{3})?$/)
+  })
+
+  it('still formats DATE columns to string', () => {
+    const inputDate = new Date('2026-07-16T00:00:00.000Z')
+
+    // @ts-ignore - testing with a mock argType
+    const result = mapArg(inputDate, { dbType: 'DATE' })
+
+    expect(typeof result).toBe('string')
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/)
   })
 })

--- a/packages/adapter-mariadb/src/conversion.test.ts
+++ b/packages/adapter-mariadb/src/conversion.test.ts
@@ -1,7 +1,7 @@
 import * as mariadb from 'mariadb'
 import { describe, expect, it } from 'vitest'
 
-import { mapRow } from './conversion'
+import { formatDateTime, mapRow } from './conversion'
 
 describe('mapRow', () => {
   it('maps datetime columns from object rows to ISO strings', () => {
@@ -34,5 +34,40 @@ describe('mapRow', () => {
     ])
 
     expect(result).toEqual(['2024-01-02T03:04:05.123+00:00', '5', null])
+  })
+})
+
+describe('formatDateTime with local time', () => {
+  it('preserves local time: uses local-time methods not UTC methods', () => {
+    // Create a date representing 2026-07-16T16:39:36.363+08:00
+    // formatDateTime now uses local-time getters (getFullYear, getMonth, etc.)
+    // so the result should reflect local time, not UTC
+    // UTC equivalent would be 08:39:36.363, local time varies by timezone
+    const date = new Date('2026-07-16T16:39:36.363+08:00')
+
+    const result = formatDateTime(date)
+
+    // Verify format is correct
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\.\d{3})?$/)
+
+    // Verify it uses the date components — the year, month, and day come from
+    // the local-time interpretation of the input (not UTC)
+    expect(result.startsWith('2026-07-16')).toBe(true)
+
+    // Critical: ensure NOT using UTC hours (which would be 08 for +08:00 offset)
+    expect(result).not.toBe('2026-07-16 08:39:36.363')
+  })
+
+  it('produces correct output for a UTC-zoned date', () => {
+    // When input is UTC, local-time and UTC methods produce the same result
+    // only in UTC timezone. Use a clearly different offset to verify local time.
+    const date = new Date('2026-07-16T16:39:36.363+05:00')
+
+    const result = formatDateTime(date)
+
+    // UTC would be 11:39:36.363, local should be 16:39:36.363 if in +05:00
+    // Since we can't know the test runner's timezone, verify the general format
+    // and that the function doesn't produce UTC output
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\.\d{3})?$/)
   })
 })

--- a/packages/adapter-mariadb/src/conversion.test.ts
+++ b/packages/adapter-mariadb/src/conversion.test.ts
@@ -56,31 +56,34 @@ describe('mapArg returns Date for datetime to let driver handle timezone', () =>
     expect(result).toBe(inputDate)
   })
 
-  it('still formats TIME columns to string (uses UTC getters)', () => {
-    // Use a UTC time not near midnight so the UTC hour is preserved
-    // regardless of host timezone. Using 14:30:00.000Z guarantees the
-    // formatted hour will be 14 in any timezone offset.
+  it('formats TIME using UTC getters with an exact expected value', () => {
+    // The Date is 2027-06-15T14:30:00.000Z. formatTime uses getUTCHours/Minutes/Seconds,
+    // so the result is always '14:30:00' regardless of the host timezone.
     const inputDate = new Date('2027-06-15T14:30:00.000Z')
 
     // @ts-ignore - testing with a mock argType
     const result = mapArg(inputDate, { dbType: 'TIME' })
 
-    expect(typeof result).toBe('string')
-    // formatTime uses UTC getters, so result matches UTC components exactly
     expect(result).toBe('14:30:00')
   })
 
-  it('still formats DATE columns to string (uses local getters)', () => {
-    // Use a UTC time at noon so the local date is unambiguous in any timezone.
-    // At noon UTC, even UTC-12 rolls forward only to 00:00 next day (not noon),
-    // so the local date is always July 16 in all timezones.
+  it('formats DATE using UTC getters with an exact expected value', () => {
+    // The Date is 2026-07-16T12:00:00.000Z. formatDate uses getUTCFullYear/Month/Date,
+    // so the result is always '2026-07-16' regardless of the host timezone.
     const inputDate = new Date('2026-07-16T12:00:00.000Z')
 
     // @ts-ignore - testing with a mock argType
     const result = mapArg(inputDate, { dbType: 'DATE' })
 
-    expect(typeof result).toBe('string')
-    // formatDate uses local getters (getFullYear/getMonth/getDate)
     expect(result).toBe('2026-07-16')
+  })
+
+  it('formats TIME with milliseconds when the UTC value has sub-second precision', () => {
+    const inputDate = new Date('2027-06-15T14:30:00.123Z')
+
+    // @ts-ignore - testing with a mock argType
+    const result = mapArg(inputDate, { dbType: 'TIME' })
+
+    expect(result).toBe('14:30:00.123')
   })
 })

--- a/packages/adapter-mariadb/src/conversion.test.ts
+++ b/packages/adapter-mariadb/src/conversion.test.ts
@@ -56,23 +56,31 @@ describe('mapArg returns Date for datetime to let driver handle timezone', () =>
     expect(result).toBe(inputDate)
   })
 
-  it('still formats TIME columns to string', () => {
-    const inputDate = new Date('1970-01-01T14:30:00.000Z')
+  it('still formats TIME columns to string (uses UTC getters)', () => {
+    // Use a UTC time not near midnight so the UTC hour is preserved
+    // regardless of host timezone. Using 14:30:00.000Z guarantees the
+    // formatted hour will be 14 in any timezone offset.
+    const inputDate = new Date('2027-06-15T14:30:00.000Z')
 
     // @ts-ignore - testing with a mock argType
     const result = mapArg(inputDate, { dbType: 'TIME' })
 
     expect(typeof result).toBe('string')
-    expect(result).toMatch(/^\d{2}:\d{2}:\d{2}(\.\d{3})?$/)
+    // formatTime uses UTC getters, so result matches UTC components exactly
+    expect(result).toBe('14:30:00')
   })
 
-  it('still formats DATE columns to string', () => {
-    const inputDate = new Date('2026-07-16T00:00:00.000Z')
+  it('still formats DATE columns to string (uses local getters)', () => {
+    // Use a UTC time at noon so the local date is unambiguous in any timezone.
+    // At noon UTC, even UTC-12 rolls forward only to 00:00 next day (not noon),
+    // so the local date is always July 16 in all timezones.
+    const inputDate = new Date('2026-07-16T12:00:00.000Z')
 
     // @ts-ignore - testing with a mock argType
     const result = mapArg(inputDate, { dbType: 'DATE' })
 
     expect(typeof result).toBe('string')
-    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    // formatDate uses local getters (getFullYear/getMonth/getDate)
+    expect(result).toBe('2026-07-16')
   })
 })

--- a/packages/adapter-mariadb/src/conversion.ts
+++ b/packages/adapter-mariadb/src/conversion.ts
@@ -129,7 +129,7 @@ export function mapArg<A>(arg: A | Date, argType: ArgType): null | BigInt | stri
       case MariaDbColumnType.NEWDATE:
         return formatDate(arg)
       default:
-        return formatDateTime(arg)
+        return arg
     }
   }
 

--- a/packages/adapter-mariadb/src/conversion.ts
+++ b/packages/adapter-mariadb/src/conversion.ts
@@ -177,28 +177,28 @@ export const typeCast: mariadb.TypeCastFunction = (field, next) => {
   return next()
 }
 
-function formatDateTime(date: Date): string {
+export function formatDateTime(date: Date): string {
   const pad = (n: number, z = 2) => String(n).padStart(z, '0')
-  const ms = date.getUTCMilliseconds()
+  const ms = date.getMilliseconds()
   return (
-    pad(date.getUTCFullYear(), 4) +
+    pad(date.getFullYear(), 4) +
     '-' +
-    pad(date.getUTCMonth() + 1) +
+    pad(date.getMonth() + 1) +
     '-' +
-    pad(date.getUTCDate()) +
+    pad(date.getDate()) +
     ' ' +
-    pad(date.getUTCHours()) +
+    pad(date.getHours()) +
     ':' +
-    pad(date.getUTCMinutes()) +
+    pad(date.getMinutes()) +
     ':' +
-    pad(date.getUTCSeconds()) +
+    pad(date.getSeconds()) +
     (ms ? '.' + String(ms).padStart(3, '0') : '')
   )
 }
 
 function formatDate(date: Date): string {
   const pad = (n: number, z = 2) => String(n).padStart(z, '0')
-  return pad(date.getUTCFullYear(), 4) + '-' + pad(date.getUTCMonth() + 1) + '-' + pad(date.getUTCDate())
+  return pad(date.getFullYear(), 4) + '-' + pad(date.getMonth() + 1) + '-' + pad(date.getDate())
 }
 
 function formatTime(date: Date): string {

--- a/packages/adapter-mariadb/src/conversion.ts
+++ b/packages/adapter-mariadb/src/conversion.ts
@@ -198,7 +198,7 @@ export function formatDateTime(date: Date): string {
 
 function formatDate(date: Date): string {
   const pad = (n: number, z = 2) => String(n).padStart(z, '0')
-  return pad(date.getFullYear(), 4) + '-' + pad(date.getMonth() + 1) + '-' + pad(date.getDate())
+  return pad(date.getUTCFullYear(), 4) + '-' + pad(date.getUTCMonth() + 1) + '-' + pad(date.getUTCDate())
 }
 
 function formatTime(date: Date): string {


### PR DESCRIPTION
## Summary

  Bugfix for [#29728](https://github.com/prisma/prisma/issues/29728) — `@prisma/adapter-mariadb` was serializing `DateTime` fields to
  UTC ISO strings (e.g. `2026-07-16T08:39:36.363Z`) instead of preserving the local timezone, causing data loss when the DB timezone  differs from UTC.

  **Root cause:** Driver adapter was converting Date objects to UTC ISO strings before passing to the mariadb driver, which then wrote
  the wrong timezone value to MySQL. Native mariadb driver handles Date objects correctly — Prisma was doing an unnecessary conversion.

  **Fix:** Pass the original `Date` object to the driver adapter without UTC conversion, letting the mariadb driver handle timezone
  conversion natively.

  ## Testing
  - Minimal test: passes ✓
  - Regression: passes ✓

  ## Files changed
  - `packages/adapter-mariadb/src/conversion.ts` — remove premature UTC serialization
  - `packages/adapter-mariadb/src/conversion.test.ts` — add test for local timezone preservation

  Closes #29728
