### PR TITLE
fix(deps): patch fast-uri production audit advisories (7.9.x)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ overrides:
   ajv@^8.0.0: '>=8.18.0'
   '@azure/core-rest-pipeline@^1.0.0': '>=1.14.0'
   '@azure/msal-node>uuid': '>=14.0.0'
-  fast-uri@<=3.1.1: '>=3.1.2'
+  fast-uri@<=3.1.3: '>=3.1.4 <4'
   ws@>=8.0.0 <8.20.1: '>=8.20.1'
 
 importers:
@@ -5944,8 +5944,8 @@ packages:
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fastq@1.15.0:
     resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
@@ -10909,7 +10909,7 @@ snapshots:
   '@redocly/ajv@8.17.1':
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -11895,7 +11895,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -13164,7 +13164,7 @@ snapshots:
     dependencies:
       fast-decode-uri-component: 1.0.1
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.4: {}
 
   fastq@1.15.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,7 +23,7 @@ overrides:
   ajv@^8.0.0: '>=8.18.0'
   '@azure/core-rest-pipeline@^1.0.0': '>=1.14.0'
   '@azure/msal-node>uuid': '>=14.0.0'
-  fast-uri@<=3.1.1: '>=3.1.2'
+  fast-uri@<=3.1.3: '>=3.1.4 <4'
   ws@>=8.0.0 <8.20.1: '>=8.20.1'
 
 peerDependencyRules:


### PR DESCRIPTION
## Overview

Backport of #29758 to the `7.9.x` release branch.

`pnpm audit --prod` (the audit CI gates on in `test-template.yml`) flags two advisories on `7.9.x`, both in `fast-uri` via the shipped dependency path `packages/cli > @prisma/dev > @prisma/streams-local > ajv`:

- [GHSA-4c8g-83qw-93j6](https://github.com/advisories/GHSA-4c8g-83qw-93j6) — host confusion via failed IDN canonicalization (patched `>=3.1.3`)
- [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx) — host confusion via literal backslash authority delimiter (patched `>=3.1.4`)

The branch still carries `fast-uri@<=3.1.1: '>=3.1.2'`, which resolves to a version inside both advisories' vulnerable ranges.

## Changes

Raises the existing override in `pnpm-workspace.yaml` from `fast-uri@<=3.1.1: '>=3.1.2'` to `fast-uri@<=3.1.3: '>=3.1.4 <4'`, resolving `fast-uri` to 3.1.4. The upper bound keeps the resolution within the `^3.x` range `ajv` declares — without it, pnpm resolves to `fast-uri@4.x`, a major `ajv` is not tested against.

The override line is byte-identical to the one already on `main`. Unlike #29758, the lockfile picks up no incidental re-resolution churn here — the diff is 12 lines, confined to `fast-uri` moving 3.1.2 → 3.1.4 at each call site — because `7.9.x`'s lockfile was regenerated recently by #29795.

## Out of scope

Dev-tooling-only advisories reported by the full `pnpm audit` are intentionally left untouched, consistent with #29758 and prior audit fixes — they are not part of any published package's runtime dependency tree.

## Verification

- `pnpm audit --prod` → `No known vulnerabilities found` (exit 0). This is the exact command CI gates on.
- `CI=true pnpm install --frozen-lockfile --lockfile-only` passes — no lockfile drift.
- `fast-uri` resolves to a single version, `3.1.4`, at every site in the lockfile.

Note: `pnpm build` was **not** run locally — the machine ran out of disk during `pnpm install`, so no `node_modules` tree could be materialised. `fast-uri` is a runtime transitive dependency of the published CLI rather than a build input, and this change touches no source, so `pnpm audit --prod` is the relevant gate; CI will exercise the build regardless.