### PR TITLE
ci: prefix the dispatch-driven workflows with v7-

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,7 +7,7 @@ on:
       - '*.*.x'
     paths-ignore:
       # Any update here needs to be done for `pull_request` (see below) and all files
-      # (test.yml, benchmark.yml, release.yml, bundle-size.yml, ci-aux-files.yml)
+      # (test.yml, benchmark.yml, v7-release.yml, bundle-size.yml, ci-aux-files.yml)
       - '*.md'
       # - '*.bench.ts' -> should not be ignored in this workflow
       - 'LICENSE'
@@ -23,7 +23,7 @@ on:
   pull_request:
     paths-ignore:
       # Any update here needs to be done for `branches` (see above) and all files
-      # (test.yml, benchmark.yml, release.yml, bundle-size.yml, ci-aux-files.yml)
+      # (test.yml, benchmark.yml, v7-release.yml, bundle-size.yml, ci-aux-files.yml)
       - '*.md'
       # - '*.bench.ts' -> should not be ignored in this workflow
       - 'LICENSE'

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths-ignore:
       # Any update here needs to be done for all files
-      # (test.yml, benchmark.yml, release.yml, bundle-size.yml, ci-aux-files.yml)
+      # (test.yml, benchmark.yml, v7-release.yml, bundle-size.yml, ci-aux-files.yml)
       - '*.md'
       - '*.bench.ts'
       - 'LICENSE'

--- a/.github/workflows/ci-aux-files.yml
+++ b/.github/workflows/ci-aux-files.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       # Any update here needs to be done for all files
-      # (test.yml, benchmark.yml, release.yml, bundle-size.yml, ci-aux-files.yml)
+      # (test.yml, benchmark.yml, v7-release.yml, bundle-size.yml, ci-aux-files.yml)
       - '*.md'
       - '*.bench.ts'
       - 'LICENSE'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
       - '*.*.x'
     paths-ignore:
       # Any update here needs to be done for `pull_request` (see below) and all files
-      # (test.yml, benchmark.yml, release.yml, bundle-size.yml, ci-aux-files.yml)
+      # (test.yml, benchmark.yml, v7-release.yml, bundle-size.yml, ci-aux-files.yml)
       - '*.md'
       - '*.bench.ts'
       - 'LICENSE'
@@ -23,7 +23,7 @@ on:
   pull_request:
     paths-ignore:
       # Any update here needs to be done for `branches` (see above) and all files
-      # (test.yml, benchmark.yml, release.yml, bundle-size.yml, ci-aux-files.yml)
+      # (test.yml, benchmark.yml, v7-release.yml, bundle-size.yml, ci-aux-files.yml)
       - '*.md'
       - '*.bench.ts'
       - 'LICENSE'
@@ -91,7 +91,7 @@ jobs:
           )
         uses: benc-uk/workflow-dispatch@v1
         with:
-          workflow: release.yml
+          workflow: v7-release.yml
           token: ${{ secrets.BOT_TOKEN }}
           inputs: '{ "forceIntegrationRelease": "true" }'
           ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/v7-daily-buildpulse.yml
+++ b/.github/workflows/v7-daily-buildpulse.yml
@@ -1,4 +1,4 @@
-name: Daily BuildPulse run
+name: v7 - Daily BuildPulse run
 
 on:
   workflow_dispatch:

--- a/.github/workflows/v7-daily-test.yml
+++ b/.github/workflows/v7-daily-test.yml
@@ -1,4 +1,4 @@
-name: Daily Test
+name: v7 - Daily Test
 
 on:
   workflow_dispatch:

--- a/.github/workflows/v7-manage-dist-tag.yml
+++ b/.github/workflows/v7-manage-dist-tag.yml
@@ -1,4 +1,4 @@
-name: npm - manage dist tag
+name: v7 - npm - manage dist tag
 run-name: npm - manage dist tag / ${{ github.event.inputs.tagAction}} ${{ github.event.inputs.tagName}} (on ${{ github.event.inputs.targetVersion}})
 
 on:

