### PR TITLE
ci: run the repository's scheduled workflows from the default branch

### DIFF
--- a/.github/workflows/auto-close-github-discussions.yml
+++ b/.github/workflows/auto-close-github-discussions.yml
@@ -6,7 +6,9 @@ name: Auto Close Stale Discussions
 # written for.
 on:
   schedule:
-    - cron: '0 0 * * *' # Runs daily at midnight UTC
+    # Offset from the top of the hour: GitHub delays or drops scheduled runs
+    # queued on the hour, where load across the platform concentrates.
+    - cron: '17 0 * * *'
   workflow_dispatch: # Enables manual run from the Actions tab
 
 permissions:
@@ -16,6 +18,7 @@ permissions:
 jobs:
   close-discussions:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -25,13 +28,6 @@ jobs:
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .tool-versions
-
-      # The script talks to the GitHub API and reads nothing from the workspace,
-      # so it resolves its two dependencies out of its own directory instead of
-      # installing the workspace.
-      - name: Install script dependencies
-        working-directory: .github/workflows/scripts
-        run: npm install --no-save --no-package-lock @octokit/rest@21.1.1 @octokit/graphql@8.2.1
 
       - name: Close stale Q&A discussions
         env:

--- a/.github/workflows/auto-close-github-discussions.yml
+++ b/.github/workflows/auto-close-github-discussions.yml
@@ -1,0 +1,47 @@
+name: Auto Close Stale Discussions
+
+# Repository-level automation: it acts on the repository's Q&A discussions, not
+# on the code of any one branch. Scheduled workflows only ever run from the
+# default branch, so this lives here rather than alongside the code line it was
+# written for.
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs daily at midnight UTC
+  workflow_dispatch: # Enables manual run from the Actions tab
+
+permissions:
+  contents: read
+  discussions: write
+
+jobs:
+  close-discussions:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version-file: .tool-versions
+
+      # The script talks to the GitHub API and reads nothing from the workspace,
+      # so it resolves its two dependencies out of its own directory instead of
+      # installing the workspace.
+      - name: Install script dependencies
+        working-directory: .github/workflows/scripts
+        run: npm install --no-save --no-package-lock @octokit/rest@21.1.1 @octokit/graphql@8.2.1
+
+      - name: Close stale Q&A discussions
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLOSING_MESSAGE: |
+            Hi,
+
+            As we have not heard back from you, we are closing this discussion to keep our discussions organized.
+
+            Feel free to start a new discussion if this remains relevant.
+
+            Thank you for being part of the community!
+        run: node ./.github/workflows/scripts/auto-close-github-discussions.mjs

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,63 @@
+name: 'CodeQL: Code Scanning'
+
+# Scheduled workflows only ever run from the default branch, so every code line
+# that needs scanning is checked out explicitly by the matrix below and its
+# results are attributed back to its own ref.
+on:
+  schedule:
+    # Runs at 14:43 UTC on Sun.
+    - cron: '43 14 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.ref }})
+    # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ref: ['main', 'v7']
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://git.io/codeql-language-support
+        language: ['javascript']
+
+    steps:
+      - name: Checkout ${{ matrix.ref }}
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ matrix.ref }}
+          persist-credentials: false
+
+      - name: Resolve analysed commit
+        id: commit
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        with:
+          # `ref`/`sha` file the alerts against the branch that was analysed
+          # rather than the branch the schedule fired from; `category` keeps the
+          # two branches' result sets from overwriting one another.
+          ref: refs/heads/${{ matrix.ref }}
+          sha: ${{ steps.commit.outputs.sha }}
+          category: /language:${{ matrix.language }}/ref:${{ matrix.ref }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           # `ref`/`sha` file the alerts against the branch that was analysed
           # rather than the branch the schedule fired from; `category` keeps the

--- a/.github/workflows/label-stale-issues.yml
+++ b/.github/workflows/label-stale-issues.yml
@@ -5,7 +5,9 @@ name: 'Labels stale issues'
 # this lives here rather than alongside the code line it was written for.
 on:
   schedule:
-    - cron: '0 0 * * *'
+    # Offset from the top of the hour: GitHub delays or drops scheduled runs
+    # queued on the hour, where load across the platform concentrates.
+    - cron: '23 0 * * *'
   workflow_dispatch:
 
 # The action walks both issues and pull requests, applying `status/needs-action`

--- a/.github/workflows/label-stale-issues.yml
+++ b/.github/workflows/label-stale-issues.yml
@@ -1,0 +1,33 @@
+name: 'Labels stale issues'
+
+# Repository-level automation: it acts on the issue tracker, not on the code of
+# any one branch. Scheduled workflows only ever run from the default branch, so
+# this lives here rather than alongside the code line it was written for.
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+# The action walks both issues and pull requests, applying `status/needs-action`
+# to each, so it needs write access to both.
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: pantharshit00/stale@d8f5f16c524d29fdc37f67da93ecb7ecdd4c2a77 # v3.1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'DUMMY, FOR ENABLING'
+          days-before-stale: 90
+          days-before-close: -1
+          exempt-issue-labels: 'kind/discussion,kind/docs,kind/feature,kind/improvement,kind/question,kind/epic,kind/subtask'
+          stale-issue-label: 'status/needs-action'
+          skip-stale-issue-message: true
+          skip-stale-pr-message: true
+          ascending: true
+          operations-per-run: 100

--- a/.github/workflows/scripts/auto-close-github-discussions.mjs
+++ b/.github/workflows/scripts/auto-close-github-discussions.mjs
@@ -1,5 +1,8 @@
-import { Octokit } from '@octokit/rest'
-import { graphql } from '@octokit/graphql'
+const GITHUB_API = 'https://api.github.com'
+
+// Bound so a hung GitHub call fails the scheduled run promptly instead of
+// occupying a runner until the job-level timeout.
+const REQUEST_TIMEOUT_MS = 30_000
 
 // Get current repository details from the GITHUB_REPOSITORY environment variable ("owner/repo")
 const repoInfo = process.env.GITHUB_REPOSITORY
@@ -21,33 +24,47 @@ async function run() {
 
   const closingMessage = process.env.CLOSING_MESSAGE || 'Closing discussion due to inactivity.'
 
-  const octokit = new Octokit({
-    auth: token,
-    userAgent: 'auto-close-discussions',
-  })
+  const headers = {
+    accept: 'application/vnd.github+json',
+    authorization: `token ${token}`,
+    'user-agent': 'auto-close-discussions',
+  }
 
-  // Set up GraphQL client
-  const graphqlWithAuth = graphql.defaults({
-    headers: {
-      authorization: `token ${token}`,
-    },
-  })
+  const rest = async (path) => {
+    const response = await fetch(`${GITHUB_API}${path}`, {
+      headers,
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    })
+    if (!response.ok) {
+      throw new Error(`GitHub REST ${path} responded ${response.status}: ${await response.text()}`)
+    }
+    return response.json()
+  }
+
+  const graphqlWithAuth = async (query, variables) => {
+    const response = await fetch(`${GITHUB_API}/graphql`, {
+      method: 'POST',
+      headers: { ...headers, 'content-type': 'application/json' },
+      body: JSON.stringify({ query, variables }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    })
+    const payload = await response.json()
+    if (payload.errors) {
+      const error = new Error(payload.errors.map((entry) => entry.message).join('; '))
+      error.errors = payload.errors
+      throw error
+    }
+    return payload.data
+  }
 
   try {
     // 1. Get the repository ID first (needed for GraphQL)
-    const repoData = await octokit.repos.get({
-      owner: OWNER,
-      repo: REPO,
-    })
-    const repoId = repoData.data.node_id
+    const repoData = await rest(`/repos/${OWNER}/${REPO}`)
+    const repoId = repoData.node_id
 
-    // NEW: Fetch collaborators with write (push) access
-    const collabResponse = await octokit.repos.listCollaborators({
-      owner: OWNER,
-      repo: REPO,
-    })
+    const collabResponse = await rest(`/repos/${OWNER}/${REPO}/collaborators`)
 
-    const collaborators = collabResponse.data
+    const collaborators = collabResponse
       .filter((user) => user.permissions && user.permissions.push)
       .map((user) => user.login)
     console.log(`Found ${collaborators.length} collaborators with write access.`)

--- a/.github/workflows/scripts/auto-close-github-discussions.mjs
+++ b/.github/workflows/scripts/auto-close-github-discussions.mjs
@@ -1,0 +1,266 @@
+import { Octokit } from '@octokit/rest'
+import { graphql } from '@octokit/graphql'
+
+// Get current repository details from the GITHUB_REPOSITORY environment variable ("owner/repo")
+const repoInfo = process.env.GITHUB_REPOSITORY
+if (!repoInfo) {
+  console.error('GITHUB_REPOSITORY environment variable not set')
+  process.exit(1)
+}
+const [OWNER, REPO] = repoInfo.split('/')
+
+// ONE_WEEK_MS is set to one week (in milliseconds)
+const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
+
+async function run() {
+  const token = process.env.GITHUB_TOKEN
+  if (!token) {
+    console.error('GITHUB_TOKEN not set')
+    process.exit(1)
+  }
+
+  const closingMessage = process.env.CLOSING_MESSAGE || 'Closing discussion due to inactivity.'
+
+  const octokit = new Octokit({
+    auth: token,
+    userAgent: 'auto-close-discussions',
+  })
+
+  // Set up GraphQL client
+  const graphqlWithAuth = graphql.defaults({
+    headers: {
+      authorization: `token ${token}`,
+    },
+  })
+
+  try {
+    // 1. Get the repository ID first (needed for GraphQL)
+    const repoData = await octokit.repos.get({
+      owner: OWNER,
+      repo: REPO,
+    })
+    const repoId = repoData.data.node_id
+
+    // NEW: Fetch collaborators with write (push) access
+    const collabResponse = await octokit.repos.listCollaborators({
+      owner: OWNER,
+      repo: REPO,
+    })
+
+    const collaborators = collabResponse.data
+      .filter((user) => user.permissions && user.permissions.push)
+      .map((user) => user.login)
+    console.log(`Found ${collaborators.length} collaborators with write access.`)
+
+    const categoriesQuery = await graphqlWithAuth(
+      `query getCategories($repoId: ID!) {
+        node(id: $repoId) {
+          ... on Repository {
+            discussionCategories(first: 25) {
+              nodes {
+                id
+                name
+              }
+            }
+          }
+        }
+      }`,
+      { repoId },
+    )
+    const categories = categoriesQuery.node.discussionCategories.nodes
+    const qaCategory = categories.find((cat) => cat.name === 'Q&A')
+    if (!qaCategory) {
+      console.error('No Q&A category found.')
+      process.exit(1)
+    }
+    console.log(`Found Q&A category with ID: ${qaCategory.id}`)
+
+    // 2. Fetch top 50 open discussions in the Q&A category
+    const discussionsQuery = await graphqlWithAuth(
+      `query getDiscussions($repoId: ID!, $categoryId: ID!) {
+        node(id: $repoId) {
+          ... on Repository {
+            discussions(first: 50, states: OPEN, categoryId: $categoryId) {
+              nodes {
+                id
+                number
+                title
+                body
+                createdAt
+                updatedAt
+                labels(first: 10) {
+                  nodes {
+                    id
+                    name
+                  }
+                }
+                comments(first: 50) {
+                  nodes {
+                    id
+                    createdAt
+                    author {
+                      login
+                    }
+                    replies(first: 50) {
+                      nodes {
+                        id
+                        createdAt
+                        author {
+                          login
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }`,
+      { repoId, categoryId: qaCategory.id },
+    )
+
+    // Extract discussions
+    const discussions = discussionsQuery.node.discussions.nodes
+    console.log(`Fetched ${discussions.length} discussions`)
+
+    // 3. Filter open discussions that have at least one of the target labels
+    const targetLabels = ['discussion/needs-information', 'discussion/needs-confirmation']
+    const filteredDiscussions = discussions.filter((discussion) => {
+      if (!discussion.labels.nodes || discussion.labels.nodes.length === 0) return false
+      const labels = discussion.labels.nodes.map((label) => label.name)
+      return targetLabels.some((target) => labels.includes(target))
+    })
+
+    console.log(`Found ${filteredDiscussions.length} open Q&A discussions with at least one target label.`)
+
+    // 4. Process each filtered discussion
+    for (const discussion of filteredDiscussions) {
+      const discussionNumber = discussion.number
+      console.log(`Processing discussion #${discussionNumber}: ${discussion.title}`)
+
+      // Find the most recent activity (comment or reply)
+      let lastActivity = null
+      let lastActivityDate = null
+      let lastActivityAuthor = null
+
+      // Check if there are comments
+      if (!discussion.comments.nodes.length) {
+        console.log('No comments found, skipping.')
+        continue
+      }
+
+      // Find the most recent activity date from all comments and replies
+      for (const comment of discussion.comments.nodes) {
+        const commentDate = new Date(comment.createdAt)
+        if (!lastActivityDate || commentDate > lastActivityDate) {
+          lastActivity = 'comment'
+          lastActivityDate = commentDate
+          lastActivityAuthor = comment.author.login
+        }
+        if (comment.replies && comment.replies.nodes) {
+          for (const reply of comment.replies.nodes) {
+            const replyDate = new Date(reply.createdAt)
+            if (!lastActivityDate || replyDate > lastActivityDate) {
+              lastActivity = 'reply'
+              lastActivityDate = replyDate
+              lastActivityAuthor = reply.author.login
+            }
+          }
+        }
+      }
+
+      console.log(
+        `Last activity on discussion #${discussionNumber} was a ${lastActivity} from ${lastActivityAuthor} on ${lastActivityDate}`,
+      )
+
+      // Check if the last activity is by a collaborator with write access and older than one week
+      const now = new Date()
+
+      if (collaborators.includes(lastActivityAuthor) && now.getTime() - lastActivityDate.getTime() > ONE_WEEK_MS) {
+        console.log(
+          `Discussion #${discussionNumber} qualifies for closure. Last activity was from collaborator ${lastActivityAuthor} more than a week ago.`,
+        )
+
+        // 5. Add a closing comment using GraphQL
+        try {
+          await graphqlWithAuth(
+            `mutation AddDiscussionComment($discussionId: ID!, $body: String!) {
+                addDiscussionComment(input: {discussionId: $discussionId, body: $body}) {
+                  comment {
+                    id
+                  }
+                }
+            }`,
+            {
+              discussionId: discussion.id,
+              body: closingMessage,
+            },
+          )
+          console.log(`Posted closing comment on discussion #${discussionNumber}.`)
+        } catch (commentError) {
+          console.error(`Error posting comment: ${commentError.message}`)
+          if (commentError.response) console.error(JSON.stringify(commentError.response, null, 2))
+          continue
+        }
+
+        // 6. Remove target labels using GraphQL removeLabelsFromLabelable mutation
+        try {
+          const labelsToRemove = discussion.labels.nodes
+            .filter((label) => targetLabels.includes(label.name))
+            .map((label) => label.id)
+
+          if (labelsToRemove.length > 0) {
+            await graphqlWithAuth(
+              `mutation RemoveLabels($labelableId: ID!, $labelIds: [ID!]!) {
+                  removeLabelsFromLabelable(input: {
+                    labelableId: $labelableId,
+                    labelIds: $labelIds
+                  }) {
+                    clientMutationId
+                  }
+              }`,
+              {
+                labelableId: discussion.id,
+                labelIds: labelsToRemove,
+              },
+            )
+            console.log(`Removed target labels from discussion #${discussionNumber}.`)
+          } else {
+            console.log(`No target labels to remove from discussion #${discussionNumber}.`)
+          }
+        } catch (labelError) {
+          console.error(`Error removing labels: ${labelError.message}`)
+          if (labelError.errors) console.error(JSON.stringify(labelError.errors, null, 2))
+        }
+
+        // 7. Close the discussion using GraphQL with the OUTDATED reason
+        try {
+          await graphqlWithAuth(
+            `mutation CloseDiscussion($discussionId: ID!) {
+              closeDiscussion(input: {discussionId: $discussionId, reason: OUTDATED}) {
+                discussion {
+                  id
+                }
+              }
+            }`,
+            {
+              discussionId: discussion.id,
+            },
+          )
+          console.log(`Closed discussion #${discussionNumber} as OUTDATED.`)
+        } catch (closeError) {
+          console.error(`Error closing discussion: ${closeError.message}`)
+          if (closeError.response) console.error(JSON.stringify(closeError.response, null, 2))
+        }
+      } else {
+        console.log(`Discussion #${discussionNumber} does not qualify for closure.`)
+      }
+    }
+  } catch (error) {
+    console.error('Error processing discussions:', error)
+    if (error.response) console.error(JSON.stringify(error.response, null, 2))
+  }
+}
+
+run()


### PR DESCRIPTION
## Linked issue

n/a — follows from the `v7` / `main` branch swap. Addresses the "Scheduled workflows (become inert on `v7`)" item of the migration plan.

## Summary

GitHub reads cron schedules only from the default branch. Three scheduled workflows currently live on the `v7` line, where their schedules no longer fire at all: stale-issue labelling, Q&A discussion cleanup, and weekly CodeQL scanning have stopped running.

`label-stale-issues` and `auto-close-github-discussions` act on the issue tracker and on Discussions rather than on the code of any one branch, so they belong on the default branch outright.

`codeql-analysis` does depend on branch content, so it takes a matrix over the refs to scan. Each entry checks out its ref and passes `ref`/`sha` to the analyze step, so alerts are filed against the branch that was analysed rather than against whichever branch the schedule fired from, and a per-ref `category` keeps the two result sets from overwriting one another. Note that this introduces CodeQL scanning of `main` for the first time — trimming the matrix to `['v7']` is a one-line change if that is not wanted yet.

`daily-test.yml` and `daily-buildpulse.yml` are deliberately left on `v7`: their schedules are already commented out, and they call `./.github/workflows/test-template.yml`, which resolves against the calling workflow's own ref.

prisma/prisma#29824 removes the copies left behind on `v7`.

### Adaptations to this workspace

- The discussion-cleanup script is ESM (`.mjs`), matching the root `"type": "module"`. Its CommonJS `require()` calls would fail here.
- It reaches the GitHub REST and GraphQL APIs through `fetch`, so the workflow installs no dependencies at all.
- Actions are pinned to commit SHAs and every job declares least-privilege permissions, following the other workflows here. Dependabot's `github-actions` ecosystem already watches `/`, so the new pins will be maintained.

Beyond the API client, the script's logic is unchanged from its `v7` counterpart.

## Review feedback addressed

- **Ad-hoc install outside a lockfile**, and **the redundant second GraphQL client** — resolved together by dropping `@octokit/rest` and `@octokit/graphql` for `fetch`. There is now no install step to lock, and one authenticated path rather than two.
- **Request and job timeouts** — 30s per GitHub request via `AbortSignal.timeout`, 10 minutes on the job.
- **Crons off the top of the hour** — `17 0 * * *` and `23 0 * * *`, distinct so they do not contend.
- **CodeQL v3 → v4** — both steps repinned to the v4 commit.

## Testing performed

- YAML parsed and workflow structure checked for all three files.
- `node --check` on the ESM script.
- Diffed the script against its `v7` counterpart to confirm the changes are confined to the API-client wiring; the discussion-selection and closing logic is untouched.
- Confirmed `ref`, `sha` and `category` are supported inputs of `github/codeql-action/analyze` by reading the action's own `action.yml`.

Scheduled workflows cannot be exercised before merge — they become reachable only once the files are on the default branch. The first scheduled runs are the real test.

One thing a reviewer may want to weigh in on: the collaborator lookup is unpaginated, as it was on `v7`, so it sees the first page only. That is pre-existing behaviour and I have not changed it, but on a repository with many collaborators it means the "last activity was from a collaborator" test can miss people.

## Skill update

n/a — internal only. No CLI, config, API or error-code surface is touched.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco).
- [x] The change is scoped to one logical concern.
- [ ] Tests are updated — n/a, workflow configuration only.
- [ ] PR title in `TML-NNNN: <sentence-case title>` form — no Linear ticket exists for this change; happy to retitle if one should be raised.
