### PR TITLE
ci: register the 7.x dispatch-driven workflows on the default branch

### DIFF
--- a/.github/workflows/v7-daily-buildpulse.yml
+++ b/.github/workflows/v7-daily-buildpulse.yml
@@ -1,0 +1,21 @@
+name: v7 - Daily BuildPulse run
+
+# Registration stub. The workflow that does the work lives at this path on the
+# `v7` branch. GitHub keeps a workflow dispatchable only while it is present on
+# the default branch or holds recent runs, so this file holds the registration
+# open unconditionally. A dispatch carrying `ref: v7` runs the `v7` copy; the
+# job below is reached only when someone dispatches against the default branch
+# by mistake.
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  wrong-ref:
+    name: Dispatched against the wrong ref
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "::error::This workflow belongs to the 7.x line. Re-run it against ref 'v7'."
+          exit 1

--- a/.github/workflows/v7-daily-test.yml
+++ b/.github/workflows/v7-daily-test.yml
@@ -1,0 +1,21 @@
+name: v7 - Daily Test
+
+# Registration stub. The workflow that does the work lives at this path on the
+# `v7` branch. GitHub keeps a workflow dispatchable only while it is present on
+# the default branch or holds recent runs, so this file holds the registration
+# open unconditionally. A dispatch carrying `ref: v7` runs the `v7` copy; the
+# job below is reached only when someone dispatches against the default branch
+# by mistake.
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  wrong-ref:
+    name: Dispatched against the wrong ref
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "::error::This workflow belongs to the 7.x line. Re-run it against ref 'v7'."
+          exit 1

--- a/.github/workflows/v7-manage-dist-tag.yml
+++ b/.github/workflows/v7-manage-dist-tag.yml
@@ -1,0 +1,37 @@
+name: v7 - npm - manage dist tag
+
+# Registration stub. The workflow that does the work lives at this path on the
+# `v7` branch. GitHub keeps a workflow dispatchable only while it is present on
+# the default branch or holds recent runs, so this file holds the registration
+# open unconditionally. A dispatch carrying `ref: v7` runs the `v7` copy; the
+# job below is reached only when someone dispatches against the default branch
+# by mistake.
+on:
+  workflow_dispatch:
+    inputs:
+      tagAction:
+        description: 'What action do you want to do with the tag?'
+        type: choice
+        options:
+          - 'add'
+          - 'rm'
+        required: true
+      tagName:
+        description: 'What is the name of the dist tag to be managed (created/updated or deleted)?'
+        type: string
+        required: true
+      targetVersion:
+        description: 'Version to act on (Only needed with `add` in format of semver version to tag, otherwise empty).'
+        type: string
+        required: false
+
+permissions: {}
+
+jobs:
+  wrong-ref:
+    name: Dispatched against the wrong ref
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "::error::This workflow belongs to the 7.x line. Re-run it against ref 'v7'."
+          exit 1

--- a/.github/workflows/v7-release.yml
+++ b/.github/workflows/v7-release.yml
@@ -1,0 +1,46 @@
+name: v7 - npm - release
+
+# Registration stub. The workflow that does the work lives at this path on the
+# `v7` branch. GitHub keeps a workflow dispatchable only while it is present on
+# the default branch or holds recent runs, so this file holds the registration
+# open unconditionally. A dispatch carrying `ref: v7` runs the `v7` copy; the
+# job below is reached only when someone dispatches against the default branch
+# by mistake.
+#
+# The `v7` copy also carries `push` triggers. They are deliberately absent here:
+# pushes to this branch must never publish the 7.x packages.
+on:
+  workflow_dispatch:
+    inputs:
+      targetVersion:
+        description: 'Version to publish on latest tag (e.g. 5.0.0)'
+        type: string
+      skipEcosystemTestsChecks:
+        description: 'Skip ecosystem tests checks'
+        type: boolean
+      skipPackages:
+        description: 'Skip publishing some packages? (e.g. `@prisma/debug,@prisma/internals`)'
+        type: string
+      onlyPackages:
+        description: 'Only publish some packages? (e.g. `@prisma/debug,@prisma/internals`)'
+        type: string
+      dryRun:
+        description: 'Check to do a dry run (does not publish packages)'
+        type: boolean
+      forceIntegrationRelease:
+        description: 'Check to force an integration release for any given branch name'
+        type: boolean
+      customDistTag:
+        description: 'Custom dist tag to publish to (e.g. `prev`)'
+        type: string
+
+permissions: {}
+
+jobs:
+  wrong-ref:
+    name: Dispatched against the wrong ref
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "::error::This workflow belongs to the 7.x line. Re-run it against ref 'v7'."
+          exit 1

