### PR TITLE
tml-2913: native scalar-list query & update operations

### DIFF
--- a/packages/1-framework/1-core/operations/src/index.ts
+++ b/packages/1-framework/1-core/operations/src/index.ts
@@ -10,8 +10,14 @@ export interface ReturnSpec {
 }
 
 export type SelfSpec =
-  | { readonly codecId: string; readonly traits?: never }
-  | { readonly traits: readonly string[]; readonly codecId?: never };
+  | { readonly codecId: string; readonly traits?: never; readonly many?: never }
+  | { readonly traits: readonly string[]; readonly codecId?: never; readonly many?: never }
+  | {
+      readonly many: true;
+      readonly elementTraits?: readonly string[];
+      readonly codecId?: never;
+      readonly traits?: never;
+    };
 
 export interface OperationEntry {
   readonly self?: SelfSpec;
@@ -42,10 +48,12 @@ export function createOperationRegistry<
       if (descriptor.self) {
         const hasCodecId = descriptor.self.codecId !== undefined;
         const hasTraits = descriptor.self.traits !== undefined && descriptor.self.traits.length > 0;
-        if (!hasCodecId && !hasTraits) {
+        const hasMany = descriptor.self.many === true;
+        const targetCount = Number(hasCodecId) + Number(hasTraits) + Number(hasMany);
+        if (targetCount === 0) {
           throw new Error(`Operation "${name}" self has neither codecId nor traits`);
         }
-        if (hasCodecId && hasTraits) {
+        if (targetCount > 1) {
           throw new Error(`Operation "${name}" self has both codecId and traits`);
         }
       }

--- a/packages/1-framework/1-core/operations/test/operations-registry.test.ts
+++ b/packages/1-framework/1-core/operations/test/operations-registry.test.ts
@@ -96,6 +96,32 @@ describe('OperationRegistry', () => {
     ).not.toThrow();
   });
 
+  it('accepts a list (many) self', () => {
+    const registry = createOperationRegistry();
+
+    expect(() => registry.register('has', descriptor({ self: { many: true } }))).not.toThrow();
+  });
+
+  it('accepts a list (many) self with elementTraits', () => {
+    const registry = createOperationRegistry();
+
+    expect(() =>
+      registry.register('has', descriptor({ self: { many: true, elementTraits: ['equality'] } })),
+    ).not.toThrow();
+  });
+
+  it('throws when self combines many with codecId', () => {
+    const registry = createOperationRegistry();
+
+    expect(() =>
+      registry.register('bad', {
+        // @ts-expect-error — SelfSpec disallows many alongside codecId
+        self: { many: true, codecId: 'pg/text@1' },
+        impl: noopImpl,
+      }),
+    ).toThrow('Operation "bad" self has both codecId and traits');
+  });
+
   it('accepts self-less operation', () => {
     const registry = createOperationRegistry();
 

--- a/packages/2-sql/3-tooling/emitter/src/index.ts
+++ b/packages/2-sql/3-tooling/emitter/src/index.ts
@@ -587,8 +587,9 @@ function generateTableLiteralType(table: StorageTable): string {
         ? `; readonly typeParams: ${serializeTypeParamsLiteral(col.typeParams)}`
         : '';
     const typeRefSpec = col.typeRef ? `; readonly typeRef: ${serializeValue(col.typeRef)}` : '';
+    const manySpec = col.many === true ? '; readonly many: true' : '';
     columns.push(
-      `readonly ${colName}: { readonly nativeType: ${nativeType}; readonly codecId: ${codecId}; readonly nullable: ${nullable}${defaultSpec}${typeParamsSpec}${typeRefSpec} }`,
+      `readonly ${colName}: { readonly nativeType: ${nativeType}; readonly codecId: ${codecId}; readonly nullable: ${nullable}${manySpec}${defaultSpec}${typeParamsSpec}${typeRefSpec} }`,
     );
   }
 

--- a/packages/2-sql/3-tooling/emitter/test/emitter-hook.storage-column-types.test.ts
+++ b/packages/2-sql/3-tooling/emitter/test/emitter-hook.storage-column-types.test.ts
@@ -919,4 +919,37 @@ describe('StorageColumnTypes', () => {
       "readonly labels: ReadonlyArray<CodecTypes['pg/text@1']['input']> | null",
     );
   });
+
+  it('projects many: true onto the storage table column literal for a native many[] column', () => {
+    const contract = createContract({
+      models: {
+        Post: {
+          storage: { table: 'post', fields: { tags: { column: 'tags' } } },
+          fields: {
+            tags: { nullable: false, many: true, type: { kind: 'scalar', codecId: 'pg/text@1' } },
+          },
+          relations: {},
+        },
+      },
+      storage: {
+        tables: {
+          post: {
+            columns: {
+              tags: { nativeType: 'text', codecId: 'pg/text@1', nullable: false, many: true },
+            },
+            primaryKey: { columns: ['tags'] },
+            uniques: [],
+            indexes: [],
+            foreignKeys: [],
+          },
+        },
+      },
+    });
+
+    const dts = generateContractDts(contract, sqlEmission, [], testHashes);
+
+    expect(dts).toContain(
+      "readonly tags: { readonly nativeType: 'text'; readonly codecId: 'pg/text@1'; readonly nullable: false; readonly many: true }",
+    );
+  });
 });

--- a/packages/2-sql/4-lanes/relational-core/src/expression.ts
+++ b/packages/2-sql/4-lanes/relational-core/src/expression.ts
@@ -33,7 +33,7 @@ export type Expression<T extends ScopeField> = QueryOperationReturn & {
   buildAst(): AstExpression;
 };
 
-type CodecIdsWithTrait<
+export type CodecIdsWithTrait<
   CT extends Record<string, { readonly input: unknown }>,
   RequiredTraits extends readonly string[],
 > = {

--- a/packages/2-sql/4-lanes/sql-builder/src/expression.ts
+++ b/packages/2-sql/4-lanes/sql-builder/src/expression.ts
@@ -1,13 +1,37 @@
 import type { QueryOperationTypesBase } from '@prisma-next/sql-contract/types';
 import type {
   CodecExpression,
+  CodecIdsWithTrait,
+  CodecValue,
   Expression,
   RawSqlTag,
+  ScalarListExpression,
   TraitExpression,
 } from '@prisma-next/sql-relational-core/expression';
 import type { Expand, QueryContext, Scope, ScopeField, ScopeTable, Subquery } from './scope';
 
 export type { CodecExpression, Expression, RawSqlTag, TraitExpression };
+
+/**
+ * List-operand call signature for a comparison builtin. Applies when the
+ * receiver is a whole-list expression (`ScalarListExpression`, `many: true`)
+ * whose element codec carries every trait in `RequiredTraits` — `['equality']`
+ * for `eq`/`ne`, `['order']` for `gt`/`gte`/`lt`/`lte`. The value side accepts a
+ * matching list expression or a literal `readonly ElementValue[]`, and the whole
+ * comparison lowers to the same boolean expression the scalar path returns.
+ *
+ * Kept disjoint from the scalar signature by the `many` discriminant: a
+ * `ScalarListExpression` (`many: true`) never satisfies the scalar
+ * `CodecExpression` slot (`many?: never`) and vice-versa, so scalar-call
+ * inference is untouched.
+ */
+type ListComparison<
+  CT extends Record<string, { readonly input: unknown }>,
+  RequiredTraits extends readonly string[],
+> = <CodecId extends CodecIdsWithTrait<CT, RequiredTraits>>(
+  a: ScalarListExpression<CodecId, boolean>,
+  b: ScalarListExpression<CodecId, boolean> | readonly CodecValue<CodecId, false, CT>[],
+) => Expression<BooleanCodecType>;
 
 export type BooleanCodecType = { codecId: 'pg/bool@1'; nullable: boolean };
 
@@ -61,30 +85,36 @@ type DeriveExtFunctions<OT extends QueryOperationTypesBase> = {
 };
 
 export type BuiltinFunctions<CT extends Record<string, { readonly input: unknown }>> = {
-  eq: <CodecId extends string>(
-    a: CodecExpression<CodecId, boolean, CT> | null,
-    b: CodecExpression<CodecId, boolean, CT> | null,
-  ) => Expression<BooleanCodecType>;
-  ne: <CodecId extends string, N extends boolean>(
-    a: CodecExpression<CodecId, N, CT> | null,
-    b: CodecExpression<CodecId, N, CT> | null,
-  ) => Expression<BooleanCodecType>;
-  gt: <CodecId extends string, N extends boolean>(
-    a: CodecExpression<CodecId, N, CT>,
-    b: CodecExpression<CodecId, N, CT>,
-  ) => Expression<BooleanCodecType>;
-  gte: <CodecId extends string, N extends boolean>(
-    a: CodecExpression<CodecId, N, CT>,
-    b: CodecExpression<CodecId, N, CT>,
-  ) => Expression<BooleanCodecType>;
-  lt: <CodecId extends string, N extends boolean>(
-    a: CodecExpression<CodecId, N, CT>,
-    b: CodecExpression<CodecId, N, CT>,
-  ) => Expression<BooleanCodecType>;
-  lte: <CodecId extends string, N extends boolean>(
-    a: CodecExpression<CodecId, N, CT>,
-    b: CodecExpression<CodecId, N, CT>,
-  ) => Expression<BooleanCodecType>;
+  eq: ListComparison<CT, ['equality']> &
+    (<CodecId extends string>(
+      a: CodecExpression<CodecId, boolean, CT> | null,
+      b: CodecExpression<CodecId, boolean, CT> | null,
+    ) => Expression<BooleanCodecType>);
+  ne: ListComparison<CT, ['equality']> &
+    (<CodecId extends string, N extends boolean>(
+      a: CodecExpression<CodecId, N, CT> | null,
+      b: CodecExpression<CodecId, N, CT> | null,
+    ) => Expression<BooleanCodecType>);
+  gt: ListComparison<CT, ['order']> &
+    (<CodecId extends string, N extends boolean>(
+      a: CodecExpression<CodecId, N, CT>,
+      b: CodecExpression<CodecId, N, CT>,
+    ) => Expression<BooleanCodecType>);
+  gte: ListComparison<CT, ['order']> &
+    (<CodecId extends string, N extends boolean>(
+      a: CodecExpression<CodecId, N, CT>,
+      b: CodecExpression<CodecId, N, CT>,
+    ) => Expression<BooleanCodecType>);
+  lt: ListComparison<CT, ['order']> &
+    (<CodecId extends string, N extends boolean>(
+      a: CodecExpression<CodecId, N, CT>,
+      b: CodecExpression<CodecId, N, CT>,
+    ) => Expression<BooleanCodecType>);
+  lte: ListComparison<CT, ['order']> &
+    (<CodecId extends string, N extends boolean>(
+      a: CodecExpression<CodecId, N, CT>,
+      b: CodecExpression<CodecId, N, CT>,
+    ) => Expression<BooleanCodecType>);
   and: (...ands: CodecExpression<'pg/bool@1', boolean, CT>[]) => Expression<BooleanCodecType>;
   or: (...ors: CodecExpression<'pg/bool@1', boolean, CT>[]) => Expression<BooleanCodecType>;
 

--- a/packages/2-sql/4-lanes/sql-builder/src/expression.ts
+++ b/packages/2-sql/4-lanes/sql-builder/src/expression.ts
@@ -1,37 +1,13 @@
 import type { QueryOperationTypesBase } from '@prisma-next/sql-contract/types';
 import type {
   CodecExpression,
-  CodecIdsWithTrait,
-  CodecValue,
   Expression,
   RawSqlTag,
-  ScalarListExpression,
   TraitExpression,
 } from '@prisma-next/sql-relational-core/expression';
 import type { Expand, QueryContext, Scope, ScopeField, ScopeTable, Subquery } from './scope';
 
 export type { CodecExpression, Expression, RawSqlTag, TraitExpression };
-
-/**
- * List-operand call signature for a comparison builtin. Applies when the
- * receiver is a whole-list expression (`ScalarListExpression`, `many: true`)
- * whose element codec carries every trait in `RequiredTraits` — `['equality']`
- * for `eq`/`ne`, `['order']` for `gt`/`gte`/`lt`/`lte`. The value side accepts a
- * matching list expression or a literal `readonly ElementValue[]`, and the whole
- * comparison lowers to the same boolean expression the scalar path returns.
- *
- * Kept disjoint from the scalar signature by the `many` discriminant: a
- * `ScalarListExpression` (`many: true`) never satisfies the scalar
- * `CodecExpression` slot (`many?: never`) and vice-versa, so scalar-call
- * inference is untouched.
- */
-type ListComparison<
-  CT extends Record<string, { readonly input: unknown }>,
-  RequiredTraits extends readonly string[],
-> = <CodecId extends CodecIdsWithTrait<CT, RequiredTraits>>(
-  a: ScalarListExpression<CodecId, boolean>,
-  b: ScalarListExpression<CodecId, boolean> | readonly CodecValue<CodecId, false, CT>[],
-) => Expression<BooleanCodecType>;
 
 export type BooleanCodecType = { codecId: 'pg/bool@1'; nullable: boolean };
 
@@ -85,36 +61,30 @@ type DeriveExtFunctions<OT extends QueryOperationTypesBase> = {
 };
 
 export type BuiltinFunctions<CT extends Record<string, { readonly input: unknown }>> = {
-  eq: ListComparison<CT, ['equality']> &
-    (<CodecId extends string>(
-      a: CodecExpression<CodecId, boolean, CT> | null,
-      b: CodecExpression<CodecId, boolean, CT> | null,
-    ) => Expression<BooleanCodecType>);
-  ne: ListComparison<CT, ['equality']> &
-    (<CodecId extends string, N extends boolean>(
-      a: CodecExpression<CodecId, N, CT> | null,
-      b: CodecExpression<CodecId, N, CT> | null,
-    ) => Expression<BooleanCodecType>);
-  gt: ListComparison<CT, ['order']> &
-    (<CodecId extends string, N extends boolean>(
-      a: CodecExpression<CodecId, N, CT>,
-      b: CodecExpression<CodecId, N, CT>,
-    ) => Expression<BooleanCodecType>);
-  gte: ListComparison<CT, ['order']> &
-    (<CodecId extends string, N extends boolean>(
-      a: CodecExpression<CodecId, N, CT>,
-      b: CodecExpression<CodecId, N, CT>,
-    ) => Expression<BooleanCodecType>);
-  lt: ListComparison<CT, ['order']> &
-    (<CodecId extends string, N extends boolean>(
-      a: CodecExpression<CodecId, N, CT>,
-      b: CodecExpression<CodecId, N, CT>,
-    ) => Expression<BooleanCodecType>);
-  lte: ListComparison<CT, ['order']> &
-    (<CodecId extends string, N extends boolean>(
-      a: CodecExpression<CodecId, N, CT>,
-      b: CodecExpression<CodecId, N, CT>,
-    ) => Expression<BooleanCodecType>);
+  eq: <CodecId extends string>(
+    a: CodecExpression<CodecId, boolean, CT> | null,
+    b: CodecExpression<CodecId, boolean, CT> | null,
+  ) => Expression<BooleanCodecType>;
+  ne: <CodecId extends string, N extends boolean>(
+    a: CodecExpression<CodecId, N, CT> | null,
+    b: CodecExpression<CodecId, N, CT> | null,
+  ) => Expression<BooleanCodecType>;
+  gt: <CodecId extends string, N extends boolean>(
+    a: CodecExpression<CodecId, N, CT>,
+    b: CodecExpression<CodecId, N, CT>,
+  ) => Expression<BooleanCodecType>;
+  gte: <CodecId extends string, N extends boolean>(
+    a: CodecExpression<CodecId, N, CT>,
+    b: CodecExpression<CodecId, N, CT>,
+  ) => Expression<BooleanCodecType>;
+  lt: <CodecId extends string, N extends boolean>(
+    a: CodecExpression<CodecId, N, CT>,
+    b: CodecExpression<CodecId, N, CT>,
+  ) => Expression<BooleanCodecType>;
+  lte: <CodecId extends string, N extends boolean>(
+    a: CodecExpression<CodecId, N, CT>,
+    b: CodecExpression<CodecId, N, CT>,
+  ) => Expression<BooleanCodecType>;
   and: (...ands: CodecExpression<'pg/bool@1', boolean, CT>[]) => Expression<BooleanCodecType>;
   or: (...ors: CodecExpression<'pg/bool@1', boolean, CT>[]) => Expression<BooleanCodecType>;
 

--- a/packages/2-sql/4-lanes/sql-builder/test/types/scalar-list-ops.types.test-d.ts
+++ b/packages/2-sql/4-lanes/sql-builder/test/types/scalar-list-ops.types.test-d.ts
@@ -18,13 +18,15 @@ import type {
   ScalarListExpression,
 } from '@prisma-next/sql-relational-core/expression';
 import { expectTypeOf, test } from 'vitest';
-import type { FieldProxy, Functions } from '../../src/expression';
-import type { QueryContext, Scope } from '../../src/scope';
+import type { BooleanCodecType, FieldProxy, Functions } from '../../src/expression';
+import type { Scope } from '../../src/scope';
+
+type CmpExpr = Expression<BooleanCodecType>;
 
 type CT = {
-  'pg/int4@1': { input: number; output: number; traits: readonly ['equality', 'order'] };
-  'pg/text@1': { input: string; output: string; traits: readonly ['equality', 'textual'] };
-  'pg/bool@1': { input: boolean; output: boolean; traits: readonly ['equality'] };
+  'pg/int4@1': { input: number; output: number; traits: 'equality' | 'order' };
+  'pg/text@1': { input: string; output: string; traits: 'equality' | 'order' | 'textual' };
+  'pg/bool@1': { input: boolean; output: boolean; traits: 'equality' };
 };
 
 type BoolExpr = Expression<{ codecId: 'pg/bool@1'; nullable: false }>;
@@ -40,17 +42,24 @@ type QueryOps = {
   };
 };
 
-// A scope shaped like a `Post` table: scalar `name`, list `tags String[]`.
+// A scope shaped like a `Post` table: scalar `name`, list `tags String[]`,
+// list `flags Boolean[]` (element codec lacks the `order` trait).
 type PostColumns = {
   name: { codecId: 'pg/text@1'; nullable: false };
+  id: { codecId: 'pg/int4@1'; nullable: false };
   tags: { codecId: 'pg/text@1'; nullable: false; many: true };
+  flags: { codecId: 'pg/bool@1'; nullable: false; many: true };
 };
 type PostScope = Scope & {
   topLevel: PostColumns;
   namespaces: { Post: PostColumns };
 };
 
-type QC = QueryContext & {
+// Structurally a `QueryContext`, but `codecTypes` is the concrete `CT` (no
+// `CodecTypesBase` index-signature intersection) so trait resolution
+// (`CodecIdsWithTrait`) sees the exact codec ids — matching how a real emitted
+// contract threads its concrete `CodecTypes`.
+type QC = {
   codecTypes: CT;
   capabilities: Record<string, Record<string, boolean>>;
   queryOperationTypes: QueryOps;
@@ -78,4 +87,41 @@ test('the list op rejects a scalar receiver and a wrong-typed element', () => {
   fns.has(f.name, 'hello');
   // @ts-expect-error -- element must be text, not a number
   fns.has(f.tags, 5);
+});
+
+test('equality builtins accept whole-list operands (literal array or list expression)', () => {
+  expectTypeOf(fns.eq(f.tags, ['a', 'b'])).toEqualTypeOf<CmpExpr>();
+  expectTypeOf(fns.eq(f.tags, f.tags)).toEqualTypeOf<CmpExpr>();
+  expectTypeOf(fns.ne(f.tags, ['a'])).toEqualTypeOf<CmpExpr>();
+  // a Boolean[] list is comparable by equality (bool carries the `equality` trait)
+  fns.eq(f.flags, [true]);
+});
+
+test('ordering builtins accept whole-list operands over an orderable element', () => {
+  expectTypeOf(fns.gt(f.tags, ['a'])).toEqualTypeOf<CmpExpr>();
+  expectTypeOf(fns.gte(f.tags, f.tags)).toEqualTypeOf<CmpExpr>();
+  expectTypeOf(fns.lt(f.tags, ['z'])).toEqualTypeOf<CmpExpr>();
+  expectTypeOf(fns.lte(f.tags, ['z'])).toEqualTypeOf<CmpExpr>();
+});
+
+test('comparison builtins reject a wrong-typed list element', () => {
+  // @ts-expect-error -- tags is a text list; the array elements must be strings
+  fns.eq(f.tags, [5]);
+  // @ts-expect-error -- tags is a text list; the array elements must be strings
+  fns.gt(f.tags, [5]);
+});
+
+test('ordering builtins reject a list whose element lacks the `order` trait', () => {
+  // @ts-expect-error -- flags is a Boolean[]; bool lacks the `order` trait
+  fns.gt(f.flags, [true]);
+  // @ts-expect-error -- flags is a Boolean[]; bool lacks the `order` trait
+  fns.lt(f.flags, f.flags);
+});
+
+test('scalar comparison calls are unchanged by the list overloads', () => {
+  expectTypeOf(fns.eq(f.id, 1)).toEqualTypeOf<CmpExpr>();
+  expectTypeOf(fns.gt(f.id, 1)).toEqualTypeOf<CmpExpr>();
+  expectTypeOf(fns.eq(f.name, 'x')).toEqualTypeOf<CmpExpr>();
+  // @ts-expect-error -- id is an int scalar; a string is not a valid operand
+  fns.eq(f.id, 'nope');
 });

--- a/packages/2-sql/4-lanes/sql-builder/test/types/scalar-list-ops.types.test-d.ts
+++ b/packages/2-sql/4-lanes/sql-builder/test/types/scalar-list-ops.types.test-d.ts
@@ -14,6 +14,8 @@
 
 import type {
   CodecExpression,
+  CodecIdsWithTrait,
+  CodecValue,
   Expression,
   ScalarListExpression,
 } from '@prisma-next/sql-relational-core/expression';
@@ -31,7 +33,17 @@ type CT = {
 
 type BoolExpr = Expression<{ codecId: 'pg/bool@1'; nullable: false }>;
 
-// Same shape as the real postgres `has` operation entry.
+// Same shape as the real postgres registry entries (`has` plus the six
+// list-comparison ops). sql-builder can't import the adapter layer, so the
+// list-comparison overloads reach `fns.eq`/`fns.gt`/… through
+// `DeriveExtFunctions<QueryOps>` here exactly as they do off the real registry.
+type ListCompare<RequiredTraits extends readonly string[]> = <
+  CodecId extends CodecIdsWithTrait<CT, RequiredTraits>,
+>(
+  self: ScalarListExpression<CodecId, false>,
+  other: ScalarListExpression<CodecId, false> | readonly CodecValue<CodecId, false, CT>[],
+) => BoolExpr;
+
 type QueryOps = {
   has: {
     self: { many: true };
@@ -40,6 +52,12 @@ type QueryOps = {
       elem: CodecExpression<CodecId, false, CT>,
     ) => BoolExpr;
   };
+  eq: { self: { many: true; elementTraits: ['equality'] }; impl: ListCompare<['equality']> };
+  ne: { self: { many: true; elementTraits: ['equality'] }; impl: ListCompare<['equality']> };
+  gt: { self: { many: true; elementTraits: ['order'] }; impl: ListCompare<['order']> };
+  lt: { self: { many: true; elementTraits: ['order'] }; impl: ListCompare<['order']> };
+  gte: { self: { many: true; elementTraits: ['order'] }; impl: ListCompare<['order']> };
+  lte: { self: { many: true; elementTraits: ['order'] }; impl: ListCompare<['order']> };
 };
 
 // A scope shaped like a `Post` table: scalar `name`, list `tags String[]`,
@@ -90,18 +108,20 @@ test('the list op rejects a scalar receiver and a wrong-typed element', () => {
 });
 
 test('equality builtins accept whole-list operands (literal array or list expression)', () => {
-  expectTypeOf(fns.eq(f.tags, ['a', 'b'])).toEqualTypeOf<CmpExpr>();
-  expectTypeOf(fns.eq(f.tags, f.tags)).toEqualTypeOf<CmpExpr>();
-  expectTypeOf(fns.ne(f.tags, ['a'])).toEqualTypeOf<CmpExpr>();
+  // a whole-list comparison is always non-null (`BoolExpr`), unlike the scalar
+  // builtin whose declared return carries `nullable: boolean` (`CmpExpr`).
+  expectTypeOf(fns.eq(f.tags, ['a', 'b'])).toEqualTypeOf<BoolExpr>();
+  expectTypeOf(fns.eq(f.tags, f.tags)).toEqualTypeOf<BoolExpr>();
+  expectTypeOf(fns.ne(f.tags, ['a'])).toEqualTypeOf<BoolExpr>();
   // a Boolean[] list is comparable by equality (bool carries the `equality` trait)
   fns.eq(f.flags, [true]);
 });
 
 test('ordering builtins accept whole-list operands over an orderable element', () => {
-  expectTypeOf(fns.gt(f.tags, ['a'])).toEqualTypeOf<CmpExpr>();
-  expectTypeOf(fns.gte(f.tags, f.tags)).toEqualTypeOf<CmpExpr>();
-  expectTypeOf(fns.lt(f.tags, ['z'])).toEqualTypeOf<CmpExpr>();
-  expectTypeOf(fns.lte(f.tags, ['z'])).toEqualTypeOf<CmpExpr>();
+  expectTypeOf(fns.gt(f.tags, ['a'])).toEqualTypeOf<BoolExpr>();
+  expectTypeOf(fns.gte(f.tags, f.tags)).toEqualTypeOf<BoolExpr>();
+  expectTypeOf(fns.lt(f.tags, ['z'])).toEqualTypeOf<BoolExpr>();
+  expectTypeOf(fns.lte(f.tags, ['z'])).toEqualTypeOf<BoolExpr>();
 });
 
 test('comparison builtins reject a wrong-typed list element', () => {

--- a/packages/3-targets/6-adapters/postgres/src/core/descriptor-meta.ts
+++ b/packages/3-targets/6-adapters/postgres/src/core/descriptor-meta.ts
@@ -4,6 +4,7 @@ import { LiteralExpr } from '@prisma-next/sql-relational-core/ast';
 import {
   buildOperation,
   type CodecExpression,
+  type CodecIdsWithTrait,
   type CodecValue,
   codecOf,
   type Expression,
@@ -238,6 +239,90 @@ export function postgresQueryOperations<CT extends CodecTypesBase>(): QueryOpera
           args: [toExpr(self), arrayOperandToExpr(other)],
           returns: { codecId: PG_BOOL_CODEC_ID, nullable: false },
           lowering: { targetFamily: 'sql', strategy: 'infix', template: '{{self}} && {{arg0}}' },
+        });
+      },
+    },
+    eq: {
+      self: { many: true, elementTraits: ['equality'] },
+      impl: <CodecId extends CodecIdsWithTrait<CT, ['equality']>>(
+        self: ScalarListExpression<CodecId, false>,
+        other: ScalarListExpression<CodecId, false> | readonly CodecValue<CodecId, false, CT>[],
+      ): Expression<{ codecId: 'pg/bool@1'; nullable: false }> => {
+        return buildOperation({
+          method: 'eq',
+          args: [toExpr(self), arrayOperandToExpr(other)],
+          returns: { codecId: PG_BOOL_CODEC_ID, nullable: false },
+          lowering: { targetFamily: 'sql', strategy: 'infix', template: '{{self}} = {{arg0}}' },
+        });
+      },
+    },
+    ne: {
+      self: { many: true, elementTraits: ['equality'] },
+      impl: <CodecId extends CodecIdsWithTrait<CT, ['equality']>>(
+        self: ScalarListExpression<CodecId, false>,
+        other: ScalarListExpression<CodecId, false> | readonly CodecValue<CodecId, false, CT>[],
+      ): Expression<{ codecId: 'pg/bool@1'; nullable: false }> => {
+        return buildOperation({
+          method: 'ne',
+          args: [toExpr(self), arrayOperandToExpr(other)],
+          returns: { codecId: PG_BOOL_CODEC_ID, nullable: false },
+          lowering: { targetFamily: 'sql', strategy: 'infix', template: '{{self}} <> {{arg0}}' },
+        });
+      },
+    },
+    gt: {
+      self: { many: true, elementTraits: ['order'] },
+      impl: <CodecId extends CodecIdsWithTrait<CT, ['order']>>(
+        self: ScalarListExpression<CodecId, false>,
+        other: ScalarListExpression<CodecId, false> | readonly CodecValue<CodecId, false, CT>[],
+      ): Expression<{ codecId: 'pg/bool@1'; nullable: false }> => {
+        return buildOperation({
+          method: 'gt',
+          args: [toExpr(self), arrayOperandToExpr(other)],
+          returns: { codecId: PG_BOOL_CODEC_ID, nullable: false },
+          lowering: { targetFamily: 'sql', strategy: 'infix', template: '{{self}} > {{arg0}}' },
+        });
+      },
+    },
+    lt: {
+      self: { many: true, elementTraits: ['order'] },
+      impl: <CodecId extends CodecIdsWithTrait<CT, ['order']>>(
+        self: ScalarListExpression<CodecId, false>,
+        other: ScalarListExpression<CodecId, false> | readonly CodecValue<CodecId, false, CT>[],
+      ): Expression<{ codecId: 'pg/bool@1'; nullable: false }> => {
+        return buildOperation({
+          method: 'lt',
+          args: [toExpr(self), arrayOperandToExpr(other)],
+          returns: { codecId: PG_BOOL_CODEC_ID, nullable: false },
+          lowering: { targetFamily: 'sql', strategy: 'infix', template: '{{self}} < {{arg0}}' },
+        });
+      },
+    },
+    gte: {
+      self: { many: true, elementTraits: ['order'] },
+      impl: <CodecId extends CodecIdsWithTrait<CT, ['order']>>(
+        self: ScalarListExpression<CodecId, false>,
+        other: ScalarListExpression<CodecId, false> | readonly CodecValue<CodecId, false, CT>[],
+      ): Expression<{ codecId: 'pg/bool@1'; nullable: false }> => {
+        return buildOperation({
+          method: 'gte',
+          args: [toExpr(self), arrayOperandToExpr(other)],
+          returns: { codecId: PG_BOOL_CODEC_ID, nullable: false },
+          lowering: { targetFamily: 'sql', strategy: 'infix', template: '{{self}} >= {{arg0}}' },
+        });
+      },
+    },
+    lte: {
+      self: { many: true, elementTraits: ['order'] },
+      impl: <CodecId extends CodecIdsWithTrait<CT, ['order']>>(
+        self: ScalarListExpression<CodecId, false>,
+        other: ScalarListExpression<CodecId, false> | readonly CodecValue<CodecId, false, CT>[],
+      ): Expression<{ codecId: 'pg/bool@1'; nullable: false }> => {
+        return buildOperation({
+          method: 'lte',
+          args: [toExpr(self), arrayOperandToExpr(other)],
+          returns: { codecId: PG_BOOL_CODEC_ID, nullable: false },
+          lowering: { targetFamily: 'sql', strategy: 'infix', template: '{{self}} <= {{arg0}}' },
         });
       },
     },

--- a/packages/3-targets/6-adapters/postgres/src/core/descriptor-meta.ts
+++ b/packages/3-targets/6-adapters/postgres/src/core/descriptor-meta.ts
@@ -190,6 +190,20 @@ export function postgresQueryOperations<CT extends CodecTypesBase>(): QueryOpera
         });
       },
     },
+    arrayContains: {
+      self: { many: true, elementTraits: ['equality'] },
+      impl: <CodecId extends keyof CT & string>(
+        self: ScalarListExpression<CodecId, false>,
+        other: readonly CodecValue<CodecId, false, CT>[] | ScalarListExpression<CodecId, false>,
+      ): Expression<{ codecId: 'pg/bool@1'; nullable: false }> => {
+        return buildOperation({
+          method: 'arrayContains',
+          args: [toExpr(self), arrayOperandToExpr(other)],
+          returns: { codecId: PG_BOOL_CODEC_ID, nullable: false },
+          lowering: { targetFamily: 'sql', strategy: 'infix', template: '{{self}} @> {{arg0}}' },
+        });
+      },
+    },
     containedBy: {
       self: { many: true, elementTraits: ['equality'] },
       impl: <CodecId extends keyof CT & string>(

--- a/packages/3-targets/6-adapters/postgres/src/core/descriptor-meta.ts
+++ b/packages/3-targets/6-adapters/postgres/src/core/descriptor-meta.ts
@@ -1,7 +1,10 @@
 import type { CodecControlHooks, ExpandNativeTypeInput } from '@prisma-next/family-sql/control';
+import type { AnyExpression } from '@prisma-next/sql-relational-core/ast';
+import { LiteralExpr } from '@prisma-next/sql-relational-core/ast';
 import {
   buildOperation,
   type CodecExpression,
+  type CodecValue,
   codecOf,
   type Expression,
   type ScalarListExpression,
@@ -40,6 +43,8 @@ import {
   SQL_VARCHAR_CODEC_ID,
 } from '@prisma-next/target-postgres/codec-ids';
 import { postgresCodecRegistry } from '@prisma-next/target-postgres/codecs';
+import { blindCast } from '@prisma-next/utils/casts';
+import { ifDefined } from '@prisma-next/utils/defined';
 import type { QueryOperationTypes } from '../types/operation-types';
 
 // ============================================================================ Helper functions for reducing boilerplate ============================================================================
@@ -135,6 +140,15 @@ const identityHooks: CodecControlHooks = { expandNativeType: ({ nativeType }) =>
 
 type CodecTypesBase = Record<string, { readonly input: unknown; readonly output: unknown }>;
 
+/**
+ * Lower a whole-array operand for the array filter ops. A raw JS array renders
+ * as a `ARRAY[...]` literal; a list expression (another list column) is lowered
+ * through its own AST.
+ */
+function arrayOperandToExpr(operand: unknown): AnyExpression {
+  return Array.isArray(operand) ? LiteralExpr.of(operand) : toExpr(operand);
+}
+
 export function postgresQueryOperations<CT extends CodecTypesBase>(): QueryOperationTypes<CT> {
   return {
     ilike: {
@@ -173,6 +187,79 @@ export function postgresQueryOperations<CT extends CodecTypesBase>(): QueryOpera
             strategy: 'infix',
             template: '{{arg0}} = ANY({{self}})',
           },
+        });
+      },
+    },
+    containedBy: {
+      self: { many: true, elementTraits: ['equality'] },
+      impl: <CodecId extends keyof CT & string>(
+        self: ScalarListExpression<CodecId, false>,
+        other: readonly CodecValue<CodecId, false, CT>[] | ScalarListExpression<CodecId, false>,
+      ): Expression<{ codecId: 'pg/bool@1'; nullable: false }> => {
+        return buildOperation({
+          method: 'containedBy',
+          args: [toExpr(self), arrayOperandToExpr(other)],
+          returns: { codecId: PG_BOOL_CODEC_ID, nullable: false },
+          lowering: { targetFamily: 'sql', strategy: 'infix', template: '{{self}} <@ {{arg0}}' },
+        });
+      },
+    },
+    overlaps: {
+      self: { many: true, elementTraits: ['equality'] },
+      impl: <CodecId extends keyof CT & string>(
+        self: ScalarListExpression<CodecId, false>,
+        other: readonly CodecValue<CodecId, false, CT>[] | ScalarListExpression<CodecId, false>,
+      ): Expression<{ codecId: 'pg/bool@1'; nullable: false }> => {
+        return buildOperation({
+          method: 'overlaps',
+          args: [toExpr(self), arrayOperandToExpr(other)],
+          returns: { codecId: PG_BOOL_CODEC_ID, nullable: false },
+          lowering: { targetFamily: 'sql', strategy: 'infix', template: '{{self}} && {{arg0}}' },
+        });
+      },
+    },
+    length: {
+      self: { many: true },
+      impl: <CodecId extends keyof CT & string>(
+        self: ScalarListExpression<CodecId, false>,
+      ): Expression<{ codecId: 'pg/int4@1'; nullable: false }> => {
+        return buildOperation({
+          method: 'length',
+          args: [toExpr(self)],
+          returns: { codecId: PG_INT4_CODEC_ID, nullable: false },
+          lowering: {
+            targetFamily: 'sql',
+            strategy: 'function',
+            template: 'cardinality({{self}})',
+          },
+        });
+      },
+    },
+    index: {
+      self: { many: true },
+      impl: <CodecId extends keyof CT & string>(
+        self: ScalarListExpression<CodecId, false>,
+        i: CodecExpression<'pg/int4@1', false, CT>,
+      ): Expression<{ codecId: CodecId; nullable: true }> => {
+        const listCodec = codecOf(self);
+        const elementCodec =
+          listCodec === undefined
+            ? undefined
+            : listCodec.typeParams === undefined
+              ? { codecId: listCodec.codecId }
+              : { codecId: listCodec.codecId, typeParams: listCodec.typeParams };
+        return buildOperation<{ codecId: CodecId; nullable: true }>({
+          method: 'index',
+          args: [toExpr(self), toExpr(i, { codecId: PG_INT4_CODEC_ID })],
+          returns: {
+            codecId: blindCast<
+              CodecId,
+              "the element codecId resolved from the list receiver's own codec is, by construction, this op's declared element CodecId; the runtime string can't be tied back to the generic"
+            >(listCodec?.codecId),
+            nullable: true,
+            ...ifDefined('codec', elementCodec),
+          },
+          lowering: { targetFamily: 'sql', strategy: 'infix', template: '{{self}}[{{arg0}}]' },
         });
       },
     },

--- a/packages/3-targets/6-adapters/postgres/src/core/descriptor-meta.ts
+++ b/packages/3-targets/6-adapters/postgres/src/core/descriptor-meta.ts
@@ -2,7 +2,9 @@ import type { CodecControlHooks, ExpandNativeTypeInput } from '@prisma-next/fami
 import {
   buildOperation,
   type CodecExpression,
+  codecOf,
   type Expression,
+  type ScalarListExpression,
   type TraitExpression,
   toExpr,
 } from '@prisma-next/sql-relational-core/expression';
@@ -146,6 +148,31 @@ export function postgresQueryOperations<CT extends CodecTypesBase>(): QueryOpera
           args: [toExpr(self), toExpr(pattern, { codecId: PG_TEXT_CODEC_ID })],
           returns: { codecId: PG_BOOL_CODEC_ID, nullable: false },
           lowering: { targetFamily: 'sql', strategy: 'infix', template: '{{self}} ILIKE {{arg0}}' },
+        });
+      },
+    },
+    has: {
+      self: { many: true, elementTraits: ['equality'] },
+      impl: <CodecId extends keyof CT & string>(
+        self: ScalarListExpression<CodecId, false>,
+        elem: CodecExpression<CodecId, false, CT>,
+      ): Expression<{ codecId: 'pg/bool@1'; nullable: false }> => {
+        const listCodec = codecOf(self);
+        const elementCodec =
+          listCodec === undefined
+            ? undefined
+            : listCodec.typeParams === undefined
+              ? { codecId: listCodec.codecId }
+              : { codecId: listCodec.codecId, typeParams: listCodec.typeParams };
+        return buildOperation({
+          method: 'has',
+          args: [toExpr(self), toExpr(elem, elementCodec)],
+          returns: { codecId: PG_BOOL_CODEC_ID, nullable: false },
+          lowering: {
+            targetFamily: 'sql',
+            strategy: 'infix',
+            template: '{{arg0}} = ANY({{self}})',
+          },
         });
       },
     },

