### PR TITLE
fix(migrate,cli): import from @prisma/internals's public entry, not its src/

### DIFF
--- a/packages/cli/src/bootstrap/bootstrap-completion.ts
+++ b/packages/cli/src/bootstrap/bootstrap-completion.ts
@@ -1,5 +1,5 @@
-import { completionApiKeyHint, completionDatabaseIdHint } from '@prisma/internals/src/cli/completion-values'
-import type { CommandCompletion } from '@prisma/internals/src/cli/types'
+import type { CommandCompletion } from '@prisma/internals'
+import { completionApiKeyHint, completionDatabaseIdHint } from '@prisma/internals'
 
 import { CURATED_TEMPLATES } from './template-definitions'
 

--- a/packages/cli/src/completions/Completions.ts
+++ b/packages/cli/src/completions/Completions.ts
@@ -1,8 +1,7 @@
 import t from '@bomb.sh/tab'
 import type { PrismaConfigInternal } from '@prisma/config'
-import { HelpError } from '@prisma/internals/src/cli/Help'
-import type { Command, CommandCompletion, CompletionOption } from '@prisma/internals/src/cli/types'
-import { arg, isError } from '@prisma/internals/src/cli/utils'
+import type { Command, CommandCompletion, CompletionOption } from '@prisma/internals'
+import { arg, HelpError, isError } from '@prisma/internals'
 
 import { ALL_COMPLETIONS, SUPPORTED_SHELLS } from './completion-definitions'
 

--- a/packages/cli/src/completions/completion-definitions.ts
+++ b/packages/cli/src/completions/completion-definitions.ts
@@ -1,10 +1,10 @@
+import type { CommandCompletion, CompletionOption } from '@prisma/internals'
 import {
   completionDevDbPorts,
   completionDevHttpPorts,
   completionDevServerNames,
   completionDevShadowDbPorts,
-} from '@prisma/internals/src/cli/completion-values'
-import type { CommandCompletion, CompletionOption } from '@prisma/internals/src/cli/types'
+} from '@prisma/internals'
 import { dbCompletion } from '@prisma/migrate/src/commands/db-command-completion'
 import { dbExecuteCompletion } from '@prisma/migrate/src/commands/db-execute-completion'
 import { dbPullCompletion } from '@prisma/migrate/src/commands/db-pull-completion'

