### PR TITLE
TML-3108: serialize queries per pinned pg client in the Postgres runtime driver

### DIFF
--- a/packages/3-targets/7-drivers/postgres/src/postgres-driver.ts
+++ b/packages/3-targets/7-drivers/postgres/src/postgres-driver.ts
@@ -26,6 +26,12 @@ import { isAlreadyConnectedError, isPostgresError, normalizePgError } from './no
 
 export type QueryResult<T extends QueryResultRow = QueryResultRow> = PgQueryResult<T>;
 
+/**
+ * Concurrency contract: the driver serializes queries per physical client, so
+ * overlapping calls on a `pgClient` binding, a pinned connection, or a
+ * transaction handle run strictly sequentially in FIFO order. Pool bindings
+ * run each driver-level call on its own pool client and are unaffected.
+ */
 export type PostgresBinding =
   | { readonly kind: 'url'; readonly url: string }
   | { readonly kind: 'pgPool'; readonly pool: PoolType }
@@ -117,15 +123,19 @@ class AsyncMutex {
   }
 }
 
-// Serializes BEGIN…COMMIT stream spans per physical client so two concurrent
-// streams on a shared client cannot interleave their transaction boundaries.
-const streamSpanLocks = new WeakMap<object, AsyncMutex>();
+// One query in flight per physical client: pg@9 removes pg@8's internal query
+// queue and throws when a query is sent while another is running, so the
+// driver owns FIFO serialization. Held across a whole unit of work (an entire
+// runQuery stream span, a buffered query, a transaction boundary statement),
+// which also keeps concurrent streams on a shared client from interleaving
+// their BEGIN…COMMIT wraps.
+const clientQueryLocks = new WeakMap<object, AsyncMutex>();
 