--- a/.github/workflows/v7-update-engines-version.yml
+++ b/.github/workflows/v7-update-engines-version.yml
@@ -1,0 +1,33 @@
+name: v7 - Update Engines Version
+
+# Registration stub. The workflow that does the work lives at this path on the
+# `v7` branch. GitHub keeps a workflow dispatchable only while it is present on
+# the default branch or holds recent runs, so this file holds the registration
+# open unconditionally. A dispatch carrying `ref: v7` runs the `v7` copy; the
+# job below is reached only when someone dispatches against the default branch
+# by mistake.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to check and update the engines version'
+        required: true
+      npmDistTag:
+        description: 'npm tag used for `@prisma/engines-version` in prisma/engines-wrapper repo (`latest` or `integration` or `patch`)'
+        required: true
+        type: choice
+        options:
+          - latest
+          - integration
+          - patch
+
+permissions: {}
+
+jobs:
+  wrong-ref:
+    name: Dispatched against the wrong ref
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "::error::This workflow belongs to the 7.x line. Re-run it against ref 'v7'."
+          exit 1

--- a/.github/workflows/v7-update-studio-version.yml
+++ b/.github/workflows/v7-update-studio-version.yml
@@ -1,0 +1,25 @@
+name: v7 - Update Studio Version
+
+# Registration stub. The workflow that does the work lives at this path on the
+# `v7` branch. GitHub keeps a workflow dispatchable only while it is present on
+# the default branch or holds recent runs, so this file holds the registration
+# open unconditionally. A dispatch carrying `ref: v7` runs the `v7` copy; the
+# job below is reached only when someone dispatches against the default branch
+# by mistake.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to check and update the studio version'
+        required: true
+
+permissions: {}
+
+jobs:
+  wrong-ref:
+    name: Dispatched against the wrong ref
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "::error::This workflow belongs to the 7.x line. Re-run it against ref 'v7'."
+          exit 1


### PR DESCRIPTION
## Linked issue

n/a — follows from the `v7` / `main` branch swap.

## Summary

GitHub keeps a workflow dispatchable while it is present on the default branch **or** holds recent runs. The 7.x line's dispatch-driven workflows live on `v7` and satisfy neither condition durably. Probing each one with a deliberately non-existent ref (which resolves the workflow but starts nothing) gives:

| Workflow | Registry state | Dispatch |
|---|---|---|
| `record-cli.yml` *(on `main`, control)* | active | resolves |
| `release.yml` | active | resolves |
| `update-engines-version.yml` | deleted | resolves |
| `daily-test.yml` | deleted | resolves |
| `manage-dist-tag.yml` | absent | **Not Found** |
| `update-studio-version.yml` | absent | **Not Found** |

`manage-dist-tag` and `update-studio-version` have already fallen out of the registry and answer a dispatch with 404. `update-engines-version` and `release` remain reachable only for as long as engine bumps and pushes to `v7` keep arriving; let either cadence lapse past run retention and they reach the same state. A workflow that cannot be dispatched also cannot re-register itself by running, so the loss is not self-healing — it would surface mid-release.

Presence on the default branch is unconditional. Each of the six therefore gets a stub here at the path its real counterpart occupies on `v7`. A dispatch carrying `ref: v7` runs the `v7` copy; the stub's job is reached only when someone dispatches against the default branch, and fails with a message saying so.

The stubs mirror each workflow's dispatch inputs so the Actions form offers the right fields. `v7-release.yml` deliberately omits the `push` triggers its `v7` counterpart carries: pushes to this branch must never publish the 7.x packages.

### Ordering

This PR must merge **before** #29823, which renames the workflows on `v7` to these paths. Until the stubs are here, those paths have no registry entry.

## Testing performed

- YAML parsed and workflow structure checked for all six files; input counts verified against their `v7` counterparts (3, 7, 2, 1, 0, 0).
- Dispatch resolvability probed via the REST API with a non-existent ref, which distinguishes "workflow not found" from "ref not found" without starting a run. Results in the table above.

A stub cannot be exercised before merge — registration is precisely what merging confers. Once merged, dispatching any of the six against `main` should fail with the "wrong ref" message, and against `v7` should run the real workflow.

## Skill update

n/a — internal only.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco).
- [x] The change is scoped to one logical concern.
- [ ] Tests are updated — n/a, workflow configuration only.
- [ ] PR title in `TML-NNNN: <sentence-case title>` form — no Linear ticket exists for this change; happy to retitle if one should be raised.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manual workflow entry points for v7 daily builds, tests, releases, distribution-tag management, and version updates.
  * Added configurable inputs for release, tagging, and engine or studio version operations.

* **Bug Fixes**
  * Added safeguards that clearly indicate when these workflows are run from the wrong branch and require rerunning against the v7 ref.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->