--- a/packages/3-targets/6-adapters/postgres/src/core/descriptor-meta.ts
+++ b/packages/3-targets/6-adapters/postgres/src/core/descriptor-meta.ts
@@ -149,6 +149,15 @@ function arrayOperandToExpr(operand: unknown): AnyExpression {
   return Array.isArray(operand) ? LiteralExpr.of(operand) : toExpr(operand);
 }
 
+/** Element {@link CodecRef} for a list receiver, preserving type params when present. */
+function elementCodecOf(self: unknown) {
+  const listCodec = codecOf(self);
+  if (listCodec === undefined) return undefined;
+  return listCodec.typeParams === undefined
+    ? { codecId: listCodec.codecId }
+    : { codecId: listCodec.codecId, typeParams: listCodec.typeParams };
+}
+
 export function postgresQueryOperations<CT extends CodecTypesBase>(): QueryOperationTypes<CT> {
   return {
     ilike: {
@@ -274,6 +283,60 @@ export function postgresQueryOperations<CT extends CodecTypesBase>(): QueryOpera
             ...ifDefined('codec', elementCodec),
           },
           lowering: { targetFamily: 'sql', strategy: 'infix', template: '{{self}}[{{arg0}}]' },
+        });
+      },
+    },
+    arrayAppend: {
+      self: { many: true, elementTraits: ['equality'] },
+      impl: <CodecId extends keyof CT & string>(
+        self: ScalarListExpression<CodecId, false>,
+        elem: CodecExpression<CodecId, false, CT>,
+      ): Expression<{ codecId: CodecId; nullable: false; many: true }> => {
+        const elementCodec = elementCodecOf(self);
+        return buildOperation<{ codecId: CodecId; nullable: false; many: true }>({
+          method: 'arrayAppend',
+          args: [toExpr(self), toExpr(elem, elementCodec)],
+          returns: {
+            codecId: blindCast<
+              CodecId,
+              "the element codecId resolved from the list receiver's own codec is, by construction, this op's declared element CodecId; the runtime string can't be tied back to the generic"
+            >(codecOf(self)?.codecId),
+            nullable: false,
+            many: true,
+            ...ifDefined('codec', elementCodec),
+          },
+          lowering: {
+            targetFamily: 'sql',
+            strategy: 'function',
+            template: 'array_append({{self}}, {{arg0}})',
+          },
+        });
+      },
+    },
+    arrayRemove: {
+      self: { many: true, elementTraits: ['equality'] },
+      impl: <CodecId extends keyof CT & string>(
+        self: ScalarListExpression<CodecId, false>,
+        elem: CodecExpression<CodecId, false, CT>,
+      ): Expression<{ codecId: CodecId; nullable: false; many: true }> => {
+        const elementCodec = elementCodecOf(self);
+        return buildOperation<{ codecId: CodecId; nullable: false; many: true }>({
+          method: 'arrayRemove',
+          args: [toExpr(self), toExpr(elem, elementCodec)],
+          returns: {
+            codecId: blindCast<
+              CodecId,
+              "the element codecId resolved from the list receiver's own codec is, by construction, this op's declared element CodecId; the runtime string can't be tied back to the generic"
+            >(codecOf(self)?.codecId),
+            nullable: false,
+            many: true,
+            ...ifDefined('codec', elementCodec),
+          },
+          lowering: {
+            targetFamily: 'sql',
+            strategy: 'function',
+            template: 'array_remove({{self}}, {{arg0}})',
+          },
         });
       },
     },

