### PR TITLE
feat(client): expose $datamodel and $provider reflection properties

### DIFF
--- a/packages/client-generator-js/src/TSClient/PrismaClient.ts
+++ b/packages/client-generator-js/src/TSClient/PrismaClient.ts
@@ -446,6 +446,18 @@ export class PrismaClient<
    */
   $disconnect(): $Utils.JsPromise<void>;
 
+  /**
+   * The datamodel the client was generated from, in its runtime representation:
+   * models with their fields' kind, type, list and required flags. A read-only
+   * reflection surface for tools that need model metadata at runtime.
+   */
+  readonly $datamodel: runtime.RuntimeDataModel;
+
+  /**
+   * The datasource provider the client was generated for (e.g. "postgresql").
+   */
+  readonly $provider: string;
+
 ${[
   executeRawDefinition(this.context),
   queryRawDefinition(this.context),

--- a/packages/client-generator-ts/src/TSClient/PrismaClient.ts
+++ b/packages/client-generator-ts/src/TSClient/PrismaClient.ts
@@ -297,6 +297,18 @@ export interface PrismaClient<
    */
   $disconnect(): runtime.Types.Utils.JsPromise<void>;
 
+  /**
+   * The datamodel the client was generated from, in its runtime representation:
+   * models with their fields' kind, type, list and required flags. A read-only
+   * reflection surface for tools that need model metadata at runtime.
+   */
+  readonly $datamodel: runtime.RuntimeDataModel;
+
+  /**
+   * The datasource provider the client was generated for (e.g. "postgresql").
+   */
+  readonly $provider: string;
+
 ${[
   executeRawDefinition(this.context),
   queryRawDefinition(this.context),

--- a/packages/client/src/runtime/core/types/exported/Extensions.ts
+++ b/packages/client/src/runtime/core/types/exported/Extensions.ts
@@ -1,4 +1,4 @@
-import { FluentOperation, NonModelOperation, Operation } from '@prisma/client-common'
+import { FluentOperation, NonModelOperation, Operation, RuntimeDataModel } from '@prisma/client-common'
 import { Sql } from '@prisma/client-runtime-utils'
 
 import { RequiredExtensionArgs as UserArgs } from './ExtensionArgs'
@@ -303,6 +303,18 @@ export type DynamicClientExtensionThisBuiltin<
   ): Promise<R>
   $disconnect(): Promise<void>
   $connect(): Promise<void>
+
+  /**
+   * The datamodel the client was generated from, in its runtime representation:
+   * models with their fields' kind, type, list and required flags. A read-only
+   * reflection surface for tools that need model metadata at runtime.
+   */
+  readonly $datamodel: RuntimeDataModel
+
+  /**
+   * The datasource provider the client was generated for (e.g. "postgresql").
+   */
+  readonly $provider: string
 }
 
 /** $extends, defineExtension */

--- a/packages/client/src/runtime/getPrismaClient.ts
+++ b/packages/client/src/runtime/getPrismaClient.ts
@@ -1126,6 +1126,25 @@ Or read our docs at https://www.prisma.io/docs/concepts/components/prisma-client
       return !!this._engineConfig.previewFeatures?.includes(feature)
     }
 
+    /**
+     * The datamodel the client was generated from, in its runtime
+     * representation: models with their fields' kind, type, list and
+     * required flags. A read-only reflection surface for tools that
+     * need model metadata at runtime, see
+     * https://github.com/prisma/prisma/issues/19392
+     */
+    get $datamodel(): RuntimeDataModel {
+      return this._runtimeDataModel
+    }
+
+    /**
+     * The datasource provider the client was generated for
+     * (e.g. "postgresql", "mysql", "sqlite").
+     */
+    get $provider(): string {
+      return this._activeProvider
+    }
+
     $extends = $extends
   }
 

--- a/packages/client/tests/functional/client-reflection/_matrix.ts
+++ b/packages/client/tests/functional/client-reflection/_matrix.ts
@@ -1,0 +1,4 @@
+import { defineMatrix } from '../_utils/defineMatrix'
+import { allProviders } from '../_utils/providers'
+
+export default defineMatrix(() => [allProviders])

