### PR TITLE
docs(roadmap): mark the lossless JSON projection defect landed

### DIFF
--- a/ROADMAP.html
+++ b/ROADMAP.html
@@ -196,19 +196,19 @@
     <div class="statusline">
       <span class="item"><span class="k">Ships</span> <span class="v teal">July 31</span></span>
       <span class="item"><span class="k">Health</span> <span class="v ok">On track</span></span>
-      <span class="item"><span class="k">Updated</span> <span class="v">July 30</span></span>
+      <span class="item"><span class="k">Updated</span> <span class="v">July 31</span></span>
       <span class="item"><span class="k">Scoreboard</span> <span class="v link"><a href="https://github.com/prisma/prisma-next/pull/1000">450 proven · 500 unproven · 30 experimental · 250 not in 8.0</a></span></span>
     </div>
     <div class="progress">
-      <p class="cap">Work on this page: <b>35 tasks</b> — 7 done, 11 in flight, 17 not started</p>
-      <div class="bar" role="img" aria-label="35 tasks: 7 done, 11 in flight, 17 not started">
-        <div class="done" style="width: 20%"></div>
-        <div class="flight" style="width: 31%"></div>
+      <p class="cap">Work on this page: <b>35 tasks</b> — 9 done, 10 in flight, 16 not started</p>
+      <div class="bar" role="img" aria-label="35 tasks: 9 done, 10 in flight, 16 not started">
+        <div class="done" style="width: 25.7%"></div>
+        <div class="flight" style="width: 28.6%"></div>
       </div>
       <div class="legend">
-        <span><span class="dot" style="background: var(--good)"></span><b>7</b> done</span>
-        <span><span class="dot" style="background: var(--accent)"></span><b>11</b> in flight</span>
-        <span><span class="dot" style="background: var(--open-bg); outline: 1px solid var(--line-strong); outline-offset: -1px;"></span><b>17</b> not started</span>
+        <span><span class="dot" style="background: var(--good)"></span><b>9</b> done</span>
+        <span><span class="dot" style="background: var(--accent)"></span><b>10</b> in flight</span>
+        <span><span class="dot" style="background: var(--open-bg); outline: 1px solid var(--line-strong); outline-offset: -1px;"></span><b>16</b> not started</span>
       </div>
       <p class="cap" style="margin-top: 16px;"><a href="https://github.com/prisma/prisma-next/pull/1000">Feature scoreboard</a>: <b>~1,230 cells</b> (~326 features × 3 databases) — 450 proven, 500 unproven, 30 experimental, 250 not in 8.0</p>
       <div class="bar" role="img" aria-label="Scoreboard: about 450 cells proven, 500 unproven, 30 experimental, 250 not in 8.0">
@@ -233,7 +233,7 @@
       <li>
         <span class="n">1</span>
         <span class="what"><a href="#req1">Queries must return correct values</a>
-          <span class="note">The main remaining defect: values read through relation-loading corrupt or fail.</span><span class="mini" aria-hidden="false"><span class="minibar" role="img" aria-label="5 tasks: 1 done · 4 in flight"><span class="d" style="width: 20.0%"></span><span class="f" style="width: 80.0%"></span></span><span class="minicount">1 done · 4 in flight</span></span></span>
+          <span class="note">The relation-loading codec defect is fixed and verified; aggregate typing and the type/runtime mismatches remain.</span><span class="mini" aria-hidden="false"><span class="minibar" role="img" aria-label="5 tasks: 3 done · 2 in flight"><span class="d" style="width: 60.0%"></span><span class="f" style="width: 40.0%"></span></span><span class="minicount">3 done · 2 in flight</span></span></span>
         <span class="owner">Alexey</span>
         <span class="pill flight">In progress</span>
       </li>
@@ -280,14 +280,14 @@
     <span class="reqno">Requirement 1</span>
     <span class="owner" style="margin-left: 8px;">Alexey</span>
     <h2>Queries must return correct values</h2>