--- a/packages/3-targets/6-adapters/postgres/src/types/operation-types.ts
+++ b/packages/3-targets/6-adapters/postgres/src/types/operation-types.ts
@@ -1,6 +1,7 @@
 import type { SqlQueryOperationTypes } from '@prisma-next/sql-contract/types';
 import type {
   CodecExpression,
+  CodecIdsWithTrait,
   CodecValue,
   Expression,
   ScalarListExpression,
@@ -45,6 +46,48 @@ export type QueryOperationTypes<CT extends CodecTypesBase> = SqlQueryOperationTy
       readonly impl: <CodecId extends keyof CT & string>(
         self: ScalarListExpression<CodecId, false>,
         other: readonly CodecValue<CodecId, false, CT>[] | ScalarListExpression<CodecId, false>,
+      ) => Expression<{ codecId: 'pg/bool@1'; nullable: false }>;
+    };
+    readonly eq: {
+      readonly self: { readonly many: true; readonly elementTraits: readonly ['equality'] };
+      readonly impl: <CodecId extends CodecIdsWithTrait<CT, ['equality']>>(
+        self: ScalarListExpression<CodecId, false>,
+        other: ScalarListExpression<CodecId, false> | readonly CodecValue<CodecId, false, CT>[],
+      ) => Expression<{ codecId: 'pg/bool@1'; nullable: false }>;
+    };
+    readonly ne: {
+      readonly self: { readonly many: true; readonly elementTraits: readonly ['equality'] };
+      readonly impl: <CodecId extends CodecIdsWithTrait<CT, ['equality']>>(
+        self: ScalarListExpression<CodecId, false>,
+        other: ScalarListExpression<CodecId, false> | readonly CodecValue<CodecId, false, CT>[],
+      ) => Expression<{ codecId: 'pg/bool@1'; nullable: false }>;
+    };
+    readonly gt: {
+      readonly self: { readonly many: true; readonly elementTraits: readonly ['order'] };
+      readonly impl: <CodecId extends CodecIdsWithTrait<CT, ['order']>>(
+        self: ScalarListExpression<CodecId, false>,
+        other: ScalarListExpression<CodecId, false> | readonly CodecValue<CodecId, false, CT>[],
+      ) => Expression<{ codecId: 'pg/bool@1'; nullable: false }>;
+    };
+    readonly lt: {
+      readonly self: { readonly many: true; readonly elementTraits: readonly ['order'] };
+      readonly impl: <CodecId extends CodecIdsWithTrait<CT, ['order']>>(
+        self: ScalarListExpression<CodecId, false>,
+        other: ScalarListExpression<CodecId, false> | readonly CodecValue<CodecId, false, CT>[],
+      ) => Expression<{ codecId: 'pg/bool@1'; nullable: false }>;
+    };
+    readonly gte: {
+      readonly self: { readonly many: true; readonly elementTraits: readonly ['order'] };
+      readonly impl: <CodecId extends CodecIdsWithTrait<CT, ['order']>>(
+        self: ScalarListExpression<CodecId, false>,
+        other: ScalarListExpression<CodecId, false> | readonly CodecValue<CodecId, false, CT>[],
+      ) => Expression<{ codecId: 'pg/bool@1'; nullable: false }>;
+    };
+    readonly lte: {
+      readonly self: { readonly many: true; readonly elementTraits: readonly ['order'] };
+      readonly impl: <CodecId extends CodecIdsWithTrait<CT, ['order']>>(
+        self: ScalarListExpression<CodecId, false>,
+        other: ScalarListExpression<CodecId, false> | readonly CodecValue<CodecId, false, CT>[],
       ) => Expression<{ codecId: 'pg/bool@1'; nullable: false }>;
     };
     readonly length: {

--- a/packages/3-targets/6-adapters/postgres/src/types/operation-types.ts
+++ b/packages/3-targets/6-adapters/postgres/src/types/operation-types.ts
@@ -26,6 +26,13 @@ export type QueryOperationTypes<CT extends CodecTypesBase> = SqlQueryOperationTy
         elem: CodecExpression<CodecId, false, CT>,
       ) => Expression<{ codecId: 'pg/bool@1'; nullable: false }>;
     };
