### PR TITLE
docs: point the 7.x documentation at its own branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Welcome! You've arrived at our Contributing page and are now one step away from joining our quest to make databases easy. We're thankful for all your contributions, whether it's helping us find issues in our code, highlighting features we're missing, or contributing to the codebase. If you've found your way here, you'll soon be ready to join in the fun of building features and fixing bugs directly with us - and we're thrilled to have you on board!
 
-To get you started on a good foot, we've created an easy overview of the most important things to get you started contributing code to Prisma below as well as a [Code of Conduct](https://github.com/prisma/prisma/blob/main/CODE_OF_CONDUCT.md) for contributing to the development of Prisma.
+To get you started on a good foot, we've created an easy overview of the most important things to get you started contributing code to Prisma below as well as a [Code of Conduct](https://github.com/prisma/prisma/blob/v7/CODE_OF_CONDUCT.md) for contributing to the development of Prisma.
 
 We also encourage you to join our sprawling [community](https://www.prisma.io/community) online, where you can discuss ideas, ask questions and get inspiration for what to build next.
 
@@ -167,10 +167,10 @@ pnpm run test integration
 
 ###### Creating a new folder-based integration test
 
-If you want to create a new one, we recommend to copy over the [minimal test](https://github.com/prisma/prisma/tree/main/packages/client/src/__tests__/integration/happy/minimal) and adjust it to your needs.
+If you want to create a new one, we recommend to copy over the [minimal test](https://github.com/prisma/prisma/tree/v7/packages/client/src/__tests__/integration/happy/minimal) and adjust it to your needs.
 It will give you an in-memory Prisma Client instance to use in the test. It utilizes the `getTestClient`) helper method.
 
-Sometimes you need an actual generated Client, that has been generated to the filesystem. In that case use `generateTestClient`. An example that uses this helper is the [blog example](https://github.com/prisma/prisma/tree/main/packages/client/src/__tests__/integration/happy/blog)
+Sometimes you need an actual generated Client, that has been generated to the filesystem. In that case use `generateTestClient`. An example that uses this helper is the [blog example](https://github.com/prisma/prisma/tree/v7/packages/client/src/__tests__/integration/happy/blog)
 
 ##### General Client integration tests (`./integration-tests`)
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 <div align="center">
   <h1>Prisma</h1>
   <a href="https://www.npmjs.com/package/prisma"><img src="https://img.shields.io/npm/v/prisma.svg?style=flat" /></a>
-  <a href="https://github.com/prisma/prisma/blob/main/CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" /></a>
-  <a href="https://github.com/prisma/prisma/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202-blue" /></a>
+  <a href="https://github.com/prisma/prisma/blob/v7/CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" /></a>
+  <a href="https://github.com/prisma/prisma/blob/v7/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202-blue" /></a>
   <a href="https://pris.ly/discord"><img alt="Discord" src="https://img.shields.io/discord/937751382725886062?label=Discord"></a>
   <br />
   <br />
@@ -26,6 +26,8 @@
   <br />
   <hr />
 </div>
+
+> **This is the Prisma ORM 7.x line, maintained on the `v7` branch.** The default branch of this repository now hosts [Prisma Next](https://github.com/prisma/prisma/tree/main), a TypeScript rewrite of Prisma ORM. The `prisma` and `@prisma/*` packages on npm are published from here.
 
 ## What is Prisma?
 
@@ -365,11 +367,11 @@ If the feature on the roadmap is linked to a GitHub issue, please make sure to l
 
 ## Contributing
 
-Refer to our [contribution guidelines](https://github.com/prisma/prisma/blob/main/CONTRIBUTING.md) and [Code of Conduct for contributors](https://github.com/prisma/prisma/blob/main/CODE_OF_CONDUCT.md).
+Refer to our [contribution guidelines](https://github.com/prisma/prisma/blob/v7/CONTRIBUTING.md) and [Code of Conduct for contributors](https://github.com/prisma/prisma/blob/v7/CODE_OF_CONDUCT.md).
 
 ## Tests Status
 
 - Prisma Tests Status:
-  [![Prisma Tests Status](https://github.com/prisma/prisma/workflows/CI/badge.svg)](https://github.com/prisma/prisma/actions/workflows/test.yml?query=branch%3Amain)
+  [![Prisma Tests Status](https://github.com/prisma/prisma/actions/workflows/test.yml/badge.svg?branch=v7)](https://github.com/prisma/prisma/actions/workflows/test.yml?query=branch%3Av7)
 
 Scheduled CI is currently disabled across the ORM repos; test workflows run on push, pull request, and manual `workflow_dispatch`. See the [Actions tab](https://github.com/prisma/prisma/actions) for recent runs.

--- a/TESTING.md
+++ b/TESTING.md
@@ -372,8 +372,8 @@ on CI.
 
 By creating a Pull Request the following pipelines will be triggered
 
-- [GitHub Action `CI`](https://github.com/prisma/prisma/blob/main/.github/workflows/test.yml)
-- [GitHub Action `Benchmark`](https://github.com/prisma/prisma/blob/main/.github/workflows/benchmark.yml)
+- [GitHub Action `CI`](https://github.com/prisma/prisma/blob/v7/.github/workflows/test.yml)
+- [GitHub Action `Benchmark`](https://github.com/prisma/prisma/blob/v7/.github/workflows/benchmark.yml)
 
 `CI` will need to be successful before merging ("flaky" tests might show up and might be ignored).
 
@@ -381,7 +381,7 @@ By default, some tests are tested only during daily builds. If you need to run a
 
 ### Publishing all the packages to npm on the `integration` tag
 
-If a branch name starts with `integration/` like `integration/fix-all-the-things` the [GitHub Actions - npm - release to dev/integration](https://github.com/prisma/prisma/blob/main/.github/workflows/release-ci.yml) pipeline will be triggered.
+If a branch name starts with `integration/` like `integration/fix-all-the-things` the [GitHub Actions - v7 - npm - release](https://github.com/prisma/prisma/blob/v7/.github/workflows/v7-release.yml) pipeline will be triggered.
 This workflow will directly publish (without running tests) the packages to npm on the `integration` tag with a version like `5.3.0-integration-fix-all-the-things.1` (where `5.3.0-` is the current dev version prefix, `integration-` is statically added, `fix-all-the-things` is from the branch name and `.1` indicates the first version published from this branch)
 
 To make a Pull Request which will release a version to the `integration` tag automatically, the name of the branch of the PR would need to start with `integration/`.
@@ -390,10 +390,10 @@ Alternatively, add `/integration` in the Pull Request description:
 - If this is added before opening the Pull Request, a release will happen automatically.
 - If this is added after the creation of the PR, the `Detect jobs to run` job from the `CI` workflow needs to be re-triggered to get a release.
 
-The [GitHub Actions - npm - release to dev/integration](https://github.com/prisma/prisma/blob/main/.github/workflows/release-ci.yml) workflow can also be manually triggered to run on any branch.
+The [GitHub Actions - v7 - npm - release](https://github.com/prisma/prisma/blob/v7/.github/workflows/v7-release.yml) workflow can also be manually triggered to run on any branch.
 Example:
 
-- Go to https://github.com/prisma/prisma/actions/workflows/release-ci.yml?query=branch%3Ajoel%2Fdotenv
+- Go to https://github.com/prisma/prisma/actions/workflows/v7-release.yml?query=branch%3Ajoel%2Fdotenv
 - Click "Run workflow"
 - Change "Use workflow from" to match the branch you want to release, here `joel/dotenv`
 - Check the box for "Check to force an integration release for any given branch name"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 name: prisma-prisma
 
 # For connection urls to the following instances, see
-# https://github.com/prisma/prisma/blob/main/TESTING.md#environment-variables
+# https://github.com/prisma/prisma/blob/v7/TESTING.md#environment-variables
 services:
   postgres:
     build:


### PR DESCRIPTION
## Summary

Companion to prisma/prisma#29826, which adds the reciprocal signpost on the default branch.

**A banner at the top of the README** says which line this branch carries, and where the default branch went. Readers arrive here from links and search results as often as from the repository root, so "you are on the 7.x line" is worth saying in place.

**Twelve self-links move from `/main/` to `/v7/`.** Written as `blob/main` and `tree/main`, they now resolve into the Prisma Next tree on the default branch, so the contribution guide, the code of conduct, the workflow files and the integration-test examples all lead somewhere unrelated to this code. All twelve are `github.com/prisma/prisma` self-links; links to other repositories are untouched.

**The tests badge** used the legacy `workflows/CI/badge.svg` form, which reports the *default* branch's status for a workflow named `CI` — and there are no such runs there, since `test.yml` triggers on this branch. It now names `test.yml` explicitly and filters on `v7`:

```diff
-[![Prisma Tests Status](https://github.com/prisma/prisma/workflows/CI/badge.svg)](…?query=branch%3Amain)
+[![Prisma Tests Status](…/actions/workflows/test.yml/badge.svg?branch=v7)](…?query=branch%3Av7)
```

**`TESTING.md` linked `release-ci.yml`**, which has not existed for some time and is now `v7-release.yml` following prisma/prisma#29823. The link text follows the workflow's current display name.

## A note on CI cost

Three of the four files are root-level `*.md` and so match `test.yml`'s `paths-ignore`. `docker/docker-compose.yml` does not, and its change is a single comment line — so this documentation-only PR will run the full test matrix. Worth knowing rather than being surprised by; I kept the fix rather than leaving one stale link behind for tidiness' sake.

## Testing performed

- Confirmed `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` exist on this branch, so the repointed links resolve.
- Swept all four files afterwards for surviving `/main/` self-links, `release-ci.yml` references and `branch%3Amain` queries: the only match is the banner's own deliberate link to the default branch.
- Documentation is not exercised by CI; the links are the thing to spot-check on the rendered page.

## Checklist

- [x] All commits are signed off per the DCO.
- [x] The change is scoped to one logical concern.
