### PR TITLE
ci: retarget CI and release workflows at the v7 branch

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,7 +3,7 @@ name: Benchmark
 on:
   push:
     branches:
-      - main
+      - v7
       - '*.*.x'
     paths-ignore:
       # Any update here needs to be done for `pull_request` (see below) and all files
@@ -65,7 +65,7 @@ jobs:
         run: pnpm run bench
 
       - name: Store benchmark result
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/v7' }}
         uses: rhysd/github-action-benchmark@v1
         with:
           name: Benchmark.js Benchmark

--- a/.github/workflows/pr-code-security.yml
+++ b/.github/workflows/pr-code-security.yml
@@ -2,7 +2,7 @@ name: PR Code Security
 
 on:
   pull_request:
-    branches: [main]
+    branches: [v7]
 
 jobs:
   secret-detection:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: npm - release
 on:
   push:
     branches:
-      - main
+      - v7
       - 'integration/*'
       - '*.*.x'
     paths-ignore:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - v7
       - '*.*.x'
     paths-ignore:
       # Any update here needs to be done for `pull_request` (see below) and all files

--- a/.github/workflows/update-engines-version.yml
+++ b/.github/workflows/update-engines-version.yml
@@ -125,7 +125,7 @@ jobs:
           labels: automerge
           title: 'chore(deps): update engines to ${{ github.event.inputs.version }}'
           body: |
-            The base branch for this PR is: main
+            The base branch for this PR is: v7
             This automatic PR updates the engines to version `${{ github.event.inputs.version }}`.
             This will get automatically merged if all the tests pass.
             :warning: If this PR needs to be updated, first remove the `automerge` label before pushing to avoid automerge to merge without waiting for tests.
@@ -173,7 +173,7 @@ jobs:
           draft: true
           title: 'chore(Automated Integration PR): update engines to ${{ github.event.inputs.version }}'
           body: |
-            The base branch for this PR is: main
+            The base branch for this PR is: v7
             This automatic integration PR updates the engines to version `${{ github.event.inputs.version }}`.
             :warning: This PR should normally not be merged.
             ## Packages


### PR DESCRIPTION
Prisma 7 development moves to the `v7` branch, and prisma/prisma-next's code becomes the new `main`. This PR does only the CI and release-automation part of that move, so that CI and releases keep working on `v7`.

**This PR targets `v7`, not `main`.**

## What changed

| File | Change |
| --- | --- |
| `.github/workflows/release.yml` | `on.push.branches`: `main` → `v7` (keeping `integration/*` and `*.*.x`) |
| `.github/workflows/test.yml` | `on.push.branches`: `main` → `v7` |
| `.github/workflows/benchmark.yml` | `on.push.branches`: `main` → `v7`, and the "Store benchmark result" gate `github.ref == 'refs/heads/main'` → `refs/heads/v7` |
| `.github/workflows/pr-code-security.yml` | `on.pull_request.branches`: `[main]` → `[v7]` |
| `.github/workflows/update-engines-version.yml` | The two hardcoded "The base branch for this PR is: main" strings in the `latest` and `integration` PR bodies now say `v7` |

## Why

A push-triggered workflow runs the pushed branch's own copy of the workflow file. On the `v7` branch the `main` entries are therefore dead weight, and — more to the point — a push to `v7` currently triggers no release and no CI at all. The same applies to the benchmark storage gate, which would never fire on `v7` and so would stop recording the baseline and raising regression alerts.

`pr-code-security.yml` uses a base-branch filter, so without this change PRs targeting `v7` skip secret detection entirely. The `prisma/.github/.github/workflows/secret_detection.yml@main` references are left alone: that `@main` is the org meta-repo's own branch and is unrelated to this migration.

For the engines bump, no explicit `base:` is added to the `create-pull-request` steps — they correctly inherit the checked-out branch, which follows the ref the workflow is dispatched with. The dispatch side is fixed separately (see below). The `patch` path, which derives `base: X.Y.x` from the version, is untouched.

## Companion PRs

- **prisma/engines-wrapper** — adds `ref: v7` to the `update-engines-version.yml` dispatch, so the workflow checks out `v7` and the created PR targets it.
- **prisma/prisma-engines** — fixes the `PRISMA_BRANCH` default.

## Explicitly out of scope

These are known and deliberately left for follow-ups:

1. **Doc links.** `blob/main` links throughout the docs and the README CI badge (`?query=branch%3Amain`) still point at `main` and need a separate sweep.
2. **`dependabot.yml`.** Dependabot only reads its config from the repository's default branch. Once the new `main` lands, it will need a `target-branch: v7` entry for 7.x to keep receiving dependency PRs.
3. **Cron-scheduled workflows.** CodeQL, the stale-issue bot and the discussion bots only ever run from the default branch, so their copies on `v7` are inert. They must be ported to the new `main`.
4. **Transition-window caution.** While both `main` and `v7` still trigger `release.yml`, pushes to either branch publish to the same `dev` dist-tag. Coordinate pushes during the changeover, or one branch will overwrite the other's `dev` release.

## Verification

All five files were re-read after editing and confirmed to parse as YAML with the intended `on:` shape. `actionlint` was not run locally (neither the binary nor the pinned `rhysd/actionlint:1.7.1` image was available offline); the `Lint GitHub Actions workflows` job on this PR covers it.
