### PR TITLE
ci: rename the release workflow to publish.yml

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,7 +7,7 @@ on:
       - '*.*.x'
     paths-ignore:
       # Any update here needs to be done for `pull_request` (see below) and all files
-      # (test.yml, benchmark.yml, v7-release.yml, bundle-size.yml, ci-aux-files.yml)
+      # (test.yml, benchmark.yml, publish.yml, bundle-size.yml, ci-aux-files.yml)
       - '*.md'
       # - '*.bench.ts' -> should not be ignored in this workflow
       - 'LICENSE'
@@ -23,7 +23,7 @@ on:
   pull_request:
     paths-ignore:
       # Any update here needs to be done for `branches` (see above) and all files
-      # (test.yml, benchmark.yml, v7-release.yml, bundle-size.yml, ci-aux-files.yml)
+      # (test.yml, benchmark.yml, publish.yml, bundle-size.yml, ci-aux-files.yml)
       - '*.md'
       # - '*.bench.ts' -> should not be ignored in this workflow
       - 'LICENSE'

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths-ignore:
       # Any update here needs to be done for all files
-      # (test.yml, benchmark.yml, v7-release.yml, bundle-size.yml, ci-aux-files.yml)
+      # (test.yml, benchmark.yml, publish.yml, bundle-size.yml, ci-aux-files.yml)
       - '*.md'
       - '*.bench.ts'
       - 'LICENSE'

--- a/.github/workflows/ci-aux-files.yml
+++ b/.github/workflows/ci-aux-files.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       # Any update here needs to be done for all files
-      # (test.yml, benchmark.yml, v7-release.yml, bundle-size.yml, ci-aux-files.yml)
+      # (test.yml, benchmark.yml, publish.yml, bundle-size.yml, ci-aux-files.yml)
       - '*.md'
       - '*.bench.ts'
       - 'LICENSE'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
       - '*.*.x'
     paths-ignore:
       # Any update here needs to be done for all files
-      # (test.yml, benchmark.yml, v7-release.yml, bundle-size.yml, ci-aux-files.yml)
+      # (test.yml, benchmark.yml, publish.yml, bundle-size.yml, ci-aux-files.yml)
       - '*.md'
       - '*.bench.ts'
       - 'LICENSE'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
       - '*.*.x'
     paths-ignore:
       # Any update here needs to be done for `pull_request` (see below) and all files
-      # (test.yml, benchmark.yml, v7-release.yml, bundle-size.yml, ci-aux-files.yml)
+      # (test.yml, benchmark.yml, publish.yml, bundle-size.yml, ci-aux-files.yml)
       - '*.md'
       - '*.bench.ts'
       - 'LICENSE'
@@ -23,7 +23,7 @@ on:
   pull_request:
     paths-ignore:
       # Any update here needs to be done for `branches` (see above) and all files
-      # (test.yml, benchmark.yml, v7-release.yml, bundle-size.yml, ci-aux-files.yml)
+      # (test.yml, benchmark.yml, publish.yml, bundle-size.yml, ci-aux-files.yml)
       - '*.md'
       - '*.bench.ts'
       - 'LICENSE'
@@ -91,7 +91,7 @@ jobs:
           )
         uses: benc-uk/workflow-dispatch@v1
         with:
-          workflow: v7-release.yml
+          workflow: publish.yml
           token: ${{ secrets.BOT_TOKEN }}
           inputs: '{ "forceIntegrationRelease": "true" }'
           ref: ${{ github.event.pull_request.head.ref }}

--- a/TESTING.md
+++ b/TESTING.md
@@ -381,7 +381,7 @@ By default, some tests are tested only during daily builds. If you need to run a
 
 ### Publishing all the packages to npm on the `integration` tag
 