+    readonly arrayContains: {
+      readonly self: { readonly many: true; readonly elementTraits: readonly ['equality'] };
+      readonly impl: <CodecId extends keyof CT & string>(
+        self: ScalarListExpression<CodecId, false>,
+        other: readonly CodecValue<CodecId, false, CT>[] | ScalarListExpression<CodecId, false>,
+      ) => Expression<{ codecId: 'pg/bool@1'; nullable: false }>;
+    };
     readonly containedBy: {
       readonly self: { readonly many: true; readonly elementTraits: readonly ['equality'] };
       readonly impl: <CodecId extends keyof CT & string>(

--- a/packages/3-targets/6-adapters/postgres/src/types/operation-types.ts
+++ b/packages/3-targets/6-adapters/postgres/src/types/operation-types.ts
@@ -60,5 +60,19 @@ export type QueryOperationTypes<CT extends CodecTypesBase> = SqlQueryOperationTy
         i: CodecExpression<'pg/int4@1', false, CT>,
       ) => Expression<{ codecId: CodecId; nullable: true }>;
     };
+    readonly arrayAppend: {
+      readonly self: { readonly many: true; readonly elementTraits: readonly ['equality'] };
+      readonly impl: <CodecId extends keyof CT & string>(
+        self: ScalarListExpression<CodecId, false>,
+        elem: CodecExpression<CodecId, false, CT>,
+      ) => Expression<{ codecId: CodecId; nullable: false; many: true }>;
+    };
+    readonly arrayRemove: {
+      readonly self: { readonly many: true; readonly elementTraits: readonly ['equality'] };
+      readonly impl: <CodecId extends keyof CT & string>(
+        self: ScalarListExpression<CodecId, false>,
+        elem: CodecExpression<CodecId, false, CT>,
+      ) => Expression<{ codecId: CodecId; nullable: false; many: true }>;
+    };
   }
 >;

