### PR TITLE
feat(client): add truncateMiddle helper export to runtime log utils

### DIFF
--- a/packages/client/src/runtime/utils/log.ts
+++ b/packages/client/src/runtime/utils/log.ts
@@ -10,3 +10,12 @@ export function clog(value, options?: Options) {
   const depth = options?.depth ?? 4
   console.debug(inspect(value, { depth }))
 }
+
+export function truncateMiddle(str: string, maxLength: number): string {
+  if (typeof str !== 'string' || str.length <= maxLength || maxLength <= 3) {
+    return str
+  }
+  const charsToShow = Math.ceil((maxLength - 3) / 2)
+  const backChars = Math.floor((maxLength - 3) / 2)
+  return `${str.slice(0, charsToShow)}...${str.slice(str.length - backChars)}`
+}


### PR DESCRIPTION
## Description
Adds a type-safe \	runcateMiddle(str, maxLength)\ string formatting helper function to \packages/client/src/runtime/utils/log.ts\ for cleanly rendering long SQL query strings, database model names, and log identifiers in Prisma Client runtime.

## Features
- Middle string truncation with \...\ ellipsis.
- Exported from \@prisma/client\ runtime utilities.