--- a/packages/cli/src/debug-info-completion.ts
+++ b/packages/cli/src/debug-info-completion.ts
@@ -1,5 +1,5 @@
-import { completionConfigPaths, completionSchemaPaths } from '@prisma/internals/src/cli/completion-values'
-import type { CommandCompletion } from '@prisma/internals/src/cli/types'
+import type { CommandCompletion } from '@prisma/internals'
+import { completionConfigPaths, completionSchemaPaths } from '@prisma/internals'
 
 export const debugInfoCompletion: CommandCompletion = {
   name: 'debug',

--- a/packages/cli/src/format-completion.ts
+++ b/packages/cli/src/format-completion.ts
@@ -1,5 +1,5 @@
-import { completionConfigPaths, completionSchemaPaths } from '@prisma/internals/src/cli/completion-values'
-import type { CommandCompletion } from '@prisma/internals/src/cli/types'
+import type { CommandCompletion } from '@prisma/internals'
+import { completionConfigPaths, completionSchemaPaths } from '@prisma/internals'
 
 export const formatCompletion: CommandCompletion = {
   name: 'format',

--- a/packages/cli/src/generate-completion.ts
+++ b/packages/cli/src/generate-completion.ts
@@ -1,9 +1,5 @@
-import {
-  completionConfigPaths,
-  completionGeneratorNames,
-  completionSchemaPaths,
-} from '@prisma/internals/src/cli/completion-values'
-import type { CommandCompletion } from '@prisma/internals/src/cli/types'
+import type { CommandCompletion } from '@prisma/internals'
+import { completionConfigPaths, completionGeneratorNames, completionSchemaPaths } from '@prisma/internals'
 
 export const generateCompletion: CommandCompletion = {
   name: 'generate',

--- a/packages/cli/src/generate/introspectSql.ts
+++ b/packages/cli/src/generate/introspectSql.ts
@@ -1,5 +1,5 @@
 import { inferDirectoryConfig, isValidJsIdentifier, type SchemaContext } from '@prisma/internals'
-import { PrismaConfigWithDatasource } from '@prisma/internals/src/utils/validatePrismaConfigWithDatasource'
+import { PrismaConfigWithDatasource } from '@prisma/internals'
 import { introspectSql as migrateIntrospectSql, IntrospectSqlError, IntrospectSqlInput } from '@prisma/migrate'
 import fs from 'fs/promises'
 import { bold } from 'kleur/colors'

--- a/packages/cli/src/init-completion.ts
+++ b/packages/cli/src/init-completion.ts
@@ -1,11 +1,11 @@
+import type { CommandCompletion } from '@prisma/internals'
 import {
   completionClientOutputPaths,
   completionDatasourceProviders,
   completionDatasourceUrls,
   completionGeneratorProviders,
   completionPreviewFeatures,
-} from '@prisma/internals/src/cli/completion-values'
-import type { CommandCompletion } from '@prisma/internals/src/cli/types'
+} from '@prisma/internals'
 
 export const initCompletion: CommandCompletion = {
   name: 'init',

--- a/packages/cli/src/mcp/mcp-completion.ts
+++ b/packages/cli/src/mcp/mcp-completion.ts
@@ -1,4 +1,4 @@
-import type { CommandCompletion } from '@prisma/internals/src/cli/types'
+import type { CommandCompletion } from '@prisma/internals'
 
 export const mcpCompletion: CommandCompletion = {
   name: 'mcp',

--- a/packages/cli/src/platform/platform-completion.ts
+++ b/packages/cli/src/platform/platform-completion.ts
@@ -1,4 +1,4 @@
-import type { CommandCompletion } from '@prisma/internals/src/cli/types'
+import type { CommandCompletion } from '@prisma/internals'
 
 export const platformCompletion: CommandCompletion = {
   name: 'platform',

--- a/packages/cli/src/postgres/link/link-completion.ts
+++ b/packages/cli/src/postgres/link/link-completion.ts
@@ -1,5 +1,5 @@
-import { completionApiKeyHint, completionDatabaseIdHint } from '@prisma/internals/src/cli/completion-values'
-import type { CommandCompletion } from '@prisma/internals/src/cli/types'
+import type { CommandCompletion } from '@prisma/internals'
+import { completionApiKeyHint, completionDatabaseIdHint } from '@prisma/internals'
 
 export const postgresLinkCompletion: CommandCompletion = {
   name: 'postgres link',

--- a/packages/cli/src/postgres/postgres-completion.ts
+++ b/packages/cli/src/postgres/postgres-completion.ts
@@ -1,4 +1,4 @@
-import type { CommandCompletion } from '@prisma/internals/src/cli/types'
+import type { CommandCompletion } from '@prisma/internals'
 
 export const postgresCompletion: CommandCompletion = {
   name: 'postgres',

--- a/packages/cli/src/studio-completion.ts
+++ b/packages/cli/src/studio-completion.ts
@@ -1,10 +1,10 @@
+import type { CommandCompletion } from '@prisma/internals'
 import {
   completionConfigPaths,
   completionDatasourceUrls,
   completionStudioBrowsers,
   completionStudioPorts,
-} from '@prisma/internals/src/cli/completion-values'
-import type { CommandCompletion } from '@prisma/internals/src/cli/types'
+} from '@prisma/internals'
 
 export const studioCompletion: CommandCompletion = {
   name: 'studio',

--- a/packages/cli/src/validate-completion.ts
+++ b/packages/cli/src/validate-completion.ts
@@ -1,5 +1,5 @@
-import { completionConfigPaths, completionSchemaPaths } from '@prisma/internals/src/cli/completion-values'
-import type { CommandCompletion } from '@prisma/internals/src/cli/types'
+import type { CommandCompletion } from '@prisma/internals'
+import { completionConfigPaths, completionSchemaPaths } from '@prisma/internals'
 
 export const validateCompletion: CommandCompletion = {
   name: 'validate',

--- a/packages/cli/src/version-completion.ts
+++ b/packages/cli/src/version-completion.ts
@@ -1,4 +1,4 @@
-import type { CommandCompletion } from '@prisma/internals/src/cli/types'
+import type { CommandCompletion } from '@prisma/internals'
 
 export const versionCompletion: CommandCompletion = {
   name: 'version',

--- a/packages/migrate/src/commands/db-command-completion.ts
+++ b/packages/migrate/src/commands/db-command-completion.ts
@@ -1,5 +1,5 @@
-import { completionConfigPaths, completionSchemaPaths } from '@prisma/internals/src/cli/completion-values'
-import type { CommandCompletion } from '@prisma/internals/src/cli/types'
+import type { CommandCompletion } from '@prisma/internals'
+import { completionConfigPaths, completionSchemaPaths } from '@prisma/internals'
 
 export const dbCompletion: CommandCompletion = {
   name: 'db',

--- a/packages/migrate/src/commands/db-execute-completion.ts
+++ b/packages/migrate/src/commands/db-execute-completion.ts
@@ -1,5 +1,5 @@
-import { completionConfigPaths, completionSqlScriptPaths } from '@prisma/internals/src/cli/completion-values'
-import type { CommandCompletion } from '@prisma/internals/src/cli/types'
+import type { CommandCompletion } from '@prisma/internals'
+import { completionConfigPaths, completionSqlScriptPaths } from '@prisma/internals'
 
 export const dbExecuteCompletion: CommandCompletion = {
   name: 'db execute',

--- a/packages/migrate/src/commands/db-pull-completion.ts
+++ b/packages/migrate/src/commands/db-pull-completion.ts
@@ -1,11 +1,11 @@
+import type { CommandCompletion } from '@prisma/internals'
 import {
   completionCompositeTypeDepths,
   completionConfigPaths,
   completionDatabaseSchemas,
   completionDatasourceUrls,
   completionSchemaPaths,
-} from '@prisma/internals/src/cli/completion-values'
-import type { CommandCompletion } from '@prisma/internals/src/cli/types'
+} from '@prisma/internals'
 
 export const dbPullCompletion: CommandCompletion = {
   name: 'db pull',

--- a/packages/migrate/src/commands/db-push-completion.ts
+++ b/packages/migrate/src/commands/db-push-completion.ts
@@ -1,9 +1,5 @@
-import {
-  completionConfigPaths,
-  completionDatasourceUrls,
-  completionSchemaPaths,
-} from '@prisma/internals/src/cli/completion-values'
-import type { CommandCompletion } from '@prisma/internals/src/cli/types'
+import type { CommandCompletion } from '@prisma/internals'
+import { completionConfigPaths, completionDatasourceUrls, completionSchemaPaths } from '@prisma/internals'
 
 export const dbPushCompletion: CommandCompletion = {
   name: 'db push',

--- a/packages/migrate/src/commands/db-seed-completion.ts
+++ b/packages/migrate/src/commands/db-seed-completion.ts
@@ -1,5 +1,5 @@
-import { completionConfigPaths, completionSchemaPaths } from '@prisma/internals/src/cli/completion-values'
-import type { CommandCompletion } from '@prisma/internals/src/cli/types'
+import type { CommandCompletion } from '@prisma/internals'
+import { completionConfigPaths, completionSchemaPaths } from '@prisma/internals'
 
 export const dbSeedCompletion: CommandCompletion = {
   name: 'db seed',

--- a/packages/migrate/src/commands/migrate-command-completion.ts
+++ b/packages/migrate/src/commands/migrate-command-completion.ts
@@ -1,5 +1,5 @@
-import { completionConfigPaths, completionSchemaPaths } from '@prisma/internals/src/cli/completion-values'
-import type { CommandCompletion } from '@prisma/internals/src/cli/types'
+import type { CommandCompletion } from '@prisma/internals'
+import { completionConfigPaths, completionSchemaPaths } from '@prisma/internals'
 
 export const migrateCompletion: CommandCompletion = {
   name: 'migrate',

--- a/packages/migrate/src/commands/migrate-deploy-completion.ts
+++ b/packages/migrate/src/commands/migrate-deploy-completion.ts
@@ -1,5 +1,5 @@
-import { completionConfigPaths, completionSchemaPaths } from '@prisma/internals/src/cli/completion-values'
-import type { CommandCompletion } from '@prisma/internals/src/cli/types'
+import type { CommandCompletion } from '@prisma/internals'
+import { completionConfigPaths, completionSchemaPaths } from '@prisma/internals'
 
 export const migrateDeployCompletion: CommandCompletion = {
   name: 'migrate deploy',

--- a/packages/migrate/src/commands/migrate-dev-completion.ts
+++ b/packages/migrate/src/commands/migrate-dev-completion.ts
@@ -1,10 +1,10 @@
+import type { CommandCompletion } from '@prisma/internals'
 import {
   completionConfigPaths,
   completionDatasourceUrls,
   completionMigrationNames,
   completionSchemaPaths,
-} from '@prisma/internals/src/cli/completion-values'
-import type { CommandCompletion } from '@prisma/internals/src/cli/types'
+} from '@prisma/internals'
 
 export const migrateDevCompletion: CommandCompletion = {
   name: 'migrate dev',

--- a/packages/migrate/src/commands/migrate-diff-completion.ts
+++ b/packages/migrate/src/commands/migrate-diff-completion.ts
@@ -1,10 +1,10 @@
+import type { CommandCompletion } from '@prisma/internals'
 import {
   completionConfigPaths,
   completionDiffOutputPaths,
   completionMigrationsDirPaths,
   completionSchemaPaths,
-} from '@prisma/internals/src/cli/completion-values'
-import type { CommandCompletion } from '@prisma/internals/src/cli/types'
+} from '@prisma/internals'
 
 export const migrateDiffCompletion: CommandCompletion = {
   name: 'migrate diff',

--- a/packages/migrate/src/commands/migrate-reset-completion.ts
+++ b/packages/migrate/src/commands/migrate-reset-completion.ts
@@ -1,5 +1,5 @@
-import { completionConfigPaths, completionSchemaPaths } from '@prisma/internals/src/cli/completion-values'
-import type { CommandCompletion } from '@prisma/internals/src/cli/types'
+import type { CommandCompletion } from '@prisma/internals'
+import { completionConfigPaths, completionSchemaPaths } from '@prisma/internals'
 
 export const migrateResetCompletion: CommandCompletion = {
   name: 'migrate reset',

--- a/packages/migrate/src/commands/migrate-resolve-completion.ts
+++ b/packages/migrate/src/commands/migrate-resolve-completion.ts
@@ -1,9 +1,5 @@
-import {
-  completionConfigPaths,
-  completionMigrationIds,
-  completionSchemaPaths,
-} from '@prisma/internals/src/cli/completion-values'
-import type { CommandCompletion } from '@prisma/internals/src/cli/types'
+import type { CommandCompletion } from '@prisma/internals'
+import { completionConfigPaths, completionMigrationIds, completionSchemaPaths } from '@prisma/internals'
 
 export const migrateResolveCompletion: CommandCompletion = {
   name: 'migrate resolve',

--- a/packages/migrate/src/commands/migrate-status-completion.ts
+++ b/packages/migrate/src/commands/migrate-status-completion.ts
@@ -1,5 +1,5 @@
-import { completionConfigPaths, completionSchemaPaths } from '@prisma/internals/src/cli/completion-values'
-import type { CommandCompletion } from '@prisma/internals/src/cli/types'
+import type { CommandCompletion } from '@prisma/internals'
+import { completionConfigPaths, completionSchemaPaths } from '@prisma/internals'
 
 export const migrateStatusCompletion: CommandCompletion = {
   name: 'migrate status',


### PR DESCRIPTION
## Description

`@prisma/migrate` 7.9.0 fails immediately on `require`/`import` with `MODULE_NOT_FOUND`, before any of its APIs can be used:

```
Error: Cannot find module '@prisma/internals/src/cli/completion-values'
Require stack:
- node_modules/@prisma/migrate/dist/chunk-WA2SOLDQ.js
- node_modules/@prisma/migrate/dist/index.js
```

The tab-completion files added in #28351 (`*-completion.ts` in `packages/migrate` and `packages/cli`, plus a couple of related command files) import types and values from deep `@prisma/internals/src/...` paths — source paths that only resolve inside the monorepo via workspace symlinks. The published `@prisma/internals` package ships `dist/`, not `src/`, so this breaks as soon as `@prisma/migrate`/`@prisma/cli` are installed from npm as independent packages, which is exactly what the published `prisma` CLI does.

I found this affects 4 distinct deep-import paths across 27 files, not just the one path in the original report:
- `@prisma/internals/src/cli/completion-values`
- `@prisma/internals/src/cli/types`
- `@prisma/internals/src/cli/utils`
- `@prisma/internals/src/cli/Help`
- `@prisma/internals/src/utils/validatePrismaConfigWithDatasource`

All of these are already re-exported from `@prisma/internals`'s public entry (`packages/internals/src/index.ts`), so this switches every occurrence to import from `'@prisma/internals'` directly — matching how the rest of the codebase already imports from that package (e.g. `DbCommand.ts`, `Format.ts`).

Closes #29772

## Test plan

- Reproduced the exact failure from the issue: built `packages/migrate` and confirmed `require('./dist/index.js')` failed with `MODULE_NOT_FOUND` before the fix, and loads successfully (31 exports) after it.
- `pnpm run test completion` in `packages/cli` — 5/5 passing.
- `pnpm run test DbCommand MigrateCommand` in `packages/migrate` — 8/8 passing.
- `eslint` on all changed files — no errors (some files ended up with the value and type imports as two separate `import`/`import type` statements from `@prisma/internals`, which `eslint --fix` normalizes and the project's lint config accepts).
- Confirmed via `grep` that no `@prisma/internals/src/...` import remains anywhere in the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized CLI completion and migration command imports through the public internals package interface.
  * Preserved all existing command options, completion definitions, and runtime behavior.
* **Compatibility**
  * Improved resilience to internal module structure changes without altering the command-line experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->