--- a/packages/3-targets/6-adapters/postgres/src/types/operation-types.ts
+++ b/packages/3-targets/6-adapters/postgres/src/types/operation-types.ts
@@ -1,6 +1,7 @@
 import type { SqlQueryOperationTypes } from '@prisma-next/sql-contract/types';
 import type {
   CodecExpression,
+  CodecValue,
   Expression,
   ScalarListExpression,
   TraitExpression,
@@ -24,6 +25,33 @@ export type QueryOperationTypes<CT extends CodecTypesBase> = SqlQueryOperationTy
         self: ScalarListExpression<CodecId, false>,
         elem: CodecExpression<CodecId, false, CT>,
       ) => Expression<{ codecId: 'pg/bool@1'; nullable: false }>;
+    };
+    readonly containedBy: {
+      readonly self: { readonly many: true; readonly elementTraits: readonly ['equality'] };
+      readonly impl: <CodecId extends keyof CT & string>(
+        self: ScalarListExpression<CodecId, false>,
+        other: readonly CodecValue<CodecId, false, CT>[] | ScalarListExpression<CodecId, false>,
+      ) => Expression<{ codecId: 'pg/bool@1'; nullable: false }>;
+    };
+    readonly overlaps: {
+      readonly self: { readonly many: true; readonly elementTraits: readonly ['equality'] };
+      readonly impl: <CodecId extends keyof CT & string>(
+        self: ScalarListExpression<CodecId, false>,
+        other: readonly CodecValue<CodecId, false, CT>[] | ScalarListExpression<CodecId, false>,
+      ) => Expression<{ codecId: 'pg/bool@1'; nullable: false }>;
+    };
+    readonly length: {
+      readonly self: { readonly many: true };
+      readonly impl: <CodecId extends keyof CT & string>(
+        self: ScalarListExpression<CodecId, false>,
+      ) => Expression<{ codecId: 'pg/int4@1'; nullable: false }>;
+    };
+    readonly index: {
+      readonly self: { readonly many: true };
+      readonly impl: <CodecId extends keyof CT & string>(
+        self: ScalarListExpression<CodecId, false>,
+        i: CodecExpression<'pg/int4@1', false, CT>,
+      ) => Expression<{ codecId: CodecId; nullable: true }>;
     };
   }
 >;

--- a/packages/3-targets/6-adapters/postgres/src/types/operation-types.ts
+++ b/packages/3-targets/6-adapters/postgres/src/types/operation-types.ts
@@ -2,6 +2,7 @@ import type { SqlQueryOperationTypes } from '@prisma-next/sql-contract/types';
 import type {
   CodecExpression,
   Expression,
+  ScalarListExpression,
   TraitExpression,
 } from '@prisma-next/sql-relational-core/expression';
 
@@ -15,6 +16,13 @@ export type QueryOperationTypes<CT extends CodecTypesBase> = SqlQueryOperationTy
       readonly impl: (
         self: TraitExpression<readonly ['textual'], false, CT>,
         pattern: CodecExpression<'pg/text@1', false, CT>,
+      ) => Expression<{ codecId: 'pg/bool@1'; nullable: false }>;
+    };
+    readonly has: {
+      readonly self: { readonly many: true; readonly elementTraits: readonly ['equality'] };
+      readonly impl: <CodecId extends keyof CT & string>(
+        self: ScalarListExpression<CodecId, false>,
+        elem: CodecExpression<CodecId, false, CT>,
       ) => Expression<{ codecId: 'pg/bool@1'; nullable: false }>;
     };
   }

--- a/test/integration/test/scalar-lists/orm-list-read.integration.test.ts
+++ b/test/integration/test/scalar-lists/orm-list-read.integration.test.ts
@@ -6,6 +6,7 @@
  * accessors fully typed: `db.public.Item` is a real `Item` collection rather
  * than an index signature.
  */
+import { postgresRawCodecInferer } from '@prisma-next/adapter-postgres/adapter';
 import postgresAdapter from '@prisma-next/adapter-postgres/control';
 import postgresRuntimeAdapter from '@prisma-next/adapter-postgres/runtime';
 import type { Contract as FrameworkContract } from '@prisma-next/contract/types';
@@ -13,9 +14,14 @@ import postgresControlDriver from '@prisma-next/driver-postgres/control';
 import sql, { INIT_ADDITIVE_POLICY } from '@prisma-next/family-sql/control';
 import { APP_SPACE_ID, createControlStack } from '@prisma-next/framework-components/control';
 import { buildSynthMigrationEdge } from '@prisma-next/migration-tools/aggregate';
+import { sql as sqlBuilder } from '@prisma-next/sql-builder/runtime';
 import type { SqlStorage } from '@prisma-next/sql-contract/types';
 import { orm } from '@prisma-next/sql-orm-client';