--- a/.github/workflows/v7-release.yml
+++ b/.github/workflows/v7-release.yml
@@ -1,4 +1,4 @@
-name: npm - release
+name: v7 - npm - release
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
       - '*.*.x'
     paths-ignore:
       # Any update here needs to be done for all files
-      # (test.yml, benchmark.yml, release.yml, bundle-size.yml, ci-aux-files.yml)
+      # (test.yml, benchmark.yml, v7-release.yml, bundle-size.yml, ci-aux-files.yml)
       - '*.md'
       - '*.bench.ts'
       - 'LICENSE'

--- a/.github/workflows/v7-update-engines-version.yml
+++ b/.github/workflows/v7-update-engines-version.yml
@@ -1,4 +1,4 @@
-name: Update Engines Version
+name: v7 - Update Engines Version
 run-name: Update Engines on npm ${{ inputs.npmDistTag }} ${{ inputs.version }}
 
 on:

--- a/.github/workflows/v7-update-studio-version.yml
+++ b/.github/workflows/v7-update-studio-version.yml
@@ -1,4 +1,4 @@
-name: Update Studio Version
+name: v7 - Update Studio Version
 run-name: Update Studio - version ${{ inputs.version }}
 
 on:


### PR DESCRIPTION
## Summary

Six workflows on this branch are reached by `workflow_dispatch`, and GitHub keys a workflow's registry entry on its file path. Registration stubs on the default branch hold those paths open — a workflow absent from the default branch keeps its entry only while it has recent runs, which has already cost `manage-dist-tag` and `update-studio-version` their dispatchability entirely.

The paths here must therefore match the stubs, and the `v7-` prefix keeps it plain in the repository's Actions list which line each workflow belongs to:

| Was | Now |
|---|---|
| `manage-dist-tag.yml` | `v7-manage-dist-tag.yml` |
| `update-studio-version.yml` | `v7-update-studio-version.yml` |
| `update-engines-version.yml` | `v7-update-engines-version.yml` |
| `release.yml` | `v7-release.yml` |
| `daily-test.yml` | `v7-daily-test.yml` |
| `daily-buildpulse.yml` | `v7-daily-buildpulse.yml` |

Display names take the same prefix (`npm - release` → `v7 - npm - release`, and so on).

`test.yml` dispatches the release workflow by filename for the integration-release trigger, and is updated to the new one. The sibling comments enumerating the `paths-ignore` group are updated to match.

Nothing else in the six files changes: apart from the `name:` line — and, in the release workflow, one comment — they are byte-identical to their previous contents.

## Downstream

`prisma/engines-wrapper` dispatches `Update Engines Version` **by display name**. prisma/engines-wrapper#538 switches it to dispatch by filename, which is the canonical identifier and immune to future display-name edits. That PR should merge immediately after this one; in the gap between the two, engine-bump dispatches will fail and need re-running by hand.

Whether anything automated dispatches `Update Studio Version` I could not establish — GitHub code search returned nothing even for strings known to exist, so it is not functioning and the question is open. Any such sender needs the same update.

## Testing performed

- YAML parsed and structure checked for all ten touched files.
- Diffed each renamed file against its previous contents to confirm the `name:` line is the only change (plus one comment in the release workflow).
- Swept the whole branch for references to the six filenames; `test.yml:94` was the only functional one. The `daily-test` matches elsewhere are input *values* (`reason: daily-test`), not paths, and are left alone.
- Renames cannot be exercised before merge. After merge, the integration-release trigger in `test.yml` and a dispatch of each workflow against `v7` are the things to watch.

## Checklist

- [x] All commits are signed off per the DCO.
- [x] The change is scoped to one logical concern.

## A note on the failing check

The `Detect jobs to run` failure on the first run of this PR was self-inflicted and is worth recording. `test.yml` fires the integration-release dispatch when the **PR body** contains the literal string `slash-integration`(spelled with a leading slash) — and an earlier revision of this description used it while explaining the change. The dispatch duly ran and failed with `Unable to find workflow 'v7-release.yml' in prisma/prisma`, which is exactly the ordering dependency described above, demonstrated rather than argued.

The wording here no longer contains that string. It is worth noting that the trigger matches anywhere in the body, prose included, so a description that merely mentions it will start a release once the path is registered.
