### PR TITLE
fix(internals): fall back to raw stderr when schema engine error has no message

### DIFF
--- a/packages/internals/src/__tests__/schemaEngineCommands.test.ts
+++ b/packages/internals/src/__tests__/schemaEngineCommands.test.ts
@@ -3,7 +3,14 @@ import tempy from 'tempy'
 import { describe, expect, test, vi } from 'vitest'
 
 import { credentialsToUri, uriToCredentials } from '../convertCredentials'
-import { canConnectToDatabase, createDatabase, dropDatabase, execaCommand } from '../schemaEngineCommands'
+import {
+  canConnectToDatabase,
+  createDatabase,
+  dropDatabase,
+  execaCommand,
+  formatSchemaEngineError,
+  type SchemaEngineLogLine,
+} from '../schemaEngineCommands'
 
 if (process.env.CI) {
   // 5s is often not enough for the "postgresql - create database" test on macOS CI.
@@ -26,6 +33,31 @@ describe('execaCommand', () => {
       expect(message.includes('mysecret')).toBeFalsy()
       expect(message.includes('<REDACTED>')).toBeTruthy()
     }
+  })
+})
+
+describe('formatSchemaEngineError', () => {
+  const log = (message: string): SchemaEngineLogLine => ({
+    timestamp: '2021-06-11T15:35:34.084486+00:00',
+    level: 'ERROR',
+    target: 'schema_engine::logger',
+    fields: { message },
+  })
+
+  test('joins messages from multiple log lines', () => {
+    expect(formatSchemaEngineError([log('first'), log('second')], 'raw stderr')).toBe('first\nsecond')
+  })
+
+  test('falls back to the raw stderr when no log line has a message', () => {
+    // e.g. when parseJsonFromStderr's `.slice(1)` drops the engine's only stderr line,
+    // leaving no logs to extract a message from.
+    expect(formatSchemaEngineError([], 'the only line of stderr, with the real error')).toBe(
+      'the only line of stderr, with the real error',
+    )
+  })
+
+  test('falls back to the raw stderr when log lines have empty messages', () => {
+    expect(formatSchemaEngineError([log('')], 'raw stderr')).toBe('raw stderr')
   })
 })
 