-import { createExecutionContext, createSqlExecutionStack } from '@prisma-next/sql-runtime';
+import {
+  createExecutionContext,
+  createSqlExecutionStack,
+  type SqlMiddleware,
+} from '@prisma-next/sql-runtime';
 import postgres from '@prisma-next/target-postgres/control';
 import postgresRuntimeTarget, {
   PostgresContractSerializer,
@@ -135,6 +141,62 @@ describe.sequential('ORM scalar-list round-trip', () => {
         type Row = (typeof rows)[number];
         expectTypeOf<Row['tags']>().toEqualTypeOf<ReadonlyArray<string>>();
         expectTypeOf<Row['scores']>().toEqualTypeOf<ReadonlyArray<number>>();
+      });
+    },
+    timeouts.spinUpPpgDev,
+  );
+
+  it(
+    'filters rows through the native `has` membership op, lowering to `= ANY(...)`',
+    async () => {
+      if (!database) throw new Error('database not initialised');
+
+      await withClient(database.connectionString, async (client) => {
+        await client.query('DROP SCHEMA IF EXISTS public CASCADE');
+        await client.query('CREATE SCHEMA public');
+        await client.query('DROP SCHEMA IF EXISTS prisma_contract CASCADE');
+      });
+      await migrateContract(database.connectionString);
+
+      await withClient(database.connectionString, async (client) => {
+        const capturedSql: string[] = [];
+        const captureMiddleware: SqlMiddleware = {
+          name: 'capture-sql',
+          beforeExecute(plan) {
+            capturedSql.push(plan.sql);
+          },
+        };
+        const runtime = await createTestRuntimeFromClient(
+          contract as FrameworkContract<SqlStorage>,
+          client,
+          { verifyMarker: false, middleware: [captureMiddleware] },
+        );
+
+        const context = createExecutionContext<Contract>({
+          contract,
+          stack: createSqlExecutionStack({
+            target: postgresRuntimeTarget,
+            adapter: postgresRuntimeAdapter,
+            extensionPacks: [],
+          }),
+        });
+
+        const db = orm({ runtime, context });
+        await db.public.Item.create({ id: 1, tags: ['react', 'vue'], scores: [1] });
+        await db.public.Item.create({ id: 2, tags: ['vue', 'svelte'], scores: [2] });
+        await db.public.Item.create({ id: 3, tags: ['svelte'], scores: [3] });
+
+        const builder = sqlBuilder({ context, rawCodecInferer: postgresRawCodecInferer });
+        const rows = await runtime.execute(
+          builder.public.item
+            .select('id')
+            .where((f, fns) => fns.has(f.tags, 'vue'))
+            .orderBy((f) => f.id)
+            .build(),
+        );
+
+        expect(capturedSql.some((s) => /= ANY\(/.test(s))).toBe(true);
+        expect(rows).toEqual([{ id: 1 }, { id: 2 }]);
       });
     },
     timeouts.spinUpPpgDev,

--- a/test/integration/test/scalar-lists/orm-list-read.integration.test.ts
+++ b/test/integration/test/scalar-lists/orm-list-read.integration.test.ts
@@ -203,7 +203,7 @@ describe.sequential('ORM scalar-list round-trip', () => {
   );
 
   it(
-    'filters rows through native array ops (containedBy <@, overlaps &&)',
+    'filters rows through native array ops (arrayContains @>, containedBy <@, overlaps &&)',
     async () => {
       if (!database) throw new Error('database not initialised');
 
@@ -264,6 +264,17 @@ describe.sequential('ORM scalar-list round-trip', () => {
         );
         expect(capturedSql.some((s) => s.includes('&&'))).toBe(true);
         expect(overlapping).toEqual([{ id: 1 }]);
+
+        const superset = await runtime.execute(
+          builder.public.item
+            .select('id')
+            .where((f, fns) => fns.arrayContains(f.tags, ['svelte']))
+            .orderBy((f) => f.id)
+            .build(),
+        );
+        expect(capturedSql.some((s) => s.includes('@>'))).toBe(true);
+        expect(capturedSql.some((s) => s.includes('ARRAY['))).toBe(true);
+        expect(superset).toEqual([{ id: 2 }, { id: 3 }]);
       });
     },
     timeouts.spinUpPpgDev,

--- a/test/integration/test/scalar-lists/orm-list-read.integration.test.ts
+++ b/test/integration/test/scalar-lists/orm-list-read.integration.test.ts
@@ -201,4 +201,134 @@ describe.sequential('ORM scalar-list round-trip', () => {
     },
     timeouts.spinUpPpgDev,
   );
+
+  it(
+    'filters rows through native array ops (containedBy <@, overlaps &&)',
+    async () => {
+      if (!database) throw new Error('database not initialised');
+
+      await withClient(database.connectionString, async (client) => {
+        await client.query('DROP SCHEMA IF EXISTS public CASCADE');
+        await client.query('CREATE SCHEMA public');
+        await client.query('DROP SCHEMA IF EXISTS prisma_contract CASCADE');
+      });
+      await migrateContract(database.connectionString);
+
+      await withClient(database.connectionString, async (client) => {
+        const capturedSql: string[] = [];
+        const captureMiddleware: SqlMiddleware = {
+          name: 'capture-sql',
+          beforeExecute(plan) {
+            capturedSql.push(plan.sql);
+          },
+        };
+        const runtime = await createTestRuntimeFromClient(
+          contract as FrameworkContract<SqlStorage>,
+          client,
+          { verifyMarker: false, middleware: [captureMiddleware] },
+        );
+
+        const context = createExecutionContext<Contract>({
+          contract,
+          stack: createSqlExecutionStack({
+            target: postgresRuntimeTarget,
+            adapter: postgresRuntimeAdapter,
+            extensionPacks: [],
+          }),
+        });
+
+        const db = orm({ runtime, context });
+        await db.public.Item.create({ id: 1, tags: ['react', 'vue'], scores: [1] });
+        await db.public.Item.create({ id: 2, tags: ['vue', 'svelte'], scores: [2] });
+        await db.public.Item.create({ id: 3, tags: ['svelte'], scores: [3] });
+
+        const builder = sqlBuilder({ context, rawCodecInferer: postgresRawCodecInferer });
+
+        const within = await runtime.execute(
+          builder.public.item
+            .select('id')
+            .where((f, fns) => fns.containedBy(f.tags, ['vue', 'svelte']))
+            .orderBy((f) => f.id)
+            .build(),
+        );
+        expect(capturedSql.some((s) => s.includes('<@'))).toBe(true);
+        expect(capturedSql.some((s) => s.includes('ARRAY['))).toBe(true);
+        expect(within).toEqual([{ id: 2 }, { id: 3 }]);
+
+        const overlapping = await runtime.execute(
+          builder.public.item
+            .select('id')
+            .where((f, fns) => fns.overlaps(f.tags, ['react']))
+            .orderBy((f) => f.id)
+            .build(),
+        );
+        expect(capturedSql.some((s) => s.includes('&&'))).toBe(true);
+        expect(overlapping).toEqual([{ id: 1 }]);
+      });
+    },
+    timeouts.spinUpPpgDev,
+  );
+
+  it(
+    'computes list length (cardinality) and 1-based nullable element access',
+    async () => {
+      if (!database) throw new Error('database not initialised');
+
+      await withClient(database.connectionString, async (client) => {
+        await client.query('DROP SCHEMA IF EXISTS public CASCADE');
+        await client.query('CREATE SCHEMA public');
+        await client.query('DROP SCHEMA IF EXISTS prisma_contract CASCADE');
+      });
+      await migrateContract(database.connectionString);
+
+      await withClient(database.connectionString, async (client) => {
+        const capturedSql: string[] = [];
+        const captureMiddleware: SqlMiddleware = {
+          name: 'capture-sql',
+          beforeExecute(plan) {
+            capturedSql.push(plan.sql);
+          },
+        };
+        const runtime = await createTestRuntimeFromClient(
+          contract as FrameworkContract<SqlStorage>,
+          client,
+          { verifyMarker: false, middleware: [captureMiddleware] },
+        );
+
+        const context = createExecutionContext<Contract>({
+          contract,
+          stack: createSqlExecutionStack({
+            target: postgresRuntimeTarget,
+            adapter: postgresRuntimeAdapter,
+            extensionPacks: [],
+          }),
+        });
+
+        const db = orm({ runtime, context });
+        await db.public.Item.create({ id: 1, tags: ['react', 'vue'], scores: [10, 20] });
+        await db.public.Item.create({ id: 2, tags: ['svelte'], scores: [30] });
+
+        const builder = sqlBuilder({ context, rawCodecInferer: postgresRawCodecInferer });
+        const rows = await runtime.execute(
+          builder.public.item
+            .select((f, fns) => ({
+              id: f.id,
+              len: fns.length(f.tags),
+              firstTag: fns.index(f.tags, 1),
+              secondScore: fns.index(f.scores, 2),
+            }))
+            .orderBy((f) => f.id)
+            .build(),
+        );
+
+        expect(capturedSql.some((s) => s.includes('cardinality('))).toBe(true);
+        expect(capturedSql.some((s) => /\[\$\d+/.test(s))).toBe(true);
+        expect(rows).toEqual([
+          { id: 1, len: 2, firstTag: 'react', secondScore: 20 },
+          { id: 2, len: 1, firstTag: 'svelte', secondScore: null },
+        ]);
+      });
+    },
+    timeouts.spinUpPpgDev,
+  );
 });

--- a/test/integration/test/scalar-lists/orm-list-read.integration.test.ts
+++ b/test/integration/test/scalar-lists/orm-list-read.integration.test.ts
@@ -281,6 +281,73 @@ describe.sequential('ORM scalar-list round-trip', () => {
   );
 
   it(
+    'compares whole lists through the eq/gt comparison builtins (FR16)',
+    async () => {
+      if (!database) throw new Error('database not initialised');
+
+      await withClient(database.connectionString, async (client) => {
+        await client.query('DROP SCHEMA IF EXISTS public CASCADE');
+        await client.query('CREATE SCHEMA public');
+        await client.query('DROP SCHEMA IF EXISTS prisma_contract CASCADE');
+      });
+      await migrateContract(database.connectionString);
+
+      await withClient(database.connectionString, async (client) => {
+        const capturedSql: string[] = [];
+        const captureMiddleware: SqlMiddleware = {
+          name: 'capture-sql',
+          beforeExecute(plan) {
+            capturedSql.push(plan.sql);
+          },
+        };
+        const runtime = await createTestRuntimeFromClient(
+          contract as FrameworkContract<SqlStorage>,
+          client,
+          { verifyMarker: false, middleware: [captureMiddleware] },
+        );
+
+        const context = createExecutionContext<Contract>({
+          contract,
+          stack: createSqlExecutionStack({
+            target: postgresRuntimeTarget,
+            adapter: postgresRuntimeAdapter,
+            extensionPacks: [],
+          }),
+        });
+
+        const db = orm({ runtime, context });
+        await db.public.Item.create({ id: 1, tags: ['react', 'vue'], scores: [1] });
+        await db.public.Item.create({ id: 2, tags: ['svelte'], scores: [2] });
+        await db.public.Item.create({ id: 3, tags: ['react', 'vue'], scores: [3] });
+
+        const builder = sqlBuilder({ context, rawCodecInferer: postgresRawCodecInferer });
+
+        const equal = await runtime.execute(
+          builder.public.item
+            .select('id')
+            .where((f, fns) => fns.eq(f.tags, ['react', 'vue']))
+            .orderBy((f) => f.id)
+            .build(),
+        );
+        expect(capturedSql.some((s) => /"tags" = \$\d+/.test(s))).toBe(true);
+        expect(equal).toEqual([{ id: 1 }, { id: 3 }]);
+
+        const greater = await runtime.execute(
+          builder.public.item
+            .select('id')
+            .where((f, fns) => fns.gt(f.tags, ['react']))
+            .orderBy((f) => f.id)
+            .build(),
+        );
+        expect(capturedSql.some((s) => /"tags" > \$\d+/.test(s))).toBe(true);
+        // ['react','vue'] and ['svelte'] both sort lexicographically after ['react']
+        expect(greater).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+      });
+    },
+    timeouts.spinUpPpgDev,
+  );
+
+  it(
     'computes list length (cardinality) and 1-based nullable element access',
     async () => {
       if (!database) throw new Error('database not initialised');

--- a/test/integration/test/scalar-lists/scalar-list-mutations.integration.test.ts
+++ b/test/integration/test/scalar-lists/scalar-list-mutations.integration.test.ts
@@ -1,0 +1,220 @@
+/**
+ * End-to-end proof of the native list update mutators (`arrayAppend`,
+ * `arrayRemove`, and whole-array replacement) on real Postgres.
+ *
+ * An update that appends to and removes from a `tags String[]` column executes
+ * the corresponding Postgres array mutation (`array_append` / `array_remove`)
+ * and the subsequent read returns the mutated list decoded element-wise (AC7).
+ */
+import { postgresRawCodecInferer } from '@prisma-next/adapter-postgres/adapter';
+import postgresAdapter from '@prisma-next/adapter-postgres/control';
+import postgresRuntimeAdapter from '@prisma-next/adapter-postgres/runtime';
+import type { Contract as FrameworkContract } from '@prisma-next/contract/types';
+import postgresControlDriver from '@prisma-next/driver-postgres/control';
+import sql, { INIT_ADDITIVE_POLICY } from '@prisma-next/family-sql/control';
+import { APP_SPACE_ID, createControlStack } from '@prisma-next/framework-components/control';
+import { buildSynthMigrationEdge } from '@prisma-next/migration-tools/aggregate';
+import { sql as sqlBuilder } from '@prisma-next/sql-builder/runtime';
+import type { SqlStorage } from '@prisma-next/sql-contract/types';
+import {
+  createExecutionContext,
+  createSqlExecutionStack,
+  type SqlMiddleware,
+} from '@prisma-next/sql-runtime';
+import postgres from '@prisma-next/target-postgres/control';
+import postgresRuntimeTarget, {
+  PostgresContractSerializer,
+} from '@prisma-next/target-postgres/runtime';
+import { createDevDatabase, type DevDatabase, timeouts, withClient } from '@prisma-next/test-utils';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Contract } from '../sql-orm-client/fixtures/scalar-lists/generated/contract';
+import contractJson from '../sql-orm-client/fixtures/scalar-lists/generated/contract.json' with {
+  type: 'json',
+};
+import { createTestRuntimeFromClient } from '../utils';
+import { postgresFrameworkComponents } from './psl-list-authoring';
+
+const controlStack = createControlStack({
+  family: sql,
+  target: postgres,
+  adapter: postgresAdapter,
+  driver: postgresControlDriver,
+  extensionPacks: [],
+});
+const familyInstance = sql.create(controlStack);
+
+const contract = new PostgresContractSerializer().deserializeContract(contractJson) as Contract;
+
+async function migrateContract(connectionString: string): Promise<void> {
+  const driver = await postgresControlDriver.create(connectionString);
+  try {
+    const schema = await familyInstance.introspect({ driver });
+    const planner = postgres.createPlanner(postgresAdapter.create(controlStack));
+    const planResult = planner.plan({
+      contract: contract as FrameworkContract<SqlStorage>,
+      schema,
+      policy: INIT_ADDITIVE_POLICY,
+      fromContract: null,
+      frameworkComponents: postgresFrameworkComponents,
+      spaceId: APP_SPACE_ID,
+    });
+    if (planResult.kind !== 'success') {
+      throw new Error(`planner failed: ${JSON.stringify(planResult)}`);
+    }
+
+    const runner = postgres.createRunner(familyInstance);
+    const runResult = await runner.execute({
+      driver,
+      perSpaceOptions: [
+        {
+          space: APP_SPACE_ID,
+          plan: planResult.plan,
+          migrationEdges: [
+            buildSynthMigrationEdge({
+              currentMarkerStorageHash: planResult.plan.origin?.storageHash,
+              destinationStorageHash: planResult.plan.destination.storageHash,
+              operationCount: planResult.plan.operations.length,
+            }),
+          ],
+          driver,
+          destinationContract: contract as FrameworkContract<SqlStorage>,
+          policy: INIT_ADDITIVE_POLICY,
+          frameworkComponents: postgresFrameworkComponents,
+        },
+      ],
+    });
+    if (!runResult.ok) {
+      throw new Error(`runner failed: ${JSON.stringify(runResult.failure)}`);
+    }
+  } finally {
+    await driver.close();
+  }
+}
+
+describe.sequential('ORM scalar-list update mutators', () => {
+  let database: DevDatabase | undefined;
+
+  beforeAll(async () => {
+    database = await createDevDatabase();
+  }, timeouts.spinUpPpgDev);
+
+  afterAll(async () => {
+    if (database) await database.close();
+  }, timeouts.spinUpPpgDev);
+
+  it(
+    'appends to and removes from a list column via array_append/array_remove, reading back the mutated list',
+    async () => {
+      if (!database) throw new Error('database not initialised');
+
+      await withClient(database.connectionString, async (client) => {
+        await client.query('DROP SCHEMA IF EXISTS public CASCADE');
+        await client.query('CREATE SCHEMA public');
+        await client.query('DROP SCHEMA IF EXISTS prisma_contract CASCADE');
+      });
+      await migrateContract(database.connectionString);
+
+      await withClient(database.connectionString, async (client) => {
+        const capturedSql: string[] = [];
+        const captureMiddleware: SqlMiddleware = {
+          name: 'capture-sql',
+          beforeExecute(plan) {
+            capturedSql.push(plan.sql);
+          },
+        };
+        const runtime = await createTestRuntimeFromClient(
+          contract as FrameworkContract<SqlStorage>,
+          client,
+          { verifyMarker: false, middleware: [captureMiddleware] },
+        );
+
+        const context = createExecutionContext<Contract>({
+          contract,
+          stack: createSqlExecutionStack({
+            target: postgresRuntimeTarget,
+            adapter: postgresRuntimeAdapter,
+            extensionPacks: [],
+          }),
+        });
+
+        const builder = sqlBuilder({ context, rawCodecInferer: postgresRawCodecInferer });
+
+        await runtime.execute(
+          builder.public.item.insert([{ id: 1, tags: ['a', 'b'], scores: [1, 2] }]).build(),
+        );
+
+        await runtime.execute(
+          builder.public.item
+            .update((f, fns) => ({ tags: fns.arrayRemove(fns.arrayAppend(f.tags, 'c'), 'a') }))
+            .where((f, fns) => fns.eq(f.id, 1))
+            .build(),
+        );
+
+        expect(capturedSql.some((s) => s.includes('array_append('))).toBe(true);
+        expect(capturedSql.some((s) => s.includes('array_remove('))).toBe(true);
+
+        const rows = await runtime.execute(
+          builder.public.item
+            .select('id', 'tags')
+            .where((f, fns) => fns.eq(f.id, 1))
+            .build(),
+        );
+        expect(rows).toEqual([{ id: 1, tags: ['b', 'c'] }]);
+      });
+    },
+    timeouts.spinUpPpgDev,
+  );
+
+  it(
+    'replaces the whole list column with a raw array literal',
+    async () => {
+      if (!database) throw new Error('database not initialised');
+
+      await withClient(database.connectionString, async (client) => {
+        await client.query('DROP SCHEMA IF EXISTS public CASCADE');
+        await client.query('CREATE SCHEMA public');
+        await client.query('DROP SCHEMA IF EXISTS prisma_contract CASCADE');
+      });
+      await migrateContract(database.connectionString);
+
+      await withClient(database.connectionString, async (client) => {
+        const runtime = await createTestRuntimeFromClient(
+          contract as FrameworkContract<SqlStorage>,
+          client,
+          { verifyMarker: false },
+        );
+
+        const context = createExecutionContext<Contract>({
+          contract,
+          stack: createSqlExecutionStack({
+            target: postgresRuntimeTarget,
+            adapter: postgresRuntimeAdapter,
+            extensionPacks: [],
+          }),
+        });
+
+        const builder = sqlBuilder({ context, rawCodecInferer: postgresRawCodecInferer });
+
+        await runtime.execute(
+          builder.public.item.insert([{ id: 1, tags: ['a', 'b'], scores: [1] }]).build(),
+        );
+
+        await runtime.execute(
+          builder.public.item
+            .update({ tags: ['x', 'y'] })
+            .where((f, fns) => fns.eq(f.id, 1))
+            .build(),
+        );
+
+        const rows = await runtime.execute(
+          builder.public.item
+            .select('id', 'tags')
+            .where((f, fns) => fns.eq(f.id, 1))
+            .build(),
+        );
+        expect(rows).toEqual([{ id: 1, tags: ['x', 'y'] }]);
+      });
+    },
+    timeouts.spinUpPpgDev,
+  );
+});

--- a/test/integration/test/scalar-lists/scalar-list-ops.types.test-d.ts
+++ b/test/integration/test/scalar-lists/scalar-list-ops.types.test-d.ts
@@ -128,3 +128,33 @@ test('index rejects a non-int index', () => {
     fns.index(f.scores, 'x'),
   );
 });
+
+test('arrayAppend/arrayRemove yield a list expression accepted in an update set map', () => {
+  db.public.item.update((f, fns) => {
+    const appended = fns.arrayAppend(f.tags, 'x');
+    expectTypeOf(appended).toExtend<
+      Expression<{ codecId: 'pg/text@1'; nullable: false; many: true }>
+    >();
+    return { tags: appended };
+  });
+  // nested compose: append then remove, both over the same text list
+  db.public.item.update((f, fns) => ({
+    tags: fns.arrayRemove(fns.arrayAppend(f.tags, 'x'), 'y'),
+  }));
+  // an Int[] list accepts an int element
+  db.public.item.update((f, fns) => ({ scores: fns.arrayAppend(f.scores, 1) }));
+});
+
+test('arrayAppend rejects a wrong-typed element', () => {
+  db.public.item.update((f, fns) => ({
+    // @ts-expect-error -- tags is a text list; the element must be a string
+    tags: fns.arrayAppend(f.tags, 5),
+  }));
+});
+
+test('a list mutator is rejected for a scalar column', () => {
+  // @ts-expect-error -- id is a scalar int column; a text list mutator is not assignable
+  db.public.item.update((f, fns) => ({
+    id: fns.arrayAppend(f.tags, 'x'),
+  }));
+});

--- a/test/integration/test/scalar-lists/scalar-list-ops.types.test-d.ts
+++ b/test/integration/test/scalar-lists/scalar-list-ops.types.test-d.ts
@@ -158,3 +158,29 @@ test('a list mutator is rejected for a scalar column', () => {
     id: fns.arrayAppend(f.tags, 'x'),
   }));
 });