-function acquireStreamSpan(client: object): Promise<() => void> {
-  let mutex = streamSpanLocks.get(client);
+function acquireClientQueryLock(client: object): Promise<() => void> {
+  let mutex = clientQueryLocks.get(client);
   if (mutex === undefined) {
     mutex = new AsyncMutex();
-    streamSpanLocks.set(client, mutex);
+    clientQueryLocks.set(client, mutex);
   }
   return mutex.lock();
 }
@@ -214,28 +224,33 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
   private async *runQuery<Row>(request: SqlExecuteRequest, name?: string): AsyncIterable<Row> {
     const client = await this.acquireClient();
     try {
-      if (!this.options.cursorDisabled) {
-        try {
-          for await (const row of this.streamWithPortalProtection(
-            client,
-            request,
-            this.options.cursorBatchSize,
-            name,
-          )) {
-            yield row as Row;
-          }
-          return;
-        } catch (cursorError) {
-          // Non-pg cursor-specific errors fall through to the buffered path;
-          // real pg errors propagate.
-          if (!(cursorError instanceof Error) || isPostgresError(cursorError)) {
-            throw cursorError;
+      const releaseLock = await acquireClientQueryLock(client);
+      try {
+        if (!this.options.cursorDisabled) {
+          try {
+            for await (const row of this.streamWithPortalProtection(
+              client,
+              request,
+              this.options.cursorBatchSize,
+              name,
+            )) {
+              yield row as Row;
+            }
+            return;
+          } catch (cursorError) {
+            // Non-pg cursor-specific errors fall through to the buffered path;
+            // real pg errors propagate.
+            if (!(cursorError instanceof Error) || isPostgresError(cursorError)) {
+              throw cursorError;
+            }
           }
         }
-      }
 
-      for await (const row of this.executeBuffered(client, request.sql, request.params, name)) {
-        yield row as Row;
+        for await (const row of this.executeBuffered(client, request.sql, request.params, name)) {
+          yield row as Row;
+        }
+      } finally {
+        releaseLock();
       }
     } finally {
       await this.releaseClient(client);
@@ -248,10 +263,15 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
     const text = `EXPLAIN (FORMAT JSON) ${request.sql}`;
     const client = await this.acquireClient();
     try {
-      const result = await client
-        .query(text, request.params as unknown[] | undefined)
-        .catch(rethrowNormalizedError);
-      return { rows: result.rows as ReadonlyArray<Record<string, unknown>> };
+      const releaseLock = await acquireClientQueryLock(client);
+      try {
+        const result = await client
+          .query(text, request.params as unknown[] | undefined)
+          .catch(rethrowNormalizedError);
+        return { rows: result.rows as ReadonlyArray<Record<string, unknown>> };
+      } finally {
+        releaseLock();
+      }
     } finally {
       await this.releaseClient(client);
     }
@@ -263,10 +283,15 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
   ): Promise<SqlQueryResult<Row>> {
     const client = await this.acquireClient();
     try {
-      const result = await client
-        .query(sql, params as unknown[] | undefined)
-        .catch(rethrowNormalizedError);
-      return result as unknown as SqlQueryResult<Row>;
+      const releaseLock = await acquireClientQueryLock(client);
+      try {
+        const result = await client
+          .query(sql, params as unknown[] | undefined)
+          .catch(rethrowNormalizedError);
+        return result as unknown as SqlQueryResult<Row>;
+      } finally {
+        releaseLock();
+      }
     } finally {
       await this.releaseClient(client);
     }
@@ -292,26 +317,24 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
       return;
     }
 
-    const releaseSpan = await acquireStreamSpan(client);
+    // The caller (runQuery) already holds the per-client query lock for the
+    // whole stream span, so the BEGIN…COMMIT wrap cannot interleave with any
+    // other query on this client.
+    await client.query('BEGIN');
+    let streamFailed = false;
     try {
-      await client.query('BEGIN');
-      let streamFailed = false;
-      try {
-        yield* this.executeWithCursor(client, request.sql, request.params, cursorBatchSize, name);
-      } catch (error) {
-        streamFailed = true;
-        throw error;
-      } finally {
-        // Terminating COMMIT runs on every exit — normal completion, stream
-        // error, and consumer abandonment (early `.return()`), the last of
-        // which leaves the generator right after this `finally`, so the COMMIT
-        // and its error handling must live inside it. `commitStreamSpan`
-        // surfaces a failing COMMIT unless the stream itself already threw
-        // (then that error wins).
-        await this.commitStreamSpan(client, streamFailed);
-      }
+      yield* this.executeWithCursor(client, request.sql, request.params, cursorBatchSize, name);
+    } catch (error) {
+      streamFailed = true;
+      throw error;
     } finally {
-      releaseSpan();
+      // Terminating COMMIT runs on every exit — normal completion, stream
+      // error, and consumer abandonment (early `.return()`), the last of
+      // which leaves the generator right after this `finally`, so the COMMIT
+      // and its error handling must live inside it. `commitStreamSpan`
+      // surfaces a failing COMMIT unless the stream itself already threw
+      // (then that error wins).
+      await this.commitStreamSpan(client, streamFailed);
     }
   }
 
@@ -403,7 +426,12 @@ class PostgresConnectionImpl extends PostgresQueryable implements SqlConnection 
   }
 
   async beginTransaction(): Promise<SqlTransaction> {
-    await this.#connection.query('BEGIN').catch(rethrowNormalizedError);
+    const releaseLock = await acquireClientQueryLock(this.#connection);
+    try {
+      await this.#connection.query('BEGIN').catch(rethrowNormalizedError);
+    } finally {
+      releaseLock();
+    }
     this.#transactionOpen = true;
     return new PostgresTransactionImpl(this.#connection, this.options, () => {
       this.#transactionOpen = false;
@@ -482,17 +510,21 @@ class PostgresTransactionImpl extends PostgresQueryable implements SqlTransactio
   // silently reopening the portal race on a connection whose transaction state
   // no longer matches reality.
   async commit(): Promise<void> {
+    const releaseLock = await acquireClientQueryLock(this.#connection);
     try {
       await this.#connection.query('COMMIT').catch(rethrowNormalizedError);
     } finally {
+      releaseLock();
       this.#settle();
     }
   }
 
   async rollback(): Promise<void> {
+    const releaseLock = await acquireClientQueryLock(this.#connection);
     try {
       await this.#connection.query('ROLLBACK').catch(rethrowNormalizedError);
     } finally {
+      releaseLock();
       this.#settle();
     }
   }

--- a/packages/3-targets/7-drivers/postgres/src/postgres-driver.ts
+++ b/packages/3-targets/7-drivers/postgres/src/postgres-driver.ts
@@ -31,6 +31,12 @@ export type QueryResult<T extends QueryResultRow = QueryResultRow> = PgQueryResu
  * overlapping calls on a `pgClient` binding, a pinned connection, or a
  * transaction handle run strictly sequentially in FIFO order. Pool bindings
  * run each driver-level call on its own pool client and are unaffected.
+ *
+ * Lock lifetime: buffered execution (cursors disabled) locks the client only
+ * while fetching; row iteration is lock-free, so a nested query on the same
+ * client inside `for await` works. Cursor-enabled streams hold the lock for
+ * the stream's entire lifetime — a nested query on the same client inside
+ * stream iteration deadlocks, exactly as under pg@8's queue.
  */
 export type PostgresBinding =
   | { readonly kind: 'url'; readonly url: string }
@@ -125,10 +131,11 @@ class AsyncMutex {
 
 // One query in flight per physical client: pg@9 removes pg@8's internal query
 // queue and throws when a query is sent while another is running, so the
-// driver owns FIFO serialization. Held across a whole unit of work (an entire
-// runQuery stream span, a buffered query, a transaction boundary statement),
-// which also keeps concurrent streams on a shared client from interleaving
-// their BEGIN…COMMIT wraps.
+// driver owns FIFO serialization. Held for exactly as long as the client is
+// busy: a buffered fetch or transaction boundary statement locks only its own
+// await, while a cursor stream span locks BEGIN…COMMIT wholesale (the cursor
+// occupies the connection for its entire lifetime), which also keeps
+// concurrent streams on a shared client from interleaving their wraps.
 const clientQueryLocks = new WeakMap<object, AsyncMutex>();
 
 function acquireClientQueryLock(client: object): Promise<() => void> {
@@ -224,33 +231,35 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
   private async *runQuery<Row>(request: SqlExecuteRequest, name?: string): AsyncIterable<Row> {
     const client = await this.acquireClient();
     try {
-      const releaseLock = await acquireClientQueryLock(client);
-      try {
-        if (!this.options.cursorDisabled) {
-          try {
-            for await (const row of this.streamWithPortalProtection(
-              client,
-              request,
-              this.options.cursorBatchSize,
-              name,
-            )) {
-              yield row as Row;
-            }
-            return;
-          } catch (cursorError) {
-            // Non-pg cursor-specific errors fall through to the buffered path;
-            // real pg errors propagate.
-            if (!(cursorError instanceof Error) || isPostgresError(cursorError)) {
-              throw cursorError;
-            }
+      if (!this.options.cursorDisabled) {
+        // A cursor occupies the connection for the stream's whole lifetime,
+        // so the lock spans it (BEGIN…COMMIT included); released in `finally`
+        // on completion, stream error, and consumer abandonment — and before
+        // the buffered fallback below, which takes its own per-statement lock.
+        const releaseLock = await acquireClientQueryLock(client);
+        try {
+          for await (const row of this.streamWithPortalProtection(
+            client,
+            request,
+            this.options.cursorBatchSize,
+            name,
+          )) {
+            yield row as Row;
           }
+          return;
+        } catch (cursorError) {
+          // Non-pg cursor-specific errors fall through to the buffered path;
+          // real pg errors propagate.
+          if (!(cursorError instanceof Error) || isPostgresError(cursorError)) {
+            throw cursorError;
+          }
+        } finally {
+          releaseLock();
         }
+      }
 
-        for await (const row of this.executeBuffered(client, request.sql, request.params, name)) {
-          yield row as Row;
-        }
-      } finally {
-        releaseLock();
+      for await (const row of this.executeBuffered(client, request.sql, request.params, name)) {
+        yield row as Row;
       }
     } finally {
       await this.releaseClient(client);
@@ -381,6 +390,9 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
     }
   }
 
+  // The lock covers only the fetch: once `client.query` resolves the client
+  // is protocol-idle, and holding the lock across the yields would hand its
+  // lifetime to the consumer (deadlocking a nested query inside `for await`).
   private async *executeBuffered(
     client: PoolClient | Client,
     sql: string,
@@ -388,7 +400,13 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
     name?: string,
   ): AsyncIterable<Record<string, unknown>> {
     const config: QueryConfig = { name, text: sql, values: (params ?? []) as unknown[] };
-    const result = await client.query(config);
+    const releaseLock = await acquireClientQueryLock(client);
+    let result: PgQueryResult;
+    try {
+      result = await client.query(config);
+    } finally {
+      releaseLock();
+    }
     for (const row of result.rows as Record<string, unknown>[]) {
       yield row;
     }

--- a/packages/3-targets/7-drivers/postgres/test/driver.pinned-client-serialization.integration.test.ts
+++ b/packages/3-targets/7-drivers/postgres/test/driver.pinned-client-serialization.integration.test.ts
@@ -88,7 +88,9 @@ async function createHarness(options?: { readonly cursorBatchSize?: number }): P
 function captureProcessWarnings(): { readonly warnings: Error[]; stop(): void } {
   const warnings: Error[] = [];
   const handler = (warning: Error): void => {
-    warnings.push(warning);
+    if (warning.name === 'DeprecationWarning') {
+      warnings.push(warning);
+    }
   };
   process.on('warning', handler);
   return {

--- a/packages/3-targets/7-drivers/postgres/test/driver.pinned-client-serialization.integration.test.ts
+++ b/packages/3-targets/7-drivers/postgres/test/driver.pinned-client-serialization.integration.test.ts
@@ -119,8 +119,11 @@ afterEach(async () => {
 }, timeouts.spinUpDbServer);
 
 describe('pinned-client serialization on a real wire', () => {
+  // pg wraps its overlap warning in util.deprecate, which fires once per
+  // process — so exactly one test owns the warning capture, and its warning
+  // assertion runs first.
   it(
-    '3-way query overlap on a direct driver stays sequential and emits no warning',
+    '3-way query overlap on a pinned client emits no pg DeprecationWarning',
     async () => {
       const h = await createHarness();
       const capture = captureProcessWarnings();
@@ -132,9 +135,8 @@ describe('pinned-client serialization on a real wire', () => {
         ]);
         await settleWarnings();
 
-        expect(results.map((r) => r.rows[0])).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
-        expect(h.maxInFlight()).toBe(1);
         expect(capture.warnings).toEqual([]);
+        expect(results.map((r) => r.rows[0])).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
       } finally {
         capture.stop();
       }
@@ -143,24 +145,36 @@ describe('pinned-client serialization on a real wire', () => {
   );
 
   it(
-    '3-way query overlap on a pinned connection stays sequential and emits no warning',
+    '3-way query overlap on a direct driver stays sequential',
+    async () => {
+      const h = await createHarness();
+      const results = await Promise.all([
+        h.driver.query<{ n: number }>('select 1 as n'),
+        h.driver.query<{ n: number }>('select 2 as n'),
+        h.driver.query<{ n: number }>('select 3 as n'),
+      ]);
+
+      expect(results.map((r) => r.rows[0])).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
+      expect(h.maxInFlight()).toBe(1);
+    },
+    timeouts.spinUpDbServer,
+  );
+
+  it(
+    '3-way query overlap on a pinned connection stays sequential',
     async () => {
       const h = await createHarness();
       const connection = await h.driver.acquireConnection();
-      const capture = captureProcessWarnings();
       try {
         const results = await Promise.all([
           connection.query<{ n: number }>('select 1 as n'),
           connection.query<{ n: number }>('select 2 as n'),
           connection.query<{ n: number }>('select 3 as n'),
         ]);
-        await settleWarnings();
 
         expect(results.map((r) => r.rows[0])).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
         expect(h.maxInFlight()).toBe(1);
-        expect(capture.warnings).toEqual([]);
       } finally {
-        capture.stop();
         await connection.release();
       }
     },
@@ -168,26 +182,22 @@ describe('pinned-client serialization on a real wire', () => {
   );
 
   it(
-    '3-way query overlap on a transaction handle stays sequential and emits no warning',
+    '3-way query overlap on a transaction handle stays sequential',
     async () => {
       const h = await createHarness();
       const connection = await h.driver.acquireConnection();
-      const transaction = await connection.beginTransaction();
-      const capture = captureProcessWarnings();
       try {
+        const transaction = await connection.beginTransaction();
         const results = await Promise.all([
           transaction.query<{ n: number }>('select 1 as n'),
           transaction.query<{ n: number }>('select 2 as n'),
           transaction.query<{ n: number }>('select 3 as n'),
         ]);
         await transaction.commit();
-        await settleWarnings();
 
         expect(results.map((r) => r.rows[0])).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
         expect(h.maxInFlight()).toBe(1);
-        expect(capture.warnings).toEqual([]);
       } finally {
-        capture.stop();
         await connection.release();
       }
     },

--- a/packages/3-targets/7-drivers/postgres/test/driver.pinned-client-serialization.integration.test.ts
+++ b/packages/3-targets/7-drivers/postgres/test/driver.pinned-client-serialization.integration.test.ts
@@ -20,7 +20,7 @@ interface Harness {
   close(): Promise<void>;
 }
 
-let harness: Harness | undefined;
+let cleanup: (() => Promise<void>) | undefined;
 
 function installConcurrencySpy(client: Client): { texts: string[]; maxInFlight(): number } {
   const texts: string[] = [];
@@ -56,39 +56,50 @@ function installConcurrencySpy(client: Client): { texts: string[]; maxInFlight()
 async function createHarness(options?: { readonly cursorBatchSize?: number }): Promise<Harness> {
   const db = await PGlite.create();
   const server = new PGLiteSocketServer({ db, port: 0, host: '127.0.0.1' });
+  let client: Client | undefined;
+  let driver: ReturnType<typeof postgresRuntimeDriverDescriptor.create> | undefined;
+  // Registered before any fallible step so afterEach tears down whatever
+  // exists when setup rejects mid-way. Ending the client after driver.close()
+  // is a no-op-safe double-end on the happy path (a connected pgClient
+  // binding already ends it) but covers a client the driver never adopted.
+  const close = async (): Promise<void> => {
+    await driver?.close().catch(() => {});
+    await client?.end().catch(() => {});
+    await server.stop().catch(() => {});
+    await db.close().catch(() => {});
+  };
+  cleanup = close;
+
   await server.start();
   const serverConn = server.getServerConn();
   const port = Number(serverConn.slice(serverConn.lastIndexOf(':') + 1));
 
-  const client = new Client({ host: '127.0.0.1', port, database: 'postgres', user: 'postgres' });
+  client = new Client({ host: '127.0.0.1', port, database: 'postgres', user: 'postgres' });
   client.on('error', () => {});
   await client.connect();
   const spy = installConcurrencySpy(client);
 
-  const driver = postgresRuntimeDriverDescriptor.create({
+  driver = postgresRuntimeDriverDescriptor.create({
     cursor: { batchSize: options?.cursorBatchSize ?? 10 },
   });
   await driver.connect({ kind: 'pgClient', client });
 
-  const created: Harness = {
+  return {
     client,
     driver,
     recordedQueryTexts: spy.texts,
     maxInFlight: spy.maxInFlight,
-    close: async () => {
-      await driver.close().catch(() => {});
-      await server.stop().catch(() => {});
-      await db.close().catch(() => {});
-    },
+    close,
   };
-  harness = created;
-  return created;
 }
 
 function captureProcessWarnings(): { readonly warnings: Error[]; stop(): void } {
   const warnings: Error[] = [];
   const handler = (warning: Error): void => {
-    if (warning.name === 'DeprecationWarning') {
+    if (
+      warning.name === 'DeprecationWarning' &&
+      warning.message.toLowerCase().includes('already executing a query')
+    ) {
       warnings.push(warning);
     }
   };
@@ -112,9 +123,9 @@ async function seedRows(h: Harness, count: number): Promise<void> {
 }
 
 afterEach(async () => {
-  if (harness) {
-    await harness.close();
-    harness = undefined;
+  if (cleanup) {
+    await cleanup();
+    cleanup = undefined;
   }
 }, timeouts.spinUpDbServer);
 

--- a/packages/3-targets/7-drivers/postgres/test/driver.pinned-client-serialization.integration.test.ts
+++ b/packages/3-targets/7-drivers/postgres/test/driver.pinned-client-serialization.integration.test.ts
@@ -1,0 +1,229 @@
+/**
+ * pg@8 silently queues a query sent while another is in flight on the same
+ * Client (emitting a DeprecationWarning); pg@9 throws instead. The driver owns
+ * FIFO serialization per physical client, so overlapping calls on any pinned
+ * client never reach pg while a query is in flight.
+ */
+
+import { PGlite } from '@electric-sql/pglite';
+import { PGLiteSocketServer } from '@electric-sql/pglite-socket';
+import { timeouts } from '@prisma-next/test-utils';
+import { Client } from 'pg';
+import { afterEach, describe, expect, it } from 'vitest';
+import postgresRuntimeDriverDescriptor from '../src/exports/runtime';
+
+interface Harness {
+  readonly client: Client;
+  readonly driver: ReturnType<typeof postgresRuntimeDriverDescriptor.create>;
+  readonly recordedQueryTexts: string[];
+  maxInFlight(): number;
+  close(): Promise<void>;
+}
+
+let harness: Harness | undefined;
+
+function installConcurrencySpy(client: Client): { texts: string[]; maxInFlight(): number } {
+  const texts: string[] = [];
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const original = client.query.bind(client);
+  const spied = (...args: unknown[]): unknown => {
+    const first = args[0];
+    if (typeof first === 'string') {
+      texts.push(first);
+    } else if (
+      typeof first === 'object' &&
+      first !== null &&
+      'text' in first &&
+      typeof (first as { text?: unknown }).text === 'string'
+    ) {
+      texts.push((first as { text: string }).text);
+    }
+    const result = (original as (...inner: unknown[]) => unknown)(...args);
+    if (result instanceof Promise) {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      return result.finally(() => {
+        inFlight--;
+      });
+    }
+    return result;
+  };
+  (client as unknown as { query: typeof spied }).query = spied;
+  return { texts, maxInFlight: () => maxInFlight };
+}
+
+async function createHarness(options?: { readonly cursorBatchSize?: number }): Promise<Harness> {
+  const db = await PGlite.create();
+  const server = new PGLiteSocketServer({ db, port: 0, host: '127.0.0.1' });
+  await server.start();
+  const serverConn = server.getServerConn();
+  const port = Number(serverConn.slice(serverConn.lastIndexOf(':') + 1));
+
+  const client = new Client({ host: '127.0.0.1', port, database: 'postgres', user: 'postgres' });
+  client.on('error', () => {});
+  await client.connect();
+  const spy = installConcurrencySpy(client);
+
+  const driver = postgresRuntimeDriverDescriptor.create({
+    cursor: { batchSize: options?.cursorBatchSize ?? 10 },
+  });
+  await driver.connect({ kind: 'pgClient', client });
+
+  const created: Harness = {
+    client,
+    driver,
+    recordedQueryTexts: spy.texts,
+    maxInFlight: spy.maxInFlight,
+    close: async () => {
+      await driver.close().catch(() => {});
+      await server.stop().catch(() => {});
+      await db.close().catch(() => {});
+    },
+  };
+  harness = created;
+  return created;
+}
+
+function captureProcessWarnings(): { readonly warnings: Error[]; stop(): void } {
+  const warnings: Error[] = [];
+  const handler = (warning: Error): void => {
+    warnings.push(warning);
+  };
+  process.on('warning', handler);
+  return {
+    warnings,
+    stop: () => {
+      process.removeListener('warning', handler);
+    },
+  };
+}
+
+async function settleWarnings(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+async function seedRows(h: Harness, count: number): Promise<void> {
+  await h.driver.query('create table items (id int primary key, n int not null)');
+  const values = Array.from({ length: count }, (_, i) => `(${i}, ${i * 2})`).join(', ');
+  await h.driver.query(`insert into items (id, n) values ${values}`);
+}
+
+afterEach(async () => {
+  if (harness) {
+    await harness.close();
+    harness = undefined;
+  }
+}, timeouts.spinUpDbServer);
+
+describe('pinned-client serialization on a real wire', () => {
+  it(
+    '3-way query overlap on a direct driver stays sequential and emits no warning',
+    async () => {
+      const h = await createHarness();
+      const capture = captureProcessWarnings();
+      try {
+        const results = await Promise.all([
+          h.driver.query<{ n: number }>('select 1 as n'),
+          h.driver.query<{ n: number }>('select 2 as n'),
+          h.driver.query<{ n: number }>('select 3 as n'),
+        ]);
+        await settleWarnings();
+
+        expect(results.map((r) => r.rows[0])).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
+        expect(h.maxInFlight()).toBe(1);
+        expect(capture.warnings).toEqual([]);
+      } finally {
+        capture.stop();
+      }
+    },
+    timeouts.spinUpDbServer,
+  );
+
+  it(
+    '3-way query overlap on a pinned connection stays sequential and emits no warning',
+    async () => {
+      const h = await createHarness();
+      const connection = await h.driver.acquireConnection();
+      const capture = captureProcessWarnings();
+      try {
+        const results = await Promise.all([
+          connection.query<{ n: number }>('select 1 as n'),
+          connection.query<{ n: number }>('select 2 as n'),
+          connection.query<{ n: number }>('select 3 as n'),
+        ]);
+        await settleWarnings();
+
+        expect(results.map((r) => r.rows[0])).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
+        expect(h.maxInFlight()).toBe(1);
+        expect(capture.warnings).toEqual([]);
+      } finally {
+        capture.stop();
+        await connection.release();
+      }
+    },
+    timeouts.spinUpDbServer,
+  );
+
+  it(
+    '3-way query overlap on a transaction handle stays sequential and emits no warning',
+    async () => {
+      const h = await createHarness();
+      const connection = await h.driver.acquireConnection();
+      const transaction = await connection.beginTransaction();
+      const capture = captureProcessWarnings();
+      try {
+        const results = await Promise.all([
+          transaction.query<{ n: number }>('select 1 as n'),
+          transaction.query<{ n: number }>('select 2 as n'),
+          transaction.query<{ n: number }>('select 3 as n'),
+        ]);
+        await transaction.commit();
+        await settleWarnings();
+
+        expect(results.map((r) => r.rows[0])).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
+        expect(h.maxInFlight()).toBe(1);
+        expect(capture.warnings).toEqual([]);
+      } finally {
+        capture.stop();
+        await connection.release();
+      }
+    },
+    timeouts.spinUpDbServer,
+  );
+
+  it(
+    'a stream and a concurrent query on one pinned client do not interleave transaction boundaries',
+    async () => {
+      const h = await createHarness({ cursorBatchSize: 5 });
+      await seedRows(h, 20);
+      h.recordedQueryTexts.length = 0;
+
+      const streamed: number[] = [];
+      const consumeStream = async (): Promise<void> => {
+        for await (const row of h.driver.execute<{ id: number }>({
+          sql: 'select id from items order by id',
+        })) {
+          streamed.push(row.id);
+        }
+      };
+
+      const [, other] = await Promise.all([
+        consumeStream(),
+        h.driver.query<{ n: number }>('select count(*)::int as n from items'),
+      ]);
+
+      expect(streamed).toHaveLength(20);
+      expect(other.rows).toEqual([{ n: 20 }]);
+
+      const begin = h.recordedQueryTexts.indexOf('BEGIN');
+      const commit = h.recordedQueryTexts.indexOf('COMMIT');
+      expect(begin).toBeGreaterThanOrEqual(0);
+      expect(commit).toBeGreaterThan(begin);
+      expect(h.recordedQueryTexts.slice(begin + 1, commit)).toEqual([
+        'select id from items order by id',
+      ]);
+    },
+    timeouts.spinUpDbServer,
+  );
+});

--- a/packages/3-targets/7-drivers/postgres/test/driver.pinned-client-serialization.test.ts
+++ b/packages/3-targets/7-drivers/postgres/test/driver.pinned-client-serialization.test.ts
@@ -1,0 +1,162 @@
+import type { PreparedExecuteRequest } from '@prisma-next/sql-relational-core/ast';
+import { timeouts } from '@prisma-next/test-utils';
+import type { Client, Pool } from 'pg';
+import { describe, expect, it } from 'vitest';
+import { createBoundDriverFromBinding } from '../src/postgres-driver';
+
+interface ConcurrencyState {
+  inFlight: number;
+  maxInFlight: number;
+  readonly started: string[];
+  readonly completed: string[];
+}
+
+function createConcurrencyState(): ConcurrencyState {
+  return { inFlight: 0, maxInFlight: 0, started: [], completed: [] };
+}
+
+function textOf(arg: unknown): string {
+  if (typeof arg === 'string') {
+    return arg;
+  }
+  if (typeof arg === 'object' && arg !== null && 'text' in arg) {
+    return String((arg as { text: unknown }).text);
+  }
+  return '<unknown>';
+}
+
+function makeTrackedClient(state: ConcurrencyState) {
+  return {
+    connect: async () => undefined,
+    end: async () => undefined,
+    query: async (arg: unknown, _values?: unknown[]) => {
+      const text = textOf(arg);
+      state.inFlight++;
+      state.maxInFlight = Math.max(state.maxInFlight, state.inFlight);
+      state.started.push(text);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      state.inFlight--;
+      state.completed.push(text);
+      return { rows: [{ echo: text }], rowCount: 1 };
+    },
+  };
+}
+
+function makeDirectDriver(state: ConcurrencyState) {
+  const client = makeTrackedClient(state);
+  return createBoundDriverFromBinding(
+    { kind: 'pgClient', client: client as unknown as Client },
+    { disabled: true },
+  );
+}
+
+async function consume<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const row of iterable) {
+    out.push(row);
+  }
+  return out;
+}
+
+function makeHandleSlot(): PreparedExecuteRequest['handle'] {
+  let value: unknown;
+  return {
+    get: () => value,
+    set: (v: unknown) => {
+      value = v;
+    },
+  };
+}
+
+describe('pinned-client serialization', { timeout: timeouts.databaseOperation }, () => {
+  it('runs concurrent query() calls on a direct driver one at a time in FIFO order', async () => {
+    const state = createConcurrencyState();
+    const driver = makeDirectDriver(state);
+
+    await Promise.all([
+      driver.query('select 1'),
+      driver.query('select 2'),
+      driver.query('select 3'),
+    ]);
+
+    expect(state.maxInFlight).toBe(1);
+    expect(state.started).toEqual(['select 1', 'select 2', 'select 3']);
+    expect(state.completed).toEqual(['select 1', 'select 2', 'select 3']);
+  });
+
+  it('serializes mixed execute/executePrepared/explain/query overlap on a direct driver', async () => {
+    const state = createConcurrencyState();
+    const driver = makeDirectDriver(state);
+
+    await Promise.all([
+      consume(driver.execute({ sql: 'select a' })),
+      consume(driver.executePrepared({ sql: 'select b', params: [], handle: makeHandleSlot() })),
+      driver.explain({ sql: 'select c' }),
+      driver.query('select d'),
+    ]);
+
+    expect(state.maxInFlight).toBe(1);
+    expect(state.started).toHaveLength(4);
+  });
+
+  it('serializes overlapping queries on a pinned connection', async () => {
+    const state = createConcurrencyState();
+    const driver = makeDirectDriver(state);
+    const connection = await driver.acquireConnection();
+
+    await Promise.all([connection.query('select 1'), connection.query('select 2')]);
+    await connection.release();
+
+    expect(state.maxInFlight).toBe(1);
+    expect(state.started).toEqual(['select 1', 'select 2']);
+  });
+
+  it('serializes overlapping queries on a transaction handle, boundaries included', async () => {
+    const state = createConcurrencyState();
+    const driver = makeDirectDriver(state);
+    const connection = await driver.acquireConnection();
+    const transaction = await connection.beginTransaction();
+
+    await Promise.all([
+      transaction.query('select 1'),
+      transaction.query('select 2'),
+      consume(transaction.execute({ sql: 'select 3' })),
+    ]);
+    await transaction.commit();
+    await connection.release();
+
+    expect(state.maxInFlight).toBe(1);
+    expect(state.started).toEqual(['BEGIN', 'select 1', 'select 2', 'select 3', 'COMMIT']);
+    expect(state.completed).toEqual(['BEGIN', 'select 1', 'select 2', 'select 3', 'COMMIT']);
+  });
+
+  it('serializes a driver-level query against an outstanding pinned connection on the same client', async () => {
+    const state = createConcurrencyState();
+    const driver = makeDirectDriver(state);
+    const connection = await driver.acquireConnection();
+
+    await Promise.all([connection.query('select lease'), driver.query('select driver')]);
+    await connection.release();
+
+    expect(state.maxInFlight).toBe(1);
+  });
+
+  it('does not serialize pool-level queries across distinct pool clients', async () => {
+    const state = createConcurrencyState();
+    const pool = {
+      connect: async () => ({
+        ...makeTrackedClient(state),
+        release: () => undefined,
+      }),
+      end: async () => undefined,
+    };
+    const driver = createBoundDriverFromBinding(
+      { kind: 'pgPool', pool: pool as unknown as Pool },
+      { disabled: true },
+    );
+
+    await Promise.all([driver.query('select 1'), driver.query('select 2')]);
+
+    expect(state.maxInFlight).toBe(2);
+  });
+});

--- a/packages/3-targets/7-drivers/postgres/test/driver.pinned-client-serialization.test.ts
+++ b/packages/3-targets/7-drivers/postgres/test/driver.pinned-client-serialization.test.ts
@@ -91,7 +91,7 @@ describe('pinned-client serialization', { timeout: timeouts.databaseOperation },
     await Promise.all([
       consume(driver.execute({ sql: 'select a' })),
       consume(driver.executePrepared({ sql: 'select b', params: [], handle: makeHandleSlot() })),
-      driver.explain({ sql: 'select c' }),
+      driver.explain?.({ sql: 'select c' }),
       driver.query('select d'),
     ]);
 

--- a/packages/3-targets/7-drivers/postgres/test/driver.pinned-client-serialization.test.ts
+++ b/packages/3-targets/7-drivers/postgres/test/driver.pinned-client-serialization.test.ts
@@ -87,11 +87,15 @@ describe('pinned-client serialization', { timeout: timeouts.databaseOperation },
   it('serializes mixed execute/executePrepared/explain/query overlap on a direct driver', async () => {
     const state = createConcurrencyState();
     const driver = makeDirectDriver(state);
+    const explain = driver.explain;
+    if (explain === undefined) {
+      throw new Error('driver.explain is not implemented');
+    }
 
     await Promise.all([
       consume(driver.execute({ sql: 'select a' })),
       consume(driver.executePrepared({ sql: 'select b', params: [], handle: makeHandleSlot() })),
-      driver.explain?.({ sql: 'select c' }),
+      explain.call(driver, { sql: 'select c' }),
       driver.query('select d'),
     ]);
 
@@ -130,7 +134,7 @@ describe('pinned-client serialization', { timeout: timeouts.databaseOperation },
     expect(state.completed).toEqual(['BEGIN', 'select 1', 'select 2', 'select 3', 'COMMIT']);
   });
 
-  it('serializes a driver-level query against an outstanding pinned connection on the same client', async () => {
+  it('serializes driver-level and pinned-connection statements sharing one physical client', async () => {
     const state = createConcurrencyState();
     const driver = makeDirectDriver(state);
     const connection = await driver.acquireConnection();
@@ -139,6 +143,73 @@ describe('pinned-client serialization', { timeout: timeouts.databaseOperation },
     await connection.release();
 
     expect(state.maxInFlight).toBe(1);
+  });
+
+  it('completes a nested query awaited inside buffered stream iteration on a pinned connection', async () => {
+    const state = createConcurrencyState();
+    const driver = makeDirectDriver(state);
+    const connection = await driver.acquireConnection();
+
+    const nested: unknown[] = [];
+    for await (const row of connection.execute<{ echo: string }>({ sql: 'select outer' })) {
+      expect(row).toEqual({ echo: 'select outer' });
+      const inner = await connection.query<{ echo: string }>('select inner');
+      nested.push(inner.rows[0]);
+    }
+    await connection.release();
+
+    expect(nested).toEqual([{ echo: 'select inner' }]);
+    expect(state.completed).toEqual(['select outer', 'select inner']);
+  });
+
+  it('completes a nested query awaited inside buffered stream iteration on a transaction', async () => {
+    const state = createConcurrencyState();
+    const driver = makeDirectDriver(state);
+    const connection = await driver.acquireConnection();
+    const transaction = await connection.beginTransaction();
+
+    const nested: unknown[] = [];
+    for await (const row of transaction.execute<{ echo: string }>({ sql: 'select outer' })) {
+      expect(row).toEqual({ echo: 'select outer' });
+      const inner = await transaction.query<{ echo: string }>('select inner');
+      nested.push(inner.rows[0]);
+    }
+    await transaction.commit();
+    await connection.release();
+
+    expect(nested).toEqual([{ echo: 'select inner' }]);
+    expect(state.completed).toEqual(['BEGIN', 'select outer', 'select inner', 'COMMIT']);
+  });
+
+  it('runs a follow-up query after a partially iterated buffered stream is abandoned', async () => {
+    const state = createConcurrencyState();
+    const driver = makeDirectDriver(state);
+
+    const iterator = driver
+      .execute<{ echo: string }>({ sql: 'select abandoned' })
+      [Symbol.asyncIterator]();
+    const first = await iterator.next();
+    expect(first.done).toBe(false);
+
+    const after = await driver.query<{ echo: string }>('select after');
+    expect(after.rows).toEqual([{ echo: 'select after' }]);
+  });
+
+  it('commits a transaction while a buffered stream on it is still open', async () => {
+    const state = createConcurrencyState();
+    const driver = makeDirectDriver(state);
+    const connection = await driver.acquireConnection();
+    const transaction = await connection.beginTransaction();
+
+    const iterator = transaction
+      .execute<{ echo: string }>({ sql: 'select open-stream' })
+      [Symbol.asyncIterator]();
+    const first = await iterator.next();
+    expect(first.done).toBe(false);
+
+    await transaction.commit();
+    await connection.release();
+    expect(state.completed).toEqual(['BEGIN', 'select open-stream', 'COMMIT']);
   });
 
   it('does not serialize pool-level queries across distinct pool clients', async () => {


### PR DESCRIPTION
Consider a Cloudflare Worker handler that fans out two independent reads on one serverless handle:

```ts
const db = postgres(context).connect({ url });
const [users, posts] = await Promise.all([
  db.sql.execute(userPlan),
  db.sql.execute(postPlan),
]);
```

Both reads share one `pg.Client`. Today this works because pg@8 silently queues the second query behind the first — a deprecated internal that pg@9 removes: a query sent while another is in flight will **throw** (maintainer-confirmed in [node-postgres discussion #3598](https://github.com/brianc/node-postgres/discussions/3598)). pg only warns when a *third* call overlaps, so the common two-wide `Promise.all` shape gives no warning at all today and becomes a hard error on the pg@9 upgrade.

This PR makes the driver own that flow control instead: a per-physical-client FIFO mutex (a `WeakMap` keyed by the underlying client, reusing the existing `AsyncMutex`) serializes statements on every pinned-client path — direct `{ kind: 'pgClient' }` drivers, pinned connections from `acquireConnection()`, and transaction handles, which covers the serverless facade and the Supabase runtime that inherits it. Pool-level calls are untouched: each checks out its own `PoolClient`, so keying by physical client means they never contend.

The lock is held for exactly as long as the client is protocol-busy, and no longer:

- **Buffered execution** (the production path — both shipped runtimes disable cursors) locks only the awaited `client.query()`. Row iteration is lock-free, so a nested query on the same client inside `for await` still works. An earlier draft held the lock across the yields; review caught that it hands lock lifetime to the consumer and deadlocks that nested shape, confirmed by execution before narrowing.
- **Cursor streams** hold the lock for the whole `BEGIN…COMMIT` span, because the cursor genuinely occupies the connection for its lifetime. This subsumes the previous `streamSpanLocks` (deleted): the same mutex now guarantees concurrent streams cannot interleave their transaction wraps.
- **Transaction boundaries** (`BEGIN`/`COMMIT`/`ROLLBACK`) each take the lock around their own statement — previously they bypassed all locking and could interleave into a concurrent statement.

Semantics are unchanged for working code: FIFO order at statement granularity is exactly what pg@8's queue provided, including its one deadlock shape (awaiting a query inside iteration of a *cursor* stream on the same client), which remains and is now documented on `PostgresBinding`. Statement-granularity locking deliberately does not fence other callers out of an open transaction on a shared client — that also matches pg@8, and no test claims otherwise.

Tests were written red-first: max-in-flight spies read 3/4/2/3/2 overlapping queries across the direct driver, mixed methods, pinned connection, transaction, and lease-overlap cases before the fix (all now 1), and the integration harness (real `pg.Client` over a PGlite socket server) captured the pg deprecation warning verbatim before and none after. Guard tests pin the other direction: pool-level queries must stay concurrent, and four timeout-guarded regressions pin the nested-query/abandoned-generator/commit-during-stream shapes that the narrowed lock must not break. The warning assertion lives in a single dedicated test because `util.deprecate` fires once per process.

Changes are confined to `@prisma-next/driver-postgres` (runtime driver + two test files). The CLI's control-plane driver needed no change — investigation on the linked ticket verified it already runs strictly sequentially (max 1 query in flight across a full migrate journey).

Refs: TML-3108

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Reworked PostgreSQL driver concurrency to serialize all operations that share the same underlying physical client, preserving strict FIFO execution and preventing interleaving.
  - Ensured cursor streaming and transaction control statements (BEGIN/COMMIT/ROLLBACK) remain consistent and don’t break during concurrent activity.
  - Kept parallelism for separate pooled connections.
- **Tests**
  - Added a pinned-client FIFO/serialization test suite covering queries, prepared/explain, transactions, streaming (including abandoned streams), and proper unlock behavior.
  - Updated integration teardown and tightened warning assertions to reliably target the expected pg overlap warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->