### PR TITLE
chore: point skills-contrib repo references at prisma/prisma

### DIFF
--- a/skills-contrib/contrib-pr/SKILL.md
+++ b/skills-contrib/contrib-pr/SKILL.md
@@ -5,7 +5,7 @@ description: Open a high-quality external contributor PR against prisma-next. Us
 
 # Contributor PR skill (external)
 
-This skill is for **external contributors** to `prisma/prisma-next` who are using an LLM-based agent to author or finalize a PR. It is intentionally separate from the maintainer-facing `create-pr` skill: it does not depend on Linear access, internal plan/spec documents, or any private context. It encodes the expectations laid out in [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) as a runnable workflow, so the PR you produce matches the shape maintainers expect on the first review round.
+This skill is for **external contributors** to `prisma/prisma` who are using an LLM-based agent to author or finalize a PR. It is intentionally separate from the maintainer-facing `create-pr` skill: it does not depend on Linear access, internal plan/spec documents, or any private context. It encodes the expectations laid out in [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) as a runnable workflow, so the PR you produce matches the shape maintainers expect on the first review round.
 
 If the user is a maintainer with access to internal Linear tickets, use `create-pr` instead.
 
@@ -141,7 +141,7 @@ EOF
 )"
 ```
 
-   The `gh` CLI must be authenticated against the contributor's GitHub account, not against `prisma/prisma-next` directly. The PR will open against `prisma:main` from the contributor's fork.
+   The `gh` CLI must be authenticated against the contributor's GitHub account, not against `prisma/prisma` directly. The PR will open against `prisma:main` from the contributor's fork.
 
 4. Return the PR URL.
 

--- a/skills-contrib/draft-release-notes/SKILL.md
+++ b/skills-contrib/draft-release-notes/SKILL.md
@@ -82,7 +82,7 @@ gh pr list --state merged --base main --limit 200 \
   --json number,title,author,labels,mergeCommit,mergedAt
 
 # Or resolve a single PR by its merge commit:
-gh api "repos/prisma/prisma-next/commits/<sha>/pulls" \
+gh api "repos/prisma/prisma/commits/<sha>/pulls" \
   --jq '.[] | {number, title, author: .user.login, labels: [.labels[].name]}'
 ```
 
@@ -120,16 +120,16 @@ Write the entries under the fixed section order from [`docs/releases/README.md`]
 3. **Fixes** — bug fixes.
 4. **New contributors** — first-time contributors, with the PR that welcomed them.
 
-Breaking changes lead because they are what a reader scanning the notes most needs to see. Every line links its PR as an **absolute markdown link** — `[#NNN](https://github.com/prisma/prisma-next/pull/NNN)`, never bare `#NNN`. Bare references only autolink inside the GitHub Release body; they render as plain text when the committed `docs/releases/v<version>.md` is read as a repo file or in PR review, so the explicit link form is what makes every reference work in every context.
+Breaking changes lead because they are what a reader scanning the notes most needs to see. Every line links its PR as an **absolute markdown link** — `[#NNN](https://github.com/prisma/prisma/pull/NNN)`, never bare `#NNN`. Bare references only autolink inside the GitHub Release body; they render as plain text when the committed `docs/releases/v<version>.md` is read as a repo file or in PR review, so the explicit link form is what makes every reference work in every context.
 
 ### 6. Anchor breaking-change entries to their migration recipe
 
 A breaking change shipping in this release has a matching upgrade-instructions directory keyed to the minor transition, following the convention enforced by [`scripts/check-upgrade-coverage.mjs`](../../scripts/check-upgrade-coverage.mjs) and authored via [`record-upgrade-instructions`](../record-upgrade-instructions/SKILL.md). The transition label is `<prev.major>.<prev.minor>-to-<head.major>.<head.minor>` — computed from the **previous stable tag's** minor and `$NEXT`'s minor (e.g. `v0.11.0` → `0.12.0` gives `0.11-to-0.12`). Point the breaking note at the recipe directory rather than restating the migration.
 