+
+test('comparison builtins accept a whole-list operand (FR16)', () => {
+  db.public.item.select('id').where((f, fns) => {
+    const byLiteral = fns.eq(f.tags, ['a', 'b']);
+    expectTypeOf(byLiteral).toExtend<Expression<BooleanCodecType>>();
+    const byExpr = fns.eq(f.tags, f.tags);
+    expectTypeOf(byExpr).toExtend<Expression<BooleanCodecType>>();
+    // ordering compares lexicographically over an orderable element list
+    const ordered = fns.gt(f.tags, ['a']);
+    expectTypeOf(ordered).toExtend<Expression<BooleanCodecType>>();
+    return fns.and(byLiteral, byExpr, ordered, fns.eq(f.scores, [1, 2]));
+  });
+  // scalar comparison calls remain unchanged
+  db.public.item.select('id').where((f, fns) => fns.eq(f.id, 1));
+});
+
+test('comparison builtins reject a wrong-typed list element', () => {
+  db.public.item.select('id').where((f, fns) =>
+    // @ts-expect-error -- tags is a text list; the array elements must be strings
+    fns.eq(f.tags, [5]),
+  );
+  db.public.item.select('id').where((f, fns) =>
+    // @ts-expect-error -- tags is a text list; the array elements must be strings
+    fns.gt(f.tags, [5]),
+  );
+});

