### PR TITLE
ci: enable CodeRabbit auto-reviews on the v7 branch

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: 'en-US'
+early_access: false
+reviews:
+  # The profile the organisation UI applies to this branch. It is set
+  # explicitly because the presence of a repository config would otherwise
+  # take the schema default of "chill" and quietly relax reviews here.
+  profile: 'assertive'
+  path_filters:
+    - '!projects/**'
+  auto_review:
+    # CodeRabbit reviews only the default branch unless a base branch is named
+    # here. The default branch carries the same entry: which copy governs the
+    # gate for a pull request based on v7 is not settled by the documentation,
+    # and a setting that silently does nothing is the failure mode worth
+    # avoiding.
+    base_branches:
+      - 'v7'


### PR DESCRIPTION
## Summary

Pull requests against this branch come back with:

> **Review skipped** — Auto reviews are disabled on base/target branches other than the default branch.

CodeRabbit reviews only the default branch unless a base branch is named in `reviews.auto_review.base_branches`, which defaults to `[]`. This branch has no `.coderabbit.yml` at all, so it adds one naming `v7`.

## Why this lands in two places

prisma/prisma#29829 adds the same entry to the copy on `main`. Belt and braces, deliberately, because which copy governs the gate is genuinely unclear:

- The [documentation](https://docs.coderabbit.ai/guides/configure-coderabbit) says *"The configuration present in the **feature branch** under review will be automatically detected and used by CodeRabbit for that review."*
- **This pull request falsifies that as stated.** Its own feature branch carries the file below, and CodeRabbit skipped it anyway, reporting `Configuration used: Organization UI`.

The observed behaviour is equally consistent with the file being read from the **base** branch — `v7`, which has no file yet, hence the fallback to organisation settings — and with the gate being evaluated from a repository-level configuration before any branch file is consulted. CodeRabbit's `Configuration used` line does separate one thing cleanly: PRs based on `main` report `Path: .coderabbit.yml` while PRs based on `v7` report `Organization UI`, so `main`'s copy is certainly not what is consulted here today.

Rather than pick a model and risk a change that merges cleanly and does nothing, the entry goes in both places. It is a handful of lines, and harmless wherever it proves redundant.

If both file copies turn out to be ignored, the configuration demonstrably in force for these pull requests is **Organization UI**, and setting the base branch there is the lever that must work — an org settings change rather than anything a PR can carry.

## The profile is pinned, not defaulted

`reviews.profile` is set to `assertive` explicitly. Reviews on this branch run on the organisation UI's assertive profile today, and merely introducing a repository config would otherwise take the schema default of `chill` and relax them as a silent side effect of enabling auto-review. The maintenance line keeps the stricter profile; the default branch, which sets no profile, keeps `chill`.

## Testing performed

- Confirmed `reviews.auto_review.base_branches` against the published schema: *"Base branches (other than the default branch) to review. Accepts regex patterns."*
- Confirmed `chill` is the schema default for `reviews.profile`, which is what made pinning it necessary rather than cosmetic.
- Confirmed the file parses and resolves to the intended values.
- Confirmed `projects/` exists on this branch and holds transient workspaces, as on `main`, so mirroring that path filter is meaningful rather than copied blindly.

This cannot be verified before merge, and this PR being skipped is itself the evidence above. The check is the first pull request opened against this branch afterwards — both that it is reviewed at all, and that the review runs assertive.

Note also that `.coderabbit.yml` is not in `test.yml`'s `paths-ignore`, so this configuration-only change runs the full test matrix. That list is duplicated across five workflow files with a comment requiring them to be kept in step, so I left it alone rather than widen this PR.

## Checklist

- [x] All commits are signed off per the DCO.
- [x] The change is scoped to one logical concern.