-**Recipe links must be absolute, tag-pinned URLs** — `https://github.com/prisma/prisma-next/blob/v$NEXT/...`. The notes file becomes the GitHub Release body via `--notes-file`, and the Release page does **not** reliably resolve repo-relative links, so a relative recipe path would publish as a dead migration link. Pinning to the release tag (`/blob/v$NEXT/`) means the link always resolves and never rots as the recipe tree evolves on `main`:
+**Recipe links must be absolute, tag-pinned URLs** — `https://github.com/prisma/prisma/blob/v$NEXT/...`. The notes file becomes the GitHub Release body via `--notes-file`, and the Release page does **not** reliably resolve repo-relative links, so a relative recipe path would publish as a dead migration link. Pinning to the release tag (`/blob/v$NEXT/`) means the link always resolves and never rots as the recipe tree evolves on `main`:
 
-- User-facing migrations: `https://github.com/prisma/prisma-next/blob/v$NEXT/skills/upgrade/prisma-next-upgrade/upgrades/<prev.minor>-to-<head.minor>/`
-- Extension-author migrations: `https://github.com/prisma/prisma-next/blob/v$NEXT/skills/extension-author/prisma-next-extension-upgrade/upgrades/<prev.minor>-to-<head.minor>/`
+- User-facing migrations: `https://github.com/prisma/prisma/blob/v$NEXT/skills/upgrade/prisma-next-upgrade/upgrades/<prev.minor>-to-<head.minor>/`
+- Extension-author migrations: `https://github.com/prisma/prisma/blob/v$NEXT/skills/extension-author/prisma-next-extension-upgrade/upgrades/<prev.minor>-to-<head.minor>/`
 
 A breaking change can affect one or both audiences — link whichever recipe directories exist.
 
@@ -149,7 +149,7 @@ Prose tells a reader *that* something changed; a short before/after snippet show
 The format is the prose bullet, then the nested example:
 
 ````md
