### PR TITLE
fix(mongo-orm): decode write results through codecs

### DIFF
--- a/packages/2-mongo-family/5-query-builders/orm/src/collection.ts
+++ b/packages/2-mongo-family/5-query-builders/orm/src/collection.ts
@@ -16,13 +16,16 @@ import type {
 } from '@prisma-next/mongo-contract';
 import type {
   AnyMongoCommand,
+  MongoFieldShape,
   MongoFilterExpr,
   MongoQueryPlan,
+  MongoResultShape,
 } from '@prisma-next/mongo-query-ast/execution';
 import {
   DeleteManyCommand,
   FindOneAndDeleteCommand,
   FindOneAndUpdateCommand,
+  freezeMongoResultShape,
   InsertManyCommand,
   InsertOneCommand,
   isMongoFilterExpr,
@@ -30,9 +33,14 @@ import {
   MongoFieldFilter,
   UpdateManyCommand,
 } from '@prisma-next/mongo-query-ast/execution';
+import {
+  contractFieldToMongoFieldShape,
+  contractModelToMongoResultShape,
+} from '@prisma-next/mongo-query-builder';
 import type { MongoValue } from '@prisma-next/mongo-value';
 import { MongoParamRef } from '@prisma-next/mongo-value';
 import { blindCast, castAs } from '@prisma-next/utils/casts';
+import { ifDefined } from '@prisma-next/utils/defined';
 import { InternalError } from '@prisma-next/utils/internal-error';
 import type { MongoIncludeExpr } from './collection-state';
 import { emptyCollectionState, type MongoCollectionState } from './collection-state';
@@ -350,10 +358,10 @@ class MongoCollectionImpl<
     );
     const document = this.#toDocument(normalized);
     const command = new InsertOneCommand(this.#collectionName, document);
-    const results = await this.#drainPlan(command);
+    const results = await this.#drainPlan(command, this.#insertOneResultShape());
     const insertedId = blindCast<
       { insertedId: unknown },
-      'InsertOneCommand runtime result exposes the server-assigned insertedId'
+      'InsertOneCommand runtime result exposes the server-assigned insertedId, decoded via the _id codec'
     >(results[0]).insertedId;
     return blindCast<
       IncludedRow<TContract, ModelName, TIncludes>,
@@ -379,10 +387,10 @@ class MongoCollectionImpl<
       );
       const documents = normalizedRows.map((d) => self.#toDocument(d));
       const command = new InsertManyCommand(self.#collectionName, documents);
-      const results = await self.#drainPlan(command);
+      const results = await self.#drainPlan(command, self.#insertManyResultShape());
       const insertedIds = blindCast<
         { insertedIds: readonly unknown[] },
-        'InsertManyCommand runtime result exposes insertedIds in input order'
+        'InsertManyCommand runtime result exposes insertedIds in input order, decoded via the _id codec'
       >(results[0]).insertedIds;
       for (let i = 0; i < normalizedRows.length; i++) {
         yield blindCast<
@@ -427,13 +435,13 @@ class MongoCollectionImpl<
     const filter = this.#mergeFilters();
     const updateDoc = this.#resolveUpdateDoc(dataOrCallback);
     const command = new FindOneAndUpdateCommand(this.#collectionName, filter, updateDoc, false);
-    const results = await this.#drainPlan(command);
+    const results = await this.#drainPlan(command, this.#modelResultShape());
     const result = results[0];
     return result === undefined
       ? null
       : blindCast<
           IncludedRow<TContract, ModelName, TIncludes>,
-          'FindOneAndUpdateCommand plan has no resultShape; collection update exposes its raw driver document as IncludedRow'
+          'FindOneAndUpdateCommand plan carries the model resultShape; the runtime decodes the returned document like a read'
         >(result);
   }
 
@@ -487,13 +495,13 @@ class MongoCollectionImpl<
     this.#rejectIncludes('delete');
     const filter = this.#mergeFilters();
     const command = new FindOneAndDeleteCommand(this.#collectionName, filter);
-    const results = await this.#drainPlan(command);
+    const results = await this.#drainPlan(command, this.#modelResultShape());
     const result = results[0];
     return result === undefined
       ? null
       : blindCast<
           IncludedRow<TContract, ModelName, TIncludes>,
-          'FindOneAndDeleteCommand plan has no resultShape; collection delete exposes its raw driver document as IncludedRow'
+          'FindOneAndDeleteCommand plan carries the model resultShape; the runtime decodes the returned document like a read'
         >(result);
   }
 
@@ -600,10 +608,10 @@ class MongoCollectionImpl<
     }
 
     const command = new FindOneAndUpdateCommand(this.#collectionName, filter, updateDoc, true);
-    const results = await this.#drainPlan(command);
+    const results = await this.#drainPlan(command, this.#modelResultShape());
     return blindCast<
       IncludedRow<TContract, ModelName, TIncludes>,
-      'FindOneAndUpdateCommand upsert plan has no resultShape; collection upsert exposes its raw driver document as IncludedRow'
+      'FindOneAndUpdateCommand upsert plan carries the model resultShape; the runtime decodes the returned document like a read'
     >(results[0]);
   }
 
@@ -656,12 +664,17 @@ class MongoCollectionImpl<
     );
   }
 
