### PR TITLE
chore(deps): update @prisma/dev to 0.24.17

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -185,7 +185,7 @@
   },
   "dependencies": {
     "@prisma/config": "workspace:*",
-    "@prisma/dev": "0.24.16",
+    "@prisma/dev": "0.24.17",
     "@prisma/engines": "workspace:*",
     "@prisma/studio-core": "0.33.0",
     "mysql2": "3.15.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -434,8 +434,8 @@ importers:
         specifier: workspace:*
         version: link:../config
       '@prisma/dev':
-        specifier: 0.24.16
-        version: 0.24.16(typescript@5.4.5)
+        specifier: 0.24.17
+        version: 0.24.17(typescript@5.4.5)
       '@prisma/engines':
         specifier: workspace:*
         version: link:../engines
@@ -3834,8 +3834,8 @@ packages:
   '@prisma/debug@7.2.0':
     resolution: {integrity: sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw==}
 
-  '@prisma/dev@0.24.16':
-    resolution: {integrity: sha512-5awBh7WvC74iYz8dKv03uHuPsCmaUHBkptQ4mEiV8qPwHBA8ia4rV5ABRAKct5hhYnwBmPZ1IrIK5WKNRUjcCg==}
+  '@prisma/dev@0.24.17':
+    resolution: {integrity: sha512-UvdZzmpFwknnfreh6Jije84ekkYGPYEJhXG1tFzCsCfQyzJifrOo38eZc0qajzvaC6OLUOrN9ML5XfCnEZL9DA==}
 
   '@prisma/engines-version@7.10.0-1.6d040c802892de6d56c7e0061b7a10b3e6a0c7a0':
     resolution: {integrity: sha512-0a/QTIPSx2PIQR/39rD0jMsCo15F88RCJ3bvGQS1WlAlDyjtu6Swcxeoy1usU7G1cvGYX8c9ngGTiRpW86W/hQ==}
@@ -8699,8 +8699,8 @@ packages:
     resolution: {integrity: sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==}
     engines: {node: '>=10.12.0'}
 
-  valibot@1.2.0:
-    resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -10816,7 +10816,7 @@ snapshots:
 
   '@prisma/debug@7.2.0': {}
 
-  '@prisma/dev@0.24.16(typescript@5.4.5)':
+  '@prisma/dev@0.24.17(typescript@5.4.5)':
     dependencies:
       '@electric-sql/pglite': 0.4.3
       '@electric-sql/pglite-socket': 0.1.3(@electric-sql/pglite@0.4.3)
@@ -10831,7 +10831,7 @@ snapshots:
       proper-lockfile: 4.1.2
       remeda: 2.33.4
       std-env: 3.10.0
-      valibot: 1.2.0(typescript@5.4.5)
+      valibot: 1.4.2(typescript@5.4.5)
       zeptomatch: 2.1.0
     transitivePeerDependencies:
       - typescript
@@ -16273,7 +16273,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.4
       convert-source-map: 1.9.0
 
-  valibot@1.2.0(typescript@5.4.5):
+  valibot@1.4.2(typescript@5.4.5):
     optionalDependencies:
       typescript: 5.4.5
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,4 +35,4 @@ minimumReleaseAgeExclude:
   - '@prisma/prisma-schema-wasm@7.10.0-1.6d040c802892de6d56c7e0061b7a10b3e6a0c7a0'
   - '@prisma/query-compiler-wasm@7.10.0-1.6d040c802892de6d56c7e0061b7a10b3e6a0c7a0'
   - '@prisma/schema-engine-wasm@7.10.0-1.6d040c802892de6d56c7e0061b7a10b3e6a0c7a0'
-  - '@prisma/dev@0.24.16'
+  - '@prisma/dev@0.24.17'


### PR DESCRIPTION
## Overview

Updates the `@prisma/dev` dependency in `packages/cli` from `0.24.16` to `0.24.17`.

## Changes

- Bump `@prisma/dev` to `0.24.17` in `packages/cli/package.json`.
- Refresh `pnpm-lock.yaml` accordingly (pulls in `valibot` `1.2.0` → `1.4.2` transitively).
- Point the `@prisma/dev` entry in `minimumReleaseAgeExclude` in `pnpm-workspace.yaml` at `0.24.17`, matching the existing convention for freshly published Prisma packages. `0.24.17` was published on 2026-07-27 at 09:46 UTC, so without the exclusion `pnpm install` rejects the lockfile with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` under pnpm 11's default 24-hour cooldown — including in CI, where `--frozen-lockfile` is not exempt. The superseded `0.24.16` entry is replaced rather than kept, since that version is no longer referenced by the lockfile.

## Verification

- `pnpm build` — 44/44 tasks successful; the CLI's type-declaration build passes against the new dependency.
- `pnpm --filter prisma test ppgInfo` — 15/15 passed (the only unit tests that exercise `@prisma/dev`).
- Confirmed every symbol the CLI consumes is still present and callable at runtime: `startPrismaDevServer`, and `ServerState.scan` / `fromServerDump` / `createExclusively`.

## Scope

Dependency version bump only; no source changes.