-- **<title>** — <what changed and what the reader must do; recipe link>. ([#<pr>](https://github.com/prisma/prisma-next/pull/<pr>))
+- **<title>** — <what changed and what the reader must do; recipe link>. ([#<pr>](https://github.com/prisma/prisma/pull/<pr>))
 
   Before:
 
@@ -169,7 +169,7 @@ The format is the prose bullet, then the nested example:
 Preserve the "New contributors" credit that `--generate-notes` gave for free. Each first-time contributor gets a line naming the PR that welcomed them, with both the handle and the PR as absolute links:
 
 ```md
-- [@<handle>](https://github.com/<handle>) made their first contribution in [#<pr>](https://github.com/prisma/prisma-next/pull/<pr>)
+- [@<handle>](https://github.com/<handle>) made their first contribution in [#<pr>](https://github.com/prisma/prisma/pull/<pr>)
 ```
 
 Resolve first-time status from PR author metadata (e.g. `gh api` `author_association` of `FIRST_TIME_CONTRIBUTOR` / `FIRST_TIMER`, or by checking whether the author appears in the range before this PR).
@@ -185,7 +185,7 @@ Fill the [`docs/releases/README.md`](../../docs/releases/README.md) template int
 
 ## Breaking changes
 
-- **<short title>** — <what changed and what the reader must do; link the upgrade recipe>. ([#<pr>](https://github.com/prisma/prisma-next/pull/<pr>))
+- **<short title>** — <what changed and what the reader must do; link the upgrade recipe>. ([#<pr>](https://github.com/prisma/prisma/pull/<pr>))
 
   Before:
 
@@ -201,15 +201,15 @@ Fill the [`docs/releases/README.md`](../../docs/releases/README.md) template int
 
 ## Features
 
-- <new capability>. ([#<pr>](https://github.com/prisma/prisma-next/pull/<pr>))
+- <new capability>. ([#<pr>](https://github.com/prisma/prisma/pull/<pr>))
 
 ## Fixes
 
-- <bug fix>. ([#<pr>](https://github.com/prisma/prisma-next/pull/<pr>))
+- <bug fix>. ([#<pr>](https://github.com/prisma/prisma/pull/<pr>))
 
 ## New contributors
 
-- [@<handle>](https://github.com/<handle>) made their first contribution in [#<pr>](https://github.com/prisma/prisma-next/pull/<pr>)
+- [@<handle>](https://github.com/<handle>) made their first contribution in [#<pr>](https://github.com/prisma/prisma/pull/<pr>)
 ````
 
 Then **prepend** a `## v$NEXT` entry to [`CHANGELOG.md`](../../CHANGELOG.md), mirroring the notes-file body (newest-first). The CHANGELOG is a plain newest-first mirror — no second authoring format, no "Keep a Changelog" headers; copy the section bodies under the `## v$NEXT` header at the top of the entry list (below the file's intro and the `<!-- New release entries go here … -->` marker).
@@ -249,8 +249,8 @@ Cutting `v0.12.0` from `origin/main` (previous stable tag `v0.11.0`).
 3. PR #1240's title is `TML-2536: contract deserializer seam`. Read TML-2536 in Linear → the user-facing outcome is "contract deserialization now goes through an explicit adapter seam". Write that outcome in public words; cite #1240, not TML-2536.
 4. Triage: #1240 changes the contract format → **always-include, breaking**. A CI-cache tweak (#1237) and a test-only refactor (#1239) → **default-exclude**, dropped silently. A new `includeMany` capability (#1234) → feature. A null-handling bug fix (#1242) → fix. First-time contributor @somebody on #1238.
 5. Categorize: Breaking changes (#1240) → Features (#1234) → Fixes (#1242) → New contributors (@somebody, #1238).
-6. The breaking change's transition is `0.11-to-0.12`. The recipe dir `skills/upgrade/prisma-next-upgrade/upgrades/0.11-to-0.12/` exists in the checkout → the breaking note links it as a tag-pinned URL, `https://github.com/prisma/prisma-next/blob/v0.12.0/skills/upgrade/prisma-next-upgrade/upgrades/0.11-to-0.12/`. (If it were absent, the note would describe the required adapter migration inline instead.)
-7. #1240 is a code-visible contract-shape/runtime change, so it earns a before/after example — lifted from the `0.11-to-0.12` recipe (a TS runtime change, so a `ts` fence). @somebody's contributor line, with absolute links: `- [@somebody](https://github.com/somebody) made their first contribution in [#1238](https://github.com/prisma/prisma-next/pull/1238)`.
+6. The breaking change's transition is `0.11-to-0.12`. The recipe dir `skills/upgrade/prisma-next-upgrade/upgrades/0.11-to-0.12/` exists in the checkout → the breaking note links it as a tag-pinned URL, `https://github.com/prisma/prisma/blob/v0.12.0/skills/upgrade/prisma-next-upgrade/upgrades/0.11-to-0.12/`. (If it were absent, the note would describe the required adapter migration inline instead.)
+7. #1240 is a code-visible contract-shape/runtime change, so it earns a before/after example — lifted from the `0.11-to-0.12` recipe (a TS runtime change, so a `ts` fence). @somebody's contributor line, with absolute links: `- [@somebody](https://github.com/somebody) made their first contribution in [#1238](https://github.com/prisma/prisma/pull/1238)`.
 8. Write `docs/releases/v0.12.0.md` (every PR ref + handle an absolute link; the breaking entry carries a before/after):
 
 ````md
@@ -260,7 +260,7 @@ Contract deserialization gains an explicit adapter seam, and queries can now eag
 
 ## Breaking changes
 
-- **Contract deserialization requires an adapter seam** — deserialization now goes through an explicit seam adapter; existing code must register one. See the [0.11-to-0.12 upgrade recipe](https://github.com/prisma/prisma-next/blob/v0.12.0/skills/upgrade/prisma-next-upgrade/upgrades/0.11-to-0.12/). ([#1240](https://github.com/prisma/prisma-next/pull/1240))
+- **Contract deserialization requires an adapter seam** — deserialization now goes through an explicit seam adapter; existing code must register one. See the [0.11-to-0.12 upgrade recipe](https://github.com/prisma/prisma/blob/v0.12.0/skills/upgrade/prisma-next-upgrade/upgrades/0.11-to-0.12/). ([#1240](https://github.com/prisma/prisma/pull/1240))
 
   Before:
 
@@ -276,15 +276,15 @@ Contract deserialization gains an explicit adapter seam, and queries can now eag
 
 ## Features
 
-- `includeMany` eager-loads related records in a single query. ([#1234](https://github.com/prisma/prisma-next/pull/1234))
+- `includeMany` eager-loads related records in a single query. ([#1234](https://github.com/prisma/prisma/pull/1234))
 
 ## Fixes
 
-- Null values in `returning()` projections no longer throw. ([#1242](https://github.com/prisma/prisma-next/pull/1242))
+- Null values in `returning()` projections no longer throw. ([#1242](https://github.com/prisma/prisma/pull/1242))
 
 ## New contributors
 
-- [@somebody](https://github.com/somebody) made their first contribution in [#1238](https://github.com/prisma/prisma-next/pull/1238)
+- [@somebody](https://github.com/somebody) made their first contribution in [#1238](https://github.com/prisma/prisma/pull/1238)
 ````
 
    Then prepend the same body under `## v0.12.0` to `CHANGELOG.md`.

--- a/skills-contrib/record-upgrade-instructions/SKILL.md
+++ b/skills-contrib/record-upgrade-instructions/SKILL.md
@@ -19,8 +19,8 @@ This skill fires on PRs **inside this repo** that make a breaking change to Pris
 
 The published skills you will be authoring entries into:
 
-- `skills/upgrade/prisma-next-upgrade/` — distributed via `pnpm dlx skills add prisma/prisma-next/skills/upgrade --all`. **Audience: users of Prisma Next** (consumers of the public package API: `@prisma-next/postgres`, `@prisma-next/mongo`, the contract files in `prisma/`, on-disk migration shape).
-- `skills/extension-author/prisma-next-extension-upgrade/` — distributed via `pnpm dlx skills add prisma/prisma-next/skills/extension-author --all`. **Audience: authors of Prisma Next extensions** (consumers of the framework SPI: `@prisma-next/contract`, `@prisma-next/framework-components`, `@prisma-next/migration-tools`, etc.).
+- `skills/upgrade/prisma-next-upgrade/` — distributed via `pnpm dlx skills add prisma/prisma/skills/upgrade --all`. **Audience: users of Prisma Next** (consumers of the public package API: `@prisma-next/postgres`, `@prisma-next/mongo`, the contract files in `prisma/`, on-disk migration shape).
+- `skills/extension-author/prisma-next-extension-upgrade/` — distributed via `pnpm dlx skills add prisma/prisma/skills/extension-author --all`. **Audience: authors of Prisma Next extensions** (consumers of the framework SPI: `@prisma-next/contract`, `@prisma-next/framework-components`, `@prisma-next/migration-tools`, etc.).
 
 The two skill clusters are independent (no shared content). Cross-audience breaking changes — where the same on-disk transformation applies to both substrates — are recorded *separately* in each cluster, including duplicated colocated scripts.
 


### PR DESCRIPTION
Follow-up to the repo migration: the codebase now lives at `prisma/prisma`, and PRs on the old `prisma/prisma-next` were not transferred, so links generated from these skills would be dead.

What changed:

- `skills-contrib/draft-release-notes`: every PR-link template (`[#NNN](https://github.com/prisma/prisma/pull/NNN)`), the tag-pinned recipe URLs, the `gh api` commit-to-PR lookup, and the worked example now use the new repo slug.
- `skills-contrib/contrib-pr`: the contributor audience line and the `gh` auth note now name `prisma/prisma`.
- `skills-contrib/record-upgrade-instructions`: the `skills add` install paths for the upgrade and extension-author skill trees now pull from `prisma/prisma`.

No behavior changes beyond the slug. The ignite `.pilot` mirror has a matching update in prisma/ignite#179 so mirror and canonical stay in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated contributor guidance to use the current Prisma repository and main branch for pull requests.
  - Clarified that contributors must authenticate the GitHub CLI with their own account and submit changes from a fork.
  - Updated draft release note instructions, examples, recipe links, and contributor credits to reference the current repository.
  - Corrected the documented command for distributing the user-facing upgrade skill.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->