### PR TITLE
ci: review pull requests based on v7 as well as the default branch

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -4,3 +4,10 @@ early_access: false
 reviews:
   path_filters:
     - "!projects/**"
+  auto_review:
+    # CodeRabbit reviews only the default branch unless a base branch is named
+    # here. The v7 branch carries the same entry: which copy governs the gate
+    # for a pull request based on v7 is not settled by the documentation, and a
+    # setting that silently does nothing is the failure mode worth avoiding.
+    base_branches:
+      - "v7"


### PR DESCRIPTION
## Linked issue

n/a — follows from the `v7` / `main` branch swap.

## Summary

Pull requests against `v7` come back with:

> **Review skipped** — Auto reviews are disabled on base/target branches other than the default branch.

CodeRabbit reviews only the default branch unless a base branch is named in `reviews.auto_review.base_branches`, which defaults to `[]`. This names `v7`.

## Why this lands in two places

prisma/prisma#29828 adds the same entry on `v7`. Belt and braces, deliberately, because which copy governs the gate is genuinely unclear:

- The [documentation](https://docs.coderabbit.ai/guides/configure-coderabbit) says *"The configuration present in the **feature branch** under review will be automatically detected and used by CodeRabbit for that review."*
- But prisma/prisma#29828's own feature branch carries `.coderabbit.yml` with `base_branches: ["v7"]`, and CodeRabbit skipped it anyway, reporting `Configuration used: Organization UI`.

So the documented rule does not describe what actually happened, and the observed behaviour is equally consistent with the config being read from the **base** branch (`v7`, which has no file yet, hence the fallback to organisation settings) and with the gate being evaluated from a repository-level configuration before any branch file is consulted.

Rather than pick one and risk a change that merges cleanly and does nothing, the entry goes in both. It is one line, and harmless wherever it turns out to be redundant.

## If neither takes effect

The configuration demonstrably in force for `v7`-based pull requests today is **Organization UI**. If both file copies turn out to be ignored, setting the same base branch there is the lever that must work, since that is the configuration CodeRabbit reports itself as using. That is an org settings change rather than anything a PR can carry.

## Testing performed

- Confirmed `reviews.auto_review.base_branches` against the published schema: *"Base branches (other than the default branch) to review. Accepts regex patterns."*
- Confirmed the file parses and resolves to the intended values, with the existing `path_filters` intact.
- Compared CodeRabbit's own `Configuration used` line across PRs based on `main` (`Path: .coderabbit.yml`) and on `v7` (`Organization UI`), which is what established that the file on `main` is not consulted for `v7`-based PRs.

This cannot be verified before merge — a configuration change takes effect only once it is on the branch CodeRabbit reads. The check is the first pull request opened against `v7` afterwards; if it is still skipped, the organisation UI is the remaining lever.

## Skill update

n/a — CI configuration only.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco).
- [x] The change is scoped to one logical concern.
- [ ] Tests are updated — n/a, configuration only.
- [ ] PR title in `TML-NNNN: <sentence-case title>` form — no Linear ticket exists for this change; happy to retitle if one should be raised.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review configuration to include the `v7` base branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->