### PR TITLE
chore: point the package manifests at prisma/prisma

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,8 @@ Optional, only needed for specific test suites:
 ## Setup
 
 ```bash
-git clone https://github.com/prisma/prisma-next.git
-cd prisma-next
+git clone https://github.com/prisma/prisma.git
+cd prisma
 
 corepack enable                      # if you haven't already
 pnpm install --frozen-lockfile

--- a/packages/0-shared/extension-author-tools/package.json
+++ b/packages/0-shared/extension-author-tools/package.json
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/0-shared/extension-author-tools"
   },
   "peerDependencies": {

--- a/packages/1-framework/0-foundation/contract/package.json
+++ b/packages/1-framework/0-foundation/contract/package.json
@@ -58,7 +58,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/1-framework/0-foundation/contract"
   }
 }

--- a/packages/1-framework/0-foundation/utils/package.json
+++ b/packages/1-framework/0-foundation/utils/package.json
@@ -55,7 +55,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/1-framework/0-foundation/utils"
   }
 }

--- a/packages/1-framework/1-core/config/package.json
+++ b/packages/1-framework/1-core/config/package.json
@@ -51,7 +51,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/1-framework/1-core/config"
   }
 }

--- a/packages/1-framework/1-core/errors/package.json
+++ b/packages/1-framework/1-core/errors/package.json
@@ -49,7 +49,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/1-framework/1-core/errors"
   }
 }

--- a/packages/1-framework/1-core/framework-components/package.json
+++ b/packages/1-framework/1-core/framework-components/package.json
@@ -57,7 +57,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/1-framework/1-core/framework-components"
   }
 }

--- a/packages/1-framework/1-core/operations/package.json
+++ b/packages/1-framework/1-core/operations/package.json
@@ -48,7 +48,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/1-framework/1-core/operations"
   }
 }

--- a/packages/1-framework/1-core/ts-render/package.json
+++ b/packages/1-framework/1-core/ts-render/package.json
@@ -47,7 +47,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/1-framework/1-core/ts-render"
   }
 }

--- a/packages/1-framework/2-authoring/contract/package.json
+++ b/packages/1-framework/2-authoring/contract/package.json
@@ -48,7 +48,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/1-framework/2-authoring/contract"
   }
 }

--- a/packages/1-framework/2-authoring/ids/package.json
+++ b/packages/1-framework/2-authoring/ids/package.json
@@ -51,7 +51,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/1-framework/2-authoring/ids"
   }
 }

--- a/packages/1-framework/2-authoring/psl-parser/package.json
+++ b/packages/1-framework/2-authoring/psl-parser/package.json
@@ -54,7 +54,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/1-framework/2-authoring/psl-parser"
   }
 }

--- a/packages/1-framework/2-authoring/psl-printer/package.json
+++ b/packages/1-framework/2-authoring/psl-printer/package.json
@@ -56,7 +56,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/1-framework/2-authoring/psl-printer"
   }
 }

--- a/packages/1-framework/3-tooling/cli-telemetry/package.json
+++ b/packages/1-framework/3-tooling/cli-telemetry/package.json
@@ -59,7 +59,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/1-framework/3-tooling/cli-telemetry"
   }
 }

--- a/packages/1-framework/3-tooling/cli/package.json
+++ b/packages/1-framework/3-tooling/cli/package.json
@@ -172,7 +172,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/1-framework/3-tooling/cli"
   }
 }

--- a/packages/1-framework/3-tooling/config-loader/package.json
+++ b/packages/1-framework/3-tooling/config-loader/package.json
@@ -56,7 +56,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/1-framework/3-tooling/config-loader"
   }
 }

--- a/packages/1-framework/3-tooling/emitter/package.json
+++ b/packages/1-framework/3-tooling/emitter/package.json
@@ -67,7 +67,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/1-framework/3-tooling/emitter"
   }
 }

--- a/packages/1-framework/3-tooling/language-server/package.json
+++ b/packages/1-framework/3-tooling/language-server/package.json
@@ -58,7 +58,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/1-framework/3-tooling/language-server"
   }
 }

--- a/packages/1-framework/3-tooling/migration/package.json
+++ b/packages/1-framework/3-tooling/migration/package.json
@@ -119,7 +119,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/1-framework/3-tooling/migration"
   }
 }

--- a/packages/1-framework/3-tooling/prisma-next/package.json
+++ b/packages/1-framework/3-tooling/prisma-next/package.json
@@ -60,7 +60,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/1-framework/3-tooling/prisma-next"
   },
   "publishConfig": {

--- a/packages/1-framework/3-tooling/vite-plugin-contract-emit/package.json
+++ b/packages/1-framework/3-tooling/vite-plugin-contract-emit/package.json
@@ -47,7 +47,7 @@
   "types": "./dist/index.d.mts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/1-framework/3-tooling/vite-plugin-contract-emit"
   },
   "peerDependenciesMeta": {

--- a/packages/2-mongo-family/1-foundation/mongo-codec/package.json
+++ b/packages/2-mongo-family/1-foundation/mongo-codec/package.json
@@ -50,7 +50,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/2-mongo-family/1-foundation/mongo-codec"
   }
 }

--- a/packages/2-mongo-family/1-foundation/mongo-contract/package.json
+++ b/packages/2-mongo-family/1-foundation/mongo-contract/package.json
@@ -55,7 +55,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/2-mongo-family/1-foundation/mongo-contract"
   }
 }

--- a/packages/2-mongo-family/1-foundation/mongo-value/package.json
+++ b/packages/2-mongo-family/1-foundation/mongo-value/package.json
@@ -48,7 +48,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/2-mongo-family/1-foundation/mongo-value"
   }
 }

--- a/packages/2-mongo-family/2-authoring/contract-psl/package.json
+++ b/packages/2-mongo-family/2-authoring/contract-psl/package.json
@@ -57,7 +57,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/2-mongo-family/2-authoring/contract-psl"
   }
 }

--- a/packages/2-mongo-family/2-authoring/contract-ts/package.json
+++ b/packages/2-mongo-family/2-authoring/contract-ts/package.json
@@ -55,7 +55,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/2-mongo-family/2-authoring/contract-ts"
   }
 }

--- a/packages/2-mongo-family/3-tooling/emitter/package.json
+++ b/packages/2-mongo-family/3-tooling/emitter/package.json
@@ -54,7 +54,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/2-mongo-family/3-tooling/emitter"
   }
 }

--- a/packages/2-mongo-family/3-tooling/mongo-schema-ir/package.json
+++ b/packages/2-mongo-family/3-tooling/mongo-schema-ir/package.json
@@ -53,7 +53,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/2-mongo-family/3-tooling/mongo-schema-ir"
   }
 }

--- a/packages/2-mongo-family/4-query/query-ast/package.json
+++ b/packages/2-mongo-family/4-query/query-ast/package.json
@@ -59,7 +59,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/2-mongo-family/4-query/query-ast"
   }
 }

--- a/packages/2-mongo-family/5-query-builders/orm/package.json
+++ b/packages/2-mongo-family/5-query-builders/orm/package.json
@@ -60,7 +60,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/2-mongo-family/5-query-builders/orm"
   }
 }

--- a/packages/2-mongo-family/5-query-builders/query-builder/package.json
+++ b/packages/2-mongo-family/5-query-builders/query-builder/package.json
@@ -52,7 +52,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/2-mongo-family/5-query-builders/query-builder"
   }
 }

--- a/packages/2-mongo-family/6-transport/mongo-lowering/package.json
+++ b/packages/2-mongo-family/6-transport/mongo-lowering/package.json
@@ -54,7 +54,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/2-mongo-family/6-transport/mongo-lowering"
   }
 }

--- a/packages/2-mongo-family/6-transport/mongo-wire/package.json
+++ b/packages/2-mongo-family/6-transport/mongo-wire/package.json
@@ -49,7 +49,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/2-mongo-family/6-transport/mongo-wire"
   }
 }

--- a/packages/2-mongo-family/7-runtime/package.json
+++ b/packages/2-mongo-family/7-runtime/package.json
@@ -63,7 +63,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/2-mongo-family/7-runtime"
   }
 }

--- a/packages/2-mongo-family/9-family/package.json
+++ b/packages/2-mongo-family/9-family/package.json
@@ -65,7 +65,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/2-mongo-family/9-family"
   }
 }

--- a/packages/2-sql/1-core/contract/package.json
+++ b/packages/2-sql/1-core/contract/package.json
@@ -65,7 +65,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/2-sql/1-core/contract"
   }
 }

--- a/packages/2-sql/1-core/errors/package.json
+++ b/packages/2-sql/1-core/errors/package.json
@@ -45,7 +45,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/2-sql/1-core/errors"
   }
 }

--- a/packages/2-sql/1-core/operations/package.json
+++ b/packages/2-sql/1-core/operations/package.json
@@ -51,7 +51,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/2-sql/1-core/operations"
   }
 }

--- a/packages/2-sql/1-core/schema-ir/package.json
+++ b/packages/2-sql/1-core/schema-ir/package.json
@@ -52,7 +52,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/2-sql/1-core/schema-ir"
   }
 }

--- a/packages/2-sql/2-authoring/contract-psl/package.json
+++ b/packages/2-sql/2-authoring/contract-psl/package.json
@@ -58,7 +58,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/2-sql/2-authoring/contract-psl"
   }
 }

--- a/packages/2-sql/2-authoring/contract-ts/package.json
+++ b/packages/2-sql/2-authoring/contract-ts/package.json
@@ -59,7 +59,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/2-sql/2-authoring/contract-ts"
   }
 }

--- a/packages/2-sql/3-tooling/emitter/package.json
+++ b/packages/2-sql/3-tooling/emitter/package.json
@@ -52,7 +52,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/2-sql/3-tooling/emitter"
   }
 }

--- a/packages/2-sql/4-lanes/query-builder/package.json
+++ b/packages/2-sql/4-lanes/query-builder/package.json
@@ -47,7 +47,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/2-sql/4-lanes/query-builder"
   }
 }

--- a/packages/2-sql/4-lanes/relational-core/package.json
+++ b/packages/2-sql/4-lanes/relational-core/package.json
@@ -65,7 +65,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/2-sql/4-lanes/relational-core"
   }
 }

--- a/packages/2-sql/4-lanes/sql-builder/package.json
+++ b/packages/2-sql/4-lanes/sql-builder/package.json
@@ -61,7 +61,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/2-sql/4-lanes/sql-builder"
   }
 }

--- a/packages/2-sql/5-runtime/package.json
+++ b/packages/2-sql/5-runtime/package.json
@@ -61,7 +61,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/2-sql/5-runtime"
   }
 }

--- a/packages/2-sql/9-family/package.json
+++ b/packages/2-sql/9-family/package.json
@@ -72,7 +72,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/2-sql/9-family"
   }
 }

--- a/packages/3-extensions/arktype-json/package.json
+++ b/packages/3-extensions/arktype-json/package.json
@@ -61,7 +61,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/3-extensions/arktype-json"
   }
 }

--- a/packages/3-extensions/middleware-cache/package.json
+++ b/packages/3-extensions/middleware-cache/package.json
@@ -48,7 +48,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/3-extensions/middleware-cache"
   }
 }

--- a/packages/3-extensions/mongo/package.json
+++ b/packages/3-extensions/mongo/package.json
@@ -75,7 +75,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/3-extensions/mongo"
   }
 }

--- a/packages/3-extensions/paradedb/package.json
+++ b/packages/3-extensions/paradedb/package.json
@@ -66,7 +66,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/3-extensions/paradedb"
   }
 }

--- a/packages/3-extensions/pgvector/package.json
+++ b/packages/3-extensions/pgvector/package.json
@@ -74,7 +74,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/3-extensions/pgvector"
   }
 }

--- a/packages/3-extensions/postgis/package.json
+++ b/packages/3-extensions/postgis/package.json
@@ -71,7 +71,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/3-extensions/postgis"
   }
 }

--- a/packages/3-extensions/postgres/package.json
+++ b/packages/3-extensions/postgres/package.json
@@ -78,7 +78,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/3-extensions/postgres"
   }
 }

--- a/packages/3-extensions/sql-orm-client/package.json
+++ b/packages/3-extensions/sql-orm-client/package.json
@@ -67,7 +67,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/3-extensions/sql-orm-client"
   }
 }

--- a/packages/3-extensions/sqlite/package.json
+++ b/packages/3-extensions/sqlite/package.json
@@ -70,7 +70,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/3-extensions/sqlite"
   }
 }

--- a/packages/3-extensions/supabase/package.json
+++ b/packages/3-extensions/supabase/package.json
@@ -86,7 +86,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/3-extensions/supabase"
   }
 }

--- a/packages/3-mongo-target/1-mongo-target/package.json
+++ b/packages/3-mongo-target/1-mongo-target/package.json
@@ -74,7 +74,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/3-mongo-target/1-mongo-target"
   },
   "prismaNext": {

--- a/packages/3-mongo-target/2-mongo-adapter/package.json
+++ b/packages/3-mongo-target/2-mongo-adapter/package.json
@@ -77,7 +77,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/3-mongo-target/2-mongo-adapter"
   }
 }

--- a/packages/3-mongo-target/3-mongo-driver/package.json
+++ b/packages/3-mongo-target/3-mongo-driver/package.json
@@ -56,7 +56,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/3-mongo-target/3-mongo-driver"
   }
 }

--- a/packages/3-targets/3-targets/postgres/package.json
+++ b/packages/3-targets/3-targets/postgres/package.json
@@ -95,7 +95,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/3-targets/3-targets/postgres"
   },
   "prismaNext": {

--- a/packages/3-targets/3-targets/sqlite/package.json
+++ b/packages/3-targets/3-targets/sqlite/package.json
@@ -78,7 +78,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/3-targets/3-targets/sqlite"
   }
 }

--- a/packages/3-targets/6-adapters/postgres/package.json
+++ b/packages/3-targets/6-adapters/postgres/package.json
@@ -71,7 +71,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/3-targets/6-adapters/postgres"
   }
 }

--- a/packages/3-targets/6-adapters/sqlite/package.json
+++ b/packages/3-targets/6-adapters/sqlite/package.json
@@ -71,7 +71,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/3-targets/6-adapters/sqlite"
   }
 }

--- a/packages/3-targets/7-drivers/postgres/package.json
+++ b/packages/3-targets/7-drivers/postgres/package.json
@@ -62,7 +62,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/3-targets/7-drivers/postgres"
   }
 }

--- a/packages/3-targets/7-drivers/sqlite/package.json
+++ b/packages/3-targets/7-drivers/sqlite/package.json
@@ -54,7 +54,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-next.git",
+    "url": "https://github.com/prisma/prisma.git",
     "directory": "packages/3-targets/7-drivers/sqlite"
   }
 }


### PR DESCRIPTION
## Linked issue

n/a — follows from the `v7` / `main` branch swap.

## Summary

All 65 publishable manifests still name `prisma/prisma-next` in `repository.url`, along with `CONTRIBUTING.md`'s clone instructions. So npm links to the wrong repository, provenance attests against the wrong source, and pkg.pr.new's `--compact` mode cannot be restored — it reads the repository field out of the *published* manifest, which is why `preview-publish.yml` omits the flag today with a comment saying to add it back once a publish carries the field.

A single URL shape appears throughout (`https://github.com/prisma/prisma-next.git`), always in `repository.url`, so the rewrite is mechanical. Nothing in the tree validates or asserts the value; I checked.

