### PR TITLE
docs(roadmap): add seven re-verified dogfooding gotchas to section 6

### DIFF
--- a/ROADMAP.html
+++ b/ROADMAP.html
@@ -518,7 +518,20 @@
     <details class="task">
       <summary><svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg><span class="t">Take over the <code>prisma</code> package name — carefully</span><span class="pill open">Open</span></summary>
       <div class="body">
-        <p>The <code>prisma</code> package becomes Prisma 8's command-line tool, published under a pre-release tag so <code>npm install prisma</code> keeps giving people Prisma 7 until 8.0.0 final. The three per-database packages users import get new names: <code>@prisma/postgres</code>, <code>@prisma/sqlite</code>, <code>@prisma/mongo</code> (checked for collisions against the many <code>@prisma/*</code> names Prisma 7 already publishes). Only those four packages rename — the ~60 internal packages that arrive automatically as dependencies keep their <code>@prisma-next/*</code> names and are explicitly not part of the supported surface. The v8 tool installs a single command, <code>prisma-next</code> — deliberately <em>not</em> <code>prisma</code>, so in a project that has both versions installed, <code>prisma</code> always unambiguously means Prisma 7, on every package manager. (Whether v8 ever claims the bare <code>prisma</code> command is deferred; adding a command later breaks nothing.) The old <code>prisma-next</code> package gets a deprecation notice pointing at its new home.</p>
+        <p>The <code>prisma</code> package becomes Prisma 8's command-line tool, published under a pre-release tag so <code>npm install prisma</code> keeps giving people Prisma 7 until 8.0.0 final. The three per-database packages users import get new names: <code>@prisma/postgres</code>, <code>@prisma/sqlite</code>, <code>@prisma/mongo</code> (checked for collisions against the many <code>@prisma/*</code> names Prisma 7 already publishes). Only those four packages rename — the ~60 internal packages that arrive automatically as dependencies keep their <code>@prisma-next/*</code> names and are explicitly not part of the supported surface. <em>(The package naming here is superseded by the namespace restructure below — facades are now spelled like <code>@prisma/orm-postgres</code>, and the internal packages do move.)</em> The v8 tool installs a single command, <code>prisma-next</code> — deliberately <em>not</em> <code>prisma</code>, so in a project that has both versions installed, <code>prisma</code> always unambiguously means Prisma 7, on every package manager. (Whether v8 ever claims the bare <code>prisma</code> command is deferred; adding a command later breaks nothing.) The old <code>prisma-next</code> package gets a deprecation notice pointing at its new home.</p>
+      </div>
+    </details>
+
+    <details class="task">
+      <summary><svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg><span class="t">Restructure the npm package namespaces</span><span class="pill open">Open</span></summary>
+      <div class="body">
+        <p>The package-naming plan is revised; four pieces of work:</p>
+        <ul>
+          <li><strong>A new <code>@prisma-orm</code> npm namespace</strong> hosts everything that is internal today — the ~60 implementation packages published under <code>@prisma-next/*</code> move there wholesale, and stay explicitly outside the supported surface.</li>
+          <li><strong>A small number of user-facing facade packages</strong> are established under <code>@prisma/*</code> — e.g. <code>@prisma/orm-postgres</code> — and those facades are the only supported import surface.</li>
+          <li><strong>OIDC trusted publishing for every new package</strong>: CI publishes both namespaces without long-lived npm tokens, configured per package as part of the pipeline rewiring above.</li>
+          <li><strong>Every <code>@prisma-next/*</code> package is deprecated</strong> on npm with a notice pointing at its successor.</li>
+        </ul>
       </div>
     </details>
 

--- a/ROADMAP.html
+++ b/ROADMAP.html
@@ -541,12 +541,55 @@
     <span class="reqno">Requirement 6</span>
     <span class="owner" style="margin-left: 8px;">Everyone</span>
     <h2>The rough edges users hit on day one must be gone</h2>
-    <p class="soft">None of these block anything technically. All of them are what a skeptical engineer meets in their first hour, under announcement-day attention.</p>
+    <p class="soft">None of these block anything technically. All of them are what a skeptical engineer meets in their first hour, under announcement-day attention. The items marked <em>verified July 28</em> are dogfooding gotchas that were re-checked against <code>main</code> on July 28 and confirmed still present — and the migration-tooling ones among them risk real data loss, not just embarrassment.</p>
 
     <details class="task">
       <summary><svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg><span class="t">A dropped database connection can crash the host process</span><span class="pill open">Open</span></summary>
       <div class="body">
         <p>When an idle pooled connection drops (a database restart, a network blip), the error has no listener attached and crashes the whole Node.js process. A production-readiness bug, not housekeeping — fixed before anyone's production meets it. (<a href="https://linear.app/prisma-company/issue/TML-2655">TML-2655</a>)</p>
+        <p>Re-verified July 28: both places that build a <code>pg.Pool</code> from a <code>url</code> binding still attach no <code>'error'</code> handler, and the <code>db.ts</code> that <code>prisma-next init</code> scaffolds still uses exactly that path — so every scaffolded app deployed behind a connection pooler is exposed. A production app on Prisma Compute already hit this; the whole process died on each idle-connection drop. (<a href="https://linear.app/prisma-company/issue/TML-2842">TML-2842</a>)</p>
+      </div>
+    </details>
+
+    <details class="task">
+      <summary><svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg><span class="t"><code>migration plan</code> can silently generate a destructive baseline</span><span class="pill open">Open</span></summary>
+      <div class="body">
+        <p><em>Verified July 28 · data-loss risk.</em> With no <code>--from</code>, <code>migration plan</code> picks its origin from the refs index, not from the latest on-disk migration — and a ref pointing at a non-tip node is explicitly accepted, with no warning. On an empty migration graph it auto-writes a <code>baseline</code> package anchored at whatever the ref says, so a stale or destination-pointing ref yields a plan containing operations like <code>dropTable</code> toward origin. There is no dirty-ref detection and no baseline-specific destructive-operation warning, only the generic per-op <code>(destructive)</code> marker at render time. (<a href="https://linear.app/prisma-company/issue/TML-3097">TML-3097</a>)</p>
+      </div>
+    </details>
+
+    <details class="task">
+      <summary><svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg><span class="t"><code>migration new --from &lt;hash&gt;</code> silently records <code>from: null</code></span><span class="pill open">Open</span></summary>
+      <div class="body">
+        <p><em>Verified July 28.</em> When the app's migrations directory is empty, the entire <code>--from</code> resolution is skipped: the flag is accepted, the scaffolded package records <code>from: null</code>, and nothing warns that the supplied hash was ignored. On a non-empty graph the flag works (and a bad hash errors properly) — the silent path is exactly the first-migration case. (<a href="https://linear.app/prisma-company/issue/TML-3096">TML-3096</a>)</p>
+      </div>
+    </details>
+
+    <details class="task">
+      <summary><svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg><span class="t">A corrupted contract snapshot loads without complaint</span><span class="pill open">Open</span></summary>
+      <div class="body">
+        <p><em>Verified July 28.</em> No code path recomputes a loaded snapshot's storage hash and compares it to the persisted value. The snapshot store reads with a plain <code>JSON.parse</code>, the deserializer copies <code>storageHash</code> through untouched, and the migration-check codes only string-compare hash <em>fields</em> against each other. Hand-edit a snapshot's content while leaving its <code>storageHash</code> field alone and <code>migration plan</code> reports a clean <code>noOp: true</code>. The one existing recompute helper (<code>assertDescriptorSelfConsistency</code>) runs only on in-memory extension descriptors, never on disk loads. (<a href="https://linear.app/prisma-company/issue/TML-2566">TML-2566</a>)</p>
+      </div>
+    </details>
+
+    <details class="task">
+      <summary><svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg><span class="t"><code>.delete()</code> with a multi-row predicate deletes exactly one row</span><span class="pill open">Open</span></summary>
+      <div class="body">
+        <p><em>Verified July 28.</em> <code>.where({id: q.in([1,2,3])}).delete()</code> type-checks, deletes one row, and returns it. The single-row scoping is deliberate and test-pinned, and multi-row forms exist (<code>deleteAll()</code>, <code>deleteAndCount()</code>) — but nothing in the type system stops a multi-row predicate on <code>.delete()</code>, and the doc comment ("delete matching rows and return the first deleted row") reads as if it batches. A user who meant to delete three rows silently keeps two. Either the types constrain the predicate, or the name/docs make the one-row semantics impossible to miss. (<a href="https://linear.app/prisma-company/issue/TML-3093">TML-3093</a>)</p>
+      </div>
+    </details>
+
+    <details class="task">
+      <summary><svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg><span class="t">PSL <code>Json</code> is Postgres <code>json</code>; Prisma 7's <code>Json</code> is <code>jsonb</code></span><span class="pill open">Open</span></summary>
+      <div class="body">
+        <p><em>Verified July 28.</em> Anyone porting a <code>schema.prisma</code> keeps writing <code>Json</code> and silently gets <code>json</code> columns where Prisma 7 gave them <code>jsonb</code>. Emit and check both pass; only <code>db verify</code> catches it, and it caught a real project three wrong columns late. The PSL diagnostic model currently has no warning severity to hang a "did you mean <code>Jsonb</code>?" advisory on, and the divergence is documented only in Prisma-Next-internal upgrade recipes, not in porting guidance. An emit-time warning or an explicit porting-docs callout must exist before day one, because day one is exactly when the ported schemas arrive. (<a href="https://linear.app/prisma-company/issue/TML-3102">TML-3102</a>)</p>
+      </div>
+    </details>
+
+    <details class="task">
+      <summary><svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg><span class="t"><code>prisma-next init --no-skill</code> deletes an installed agent-skill file</span><span class="pill open">Open</span></summary>
+      <div class="body">
+        <p><em>Verified July 28.</em> Init queues deletion of <code>.agents/skills/prisma-next/SKILL.md</code> unconditionally as "legacy cleanup" — the same path a genuinely installed router skill occupies. In the default run the subsequent skill install masks the delete by rewriting the file; with <code>--no-skill</code> the install never runs, so init destroys the user's installed skill and reports it only in the JSON <code>filesDeleted</code> list. (<a href="https://linear.app/prisma-company/issue/TML-2637">TML-2637</a>)</p>
       </div>
     </details>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -218,11 +218,43 @@ Prisma 7's code, tests, and release automation move to a `v7` branch in prisma/p
 
 ## 6. The rough edges users hit on day one must be gone
 
-None of these block anything technically. All of them are what a skeptical engineer meets in their first hour, under announcement-day attention.
+None of these block anything technically. All of them are what a skeptical engineer meets in their first hour, under announcement-day attention. The items marked *verified July 28* are dogfooding gotchas that were re-checked against `main` on July 28 and confirmed still present — and the migration-tooling ones among them risk real data loss, not just embarrassment.
 
-<details><summary>⬜ <b>A dropped database connection can crash the host process</b></summary>
+<details><summary>⬜ <b>A dropped database connection can crash the host process</b> · verified July 28</summary>
 
 When an idle pooled connection drops (a database restart, a network blip), the error has no listener attached and crashes the whole Node.js process. A production-readiness bug, not housekeeping — fixed before anyone's production meets it. ([TML-2655](https://linear.app/prisma-company/issue/TML-2655))
+
+Re-verified July 28: both places that build a `pg.Pool` from a `url` binding still attach no `'error'` handler, and the `db.ts` that `prisma-next init` scaffolds still uses exactly that path — so every scaffolded app deployed behind a connection pooler is exposed. A production app on Prisma Compute already hit this; the whole process died on each idle-connection drop. ([TML-2842](https://linear.app/prisma-company/issue/TML-2842))
+</details>
+
+<details><summary>⬜ <b>`migration plan` can silently generate a destructive baseline</b> · verified July 28 · data-loss risk</summary>
+
+With no `--from`, `migration plan` picks its origin from the refs index, not from the latest on-disk migration — and a ref pointing at a non-tip node is explicitly accepted, with no warning. On an empty migration graph it auto-writes a `baseline` package anchored at whatever the ref says, so a stale or destination-pointing ref yields a plan containing operations like `dropTable` toward origin. There is no dirty-ref detection and no baseline-specific destructive-operation warning, only the generic per-op `(destructive)` marker at render time. ([TML-3097](https://linear.app/prisma-company/issue/TML-3097))
+</details>
+
+<details><summary>⬜ <b>`migration new --from <hash>` silently records `from: null`</b> · verified July 28</summary>
+
+When the app's migrations directory is empty, the entire `--from` resolution is skipped: the flag is accepted, the scaffolded package records `from: null`, and nothing warns that the supplied hash was ignored. On a non-empty graph the flag works (and a bad hash errors properly) — the silent path is exactly the first-migration case. ([TML-3096](https://linear.app/prisma-company/issue/TML-3096))
+</details>
+
+<details><summary>⬜ <b>A corrupted contract snapshot loads without complaint</b> · verified July 28</summary>
+
+No code path recomputes a loaded snapshot's storage hash and compares it to the persisted value. The snapshot store reads with a plain `JSON.parse`, the deserializer copies `storageHash` through untouched, and the migration-check codes only string-compare hash *fields* against each other. Hand-edit a snapshot's content while leaving its `storageHash` field alone and `migration plan` reports a clean `noOp: true`. The one existing recompute helper (`assertDescriptorSelfConsistency`) runs only on in-memory extension descriptors, never on disk loads. ([TML-2566](https://linear.app/prisma-company/issue/TML-2566))
+</details>
+
+<details><summary>⬜ <b>`.delete()` with a multi-row predicate deletes exactly one row</b> · verified July 28</summary>
+
+`.where({id: q.in([1,2,3])}).delete()` type-checks, deletes one row, and returns it. The single-row scoping is deliberate and test-pinned, and multi-row forms exist (`deleteAll()`, `deleteAndCount()`) — but nothing in the type system stops a multi-row predicate on `.delete()`, and the doc comment ("delete matching rows and return the first deleted row") reads as if it batches. A user who meant to delete three rows silently keeps two. Either the types constrain the predicate, or the name/docs make the one-row semantics impossible to miss. ([TML-3093](https://linear.app/prisma-company/issue/TML-3093))
+</details>
+
+<details><summary>⬜ <b>PSL `Json` is Postgres `json`; Prisma 7's `Json` is `jsonb`</b> · verified July 28</summary>
+
+Anyone porting a `schema.prisma` keeps writing `Json` and silently gets `json` columns where Prisma 7 gave them `jsonb`. Emit and check both pass; only `db verify` catches it, and it caught a real project three wrong columns late. The PSL diagnostic model currently has no warning severity to hang a "did you mean `Jsonb`?" advisory on, and the divergence is documented only in Prisma-Next-internal upgrade recipes, not in porting guidance. An emit-time warning or an explicit porting-docs callout must exist before day one, because day one is exactly when the ported schemas arrive. ([TML-3102](https://linear.app/prisma-company/issue/TML-3102))
+</details>
+
+<details><summary>⬜ <b>`prisma-next init --no-skill` deletes an installed agent-skill file</b> · verified July 28</summary>
+
+Init queues deletion of `.agents/skills/prisma-next/SKILL.md` unconditionally as "legacy cleanup" — the same path a genuinely installed router skill occupies. In the default run the subsequent skill install masks the delete by rewriting the file; with `--no-skill` the install never runs, so init destroys the user's installed skill and reports it only in the JSON `filesDeleted` list. ([TML-2637](https://linear.app/prisma-company/issue/TML-2637))
 </details>
 
 <details><summary>⬜ <b>A deprecation warning prints on every single database connection</b></summary>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -201,7 +201,18 @@ prisma/prisma's release automation currently exists to publish Prisma 7. After t
 
 <details><summary>⬜ <b>Take over the `prisma` package name — carefully</b></summary>
 
-The `prisma` package becomes Prisma 8's command-line tool, published under a pre-release tag so `npm install prisma` keeps giving people Prisma 7 until 8.0.0 final. The three per-database packages users import get new names: `@prisma/postgres`, `@prisma/sqlite`, `@prisma/mongo` (checked for collisions against the many `@prisma/*` names Prisma 7 already publishes). Only those four packages rename — the ~60 internal packages that arrive automatically as dependencies keep their `@prisma-next/*` names and are explicitly not part of the supported surface. The v8 tool installs a single command, `prisma-next` — deliberately *not* `prisma`, so in a project that has both versions installed, `prisma` always unambiguously means Prisma 7, on every package manager. (Whether v8 ever claims the bare `prisma` command is deferred; adding a command later breaks nothing.) The old `prisma-next` package gets a deprecation notice pointing at its new home.
+The `prisma` package becomes Prisma 8's command-line tool, published under a pre-release tag so `npm install prisma` keeps giving people Prisma 7 until 8.0.0 final. The three per-database packages users import get new names: `@prisma/postgres`, `@prisma/sqlite`, `@prisma/mongo` (checked for collisions against the many `@prisma/*` names Prisma 7 already publishes). Only those four packages rename — the ~60 internal packages that arrive automatically as dependencies keep their `@prisma-next/*` names and are explicitly not part of the supported surface. *(The package naming here is superseded by the namespace restructure below — facades are now spelled like `@prisma/orm-postgres`, and the internal packages do move.)* The v8 tool installs a single command, `prisma-next` — deliberately *not* `prisma`, so in a project that has both versions installed, `prisma` always unambiguously means Prisma 7, on every package manager. (Whether v8 ever claims the bare `prisma` command is deferred; adding a command later breaks nothing.) The old `prisma-next` package gets a deprecation notice pointing at its new home.
+</details>
+
+<details><summary>⬜ <b>Restructure the npm package namespaces</b></summary>
+
+The package-naming plan is revised; four pieces of work:
+
+- **A new `@prisma-orm` npm namespace** hosts everything that is internal today — the ~60 implementation packages published under `@prisma-next/*` move there wholesale, and stay explicitly outside the supported surface.
+- **A small number of user-facing facade packages** are established under `@prisma/*` — e.g. `@prisma/orm-postgres` — and those facades are the only supported import surface.
+- **OIDC trusted publishing for every new package**: CI publishes both namespaces without long-lived npm tokens, configured per package as part of the pipeline rewiring above.
+- **Every `@prisma-next/*` package is deprecated** on npm with a notice pointing at its successor.
+
 </details>
 
 <details><summary>⬜ <b>Decide the fate of every open v7 issue and pull request</b></summary>


### PR DESCRIPTION
Supersedes prisma/prisma-next#1069 after the repository move.

## What

Adds seven gotchas from the [\[PN\] Gotchas Linear project](https://linear.app/prisma-company/project/pn-gotchas-a6f6f5157a5c/issues) to ROADMAP.md/ROADMAP.html section 6, each re-verified against Prisma Next main (e0e739ca6) on July 28.

## Verification results

Still present (added to the roadmap):
- [TML-3097](https://linear.app/prisma-company/issue/TML-3097) — `migration plan` anchors origin on the refs index, not disk history; can auto-write a destructive baseline. **Data-loss risk.** Non-tip refs are accepted and test-pinned (`plan-resolution.test.ts:186`).
- [TML-2566](https://linear.app/prisma-company/issue/TML-2566) — no code path recomputes a loaded snapshot's storage hash; the content-addressed store reads with plain `JSON.parse`; tampered content yields `noOp: true`.
- [TML-3096](https://linear.app/prisma-company/issue/TML-3096) — `migration new --from <hash>` silently records `from: null` when the migrations dir is empty (the flag is only consulted when packages exist, `migration-new.ts:135-155`).
- [TML-3093](https://linear.app/prisma-company/issue/TML-3093) — `.delete()` with an `.in()` predicate deletes exactly one row; deliberate and test-pinned, but nothing in types or docs warns.
- [TML-3102](https://linear.app/prisma-company/issue/TML-3102) — PSL `Json` = Postgres `json`, Prisma 7 `Json` = `jsonb`; no emit-time warning, no porting-docs callout.
- [TML-2637](https://linear.app/prisma-company/issue/TML-2637) — `init --no-skill` still unconditionally deletes `.agents/skills/prisma-next/SKILL.md` (`init.ts:191`).
- [TML-2842](https://linear.app/prisma-company/issue/TML-2842) — folded into the existing TML-2655 item: neither `url`-binding pool construction site attaches a pg.Pool `'error'` handler, and the init scaffold uses that path.

Verified as fixed (not added):
- [TML-2507](https://linear.app/prisma-company/issue/TML-2507) — collMod postcheck now compares `$jsonSchema` content (`ed8aba1cb`, regression-tested).
- [TML-3098](https://linear.app/prisma-company/issue/TML-3098) — `prisma dev` works on cli-dev 0.16.26; cold-cache repro run manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the roadmap to clarify the revised npm packaging/namespacing plan, including new `@prisma/*` facade packages, internal namespace changes, and deprecating `@prisma-next/*`.
  * Refreshed the “day-one reliability” section with “verified July 28” notes and stronger warnings for migration tooling data-loss risk.
  * Added/expanded checklists for known rough edges: migration plan baselines when `--from` is omitted, `migration new` recording `from: null` on empty graphs, corrupted snapshot handling, multi-row `.delete()` deleting only one row, JSON portability, and `prisma-next init --no-skill` removing an existing skill file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->