### PR TITLE
docs: signpost Prisma ORM 7 from the default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://github.com/prisma/prisma-next">
+  <a href="https://github.com/prisma/prisma">
     <img src="./images/prisma-next.png" alt="Prisma Next" width="680" />
   </a>
 </p>
@@ -11,10 +11,12 @@
 <p align="center">
   <a href="./LICENSE"><img alt="License: Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" /></a>
   <a href="https://www.npmjs.com/package/prisma-next"><img alt="npm" src="https://img.shields.io/npm/v/prisma-next?label=prisma-next" /></a>
-  <a href="https://github.com/prisma/prisma-next/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/prisma/prisma-next/actions/workflows/ci.yml/badge.svg" /></a>
+  <a href="https://github.com/prisma/prisma/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/prisma/prisma/actions/workflows/ci.yml/badge.svg" /></a>
 </p>
 
 ---
+
+> **Looking for Prisma ORM 7?** It lives on the [`v7` branch](https://github.com/prisma/prisma/tree/v7) of this repository, and the `prisma` and `@prisma/*` packages on npm continue to be published from there.
 
 > **Prisma Next is currently in [Early Access](https://pris.ly/pn-ea)** and we're building it in the open with the community. APIs will still evolve as your feedback shapes them, so we don't recommend it for production workloads yet. Come along for the ride: star the repo, follow [@prisma on X](https://pris.ly/x), or read along on the [Prisma blog](https://www.prisma.io/blog).
 


### PR DESCRIPTION
## Linked issue

n/a — follows from the `v7` / `main` branch swap.

## Summary

Someone arriving at this repository looking for Prisma ORM 7 currently finds Prisma Next and no indication at all of where the 7.x line went. A one-line banner points them at the `v7` branch.

It sits **above** the Early Access note deliberately: a reader in the wrong place should be redirected before being asked to read anything else.

```
> **Looking for Prisma ORM 7?** It lives on the `v7` branch of this
> repository, and the `prisma` and `@prisma/*` packages on npm continue
> to be published from there.
```

While in the file, three GitHub links still named `prisma/prisma-next`: the header image anchor, and the CI badge, which was reporting another repository's status. The npm package name (`prisma-next`) and the image path keep their names — neither has changed, and only `github.com/` URLs were rewritten.

prisma/prisma#29827 adds the reciprocal banner on `v7`, along with that branch's own stale self-links.

## Testing performed

- Confirmed no `github.com/prisma/prisma-next` reference survives in the file, and that the npm badge and image path are untouched.
- Rendered-markdown change only; nothing in CI exercises it. The banner and the badge are worth a glance on the rendered page.

## Skill update

n/a — documentation only.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco).
- [x] The change is scoped to one logical concern.
- [ ] Tests are updated — n/a, documentation only.
- [ ] PR title in `TML-NNNN: <sentence-case title>` form — no Linear ticket exists for this change; happy to retitle if one should be raised.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository links and CI status badges to reflect the main Prisma repository.
  * Added guidance for finding Prisma ORM 7 on the `v7` branch.
  * Clarified where Prisma and `@prisma/*` packages are published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->