### PR TITLE
fix(adapter-ppg): report the constraint name for unique violations

### DIFF
--- a/packages/adapter-ppg/src/errors.test.ts
+++ b/packages/adapter-ppg/src/errors.test.ts
@@ -24,6 +24,66 @@ describe('convertDriverError', () => {
     })
   })
 
+  it('should handle UniqueConstraintViolation (23505) with a constraint name', () => {
+    const error = {
+      code: '23505',
+      message: 'duplicate key value violates unique constraint "users_email_key"',
+      details: {
+        severity: 'ERROR',
+        detail: 'Key (email)=(a@example.com) already exists.',
+        constraint: 'users_email_key',
+      },
+    }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'UniqueConstraintViolation',
+      constraint: { index: 'users_email_key' },
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should handle UniqueConstraintViolation (23505) with only a constraint name', () => {
+    const error = {
+      code: '23505',
+      message: 'duplicate key value violates unique constraint "users_email_key"',
+      details: { severity: 'ERROR', constraint: 'users_email_key' },
+    }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'UniqueConstraintViolation',
+      constraint: { index: 'users_email_key' },
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should fall back to the detail fields for UniqueConstraintViolation (23505) without a constraint name', () => {
+    const error = {
+      code: '23505',
+      message: 'duplicate key value violates unique constraint',
+      details: { severity: 'ERROR', detail: 'Key (first_name, last_name)=(a, b) already exists.' },
+    }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'UniqueConstraintViolation',
+      constraint: { fields: ['first_name', 'last_name'] },
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
+  it('should return an undefined constraint for UniqueConstraintViolation (23505) without a constraint name or detail', () => {
+    const error = {
+      code: '23505',
+      message: 'duplicate key value violates unique constraint',
+      details: { severity: 'ERROR' },
+    }
+    expect(convertDriverError(error)).toEqual({
+      kind: 'UniqueConstraintViolation',
+      constraint: undefined,
+      originalCode: error.code,
+      originalMessage: error.message,
+    })
+  })
+
   it.each(['40001', '40P01'])('should handle TransactionWriteConflict (%s)', (code) => {
     const error = { code, message: 'msg', details: { severity: 'ERROR' } }
     expect(convertDriverError(error)).toEqual({

--- a/packages/adapter-ppg/src/errors.ts
+++ b/packages/adapter-ppg/src/errors.ts
@@ -31,13 +31,23 @@ function mapDriverError(error: DatabaseError): MappedError {
         message: error.message,
       }
     case '23505': {
-      const fields = error.details.detail
-        ?.match(/Key \(([^)]+)\)/)
-        ?.at(1)
-        ?.split(', ')
+      let constraint: { fields: string[] } | { index: string } | undefined
+
+      if (error.details.constraint) {
+        constraint = { index: error.details.constraint }
+      } else {
+        const fields = error.details.detail
+          ?.match(/Key \(([^)]+)\)/)
+          ?.at(1)
+          ?.split(', ')
+        if (fields !== undefined) {
+          constraint = { fields }
+        }
+      }
+
       return {
         kind: 'UniqueConstraintViolation',
-        constraint: fields !== undefined ? { fields } : undefined,
+        constraint,
       }
     }
     case '23502': {


### PR DESCRIPTION
## Problem

`convertDriverError` in `packages/adapter-ppg/src/errors.ts` handles `23505` (unique violation) by parsing the `Key (...)` list out of `details.detail` and never looks at `details.constraint`. As a result, P2002 errors raised through Prisma Postgres lose the name of the violated constraint or index.

## Internal inconsistency

The same file already reads the reported constraint name in its neighbouring handlers:

- `23503` (`ForeignKeyConstraintViolation`) falls back to `{ index: error.details.constraint }`
- `23001` (`RestrictViolation`) does the same

Only `23505` ignored it. `adapter-pg` reports the constraint name for `23505` (#29587), and `adapter-neon` follows the same shape, so Prisma Postgres was the odd one out.

## Change

Prefer `details.constraint` when PostgreSQL reports it, and keep the existing detail-parsed field list as the fallback. The structure and naming mirror `adapter-pg`.

## Tests

Four cases added to `packages/adapter-ppg/src/errors.test.ts`:

- `23505` with both a constraint name and a detail -> `{ index: 'users_email_key' }`
- `23505` with only a constraint name -> `{ index: 'users_email_key' }`
- `23505` with only a detail -> falls back to `{ fields: ['first_name', 'last_name'] }`
- `23505` with neither -> `constraint: undefined`

The two constraint-name cases fail against the previous implementation and pass with the fix; the two fallback cases pass either way, confirming the existing behaviour is preserved.

`pnpm --filter @prisma/adapter-ppg test` passes (41 tests across 2 files).

## Scope

This PR covers `23505` only. The related `23502` / P2011 asymmetry in this file (which parses `details.detail` for a `Key (...)` list that PostgreSQL does not populate for not-null violations, instead of reading `details.column`) is already addressed for this adapter by the open #29484, so it is deliberately left untouched here to avoid a conflict.
