### PR TITLE
fix(adapter-better-sqlite3): return a typed error for unhandled SQLite codes

### DIFF
--- a/packages/adapter-better-sqlite3/package.json
+++ b/packages/adapter-better-sqlite3/package.json
@@ -24,7 +24,8 @@
   },
   "scripts": {
     "dev": "DEV=true tsx helpers/build.ts",
-    "build": "tsx helpers/build.ts"
+    "build": "tsx helpers/build.ts",
+    "test": "vitest run"
   },
   "files": [
     "dist",

--- a/packages/adapter-better-sqlite3/src/errors.test.ts
+++ b/packages/adapter-better-sqlite3/src/errors.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+
+import { convertDriverError } from './errors'
+
+describe('convertDriverError', () => {
+  it.each([
+    ['SQLITE_CONSTRAINT_CHECK', 'CHECK constraint failed: age > 0'],
+    ['SQLITE_MISMATCH', 'datatype mismatch'],
+    ['SQLITE_ERROR', 'table t already exists'],
+  ])('should map the unhandled code %s to a typed sqlite error', (code, message) => {
+    expect(convertDriverError({ code, message })).toEqual({
+      kind: 'sqlite',
+      extendedCode: 1,
+      message,
+      originalCode: code,
+      originalMessage: message,
+    })
+  })
+
+  it.each([
+    'SQLITE_BUSY',
+    'SQLITE_BUSY_RECOVERY',
+    'SQLITE_BUSY_SNAPSHOT',
+    // SQLITE_BUSY_TIMEOUT (773) is missing from the name table of better-sqlite3.
+    'UNKNOWN_SQLITE_ERROR_773',
+  ])('should handle SocketTimeout (%s)', (code) => {
+    const message = 'database is locked'
+    expect(convertDriverError({ code, message })).toEqual({
+      kind: 'SocketTimeout',
+      originalCode: code,
+      originalMessage: message,
+    })
+  })
+
+  it('should keep the extended code of an error missing from the name table', () => {
+    const code = 'UNKNOWN_SQLITE_ERROR_1038'
+    const message = 'disk I/O error'
+    expect(convertDriverError({ code, message })).toEqual({
+      kind: 'sqlite',
+      extendedCode: 1038,
+      message,
+      originalCode: code,
+      originalMessage: message,
+    })
+  })
+
+  it('should handle UniqueConstraintViolation', () => {
+    const code = 'SQLITE_CONSTRAINT_UNIQUE'
+    const message = 'UNIQUE constraint failed: User.email'
+    expect(convertDriverError({ code, message })).toEqual({
+      kind: 'UniqueConstraintViolation',
+      constraint: { fields: ['email'] },
+      originalCode: code,
+      originalMessage: message,
+    })
+  })
+
+  it('should handle TableDoesNotExist', () => {
+    const code = 'SQLITE_ERROR'
+    const message = 'no such table: User'
+    expect(convertDriverError({ code, message })).toEqual({
+      kind: 'TableDoesNotExist',
+      table: 'User',
+      originalCode: code,
+      originalMessage: message,
+    })
+  })
+
+  it('should rethrow errors that do not come from the driver', () => {
+    const error = new Error('boom')
+    expect(() => convertDriverError(error)).toThrow(error)
+  })
+})

--- a/packages/adapter-better-sqlite3/src/errors.test.ts
+++ b/packages/adapter-better-sqlite3/src/errors.test.ts
@@ -68,6 +68,12 @@ describe('convertDriverError', () => {
 
   it('should rethrow errors that do not come from the driver', () => {
     const error = new Error('boom')
-    expect(() => convertDriverError(error)).toThrow(error)
+    let thrown: unknown
+    try {
+      convertDriverError(error)
+    } catch (e) {
+      thrown = e
+    }
+    expect(thrown).toBe(error)
   })
 })

--- a/packages/adapter-better-sqlite3/src/errors.ts
+++ b/packages/adapter-better-sqlite3/src/errors.ts
@@ -1,5 +1,9 @@
 import { Error as DriverAdapterErrorObject } from '@prisma/driver-adapter-utils'
 
+const SQLITE_BUSY = 5
+const PRIMARY_ERROR_CODE_MASK = 0xff
+const UNKNOWN_ERROR_CODE_PREFIX = 'UNKNOWN_SQLITE_ERROR_'
+
 export function convertDriverError(error: unknown): DriverAdapterErrorObject {
   if (isDriverError(error)) {
     return {
@@ -14,10 +18,6 @@ export function convertDriverError(error: unknown): DriverAdapterErrorObject {
 
 function mapDriverError(error: DriverError): DriverAdapterErrorObject {
   switch (error.code) {
-    case 'SQLITE_BUSY':
-      return {
-        kind: 'SocketTimeout',
-      }
     case 'SQLITE_CONSTRAINT_UNIQUE':
     case 'SQLITE_CONSTRAINT_PRIMARYKEY': {
       const fields = error.message
@@ -47,8 +47,21 @@ function mapDriverError(error: DriverError): DriverAdapterErrorObject {
         kind: 'ForeignKeyConstraintViolation',
         constraint: { foreignKey: {} },
       }
-    default:
-      if (error.message.startsWith('no such table')) {
+    default: {
+      const extendedCode = extendedCodeFromName(error.code)
+
+      // Lock contention is reported through a family of extended result codes
+      // (`SQLITE_BUSY_RECOVERY`, `SQLITE_BUSY_SNAPSHOT`, ...) that all mean the
+      // same thing to the caller, so they are matched on the primary code, like
+      // the libsql adapter does by masking the extended code.
+      if (
+        error.code.startsWith('SQLITE_BUSY') ||
+        (extendedCode !== undefined && (extendedCode & PRIMARY_ERROR_CODE_MASK) === SQLITE_BUSY)
+      ) {
+        return {
+          kind: 'SocketTimeout',
+        }
+      } else if (error.message.startsWith('no such table')) {
         return {
           kind: 'TableDoesNotExist',
           table: error.message.split(': ').at(1),
@@ -65,8 +78,28 @@ function mapDriverError(error: DriverError): DriverAdapterErrorObject {
         }
       }
 
-      throw error
+      return {
+        kind: 'sqlite',
+        // Falling back to the generic code, like the d1 adapter does when the
+        // driver gives it none.
+        extendedCode: extendedCode ?? 1,
+        message: error.message,
+      }
+    }
   }
+}
+
+/**
+ * better-sqlite3 identifies result codes by name and has no numeric field for
+ * them, but codes missing from its name table are reported as
+ * `UNKNOWN_SQLITE_ERROR_<code>`, which is the only place the number survives.
+ */
+function extendedCodeFromName(code: string): number | undefined {
+  if (!code.startsWith(UNKNOWN_ERROR_CODE_PREFIX)) {
+    return undefined
+  }
+  const extendedCode = Number(code.slice(UNKNOWN_ERROR_CODE_PREFIX.length))
+  return Number.isInteger(extendedCode) ? extendedCode : undefined
 }
 
 type DriverError = {


### PR DESCRIPTION
## Summary

- return the generic `sqlite` error instead of rethrowing the driver error for SQLite codes the adapter does not map
- match the whole busy family, not only the primary code, and keep the extended code of results better-sqlite3 has no name for
- add `src/errors.test.ts` and the `test` script the other adapters already have

## Why

`mapDriverError` ends its `default` branch with `throw error`. The caller in `better-sqlite3.ts` is

```ts
throw new DriverAdapterError(convertDriverError(error))
```

so any code the switch does not list escapes as the raw driver error rather than as a `DriverAdapterError`. `adapter-libsql` and `adapter-d1` both fall back to `{ kind: 'sqlite', extendedCode, message }` for the same situation, so this adapter is the only one that can break the "always a typed error" contract.

The codes that reach it are not exotic. Running better-sqlite3 12.6.0 directly:

| statement | `error.code` | `error.message` |
| --- | --- | --- |
| insert violating a CHECK constraint | `SQLITE_CONSTRAINT_CHECK` | `CHECK constraint failed: age > 0` |
| insert with a mismatched type | `SQLITE_MISMATCH` | `datatype mismatch` |
| create an existing table | `SQLITE_ERROR` | `table t already exists` |

None of them match the message prefixes in the `default` branch, so all three rethrow today.

`SQLITE_BUSY` had the same shape of gap. better-sqlite3 identifies result codes by name, so a write conflict between two connections in WAL mode arrives as `SQLITE_BUSY_SNAPSHOT` (`database is locked`) and misses the exact `case 'SQLITE_BUSY'`, while `adapter-libsql` catches it by masking the extended code down to the primary one.

Matching the name on the `SQLITE_BUSY` prefix covers `SQLITE_BUSY_RECOVERY` and `SQLITE_BUSY_SNAPSHOT`, but not every busy code has a name here: `src/util/constants.cpp` registers those two and plain `SQLITE_BUSY`, and codes missing from that table are reported as `UNKNOWN_SQLITE_ERROR_<code>`. That is what `SQLITE_BUSY_TIMEOUT` (773) arrives as. Since the number in that name is the only place the numeric code survives, it is parsed and masked the way libsql masks `rawCode`, which also lets the generic fallback report the real extended code instead of a placeholder.

`extendedCode: 1` for the remaining cases mirrors `adapter-d1`, which uses the same generic value when the driver gives it no numeric code; better-sqlite3 errors carry only `code`, `message` and `stack`.

## Verification

- `pnpm --filter @prisma/adapter-better-sqlite3 test`: 11 passed
- reverting the fallback fails exactly the unhandled-code tests; reverting the busy handling fails exactly the extended busy tests; the mapped-code tests stay green in both
- error fixtures are the code/message pairs produced by better-sqlite3 12.6.0 on Node 24, including a real WAL write conflict for `SQLITE_BUSY_SNAPSHOT`
