### PR TITLE
feat(client): expose ModelName to compute function in Result extensions

### DIFF
--- a/packages/client/src/runtime/core/extensions/applyResultExtensions.test.ts
+++ b/packages/client/src/runtime/core/extensions/applyResultExtensions.test.ts
@@ -560,3 +560,26 @@ test('allows to omit transitive dependency of a computed team', () => {
   expect(extended).not.toHaveProperty('firstName')
   expect(extended).toHaveProperty('screamingName', 'JOHN!!!')
 })
+
+test('model name is available in compute function', () => {
+  const result = {}
+
+  const extension = {
+    result: {
+      $allModels: {
+        modelName: {
+          compute: (_, modelName) => {
+            return modelName
+          },
+        },
+      },
+    },
+  }
+
+  const extended = applyResultExtensions({
+    result,
+    modelName: 'user',
+    extensions: MergedExtensionsList.single(extension),
+  })
+  expect(extended).toHaveProperty('modelName', 'user')
+})

--- a/packages/client/src/runtime/core/extensions/applyResultExtensions.ts
+++ b/packages/client/src/runtime/core/extensions/applyResultExtensions.ts
@@ -62,7 +62,7 @@ export function applyResultExtensions({ result, modelName, select, omit, extensi
 
     if (areNeedsMet(result, field.needs)) {
       computedPropertiesLayers.push(
-        computedPropertyLayer(field, createCompositeProxy(result, computedPropertiesLayers)),
+        computedPropertyLayer(field, createCompositeProxy(result, computedPropertiesLayers), modelName),
       )
     }
   }
@@ -77,6 +77,6 @@ function areNeedsMet(result: object, neededProperties: string[]) {
   return neededProperties.every((property) => hasOwnProperty(result, property))
 }
 
-function computedPropertyLayer(field: ComputedField, result: object): CompositeProxyLayer {
-  return cacheProperties(addProperty(field.name, () => field.compute(result)))
+function computedPropertyLayer(field: ComputedField, result: object, modelName: string): CompositeProxyLayer {
+  return cacheProperties(addProperty(field.name, () => field.compute(result, modelName)))
 }

--- a/packages/client/src/runtime/core/extensions/resultUtils.test.ts
+++ b/packages/client/src/runtime/core/extensions/resultUtils.test.ts
@@ -151,6 +151,37 @@ describe('getAllComputedFields', () => {
     })
   })
 
+  test('composes computed fields from two extensions targeting the same field and forwards the active model name to both computes', () => {
+    const previousCompute = jest.fn((model: any, modelName: string) => {
+      expect(modelName).toBe('User')
+      return `${model.firstName} ${model.lastName}`
+    })
+    const nextCompute = jest.fn((model: any, modelName: string) => {
+      expect(modelName).toBe('User')
+      return model.fullName.toUpperCase()
+    })
+
+    const result = getComputedFields(
+      {
+        fullName: { name: 'fullName', needs: ['firstName', 'lastName'], compute: previousCompute },
+      },
+      {
+        result: {
+          user: {
+            fullName: {
+              compute: nextCompute,
+            },
+          },
+        },
+      },
+      'User',
+    )
+
+    const model = { firstName: 'John', lastName: 'Smith' }
+
+    expect(result?.fullName.compute(model, 'User')).toBe('JOHN SMITH')
+  })
+
   test('allows to shadow normal field with a computed fields', () => {
     const result = getComputedFields(
       {},

--- a/packages/client/src/runtime/core/extensions/resultUtils.ts
+++ b/packages/client/src/runtime/core/extensions/resultUtils.ts
@@ -97,8 +97,8 @@ function composeCompute(
   if (!previousCompute) {
     return nextCompute
   }
-  return (model) => {
-    return nextCompute({ ...model, [fieldName]: previousCompute(model) })
+  return (model, modelName) => {
+    return nextCompute({ ...model, [fieldName]: previousCompute(model, modelName) }, modelName)
   }
 }
 

--- a/packages/client/src/runtime/core/types/exported/ExtensionArgs.ts
+++ b/packages/client/src/runtime/core/types/exported/ExtensionArgs.ts
@@ -15,7 +15,7 @@ export type ResultArgs = {
   }
 }
 
-export type ResultArgsFieldCompute = (model: any) => unknown
+export type ResultArgsFieldCompute = (model: any, modelName: string) => unknown
 
 export type ResultArg = {
   [FieldName in string]: ResultFieldDefinition

--- a/packages/client/src/runtime/core/types/exported/Extensions.ts
+++ b/packages/client/src/runtime/core/types/exported/Extensions.ts
@@ -129,7 +129,10 @@ export type DynamicResultExtensionArgs<R_, TypeMap extends TypeMapDef> = {
   [K in keyof R_]: {
     [P in keyof R_[K]]?: {
       needs?: DynamicResultExtensionNeeds<TypeMap, ModelKey<TypeMap, K>, R_[K][P]>
-      compute(data: DynamicResultExtensionData<TypeMap, ModelKey<TypeMap, K>, R_[K][P]>): any
+      compute(
+        data: DynamicResultExtensionData<TypeMap, ModelKey<TypeMap, K>, R_[K][P]>,
+        modelName: ModelKey<TypeMap, K>,
+      ): any
     }
   }
 }


### PR DESCRIPTION
Closes https://github.com/prisma/prisma/issues/19821
Reopens https://github.com/prisma/prisma/pull/29181 following comment of @tensordreams 

Pass an extra parameter named modelName to compute function in result extension.
It will allow to create condition based on model name in compute function for $allModels.