--- a/test/integration/test/scalar-lists/scalar-list-ops.types.test-d.ts
+++ b/test/integration/test/scalar-lists/scalar-list-ops.types.test-d.ts
@@ -1,6 +1,7 @@
 /**
- * End-to-end type-test for the native list ops (`has`, `containedBy`,
- * `overlaps`, `length`, `index`), driven through the REAL emitted contract and
+ * End-to-end type-test for the native list ops (`has`, `arrayContains`,
+ * `containedBy`, `overlaps`, `length`, `index`), driven through the REAL emitted
+ * contract and
  * the REAL sql-builder `.where((f, fns) => …)` / `.select(alias, (f, fns) => …)`
  * surfaces — no synthetic scope. At the type level:
  *
@@ -44,17 +45,22 @@ test('has rejects a wrong-typed element', () => {
   );
 });
 
-test('array filters (containedBy/overlaps) resolve over a list column', () => {
+test('array filters (arrayContains/containedBy/overlaps) resolve over a list column', () => {
   db.public.item.select('id').where((f, fns) => {
     const contained = fns.containedBy(f.tags, ['react', 'vue']);
     expectTypeOf(contained).toExtend<Expression<BooleanCodecType>>();
+    const superset = fns.arrayContains(f.tags, ['react']);
+    expectTypeOf(superset).toExtend<Expression<BooleanCodecType>>();
     return fns.and(
       contained,
+      superset,
       fns.overlaps(f.tags, ['svelte']),
       // an Int[] list accepts an int array operand
       fns.containedBy(f.scores, [1, 2]),
+      fns.arrayContains(f.scores, [1]),
       // a list-typed operand (another list column) is accepted
       fns.overlaps(f.tags, f.tags),
+      fns.arrayContains(f.tags, f.tags),
     );
   });
 });
@@ -64,12 +70,20 @@ test('array filters reject a scalar receiver', () => {
     // @ts-expect-error -- id is a scalar column, not a list receiver
     fns.overlaps(f.id, [1]),
   );
+  db.public.item.select('id').where((f, fns) =>
+    // @ts-expect-error -- id is a scalar column, not a list receiver
+    fns.arrayContains(f.id, [1]),
+  );
 });
 
 test('array filters reject a wrong-typed array element', () => {
   db.public.item.select('id').where((f, fns) =>
     // @ts-expect-error -- tags is a text list; the array elements must be strings
     fns.containedBy(f.tags, [5]),
+  );
+  db.public.item.select('id').where((f, fns) =>
+    // @ts-expect-error -- tags is a text list; the array elements must be strings
+    fns.arrayContains(f.tags, [5]),
   );
 });
 

--- a/test/integration/test/scalar-lists/scalar-list-ops.types.test-d.ts
+++ b/test/integration/test/scalar-lists/scalar-list-ops.types.test-d.ts
@@ -1,14 +1,15 @@
 /**
- * End-to-end type-test for the native list membership op `has`, driven through
- * the REAL emitted contract and the REAL sql-builder `.where((f, fns) => …)`
- * surface — no synthetic scope. Proves AC3 at the type level:
+ * End-to-end type-test for the native list ops (`has`, `containedBy`,
+ * `overlaps`, `length`, `index`), driven through the REAL emitted contract and
+ * the REAL sql-builder `.where((f, fns) => …)` / `.select(alias, (f, fns) => …)`
+ * surfaces — no synthetic scope. At the type level:
  *
- * - `f.tags` (a `many: true` column) surfaces as a list receiver, so
- *   `fns.has(f.tags, x)` type-checks and yields a boolean expression.
+ * - `f.tags` (a `many: true` column) surfaces as a list receiver, so each op
+ *   type-checks and yields the declared return expression.
  * - a scalar column receiver (`f.id`) is a compile error.
- * - a wrong-typed element (`5` against a text list) is a compile error.
+ * - a wrong-typed element/array/index is a compile error.
  *
- * `fns.has` is the postgres adapter's registry op (`descriptor-meta.ts`),
+ * Each op is the postgres adapter's registry op (`descriptor-meta.ts`),
  * surfaced verbatim by `DeriveExtFunctions` from the contract's
  * `queryOperationTypes`.
  */
@@ -40,5 +41,76 @@ test('has rejects a wrong-typed element', () => {
   db.public.item.select('id').where((f, fns) =>
     // @ts-expect-error -- tags is a text list; the element must be a string
     fns.has(f.tags, 5),
+  );
+});
+
+test('array filters (containedBy/overlaps) resolve over a list column', () => {
+  db.public.item.select('id').where((f, fns) => {
+    const contained = fns.containedBy(f.tags, ['react', 'vue']);
+    expectTypeOf(contained).toExtend<Expression<BooleanCodecType>>();
+    return fns.and(
+      contained,
+      fns.overlaps(f.tags, ['svelte']),
+      // an Int[] list accepts an int array operand
+      fns.containedBy(f.scores, [1, 2]),
+      // a list-typed operand (another list column) is accepted
+      fns.overlaps(f.tags, f.tags),
+    );
+  });
+});
+
+test('array filters reject a scalar receiver', () => {
+  db.public.item.select('id').where((f, fns) =>
+    // @ts-expect-error -- id is a scalar column, not a list receiver
+    fns.overlaps(f.id, [1]),
+  );
+});
+
+test('array filters reject a wrong-typed array element', () => {
+  db.public.item.select('id').where((f, fns) =>
+    // @ts-expect-error -- tags is a text list; the array elements must be strings
+    fns.containedBy(f.tags, [5]),
+  );
+});
+
+test('length yields a non-null int over a list column', () => {
+  db.public.item.select('n', (f, fns) => {
+    const len = fns.length(f.tags);
+    expectTypeOf(len).toExtend<Expression<{ codecId: 'pg/int4@1'; nullable: false }>>();
+    return len;
+  });
+});
+
+test('length rejects a scalar receiver', () => {
+  db.public.item.select('n', (f, fns) =>
+    // @ts-expect-error -- id is a scalar column, not a list receiver
+    fns.length(f.id),
+  );
+});
+
+test('index yields the nullable element codec over a list column', () => {
+  db.public.item.select('first', (f, fns) => {
+    const firstTag = fns.index(f.tags, 1);
+    expectTypeOf(firstTag).toExtend<Expression<{ codecId: 'pg/text@1'; nullable: true }>>();
+    return firstTag;
+  });
+  db.public.item.select('firstScore', (f, fns) => {
+    const firstScore = fns.index(f.scores, 1);
+    expectTypeOf(firstScore).toExtend<Expression<{ codecId: 'pg/int4@1'; nullable: true }>>();
+    return firstScore;
+  });
+});
+
+test('index rejects a scalar receiver', () => {
+  db.public.item.select('first', (f, fns) =>
+    // @ts-expect-error -- id is a scalar column, not a list receiver
+    fns.index(f.id, 1),
+  );
+});
+
+test('index rejects a non-int index', () => {
+  db.public.item.select('first', (f, fns) =>
+    // @ts-expect-error -- the index must be an integer expression, not a string
+    fns.index(f.scores, 'x'),
   );
 });

--- a/test/integration/test/scalar-lists/scalar-list-ops.types.test-d.ts
+++ b/test/integration/test/scalar-lists/scalar-list-ops.types.test-d.ts
@@ -1,0 +1,44 @@
+/**
+ * End-to-end type-test for the native list membership op `has`, driven through
+ * the REAL emitted contract and the REAL sql-builder `.where((f, fns) => …)`
+ * surface — no synthetic scope. Proves AC3 at the type level:
+ *
+ * - `f.tags` (a `many: true` column) surfaces as a list receiver, so
+ *   `fns.has(f.tags, x)` type-checks and yields a boolean expression.
+ * - a scalar column receiver (`f.id`) is a compile error.
+ * - a wrong-typed element (`5` against a text list) is a compile error.
+ *
+ * `fns.has` is the postgres adapter's registry op (`descriptor-meta.ts`),
+ * surfaced verbatim by `DeriveExtFunctions` from the contract's
+ * `queryOperationTypes`.
+ */
+
+import type { BooleanCodecType, Db, Expression } from '@prisma-next/sql-builder/types';
+import { expectTypeOf, test } from 'vitest';
+import type { Contract } from '../sql-orm-client/fixtures/scalar-lists/generated/contract';
+
+declare const db: Db<Contract>;
+
+test('has membership resolves over a list column in a where-callback body', () => {
+  db.public.item.select('id').where((f, fns) => {
+    const result = fns.has(f.tags, 'react');
+    expectTypeOf(result).toExtend<Expression<BooleanCodecType>>();
+    return result;
+  });
+  // an Int[] list accepts an int element
+  db.public.item.select('id').where((f, fns) => fns.has(f.scores, 1));
+});
+
+test('has rejects a scalar receiver', () => {
+  db.public.item.select('id').where((f, fns) =>
+    // @ts-expect-error -- id is a scalar column, not a list receiver
+    fns.has(f.id, 1),
+  );
+});
+
+test('has rejects a wrong-typed element', () => {
+  db.public.item.select('id').where((f, fns) =>
+    // @ts-expect-error -- tags is a text list; the element must be a string
+    fns.has(f.tags, 5),
+  );
+});

--- a/test/integration/test/sql-orm-client/fixtures/scalar-lists/generated/contract.d.ts
+++ b/test/integration/test/sql-orm-client/fixtures/scalar-lists/generated/contract.d.ts
@@ -106,11 +106,13 @@ type ContractBase = Omit<
                   readonly nativeType: 'text';
                   readonly codecId: 'pg/text@1';
                   readonly nullable: false;
+                  readonly many: true;
                 };
                 readonly scores: {
                   readonly nativeType: 'int4';
                   readonly codecId: 'pg/int4@1';
                   readonly nullable: false;
+                  readonly many: true;
                 };
               };
               primaryKey: { readonly columns: readonly ['id'] };


### PR DESCRIPTION
## What & why

Slice 3 of native-scalar-arrays (TML-2913). Slices 1–2 made SQL scalar lists first-class in storage/authoring/migration/read (native `text[]`/`int4[]` columns with element-wise codecs). This slice makes them **queryable and mutable** — the operation surface.

Branches off `main` (has slices 1 & 2, merged). Independent of the check-constraint-unification PR.

## What's here

**Read predicates & array filters** (registry ops on the sql-builder `fns` surface, lowering via `OperationExpr` templates — no new AST):
- `has` (`x = ANY(tags)`) — element membership
- `arrayContains` (`@>`), `containedBy` (`<@`), `overlaps` (`&&`) — array filters
- `length` (`cardinality`), `index` (`tags[i]`, element-typed, nullable)

**Update mutators** (element-preserving `many: true` return, on the update `set` callback):
- `arrayAppend` (`array_append`), `arrayRemove` (`array_remove`), set-whole-array (raw-values path)

**Comparison builtins widened to lists (FR16)** — `eq`/`ne`/`gt`/`lt`/`gte`/`lte` accept whole-list operands. **Type-level only** (they already lower to `BinaryExpr(op)`, which Postgres applies to arrays). Added as **disjoint overloads keyed on the `many` discriminant** so scalar-call inference is untouched (NFR3); gated by the element codec's `equality` (eq/ne) / `order` (ordering) trait.

## Decisions

- **`arrayContains` for `@>`**: the natural name `contains` is already registered by the postgis extension (geometry), and the op registry is global-by-name — so the list "contains-all" filter is `arrayContains`.
- Two incidental infra completions the operation layer needed: the framework op-registry learned the `{ many: true; elementTraits }` self-arm, and the SQL emitter now projects `many` onto the storage-column `.d.ts` literal (so `f.tags` types as a list expression). The emitter change is guarded on `many === true` — non-list contracts are byte-identical (NFR2; only the one list-column fixture regenerated).

## Acceptance criteria

- **AC3** — `where((f,fns)=>fns.has(f.tags,x))` executes `x = ANY(tags)`; wrong-typed element and scalar receiver are compile errors. ✅
- **AC7** — an update appends to and removes from `tags String[]` (`array_append`/`array_remove`) and the read returns the mutated list decoded element-wise. ✅
- **AC11** — `fns.eq(f.tags,['a','b'])` matches by array equality, `fns.gt(f.tags,['a'])` by lexicographic order; wrong-typed element and an ordering op on an unorderable-element list are compile errors. ✅

## Verification

build 68/68 · typecheck 143/143 · lint 82/82 · lint:deps clean · fixtures:check byte-clean · cast ratchet delta 0 · adapter-postgres + sql-builder green · scalar-lists integration green (real Postgres). Runtime ACs proven on embedded Postgres; compile-error ACs via `test-d.ts` with load-bearing `@ts-expect-error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added broader support for scalar list fields, including membership checks, list comparisons, length, indexing, and list append/remove updates.
  * Improved SQL generation so list operations use the expected database operators and functions.

* **Bug Fixes**
  * Tightened validation for “self” configuration to prevent conflicting list and non-list settings.
  * Preserved list and element typing more accurately across query building and emitted types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->