-  #wrapCommand(command: AnyMongoCommand): MongoQueryPlan<unknown> {
-    return { collection: this.#collectionName, command, meta: this.#planMeta() };
+  #wrapCommand(command: AnyMongoCommand, resultShape?: MongoResultShape): MongoQueryPlan<unknown> {
+    return {
+      collection: this.#collectionName,
+      command,
+      meta: this.#planMeta(),
+      ...ifDefined('resultShape', resultShape),
+    };
   }
 
-  async #drainPlan(command: AnyMongoCommand): Promise<unknown[]> {
-    const plan = this.#wrapCommand(command);
+  async #drainPlan(command: AnyMongoCommand, resultShape?: MongoResultShape): Promise<unknown[]> {
+    const plan = this.#wrapCommand(command, resultShape);
     const result = this.#executor.execute(plan);
     const rows: unknown[] = [];
     for await (const row of result) {
@@ -676,6 +689,38 @@ class MongoCollectionImpl<
       'Mongo contract model lookup preserves target storage metadata erased by the namespace helper'
     >(domainModelsAtDefaultNamespace(this.#contract.domain)[this.#modelName]);
     return model?.fields ?? {};
+  }
+
+  #idFieldShape(): MongoFieldShape {
+    const idField = this.#modelFields()['_id'];
+    return idField
+      ? contractFieldToMongoFieldShape(idField)
+      : Object.freeze({ kind: 'unknown' as const });
+  }
+
+  #insertOneResultShape(): MongoResultShape {
+    return freezeMongoResultShape({
+      kind: 'document',
+      fields: { insertedId: this.#idFieldShape() },
+    });
+  }
+
+  #insertManyResultShape(): MongoResultShape {
+    return freezeMongoResultShape({
+      kind: 'document',
+      fields: { insertedIds: { kind: 'array', nullable: false, element: this.#idFieldShape() } },
+    });
+  }
+
+  #modelResultShape(): MongoResultShape {
+    const model = blindCast<
+      MongoModelDefinition | undefined,
+      'Mongo contract model lookup preserves target storage metadata erased by the namespace helper'
+    >(domainModelsAtDefaultNamespace(this.#contract.domain)[this.#modelName]);
+    if (!model) {
+      return Object.freeze({ kind: 'unknown' as const });
+    }
+    return contractModelToMongoResultShape(model);
   }
 
   #compileWhereObject(data: Record<string, unknown>): MongoFilterExpr[] {

--- a/packages/2-mongo-family/5-query-builders/orm/test/collection.test.ts
+++ b/packages/2-mongo-family/5-query-builders/orm/test/collection.test.ts
@@ -571,6 +571,16 @@ describe('MongoCollection write methods', () => {
         expect(assigneeRef.codecId).toBe('mongo/objectId@1');
       }
     });
+
+    it('attaches a result shape decoding insertedId via the _id codec', async () => {
+      const executor = createMockExecutor([{ insertedId: 'id' }]);
+      const col = createMongoCollection(contract, 'User', executor);
+      await col.create(defaultUserData);
+      expect(executor.lastPlan!.resultShape).toEqual({
+        kind: 'document',
+        fields: { insertedId: { kind: 'leaf', codecId: 'mongo/objectId@1', nullable: false } },
+      });
+    });
   });
 
   describe('createAll()', () => {
@@ -588,6 +598,24 @@ describe('MongoCollection write methods', () => {
         { _id: 'id-1', ...defaultUserData },
         { _id: 'id-2', ...defaultUserData, name: 'Bob', email: 'b@b.c' },
       ]);
+    });
+
+    it('attaches a result shape decoding each insertedId via the _id codec', async () => {
+      const executor = createMockExecutor([{ insertedIds: ['id-1'], insertedCount: 1 }]);
+      const col = createMongoCollection(contract, 'User', executor);
+      for await (const _row of col.createAll([defaultUserData])) {
+        // drain
+      }
+      expect(executor.lastPlan!.resultShape).toEqual({
+        kind: 'document',
+        fields: {
+          insertedIds: {
+            kind: 'array',
+            nullable: false,
+            element: { kind: 'leaf', codecId: 'mongo/objectId@1', nullable: false },
+          },
+        },
+      });
     });
   });
 