## What this does **not** fix

It does not fix the failing `Publish preview` check. That deserves stating plainly, since it is the obvious thing to assume.

That check fails on **every** PR to `main` — dependabot's included — with:

```
Check failed (404): {"url":"/check", ... "message":"There is no workflow defined for K66m5cujjj"}
```

Reading pkg.pr.new's [`check.post.ts`](https://github.com/stackblitz-labs/pkg.pr.new/blob/main/packages/app/server/routes/check.post.ts), that endpoint does two things:

1. Confirms the pkg-pr-new GitHub App is installed, trying `GET /repos/{owner}/{repo}/installation` and then falling back to `GET /orgs/{org}/installation`. Failure here produces a *different* message — "The app … is not installed on {owner}/{repo}" — so this step is passing.
2. Looks up `workflowsBucket.getItem(key)`. That entry is written by the app's `workflow_run` webhook handler, keyed on a hash of owner, repo, run id, attempt and actor.

We fail at (2), which means the webhook never wrote the entry. Since (1) passes via the **org-level** fallback, the consistent reading is that the app is installed on the `prisma` org but its installation does not *select* this repository — so it satisfies the org lookup while delivering no `workflow_run` webhooks here. It was presumably scoped to `prisma/prisma-next`.

If that is right, the fix is to extend the pkg-pr-new app's repository access to `prisma/prisma` in org settings — not a code change, and nothing a PR can do.

I could not verify the installation scope directly: `GET /orgs/prisma/installations` needs the `admin:org` scope. So treat the last step as a well-evidenced inference rather than a confirmed fact; someone with org admin can settle it in a moment.

## Testing performed

- Confirmed exactly one URL shape across the manifests, always in `repository.url` (65 occurrences).
- Confirmed no script, test or lint rule reads or asserts the field.
- Confirmed no `prisma-next.git` reference survives anywhere in the resulting tree outside the lockfile.
- Read pkg.pr.new's `/check` route and webhook handler at source rather than inferring from the error string.

Manifest metadata is not exercised by CI; the real test is the next publish, where npm should show the correct repository and provenance should attest against it.

## Skill update

n/a — metadata only.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco).
- [x] The change is scoped to one logical concern.
- [ ] Tests are updated — n/a, manifest metadata only.
- [ ] PR title in `TML-NNNN: <sentence-case title>` form — no Linear ticket exists for this change; happy to retitle if one should be raised.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions to clone the main Prisma repository.

* **Chores**
  * Updated package repository links across the project to reference the main Prisma repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->