--- a/packages/internals/src/__tests__/schemaEngineCommands.test.ts
+++ b/packages/internals/src/__tests__/schemaEngineCommands.test.ts
@@ -60,6 +60,10 @@ describe('formatSchemaEngineError', () => {
   test('falls back to the raw stderr when log lines have empty messages', () => {
     expect(formatSchemaEngineError([log('')], 'raw stderr')).toBe('raw stderr')
   })
+
+  test('falls back to the raw stderr when log lines have whitespace-only messages', () => {
+    expect(formatSchemaEngineError([log('   ')], 'raw stderr')).toBe('raw stderr')
+  })
 })
 
 describe('parseJsonFromStderr', () => {

--- a/packages/internals/src/__tests__/schemaEngineCommands.test.ts
+++ b/packages/internals/src/__tests__/schemaEngineCommands.test.ts
@@ -9,6 +9,7 @@ import {
   dropDatabase,
   execaCommand,
   formatSchemaEngineError,
+  parseJsonFromStderr,
   type SchemaEngineLogLine,
 } from '../schemaEngineCommands'
 
@@ -58,6 +59,18 @@ describe('formatSchemaEngineError', () => {
 
   test('falls back to the raw stderr when log lines have empty messages', () => {
     expect(formatSchemaEngineError([log('')], 'raw stderr')).toBe('raw stderr')
+  })
+})
+
+describe('parseJsonFromStderr', () => {
+  test('does not throw on a single-line stderr with a trailing newline', () => {
+    // stderr.split(/\r?\n/).slice(1) on "real error\n" leaves [''], which used to
+    // reach JSON.parse('') and throw before formatSchemaEngineError's fallback ever ran.
+    expect(parseJsonFromStderr('real error\n')).toEqual([])
+  })
+
+  test('does not throw on a single-line stderr with no trailing newline', () => {
+    expect(parseJsonFromStderr('real error')).toEqual([])
   })
 })
 

--- a/packages/internals/src/schemaEngineCommands.ts
+++ b/packages/internals/src/schemaEngineCommands.ts
@@ -64,6 +64,16 @@ function parseJsonFromStderr(stderr: string): SchemaEngineLogLine[] {
   return logs
 }
 
+// `parseJsonFromStderr` drops the engine's first stderr line as a discardable
+// preamble. When the engine only emits that one line for a given failure, the
+// only line with real information is dropped, `logs` ends up empty, and this
+// used to produce a bare "Schema engine error:" with nothing after it. Fall
+// back to the raw stderr so the error always carries some diagnostic content.
+export function formatSchemaEngineError(logs: SchemaEngineLogLine[], stderr: string): string {
+  const messages = logs.map((log) => log.fields.message).filter(Boolean)
+  return messages.length > 0 ? messages.join('\n') : stderr
+}
+
 // could be refactored with engines using JSON RPC instead and just passing the schema
 export async function canConnectToDatabase(
   connectionString: string,
@@ -94,7 +104,7 @@ export async function canConnectToDatabase(
           message: error.fields.message,
         }
       } else {
-        throw new Error(`Schema engine error:\n${logs.map((log) => log.fields.message).join('\n')}`)
+        throw new Error(`Schema engine error:\n${formatSchemaEngineError(logs, e.stderr)}`)
       }
     } else {
       throw new Error(`Schema engine exited. ${_e}`)
@@ -132,7 +142,7 @@ export async function createDatabase(connectionString: string, cwd = process.cwd
       if (error && error.fields.error_code && error.fields.message) {
         throw new Error(`${error.fields.error_code}: ${error.fields.message}`)
       } else {
-        throw new Error(`Schema engine error:\n${logs.map((log) => log.fields.message).join('\n')}`)
+        throw new Error(`Schema engine error:\n${formatSchemaEngineError(logs, e.stderr)}`)
       }
     } else {
       throw new Error(`Schema engine exited. ${_e}`)
@@ -158,7 +168,7 @@ export async function dropDatabase(connectionString: string, cwd = process.cwd()
     if (e.stderr) {
       const logs = parseJsonFromStderr(e.stderr)
 
-      throw new Error(`Schema engine error:\n${logs.map((log) => log.fields.message).join('\n')}`)
+      throw new Error(`Schema engine error:\n${formatSchemaEngineError(logs, String(e.stderr))}`)
     } else {
       throw new Error(`Schema engine exited. ${e}`)
     }

--- a/packages/internals/src/schemaEngineCommands.ts
+++ b/packages/internals/src/schemaEngineCommands.ts
@@ -75,7 +75,7 @@ export function parseJsonFromStderr(stderr: string): SchemaEngineLogLine[] {
  * back to the raw stderr so the error always carries some diagnostic content.
  */
 export function formatSchemaEngineError(logs: SchemaEngineLogLine[], stderr: string): string {
-  const messages = logs.map((log) => log.fields.message).filter(Boolean)
+  const messages = logs.map((log) => log.fields.message).filter((message) => Boolean(message?.trim()))
   return messages.length > 0 ? messages.join('\n') : stderr
 }
 

--- a/packages/internals/src/schemaEngineCommands.ts
+++ b/packages/internals/src/schemaEngineCommands.ts
@@ -46,9 +46,12 @@ export interface ConnectionError {
   code: DatabaseErrorCodes
 }
 
-function parseJsonFromStderr(stderr: string): SchemaEngineLogLine[] {
+export function parseJsonFromStderr(stderr: string): SchemaEngineLogLine[] {
   // split by new line
-  const lines = stderr.split(/\r?\n/).slice(1) // Remove first element
+  const lines = stderr
+    .split(/\r?\n/)
+    .slice(1) // Remove first element
+    .filter((line) => line.trim() !== '') // A trailing newline leaves a blank line that isn't valid JSON
   const logs: any = []
 
   for (const line of lines) {
@@ -64,11 +67,13 @@ function parseJsonFromStderr(stderr: string): SchemaEngineLogLine[] {
   return logs
 }
 
-// `parseJsonFromStderr` drops the engine's first stderr line as a discardable
-// preamble. When the engine only emits that one line for a given failure, the
-// only line with real information is dropped, `logs` ends up empty, and this
-// used to produce a bare "Schema engine error:" with nothing after it. Fall
-// back to the raw stderr so the error always carries some diagnostic content.
+/**
+ * `parseJsonFromStderr` drops the engine's first stderr line as a discardable
+ * preamble. When the engine only emits that one line for a given failure, the
+ * only line with real information is dropped, `logs` ends up empty, and this
+ * used to produce a bare "Schema engine error:" with nothing after it. Fall
+ * back to the raw stderr so the error always carries some diagnostic content.
+ */
 export function formatSchemaEngineError(logs: SchemaEngineLogLine[], stderr: string): string {
   const messages = logs.map((log) => log.fields.message).filter(Boolean)
   return messages.length > 0 ? messages.join('\n') : stderr


### PR DESCRIPTION
## Description

Reported as `prisma migrate deploy` failing on MariaDB with a bare `Error: Schema engine error:` and nothing after it — no diagnostic content at all.

Traced it to `parseJsonFromStderr` in `packages/internals/src/schemaEngineCommands.ts`, which unconditionally drops the first line of the schema engine's stderr (`.slice(1)`) on the assumption that it's a discardable preamble. When the engine emits only a single stderr line for a given failure, that line — the only one with real information — gets dropped entirely, `logs` ends up an empty array, and the fallback error message construction (`logs.map((log) => log.fields.message).join('\n')`) produces an empty string. That matches the reported symptom exactly.

This doesn't require reproducing the underlying MariaDB failure itself (which may be a separate, engine-side issue) — regardless of *why* a given failure only produces one stderr line, the error message should never silently end up empty.

## Fix

Extracted the message-joining logic into `formatSchemaEngineError(logs, stderr)`, used in all 3 places that previously built this message (`canConnectToDatabase`, `createDatabase`, `dropDatabase`). It now falls back to the raw stderr whenever no log line yields a usable (non-empty) message, so the thrown error always carries *some* diagnostic content instead of silently swallowing the only information available.

Closes #29838

## Test plan

- Added unit tests for `formatSchemaEngineError` covering: joining multiple real messages, falling back to raw stderr when `logs` is empty, and falling back when log lines have empty messages.
- Ran the existing `schemaEngineCommands.test.ts` suite (the parts that don't require live Postgres/MySQL/SQL Server connections) — all passing, no regressions.
- `eslint` on the changed files — no new errors (one pre-existing warning on an unrelated line, from `catch (e: any)` predating this change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved schema engine error messages by combining available log details into clearer output.
  - Added a fallback to raw error output when structured log details are unavailable.
  - Applied consistent error reporting across database connection, creation, and deletion operations.
  - Prevented trailing blank lines from affecting error parsing.

- **Tests**
  - Added coverage for multi-line formatting, raw-output fallback, and single-line error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->