-    <p class="soft">Prisma 8's core promise at the RC is that the query paths it ships are correct. One significant defect class remains, plus the tail of an almost-finished one.</p>
+    <p class="soft">Prisma 8's core promise at the RC is that the query paths it ships are correct. The one significant defect class — relation-loading bypassing type codecs — is fixed as of July 31; what remains is the aggregate-typing tail, the type/runtime mismatches, and the polymorphism call.</p>
 
     <details class="task">
-      <summary><svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg><span class="t">Values read through relation-loading bypass their type codecs — big numbers silently corrupt, date columns throw</span><span class="crit">CRITICAL PATH</span><span class="pill flight">In flight</span></summary>
+      <summary><svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg><span class="t">Values read through relation-loading bypass their type codecs — big numbers silently corrupt, date columns throw</span><span class="pill done">Landed</span></summary>
       <div class="body">
-        <p>When a query loads a relation (say, a post together with its author), Postgres assembles the nested rows into JSON inside the database, using its <code>json_agg</code> function. JSON numbers cannot represent everything a database column can hold: a 64-bit integer or arbitrary-precision decimal gets silently rounded to the nearest JavaScript-representable number before Prisma's type codecs ever see it, and date/time values arrive in a format the decoder rejects — so a plain <code>DateTime</code> column read through <code>.include()</code> throws today.</p>
-        <p>The fix: every type codec gains an explicit <em>lossless</em> JSON form (big numbers travel as strings, for example), and the SQL we generate is changed to produce that form inside the database. It lands as four pull requests in strict sequence — foundations, per-database codec descriptors, the switch-over, then aggregate typing. The switch-over is a breaking change: users regenerate their contract files, and some aggregate result types change (a <code>count()</code> becomes a <code>bigint</code>, decimal sums become strings — precise instead of approximately convenient).</p>
-        <p>Tracked as <a href="https://linear.app/prisma-company/issue/TML-3060/plan-codec-json-projections">TML-3060</a>; in flight now — the first of the four PRs, the explicit-JSON-projection AST foundations, has landed (<a href="https://linear.app/prisma-company/issue/TML-3062">TML-3062</a>, <a href="https://github.com/prisma/prisma-next/pull/1023">#1023</a>).</p>
+        <p>When a query loads a relation (say, a post together with its author), Postgres assembles the nested rows into JSON inside the database, using its <code>json_agg</code> function. JSON numbers cannot represent everything a database column can hold: a 64-bit integer or arbitrary-precision decimal got silently rounded to the nearest JavaScript-representable number before Prisma's type codecs ever saw it, and date/time values arrived in a format the decoder rejects — so a plain <code>DateTime</code> column read through <code>.include()</code> threw.</p>
+        <p>The fix landed July 31: every type codec states an explicit <em>lossless</em> canonical JSON form (big numbers travel as decimal strings, binary as base64), and the SQL we generate produces that form inside the database. It shipped as three pull requests in strict sequence — the projection AST foundations (<a href="https://linear.app/prisma-company/issue/TML-3062">TML-3062</a>, <a href="https://github.com/prisma/prisma-next/pull/1023">#1023</a>), the per-database codec descriptors (<a href="https://linear.app/prisma-company/issue/TML-3061">TML-3061</a>, <a href="https://github.com/prisma/prisma-next/pull/1051">#1051</a>), and the switch-over carrying the per-codec projections and their database-backed conformance harness (<a href="https://linear.app/prisma-company/issue/TML-3100">TML-3100</a>, <a href="https://linear.app/prisma-company/issue/TML-3063">TML-3063</a>, <a href="https://github.com/prisma/prisma/pull/29844">#29844</a>). The switch-over is the promised breaking change: users regenerate their contract files, nine codecs change their JSON form on the read path, and zone-less timestamps now read as UTC. Integration tests prove each renderer produces the canonical form against a real database.</p>
+        <p>Two remainders are accepted knowingly: aggregate values are not yet decoded through codecs (<a href="https://linear.app/prisma-company/issue/TML-3064">TML-3064</a>, tracked in the type-mismatch item below), and <code>pg/geometry@1</code> keeps its non-canonical form until its SRID representation is decided and a PostGIS-capable test database exists (<a href="https://linear.app/prisma-company/issue/TML-3105">TML-3105</a>).</p>
       </div>
     </details>
 
@@ -299,21 +299,22 @@
     </details>
 
     <details class="task">
-      <summary><svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg><span class="t">Binary columns read through relation-loading return hex text instead of bytes</span><span class="pill flight">In flight</span></summary>
+      <summary><svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg><span class="t">Binary columns read through relation-loading return hex text instead of bytes</span><span class="pill done">Landed</span></summary>
       <div class="body">
-        <p>Same disease as the big one above, concrete instance: a <code>Bytes</code> column selected inside <code>.include()</code> comes back as the raw hexadecimal text Postgres uses in JSON (<code>\x48656c6c6f</code>) while the TypeScript types promise a <code>Uint8Array</code>. Fixed by the same lossless-JSON work; a separate ticket (<a href="https://linear.app/prisma-company/issue/TML-2990">TML-2990</a>) tracks it so it can't be forgotten in the sweep. In progress.</p>
+        <p>Same disease as the big one above, concrete instance: a <code>Bytes</code> column selected inside <code>.include()</code> came back as the raw hexadecimal text Postgres uses in JSON (<code>\x48656c6c6f</code>) while the TypeScript types promise a <code>Uint8Array</code>. Fixed by the lossless-JSON switch-over: <code>pg/bytea@1</code>'s canonical JSON form is base64, and an integration test reads an included <code>bytea</code> column back as its exact bytes (<a href="https://linear.app/prisma-company/issue/TML-2990">TML-2990</a>, landed as part of <a href="https://github.com/prisma/prisma/pull/29844">#29844</a>).</p>
       </div>
     </details>
 
     <details class="task">
       <summary><svg class="chev" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg><span class="t">Places where the TypeScript types and the runtime disagree</span><span class="pill flight">In flight</span></summary>
       <div class="body">
-        <p>Two known mismatches, both "the type signature promises one thing, the running code returns another":</p>
+        <p>Three known mismatches, all "the type signature promises one thing, the running code returns another":</p>
         <ul>
           <li><code>Timestamp</code>/<code>Timestamptz</code> columns: the declared output type is a branded string, but the codec actually returns a JavaScript <code>Date</code> (<a href="https://linear.app/prisma-company/issue/TML-2391">TML-2391</a>, in progress).</li>
           <li>Projects that use the schema types directly without running contract emission (<code>typeof contract</code>) get types that ignore per-instance codec parameters and enum value sets — so a column can typecheck against values the database will reject (<a href="https://linear.app/prisma-company/issue/TML-2960">TML-2960</a>, in progress).</li>
+          <li>Aggregate results: a <code>count()</code> is typed <code>bigint</code>, but the runtime still returns the text the database sent — aggregate values are not yet decoded through codecs. This is the final PR of the lossless-JSON sequence, which also delivers the public target testkits for extensions (<a href="https://linear.app/prisma-company/issue/TML-3064">TML-3064</a>, open).</li>
         </ul>
-        <p>A type that lies is a correctness bug with a delay on it; both must be resolved (or the type corrected to tell the truth) before the types freeze.</p>
+        <p>A type that lies is a correctness bug with a delay on it; all must be resolved (or the type corrected to tell the truth) before the types freeze.</p>
       </div>
     </details>
 
@@ -654,6 +655,7 @@
     <h2>Recently landed</h2>
     <ul>
       <li><strong>Expression, partial, and unique indexes landed end-to-end</strong> — authorable in PSL and TypeScript, name-identified (a wire name carries a content-hash suffix; <code>map:</code> adopts the live name verbatim), and emitted at full fidelity by <code>contract infer</code> so existing databases adopt cleanly (requirement 4).</li>
+      <li><strong>Relation-loading now reads every value losslessly through its type codec</strong> — nested JSON is canonical per codec: big integers arrive as <code>bigint</code>, decimals as exact strings, <code>Bytes</code> as bytes; a breaking change that regenerates contracts and changes nine codecs' JSON form (requirement 1).</li>
       <li><strong>One error-code scheme, delivered end-to-end</strong> — every published error is a structural envelope with a dotted code; the ORM and contract-authoring planes' codeless throws were swept onto it; the 221-code reference page ships with a CI check that keeps it complete (requirement 3).</li>
       <li><strong>Contract snapshots deduplicated into one content-addressed store</strong> — migration folders stopped carrying full contract copies, ref-paired snapshots folded in too, closing the migrations-folder layout ahead of the freeze (requirement 3).</li>
       <li><strong>Hashes lost their <code>sha256:</code> prefix</strong> — the textual form of every content hash froze without the redundant algorithm tag (requirement 3).</li>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,13 +2,13 @@
 
 Prisma Next — the contract-first rewrite of Prisma — ships as **Prisma 8**. On **July 31** we publish **`prisma@8.0.0-rc.1`** from the `prisma/prisma` repository: the same repository and the same npm package Prisma users already know. The release candidate is published under a pre-release tag, so `npm install prisma` keeps installing Prisma 7 until 8.0.0 final ships. Prisma 8 carries **PostgreSQL to general availability** — and that is all: **MongoDB ships in early access**, and **SQLite is a proof of concept** at this stage. A release candidate freezes the public API; it does not promise Prisma 7 feature parity. Its promise is different: **everything it ships works and is proven by a test**, everything experimental is labeled, and everything absent is named rather than silently missing.
 
-**Updated July 30 · Health: on track · Ships July 31 · Tasks: 7 done / 11 in flight / 18 not started · [Scoreboard](https://github.com/prisma/prisma-next/pull/1000): ~450 proven / ~500 unproven / ~30 experimental / ~250 not in 8.0**
+**Updated July 31 · Health: on track · Ships July 31 · Tasks: 9 done / 10 in flight / 16 not started · [Scoreboard](https://github.com/prisma/prisma-next/pull/1000): ~450 proven / ~500 unproven / ~30 experimental / ~250 not in 8.0**
 
 ## What needs to happen to release v8-RC1
 
 Six things must be true on release day. Everything on this page belongs to one of them.
 
-1. **[Queries must return correct values](#1-queries-must-return-correct-values)** — *in progress · Alexey.* The main remaining defect: values read through relation-loading corrupt or fail.
+1. **[Queries must return correct values](#1-queries-must-return-correct-values)** — *in progress · Alexey.* The relation-loading codec defect is fixed and verified; aggregate typing and the type/runtime mismatches remain.
 2. **[The schema language must reach its final form](#2-the-schema-language-must-reach-its-final-form)** — *in flight · Serhii.* Whatever syntax the RC ships is permanent for the life of v8; three language projects are running.
 3. **[Every name and format users depend on must be final](#3-every-name-and-format-users-depend-on-must-be-final)** — *in progress · Will.* Error codes, hashes, the migration snapshot layout, and the config-key rename are done; the `prisma-next` name sweep remains.
 4. **[The release's claims must be proven](#4-the-releases-claims-must-be-proven)** — *scoreboard drafted, proofs open · everyone.* "It works" and "you can migrate incrementally" each need a runnable receipt.
@@ -21,15 +21,15 @@ Two dated decisions still bound the work. One is now overdue: the minimum suppor
 
 ## 1. Queries must return correct values
 
-Prisma 8's core promise at the RC is that the query paths it ships are correct. One significant defect class remains, plus the tail of an almost-finished one.
+Prisma 8's core promise at the RC is that the query paths it ships are correct. The one significant defect class — relation-loading bypassing type codecs — is fixed as of July 31; what remains is the aggregate-typing tail, the type/runtime mismatches, and the polymorphism call.
 
-<details><summary>⏳ <b>Values read through relation-loading bypass their type codecs — big numbers silently corrupt, date columns throw</b> · critical path</summary>
+<details><summary>✅ <b>Values read through relation-loading bypass their type codecs — big numbers silently corrupt, date columns throw</b> · landed</summary>
 
-When a query loads a relation (say, a post together with its author), Postgres assembles the nested rows into JSON inside the database, using its `json_agg` function. JSON numbers cannot represent everything a database column can hold: a 64-bit integer or arbitrary-precision decimal gets silently rounded to the nearest JavaScript-representable number before Prisma's type codecs ever see it, and date/time values arrive in a format the decoder rejects — so a plain `DateTime` column read through `.include()` throws today.
+When a query loads a relation (say, a post together with its author), Postgres assembles the nested rows into JSON inside the database, using its `json_agg` function. JSON numbers cannot represent everything a database column can hold: a 64-bit integer or arbitrary-precision decimal got silently rounded to the nearest JavaScript-representable number before Prisma's type codecs ever saw it, and date/time values arrived in a format the decoder rejects — so a plain `DateTime` column read through `.include()` threw.
 
-The fix: every type codec gains an explicit *lossless* JSON form (big numbers travel as strings, for example), and the SQL we generate is changed to produce that form inside the database. It lands as four pull requests in strict sequence — foundations, per-database codec descriptors, the switch-over, then aggregate typing. The switch-over is a breaking change: users regenerate their contract files, and some aggregate result types change (a `count()` becomes a `bigint`, decimal sums become strings — precise instead of approximately convenient).
+The fix landed July 31: every type codec states an explicit *lossless* canonical JSON form (big numbers travel as decimal strings, binary as base64), and the SQL we generate produces that form inside the database. It shipped as three pull requests in strict sequence — the projection AST foundations ([TML-3062](https://linear.app/prisma-company/issue/TML-3062), [#1023](https://github.com/prisma/prisma-next/pull/1023)), the per-database codec descriptors ([TML-3061](https://linear.app/prisma-company/issue/TML-3061), [#1051](https://github.com/prisma/prisma-next/pull/1051)), and the switch-over carrying the per-codec projections and their database-backed conformance harness ([TML-3100](https://linear.app/prisma-company/issue/TML-3100), [TML-3063](https://linear.app/prisma-company/issue/TML-3063), [#29844](https://github.com/prisma/prisma/pull/29844)). The switch-over is the promised breaking change: users regenerate their contract files, nine codecs change their JSON form on the read path, and zone-less timestamps now read as UTC. Integration tests prove each renderer produces the canonical form against a real database.
 
-Tracked as [TML-3060](https://linear.app/prisma-company/issue/TML-3060/plan-codec-json-projections); in flight now — the first of the four PRs, the explicit-JSON-projection AST foundations, has landed ([TML-3062](https://linear.app/prisma-company/issue/TML-3062), [#1023](https://github.com/prisma/prisma-next/pull/1023)).
+Two remainders are accepted knowingly: aggregate values are not yet decoded through codecs ([TML-3064](https://linear.app/prisma-company/issue/TML-3064), tracked in the type-mismatch item below), and `pg/geometry@1` keeps its non-canonical form until its SRID representation is decided and a PostGIS-capable test database exists ([TML-3105](https://linear.app/prisma-company/issue/TML-3105)).
 </details>
 
 <details><summary>✅ <b>`date` columns fail at runtime when read through relation-loading</b> · landed</summary>
@@ -37,19 +37,20 @@ Tracked as [TML-3060](https://linear.app/prisma-company/issue/TML-3060/plan-code
 The codec that correctly handles Postgres `date` values exists and is strict (it rejects impossible dates like February 31st rather than silently normalizing them), but nothing connected the `date` column type to it — so reading a `date` column through `.include()` threw at decode time, because the column inherited the `timestamptz` codec, which rejects the bare `YYYY-MM-DD` that `json_agg` renders. `@db.Date` now binds to `pg/date@1`, and a test proves an included `date` column comes back as a `Date` ([TML-3086](https://linear.app/prisma-company/issue/TML-3086), landed as [#1038](https://github.com/prisma/prisma-next/pull/1038)).
 </details>
 
-<details><summary>⏳ <b>Binary columns read through relation-loading return hex text instead of bytes</b></summary>
+<details><summary>✅ <b>Binary columns read through relation-loading return hex text instead of bytes</b> · landed</summary>
 
-Same disease as the big one above, concrete instance: a `Bytes` column selected inside `.include()` comes back as the raw hexadecimal text Postgres uses in JSON (`\x48656c6c6f`) while the TypeScript types promise a `Uint8Array`. Fixed by the same lossless-JSON work; a separate ticket ([TML-2990](https://linear.app/prisma-company/issue/TML-2990)) tracks it so it can't be forgotten in the sweep. In progress.
+Same disease as the big one above, concrete instance: a `Bytes` column selected inside `.include()` came back as the raw hexadecimal text Postgres uses in JSON (`\x48656c6c6f`) while the TypeScript types promise a `Uint8Array`. Fixed by the lossless-JSON switch-over: `pg/bytea@1`'s canonical JSON form is base64, and an integration test reads an included `bytea` column back as its exact bytes ([TML-2990](https://linear.app/prisma-company/issue/TML-2990), landed as part of [#29844](https://github.com/prisma/prisma/pull/29844)).
 </details>
 
 <details><summary>⏳ <b>Places where the TypeScript types and the runtime disagree</b></summary>
 
-Two known mismatches, both "the type signature promises one thing, the running code returns another":
+Three known mismatches, all "the type signature promises one thing, the running code returns another":
 
 - `Timestamp`/`Timestamptz` columns: the declared output type is a branded string, but the codec actually returns a JavaScript `Date` ([TML-2391](https://linear.app/prisma-company/issue/TML-2391), in progress).
 - Projects that use the schema types directly without running contract emission (`typeof contract`) get types that ignore per-instance codec parameters and enum value sets — so a column can typecheck against values the database will reject ([TML-2960](https://linear.app/prisma-company/issue/TML-2960), in progress).
+- Aggregate results: a `count()` is typed `bigint`, but the runtime still returns the text the database sent — aggregate values are not yet decoded through codecs. This is the final PR of the lossless-JSON sequence, which also delivers the public target testkits for extensions ([TML-3064](https://linear.app/prisma-company/issue/TML-3064), open).
 
-A type that lies is a correctness bug with a delay on it; both must be resolved (or the type corrected to tell the truth) before the types freeze.
+A type that lies is a correctness bug with a delay on it; all must be resolved (or the type corrected to tell the truth) before the types freeze.
 </details>
 
 <details><summary>⏳ <b>Finish the polymorphism bug tail — then decide: stable or experimental</b></summary>
@@ -312,6 +313,7 @@ Support statements that end up in the announcement get checked first: Windows, B
 ## Recently landed
 
 - **Expression, partial, and unique indexes landed end-to-end** — authorable in PSL and TypeScript, name-identified (a wire name carries a content-hash suffix; `map:` adopts the live name verbatim), and emitted at full fidelity by `contract infer` so existing databases adopt cleanly (section 4).
+- **Relation-loading now reads every value losslessly through its type codec** — nested JSON is canonical per codec: big integers arrive as `bigint`, decimals as exact strings, `Bytes` as bytes; a breaking change that regenerates contracts and changes nine codecs' JSON form (section 1).
 - **One error-code scheme, delivered end-to-end** — every published error is a structural envelope with a dotted code; the ORM and contract-authoring planes' codeless throws were swept onto it; the 221-code reference page ships with a CI check that keeps it complete (section 3).
 - **Contract snapshots deduplicated into one content-addressed store** — migration folders stopped carrying full contract copies, ref-paired snapshots folded in too, closing the migrations-folder layout ahead of the freeze (section 3).
 - **Hashes lost their `sha256:` prefix** — the textual form of every content hash froze without the redundant algorithm tag (section 3).


### PR DESCRIPTION
# Linked issue

n/a — docs-only refresh of the RC1 roadmap.

## At a glance

```diff
-<details><summary>⏳ <b>Values read through relation-loading bypass their type codecs — big numbers silently corrupt, date columns throw</b> · critical path</summary>
+<details><summary>✅ <b>Values read through relation-loading bypass their type codecs — big numbers silently corrupt, date columns throw</b> · landed</summary>
```

The roadmap's critical-path defect — nested rows read through `.include()` bypassing their type codecs — is fixed on `main` as of today, and this PR brings `ROADMAP.md` and `ROADMAP.html` up to date with that fact.

## Summary

The lossless-JSON stack completed with the hard cut merging as #29844 (TML-3063, carrying the TML-3100 per-codec projections), on top of the descriptor foundations (#1051) and the AST foundations (#1023). Two task items flip to **Landed**, each verified against `main`:

| Item | Requirement | Was | Now | Evidence |
| --- | --- | --- | --- | --- |
| Values read through relation-loading bypass their type codecs | 1 | In flight · critical path | ✅ Landed | TML-3062 #1023, TML-3061 #1051, TML-3100 + TML-3063 #29844 |
| Binary columns read through relation-loading return hex text | 1 | In flight | ✅ Landed | TML-2990, part of #29844 (`include-codec-canonical-json.test.ts`) |

The aggregate tail moves rather than disappears: `count()` is now *typed* `bigint` but the runtime still returns the database's text, so TML-3064 joins the "types and runtime disagree" item as its third mismatch, alongside the knowingly-accepted `pg/geometry@1` exemption (TML-3105) noted in the landed entry.

Header tallies move from **6 done / 11 in flight / 17 not started** to **8 / 10 / 16**; requirement 1's minibar becomes 3 done · 2 in flight; *Recently landed* gains the lossless-JSON entry at the top. The HTML legend, which had drifted to 5/12/17 while its own caption said 6/11/17, is recomputed to match the markers.

## Testing performed

n/a — Markdown + standalone HTML. Verified the two artifacts stay in sync: MD status markers count 8 ✅ / 10 ⏳ (task items), HTML carries 8 matching `Landed` pills (two moved from `In flight`, nothing else), and the header bar / minibar counts and widths were recomputed to match.

The landed claim itself was verified against `main` before flipping: the two suites the hard-cut commit names as its evidence pass locally — `json-projection-emission.test.ts` (7 tests) and `json-projection-variants.test.ts` + `include-codecs.test.ts` (21 database-backed tests).

## Skill update

n/a — docs only.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the DCO.
- [x] I read CONTRIBUTING.md and the change is scoped to one logical concern.
- [x] Tests are updated (n/a — docs only).
- [x] The PR title follows the `docs(roadmap):` convention of prior roadmap refreshes (#1043, #29809), which carry no Linear ticket.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated roadmap progress and task statuses as of July 31.
  * Recorded completed relation-loading codec fixes, including binary support and lossless canonical JSON handling.
  * Documented remaining aggregate, geometry, and type/runtime mismatches.
  * Noted the aggregate `bigint`/text mismatch and related test coverage.
  * Added the relation-loading work to the “Recently landed” section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->