--- a/packages/client/tests/functional/client-reflection/prisma/_schema.ts
+++ b/packages/client/tests/functional/client-reflection/prisma/_schema.ts
@@ -1,0 +1,30 @@
+import { idForProvider } from '../../_utils/idForProvider'
+import testMatrix from '../_matrix'
+
+export default testMatrix.setupSchema(({ provider }) => {
+  return /* Prisma */ `
+  generator client {
+    provider = "prisma-client-js"
+  }
+
+  datasource db {
+    provider = "${provider}"
+  }
+
+  model User {
+    id ${idForProvider(provider)}
+    name String
+    bio String?
+    posts Post[]
+  }
+
+  model Post {
+    id ${idForProvider(provider)}
+    title String
+
+    authorId String
+    author   User @relation(fields: [authorId], references: [id])
+    @@index([authorId])
+  }
+  `
+})

--- a/packages/client/tests/functional/client-reflection/tests.ts
+++ b/packages/client/tests/functional/client-reflection/tests.ts
@@ -1,0 +1,40 @@
+import testMatrix from './_matrix'
+// @ts-ignore
+import type { PrismaClient } from './generated/prisma/client'
+
+declare let prisma: PrismaClient
+
+testMatrix.setupTestSuite((suiteConfig, _suiteMeta, _clientMeta, cliMeta) => {
+  // The query compiler runtime ships a pruned runtime datamodel
+  // (no cardinality or requiredness) to keep bundles small; the
+  // classic engine runtimes carry the full field metadata.
+  const pruned = cliMeta.runtime === 'client'
+
+  test('$provider reports the active datasource provider', () => {
+    expect(prisma.$provider).toEqual(suiteConfig.provider)
+  })
+
+  test('$datamodel exposes models with field metadata', () => {
+    const { models } = prisma.$datamodel
+
+    expect(Object.keys(models)).toEqual(expect.arrayContaining(['User', 'Post']))
+
+    const fields = Object.fromEntries(models.User.fields.map((field) => [field.name, field]))
+
+    expect(fields.name).toMatchObject({ kind: 'scalar', type: 'String' })
+    expect(fields.posts).toMatchObject({ kind: 'object', type: 'Post' })
+
+    if (!pruned) {
+      expect(fields.name).toMatchObject({ isList: false, isRequired: true })
+      expect(fields.bio).toMatchObject({ isRequired: false })
+      expect(fields.posts).toMatchObject({ isList: true })
+    }
+  })
+
+  test('stays available on an extended client', () => {
+    const extended = prisma.$extends({})
+
+    expect(extended.$provider).toEqual(suiteConfig.provider)
+    expect(Object.keys(extended.$datamodel.models)).toEqual(expect.arrayContaining(['User', 'Post']))
+  })
+})


### PR DESCRIPTION
Implements the minimal reflection surface proposed in #19392 (see [this comment](https://github.com/prisma/prisma/issues/19392#issuecomment-5083539675)). Opened as a draft to make the proposal concrete; happy to adjust the shape to whatever the team prefers.

## Problem

Tools that consume a `PrismaClient` have no public way to answer basic model questions at runtime: is this field a relation, is it a list, is it nullable, is it a `String`, and which provider is active. Each of those changes what a *valid* query argument looks like (`is` vs `some`, null comparisons on required columns, `mode: 'insensitive'` on non-string fields or unsupported connectors), so query-building libraries fall back to the private `_runtimeDataModel` and `_activeProvider` internals, which can break on any release.

## Change

Two readonly getters on `PrismaClient`, exposing state the client already carries (no new data, no runtime cost, non-breaking):

- `client.$datamodel`: the runtime datamodel (models with their fields' `kind`, `type`, `isList`, `isRequired`).
- `client.$provider`: the active datasource provider name.

Declared on the generated `PrismaClient` types of both generators (`prisma-client-js`, `prisma-client-ts`) and on `DynamicClientExtensionThisBuiltin`, so the members are typed on extended clients and survive `$extends`.

## Pruned datamodels

Under runtimes that ship a pruned runtime datamodel, the getter exposes the pruned shape (no `isList`/`isRequired`). The functional test asserts both shapes. If the team would rather guarantee the full shape everywhere, that trades against the bundle-size motivation for pruning; happy to follow whatever direction is preferred, but even the pruned surface is more useful than tools guessing at private fields.

## Testing

New functional suite `client-reflection` (all providers in the matrix): asserts `$provider` matches the suite provider, `$datamodel` exposes model and field metadata (both pruned and full shapes), and both members remain available on an extended client. Verified locally with `--adapter js_better_sqlite3`, code and types phases.
