### PR TITLE
fix(migrate): run the AI safety checkpoint on the interactive db push path

### DIFF
--- a/packages/migrate/src/__tests__/DbPush.test.ts
+++ b/packages/migrate/src/__tests__/DbPush.test.ts
@@ -2,6 +2,7 @@ import path from 'path'
 import prompt from 'prompts'
 
 import { DbPush } from '../commands/DbPush'
+import { Migrate } from '../Migrate'
 import { agentMatchers } from '../utils/ai-safety'
 import { setupMongo, SetupParams, tearDownMongo } from '../utils/setupMongo'
 import { setupPostgres, tearDownPostgres } from '../utils/setupPostgres'
@@ -202,12 +203,14 @@ describe('push', () => {
   it('interactive confirmation triggers the AI safety checkpoint', async () => {
     ctx.fixture('existing-db-warnings')
     process.env.CLAUDECODE = '1'
+    const push = jest.spyOn(Migrate.prototype, 'push')
 
     prompt.inject(['y'])
 
     const result = DbPush.new().parse([], await ctx.config(), ctx.configDir())
 
     await expect(result).rejects.toThrow('invoked by Claude Code')
+    expect(push).not.toHaveBeenCalledWith({ force: true })
   })
 
   it('unexecutable - drop allowed (--force-reset)', async () => {

--- a/packages/migrate/src/__tests__/DbPush.test.ts
+++ b/packages/migrate/src/__tests__/DbPush.test.ts
@@ -2,12 +2,27 @@ import path from 'path'
 import prompt from 'prompts'
 
 import { DbPush } from '../commands/DbPush'
+import { agentMatchers } from '../utils/ai-safety'
 import { setupMongo, SetupParams, tearDownMongo } from '../utils/setupMongo'
 import { setupPostgres, tearDownPostgres } from '../utils/setupPostgres'
 import { describeMatrix, mongodbOnly, postgresOnly } from './__helpers__/conditionalTests'
 import { createDefaultTestContext } from './__helpers__/context'
 
 const ctx = createDefaultTestContext()
+
+const agentEnvVars = [
+  ...new Set(agentMatchers.flatMap((matcher) => matcher.envVars)),
+  'PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION',
+]
+
+beforeEach(() => {
+  // Pushing data loss changes goes through the AI safety checkpoint, and the
+  // tests themselves may be running under an AI agent, so the inherited
+  // markers must be cleared before each test.
+  for (const name of agentEnvVars) {
+    delete process.env[name]
+  }
+})
 
 describe('push', () => {
   // A test that requires docker (e.g, because it relies on extensions being installed)
@@ -180,6 +195,17 @@ describe('push', () => {
     process.env.CLAUDECODE = '1'
 
     const result = DbPush.new().parse([flag], await ctx.config(), ctx.configDir())
+
+    await expect(result).rejects.toThrow('invoked by Claude Code')
+  })
+
+  it('interactive confirmation triggers the AI safety checkpoint', async () => {
+    ctx.fixture('existing-db-warnings')
+    process.env.CLAUDECODE = '1'
+
+    prompt.inject(['y'])
+
+    const result = DbPush.new().parse([], await ctx.config(), ctx.configDir())
 
     await expect(result).rejects.toThrow('invoked by Claude Code')
   })

--- a/packages/migrate/src/commands/DbPush.ts
+++ b/packages/migrate/src/commands/DbPush.ts
@@ -237,6 +237,8 @@ ${bold(red('All data will be lost.'))}
           process.exit(130)
         }
 
+        aiAgentConfirmationCheckpoint()
+
         try {
           await migrate.push({
             force: true,

--- a/packages/migrate/src/commands/DbPush.ts
+++ b/packages/migrate/src/commands/DbPush.ts
@@ -237,9 +237,9 @@ ${bold(red('All data will be lost.'))}
           process.exit(130)
         }
 
-        aiAgentConfirmationCheckpoint()
-
         try {
+          aiAgentConfirmationCheckpoint()
+
           await migrate.push({
             force: true,
           })


### PR DESCRIPTION
## Summary

- call `aiAgentConfirmationCheckpoint()` before the forced push that follows the interactive data loss confirmation in `prisma db push`
- clear inherited agent marker environment variables in `DbPush.test.ts`, so the suite is stable when it runs under an AI agent
- cover the interactive path with a regression test

## Why

`db push` reaches `migrate.push({ force: true })` through two routes:

- `--accept-data-loss`, which goes through the AI safety checkpoint (added in #29713)
- the interactive confirmation shown when the push reports data loss warnings, which does not

Both apply the same destructive schema change. An agent that runs with a TTY attached answers the confirmation prompt itself, so on that route it can opt into data loss without the explicit user consent the checkpoint exists to obtain. `--force-reset` and `migrate reset` are already guarded.

The checkpoint is placed after the confirmation and immediately before the push, which is where `MigrateReset` calls it, so a human running the command interactively sees no change.

## Scope

Outside tests `canPrompt()` is `isInteractive() && !isCi()`, so the gap only affects agents whose shell has a real TTY; an agent without one never reaches the prompt. Cursor agent mode and Codex CLI, both of which `ai-safety.ts` lists as detected agents, run in the user's terminal. The new test reaches the same path through the `prompts.inject()` branch of `canPrompt()`, like the existing prompt tests in this file.

## Test hygiene

`AGENTS.md` notes that the AI safety tests have to clear inherited agent markers because the test process may itself run under an agent. `DbPush.test.ts` did not, so `--accept-data-loss flag`, `unexecutable - drop allowed (--force-reset)` and both `--force-reset should succeed and display a log` tests already fail when the suite is run from an agent CLI, and this change would have added a fifth. The `beforeEach` added here reuses the `agentMatchers` env var list the same way `ai-safety.test.ts` does.

`MigrateReset.test.ts` and `DbDrop.test.ts` have the same problem today (12 of their tests fail under an agent shell). That is out of scope here, but I can send it as a separate change.

## Verification

- `pnpm --filter @prisma/migrate test DbPush.test.ts --runInBand`: 21 passed, 1 skipped (docker only), with the docker Postgres running
- reverting the one line in `DbPush.ts` makes the new test fail, and only that test
- `prettier --check` and `eslint` pass on both files; `tsc --noEmit` reports no error in them