-If a branch name starts with `integration/` like `integration/fix-all-the-things` the [GitHub Actions - v7 - npm - release](https://github.com/prisma/prisma/blob/v7/.github/workflows/v7-release.yml) pipeline will be triggered.
+If a branch name starts with `integration/` like `integration/fix-all-the-things` the [GitHub Actions - v7 - npm - release](https://github.com/prisma/prisma/blob/v7/.github/workflows/publish.yml) pipeline will be triggered.
 This workflow will directly publish (without running tests) the packages to npm on the `integration` tag with a version like `5.3.0-integration-fix-all-the-things.1` (where `5.3.0-` is the current dev version prefix, `integration-` is statically added, `fix-all-the-things` is from the branch name and `.1` indicates the first version published from this branch)
 
 To make a Pull Request which will release a version to the `integration` tag automatically, the name of the branch of the PR would need to start with `integration/`.
@@ -390,10 +390,10 @@ Alternatively, add `/integration` in the Pull Request description:
 - If this is added before opening the Pull Request, a release will happen automatically.
 - If this is added after the creation of the PR, the `Detect jobs to run` job from the `CI` workflow needs to be re-triggered to get a release.
 
-The [GitHub Actions - v7 - npm - release](https://github.com/prisma/prisma/blob/v7/.github/workflows/v7-release.yml) workflow can also be manually triggered to run on any branch.
+The [GitHub Actions - v7 - npm - release](https://github.com/prisma/prisma/blob/v7/.github/workflows/publish.yml) workflow can also be manually triggered to run on any branch.
 Example:
 
-- Go to https://github.com/prisma/prisma/actions/workflows/v7-release.yml?query=branch%3Ajoel%2Fdotenv
+- Go to https://github.com/prisma/prisma/actions/workflows/publish.yml?query=branch%3Ajoel%2Fdotenv
 - Click "Run workflow"
 - Change "Use workflow from" to match the branch you want to release, here `joel/dotenv`
 - Check the box for "Check to force an integration release for any given branch name"


### PR DESCRIPTION
> [!WARNING]
> **This rename breaks publishing until the npm trusted-publisher bindings are re-pointed**, for all 47 packages this workflow publishes. Details below — it is not speculative, it happened when prisma/prisma#29823 renamed the same file.

## Summary

Preparation for publishing Prisma Next's CLI as the `prisma` package under a separate dist-tag.

npm binds a trusted publisher to an owner/repo plus a **workflow filename**, and a package carries one such binding. For `prisma` to be published from both this branch and the default branch, both must publish through a file of the same name — and the default branch's is `publish.yml`. So `v7-release.yml` becomes `publish.yml`.

Nothing about the workflow itself changes:

- **Display name stays `v7 - npm - release`**, so runs remain identifiable as belonging to this line even though the two branches now share a path.
- **Triggers are untouched.** A push runs the copy on the branch pushed to, so this branch's definition and the default branch's never contend: pushes here (and to `integration/*` and `*.*.x`, which are cut from here) run this one; pushes to the default branch run that one.

`test.yml` dispatches this workflow by filename for the integration-release path and follows the new name, as do the sibling comments enumerating the `paths-ignore` group and three references in `TESTING.md` — twelve references in all.

## The npm bindings must be re-pointed

This branch publishes by **pure OIDC** — there is no npm token anywhere in the publish path — so every package it ships is trusted-publisher-bound to this repository plus a workflow filename. Change the filename and the token exchange stops matching.

That is exactly what happened last time. prisma/prisma#29823 renamed `release.yml` to `v7-release.yml`, merging at `12:30:01Z`; the release run triggered by that merge failed 52 seconds later with:

```
[WARN] Skipped OIDC: ERR_PNPM_AUTH_TOKEN_EXCHANGE: Failed token exchange request with body message: Unknown error (status code 404)
```

pnpm's OIDC exchange 404s when npm does not recognise the repository/workflow pair. Publishing then continues unauthenticated and `pnpm publish` fails — the run died on `@prisma/client-runtime-utils`. Releases recovered at `13:25`, once the bindings named the new filename, and `7.10.0-dev.48` and `.49` have shipped since.

So: merge, re-point the bindings for the 47 packages in scope, re-run the release. The window costs a delayed `dev` publish, which is why last time it passed almost unnoticed — but during a stable release it would be a good deal more disruptive, so this is not one to merge on a release day.

The consolation is that this is the **last** such rename. `publish.yml` is the name the default branch already uses and the one the `prisma` binding needs permanently.

## The multi-branch reach is intended

Binding `prisma` to `prisma/prisma` + `publish.yml` means any branch carrying a file at that path can publish it. That is a requirement rather than an oversight: dev and integration releases are published from pull request branches, so the trusted publisher has to reach past the two long-lived branches.

Recording it here so nobody later narrows it with a GitHub environment restricted to `main` and `v7` — that would break precisely the releases it appears to protect.

## Ordering

Merge this **before** prisma/prisma#29841, which removes the now-redundant `v7-release.yml` stub from the default branch.

Taken in that order the release path is never unregistered: the moment this lands, `publish.yml` on the default branch occupies the path and registers it. Taken the other way round, `v7-release.yml` would briefly hold its registry entry only by virtue of recent runs — which would probably hold, but there is no reason to lean on it.

## Testing performed

- Confirmed `publish.yml` does not already exist on this branch, so the rename cannot collide.
- Swept the branch afterwards for surviving `v7-release.yml` references: none.
- YAML parsed for all five workflow files, and the display names confirmed unchanged.
- Prettier-checked all six files against this branch's `.prettierrc.yml` with the pinned 3.6.2, since the lint job checks them.
- Confirmed the publish path carries no npm token, which is what makes the binding load-bearing, and read the failing run from the previous rename to establish the failure mode rather than assume it.

A rename cannot be exercised before merge. Afterwards, the things to watch are the first release run reaching npm at all, then a push to this branch publishing `prisma@dev`, then the integration-release dispatch in `test.yml` resolving.

## Checklist

- [x] All commits are signed off per the DCO.
- [x] The change is scoped to one logical concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing guidance to reference the current publishing workflow for integration-tag package releases.
  * Refreshed workflow comments to keep file references consistent.

* **CI**
  * Integration release pull requests now trigger the current publishing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->