@@ -650,6 +678,22 @@ describe('MongoCollection write methods', () => {
         const nameRef = update['$set']!['name']!;
         expect(nameRef).toBeInstanceOf(MongoParamRef);
         expect(nameRef.codecId).toBe('mongo/string@1');
+      }
+    });
+
+    it('attaches the model result shape so the returned document decodes like a read', async () => {
+      const executor = createMockExecutor([{ _id: 'id-1', name: 'Updated', email: 'a@b.c' }]);
+      const col = createMongoCollection(contract, 'User', executor);
+      await col.where(MongoFieldFilter.eq('_id', 'id-1')).update({ name: 'Updated' });
+      const shape = executor.lastPlan!.resultShape;
+      expect(shape).toBeDefined();
+      expect(shape!.kind).toBe('document');
+      if (shape!.kind === 'document') {
+        expect(shape!.fields['_id']).toEqual({
+          kind: 'leaf',
+          codecId: 'mongo/objectId@1',
+          nullable: false,
+        });
       }
     });
   });
@@ -860,6 +904,15 @@ describe('MongoCollection write methods', () => {
       const result = await col.where(MongoFieldFilter.eq('_id', 'none')).delete();
       expect(result).toBeNull();
     });
+
+    it('attaches the model result shape so the returned document decodes like a read', async () => {
+      const executor = createMockExecutor([{ _id: 'id-1', name: 'Alice', email: 'a@b.c' }]);
+      const col = createMongoCollection(contract, 'User', executor);
+      await col.where(MongoFieldFilter.eq('_id', 'id-1')).delete();
+      const shape = executor.lastPlan!.resultShape;
+      expect(shape).toBeDefined();
+      expect(shape!.kind).toBe('document');
+    });
   });
 
   describe('deleteAndCount()', () => {
@@ -887,6 +940,18 @@ describe('MongoCollection write methods', () => {
       });
       expect(result).toEqual({ _id: 'new-id', name: 'Alice', email: 'a@b.c' });
       expect(executor.lastCommand!.kind).toBe('findOneAndUpdate');
+    });
+
+    it('attaches the model result shape so the returned document decodes like a read', async () => {
+      const executor = createMockExecutor([{ _id: 'new-id', name: 'Alice', email: 'a@b.c' }]);
+      const col = createMongoCollection(contract, 'User', executor);
+      await col.where(MongoFieldFilter.eq('email', 'a@b.c')).upsert({
+        create: defaultUserData,
+        update: { name: 'Alice Updated' },
+      });
+      const shape = executor.lastPlan!.resultShape;
+      expect(shape).toBeDefined();
+      expect(shape!.kind).toBe('document');
     });
 
     it('throws without .where()', async () => {

--- a/packages/2-mongo-family/5-query-builders/orm/test/integration/orm-ergonomics.test.ts
+++ b/packages/2-mongo-family/5-query-builders/orm/test/integration/orm-ergonomics.test.ts
@@ -62,6 +62,49 @@ describe('ORM ergonomics integration (FL-04, FL-06, FL-08)', {
     await Promise.allSettled([runtime?.close(), client?.close(), replSet?.stop()]);
   }, timeouts.spinUpMongoMemoryServer);
 
+  describe('write results decode through codecs (issue #577)', () => {
+    it('create() returns _id as the decoded hex string a read returns', async () => {
+      const orm = mongoOrm({ contract, executor: runtime });
+      const created = await orm.users.create(defaultUserData);
+      expect(typeof created._id).toBe('string');
+      const fetched = await orm.users.where({ _id: created._id as string }).first();
+      expect(fetched!._id).toBe(created._id);
+    });
+
+    it('createAll() returns decoded _ids', async () => {
+      const orm = mongoOrm({ contract, executor: runtime });
+      const rows: Record<string, unknown>[] = [];
+      for await (const row of orm.users.createAll([
+        defaultUserData,
+        { ...defaultUserData, name: 'Bob', email: 'bob@test.com' },
+      ])) {
+        rows.push(row as Record<string, unknown>);
+      }
+      expect(rows).toHaveLength(2);
+      for (const row of rows) {
+        expect(typeof row['_id']).toBe('string');
+      }
+    });
+
+    it('update() returns the document decoded like a read', async () => {
+      const orm = mongoOrm({ contract, executor: runtime });
+      const created = await orm.users.create(defaultUserData);
+      const updated = await orm.users
+        .where({ _id: created._id as string })
+        .update({ name: 'Renamed' });
+      expect(updated).not.toBeNull();
+      expect((updated as Record<string, unknown>)['_id']).toBe(created._id);
+    });
+
+    it('delete() returns the document decoded like a read', async () => {
+      const orm = mongoOrm({ contract, executor: runtime });
+      const created = await orm.users.create(defaultUserData);
+      const deleted = await orm.users.where({ _id: created._id as string }).delete();
+      expect(deleted).not.toBeNull();
+      expect((deleted as Record<string, unknown>)['_id']).toBe(created._id);
+    });
+  });
+
   describe('FL-06: codec-aware where()', () => {
     it('retrieves document by ObjectId field using object where', async () => {
       const orm = mongoOrm({ contract, executor: runtime });


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma-next/issues/577

## Problem

`collection.create()` returned the server-assigned `_id` as a raw BSON `ObjectId`, while the same row read back via `.where(...).first()` returns a hex `string` (decoded by `mongoObjectIdCodec`). The static row type declares `string` in both cases, so `created._id === fetched._id` fails and the `create()` result silently mismatches its declared type.

`update()`, `delete()`, and `upsert()` had the same gap: their plans carried no `resultShape`, so they exposed the raw driver document (wire-form values for every codec field), unlike `updateAll()`/`deleteAll()`, which re-read through the normal decode path.

## Fix

Attach result shapes to the write command plans in `MongoCollectionImpl`, so the existing runtime decode path (`decodeMongoRow`) handles them exactly like reads:

- `InsertOneCommand` plans get `{ insertedId: <_id field shape> }`, so `create()` returns the decoded `_id`.
- `InsertManyCommand` plans get `{ insertedIds: array<_id field shape> }`, so `createAll()` returns decoded `_id`s. (`insertedCount` passes through untouched — unshaped keys round-trip verbatim.)
- `FindOneAndUpdateCommand` / `FindOneAndDeleteCommand` plans get the full model result shape (`contractModelToMongoResultShape`), so `update()`, `delete()`, and `upsert()` return documents decoded like reads.

Count-only commands (`createAndCount`, `updateAndCount`, `deleteAndCount`) and the deliberately wire-level `#readMatchingIds` prefetch are unchanged.

## Tests

- Unit: assert the plans carry the expected result shapes (insert one/many, update, delete, upsert).
- Integration (real MongoDB replica set): the issue's repro — `typeof created._id === 'string'` and `created._id === fetched._id` — plus decoded results for `createAll`/`update`/`delete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MongoDB write operations so returned IDs and documents are decoded consistently with their defined data models.
  - `create`, bulk create, update, delete, and upsert results now correctly match the formats used by read operations.
  - Fixed handling of returned identifiers, including decoded string IDs.

- **Tests**
  - Added coverage for decoded results across individual and bulk write operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->