### PR TITLE
fix(deps): resolve GHSA-c96f-x56v-gq3h by overriding find-my-way to >=9.7.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   '@azure/msal-node>uuid': '>=14.0.0'
   fast-uri@<=3.1.3: '>=3.1.4 <4'
   ws@>=8.0.0 <8.20.1: '>=8.20.1'
+  find-my-way: '>=9.7.0'
 
 importers:
 
@@ -6051,8 +6052,8 @@ packages:
     resolution: {integrity: sha512-OuWNfjfP05JcpAP3JPgAKUhWefjMRfI5iAoSsvE24ANYWJaepAtlSgWECSVEuRgSXpyNEc9DJwG/TZpgcOqyig==}
     engines: {node: '>=16'}
 
-  find-my-way@9.6.0:
-    resolution: {integrity: sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==}
+  find-my-way@9.7.0:
+    resolution: {integrity: sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==}
     engines: {node: '>=20'}
 
   find-up-simple@1.0.1:
@@ -10824,7 +10825,7 @@ snapshots:
       '@prisma/get-platform': 7.2.0
       '@prisma/query-plan-executor': 7.2.0
       '@prisma/streams-local': 0.1.11
-      find-my-way: 9.6.0
+      find-my-way: 9.7.0
       foreground-child: 3.3.1
       get-port-please: 3.2.0
       pathe: 2.0.3
@@ -13283,7 +13284,7 @@ snapshots:
       common-path-prefix: 3.0.0
       pkg-dir: 7.0.0
 
-  find-my-way@9.6.0:
+  find-my-way@9.7.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-querystring: 1.1.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,6 +25,7 @@ overrides:
   '@azure/msal-node>uuid': '>=14.0.0'
   fast-uri@<=3.1.3: '>=3.1.4 <4'
   ws@>=8.0.0 <8.20.1: '>=8.20.1'
+  find-my-way: '>=9.7.0'
 
 peerDependencyRules:
   allowedVersions:


### PR DESCRIPTION
Fixes GHSA-c96f-x56v-gq3h by overriding find-my-way to >=9.7.0 in pnpm-workspace.yaml.

  ## Problem
  - Prisma 7.9.0 bundles find-my-way@9.6.0 through @prisma/dev@0.24.14 as a transitive dependency.
  - Version 9.6.0 is vulnerable to GHSA-c96f-x56v-gq3h: a remotely triggerable DoS when used with Node's HTTP/2 server.
  - Although this is only used by Prisma tooling (not runtime), it triggers npm audit warnings for projects that install Prisma.

  ## Solution
  - Added find-my-way: '>=9.7.0' to pnpm-workspace.yaml overrides section to ensure resolution of the patched version.
  - The vulnerability was fixed in find-my-way 9.7.0+ by addressing the HTTP/2 server handling issue.

  ## Verification
  - After the override, `pnpm install` resolved find-my-way@9.7.0 (verified with `pnpm list find-my-way`).
  - The pnpm-lock.yaml was updated to reflect the new version.
  - The fix is minimal and targeted - we're not bumping @prisma/dev itself since the vulnerability is only in its dependency chain.

  ## References
  - GitHub Advisory: https://github.com/advisories/GHSA-c96f-x56v-gq3h
  - find-my-way changelog: https://github.com/delvedor/find-my-way/releases
  - Issue tracking: https://github.com/prisma/prisma/issues/29780