### PR TITLE
fix: only packages/9-public is publishable, enforced

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,9 @@ jobs:
         run: pnpm lint:consumer-internal-imports
       - name: Lint the legacy product name
         run: pnpm lint:legacy-name
+
+      - name: Lint publishability matches the directory layout
+        run: pnpm lint:publishability
       - name: Check upgrade-instruction coverage
         run: pnpm check:upgrade-coverage --mode pr
       - name: Check error-reference completeness

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "errors:list": "node scripts/list-error-codes.mjs",
     "check:error-reference": "node scripts/list-error-codes.mjs --verify docs/reference/error-reference.md",
     "lint:consumer-internal-imports": "node scripts/lint-consumer-internal-imports.mjs",
-    "lint:legacy-name": "node scripts/lint-legacy-name.mjs"
+    "lint:legacy-name": "node scripts/lint-legacy-name.mjs",
+    "lint:publishability": "node scripts/lint-publishability.mjs"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.5",

--- a/packages/0-shared/extension-author-tools/package.json
+++ b/packages/0-shared/extension-author-tools/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@internal/extension-author-tools",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",
-  "description": "CLI tools that pair with the prisma-8-extension-upgrade agent skill — including `prisma-8-check-pins`, the CI guard that asserts every `@internal/*` peerDep on an extension package is exact-version-pinned. Future tools for extension authors employing the upgrade skill ship from this package.",
+  "description": "CLI tools that pair with the prisma-8-extension-upgrade agent skill \u2014 including `prisma-8-check-pins`, the CI guard that asserts every `@internal/*` peerDep on an extension package is exact-version-pinned. Future tools for extension authors employing the upgrade skill ship from this package.",
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/packages/1-framework/0-foundation/contract/package.json
+++ b/packages/1-framework/0-foundation/contract/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/contract",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/1-framework/0-foundation/utils/package.json
+++ b/packages/1-framework/0-foundation/utils/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/utils",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/1-framework/1-core/config/package.json
+++ b/packages/1-framework/1-core/config/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/config",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/1-framework/1-core/errors/package.json
+++ b/packages/1-framework/1-core/errors/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/errors",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/1-framework/1-core/framework-components/package.json
+++ b/packages/1-framework/1-core/framework-components/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/framework-components",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/1-framework/1-core/operations/package.json
+++ b/packages/1-framework/1-core/operations/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/operations",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/1-framework/1-core/ts-render/package.json
+++ b/packages/1-framework/1-core/ts-render/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/ts-render",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/1-framework/2-authoring/contract/package.json
+++ b/packages/1-framework/2-authoring/contract/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/contract-authoring",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/1-framework/2-authoring/ids/package.json
+++ b/packages/1-framework/2-authoring/ids/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/ids",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/1-framework/2-authoring/psl-parser/package.json
+++ b/packages/1-framework/2-authoring/psl-parser/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/psl-parser",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/1-framework/2-authoring/psl-printer/package.json
+++ b/packages/1-framework/2-authoring/psl-printer/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/psl-printer",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/1-framework/3-tooling/cli-telemetry/package.json
+++ b/packages/1-framework/3-tooling/cli-telemetry/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/cli-telemetry",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/1-framework/3-tooling/cli/package.json
+++ b/packages/1-framework/3-tooling/cli/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/cli",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/1-framework/3-tooling/config-loader/package.json
+++ b/packages/1-framework/3-tooling/config-loader/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/config-loader",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/1-framework/3-tooling/emitter/package.json
+++ b/packages/1-framework/3-tooling/emitter/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/emitter",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/1-framework/3-tooling/language-server/package.json
+++ b/packages/1-framework/3-tooling/language-server/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/language-server",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/1-framework/3-tooling/migration/package.json
+++ b/packages/1-framework/3-tooling/migration/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/migration-tools",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/1-framework/3-tooling/vite-plugin-contract-emit/package.json
+++ b/packages/1-framework/3-tooling/vite-plugin-contract-emit/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/vite-plugin-contract-emit",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/2-mongo-family/1-foundation/mongo-codec/package.json
+++ b/packages/2-mongo-family/1-foundation/mongo-codec/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/mongo-codec",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/2-mongo-family/1-foundation/mongo-contract/package.json
+++ b/packages/2-mongo-family/1-foundation/mongo-contract/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/mongo-contract",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/2-mongo-family/1-foundation/mongo-value/package.json
+++ b/packages/2-mongo-family/1-foundation/mongo-value/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/mongo-value",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/2-mongo-family/2-authoring/contract-psl/package.json
+++ b/packages/2-mongo-family/2-authoring/contract-psl/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/mongo-contract-psl",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/2-mongo-family/2-authoring/contract-ts/package.json
+++ b/packages/2-mongo-family/2-authoring/contract-ts/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/mongo-contract-ts",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/2-mongo-family/3-tooling/emitter/package.json
+++ b/packages/2-mongo-family/3-tooling/emitter/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/mongo-emitter",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/2-mongo-family/3-tooling/mongo-schema-ir/package.json
+++ b/packages/2-mongo-family/3-tooling/mongo-schema-ir/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/mongo-schema-ir",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/2-mongo-family/4-query/query-ast/package.json
+++ b/packages/2-mongo-family/4-query/query-ast/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/mongo-query-ast",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/2-mongo-family/5-query-builders/orm/package.json
+++ b/packages/2-mongo-family/5-query-builders/orm/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/mongo-orm",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/2-mongo-family/5-query-builders/query-builder/package.json
+++ b/packages/2-mongo-family/5-query-builders/query-builder/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/mongo-query-builder",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/2-mongo-family/6-transport/mongo-lowering/package.json
+++ b/packages/2-mongo-family/6-transport/mongo-lowering/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/mongo-lowering",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/2-mongo-family/6-transport/mongo-wire/package.json
+++ b/packages/2-mongo-family/6-transport/mongo-wire/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/mongo-wire",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/2-mongo-family/7-runtime/package.json
+++ b/packages/2-mongo-family/7-runtime/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/mongo-runtime",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/2-mongo-family/9-family/package.json
+++ b/packages/2-mongo-family/9-family/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/family-mongo",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/2-sql/1-core/contract/package.json
+++ b/packages/2-sql/1-core/contract/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/sql-contract",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/2-sql/1-core/errors/package.json
+++ b/packages/2-sql/1-core/errors/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/sql-errors",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/2-sql/1-core/operations/package.json
+++ b/packages/2-sql/1-core/operations/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/sql-operations",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/2-sql/1-core/schema-ir/package.json
+++ b/packages/2-sql/1-core/schema-ir/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/sql-schema-ir",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/2-sql/2-authoring/contract-psl/package.json
+++ b/packages/2-sql/2-authoring/contract-psl/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/sql-contract-psl",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/2-sql/2-authoring/contract-ts/package.json
+++ b/packages/2-sql/2-authoring/contract-ts/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/sql-contract-ts",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/2-sql/3-tooling/emitter/package.json
+++ b/packages/2-sql/3-tooling/emitter/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/sql-contract-emitter",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/2-sql/4-lanes/query-builder/package.json
+++ b/packages/2-sql/4-lanes/query-builder/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/sql-lane-query-builder",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/2-sql/4-lanes/relational-core/package.json
+++ b/packages/2-sql/4-lanes/relational-core/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/sql-relational-core",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/2-sql/4-lanes/sql-builder/package.json
+++ b/packages/2-sql/4-lanes/sql-builder/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/sql-builder",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/2-sql/5-runtime/package.json
+++ b/packages/2-sql/5-runtime/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/sql-runtime",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/2-sql/9-family/package.json
+++ b/packages/2-sql/9-family/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/family-sql",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/3-extensions/arktype-json/package.json
+++ b/packages/3-extensions/arktype-json/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/extension-arktype-json",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/3-extensions/middleware-cache/package.json
+++ b/packages/3-extensions/middleware-cache/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/middleware-cache",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/3-extensions/mongo/package.json
+++ b/packages/3-extensions/mongo/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/mongo",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/3-extensions/paradedb/package.json
+++ b/packages/3-extensions/paradedb/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/extension-paradedb",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/3-extensions/pgvector/package.json
+++ b/packages/3-extensions/pgvector/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/extension-pgvector",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/3-extensions/postgis/package.json
+++ b/packages/3-extensions/postgis/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/extension-postgis",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/3-extensions/postgres/package.json
+++ b/packages/3-extensions/postgres/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/postgres",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/3-extensions/sql-orm-client/package.json
+++ b/packages/3-extensions/sql-orm-client/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@internal/sql-orm-client",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,
-  "description": "ORM client for Prisma Next — fluent, type-safe model collections",
+  "description": "ORM client for Prisma Next \u2014 fluent, type-safe model collections",
   "scripts": {
     "build": "tsdown",
     "emit": "cd ../../../test/integration && node ../../packages/1-framework/3-tooling/cli/dist/cli.js contract emit --config test/sql-orm-client/fixtures/prisma-next.config.ts && node ../../packages/1-framework/3-tooling/cli/dist/cli.js contract emit --config test/sql-orm-client/fixtures/polymorphism/prisma-next.config.ts && node ../../packages/1-framework/3-tooling/cli/dist/cli.js contract emit --config test/sql-orm-client/fixtures/junction-namespaces/prisma-next.config.ts && node ../../packages/1-framework/3-tooling/cli/dist/cli.js contract emit --config test/sql-orm-client/fixtures/execution-defaulted-tags/prisma-next.config.ts && node ../../packages/1-framework/3-tooling/cli/dist/cli.js contract emit --config test/sql-orm-client/fixtures/mn-psl/prisma-next.config.ts && cp test/sql-orm-client/fixtures/generated/contract.json test/sql-orm-client/fixtures/generated/contract.d.ts ../../packages/3-extensions/sql-orm-client/test/fixtures/generated/ && cp test/sql-orm-client/fixtures/junction-namespaces/generated/contract.json test/sql-orm-client/fixtures/junction-namespaces/generated/contract.d.ts ../../packages/3-extensions/sql-orm-client/test/fixtures/junction-namespaces/generated/ && cd ../../packages/3-extensions/sql-orm-client && node scripts/strip-pgvector-fixture.mjs test/fixtures/generated/contract.d.ts",

--- a/packages/3-extensions/sqlite/package.json
+++ b/packages/3-extensions/sqlite/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/sqlite",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/3-extensions/supabase/package.json
+++ b/packages/3-extensions/supabase/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/extension-supabase",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/3-mongo-target/1-mongo-target/package.json
+++ b/packages/3-mongo-target/1-mongo-target/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/target-mongo",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/3-mongo-target/2-mongo-adapter/package.json
+++ b/packages/3-mongo-target/2-mongo-adapter/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/adapter-mongo",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/3-mongo-target/3-mongo-driver/package.json
+++ b/packages/3-mongo-target/3-mongo-driver/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/driver-mongo",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/3-targets/3-targets/postgres/package.json
+++ b/packages/3-targets/3-targets/postgres/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/target-postgres",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/3-targets/3-targets/sqlite/package.json
+++ b/packages/3-targets/3-targets/sqlite/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/target-sqlite",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/3-targets/6-adapters/postgres/package.json
+++ b/packages/3-targets/6-adapters/postgres/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/adapter-postgres",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/3-targets/6-adapters/sqlite/package.json
+++ b/packages/3-targets/6-adapters/sqlite/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/adapter-sqlite",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/3-targets/7-drivers/postgres/package.json
+++ b/packages/3-targets/7-drivers/postgres/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/driver-postgres",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/3-targets/7-drivers/sqlite/package.json
+++ b/packages/3-targets/7-drivers/sqlite/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/driver-sqlite",
+  "private": true,
   "version": "0.16.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/scripts/lint-publishability.mjs
+++ b/scripts/lint-publishability.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * Publishability is a directory property (ADR 242): every package under
+ * `packages/9-public/` is publishable, and no package anywhere else is.
+ *
+ * Both directions are enforced. A publishable package outside `9-public`
+ * would ship an internal module the moment the publish workflow iterates
+ * publishable packages; a `private: true` package inside `9-public` would
+ * silently drop part of the published surface. Neither failure announces
+ * itself at build time, which is why this is a lint.
+ *
+ * Exits 1 listing every violation; exits 0 otherwise.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(fileURLToPath(import.meta.url), '../..');
+
+export function findPublishabilityViolations(root = repoRoot) {
+  const manifests = execFileSync(
+    'git',
+    [
+      'ls-files',
+      'packages/*/package.json',
+      'packages/*/*/package.json',
+      'packages/*/*/*/package.json',
+      'packages/*/*/*/*/package.json',
+    ],
+    {
+      cwd: root,
+      encoding: 'utf8',
+    },
+  )
+    .split('\n')
+    .filter(Boolean);
+
+  const violations = [];
+  for (const file of manifests) {
+    const manifest = JSON.parse(readFileSync(resolve(root, file), 'utf8'));
+    const isPublic = file.startsWith('packages/9-public/');
+    const isPrivate = manifest.private === true;
+    if (isPublic && isPrivate) {
+      violations.push({ file, name: manifest.name, rule: 'private-inside-9-public' });
+    }
+    if (!isPublic && !isPrivate) {
+      violations.push({ file, name: manifest.name, rule: 'publishable-outside-9-public' });
+    }
+  }
+  return violations;
+}
+
+function main() {
+  const violations = findPublishabilityViolations();
+  if (violations.length === 0) {
+    console.log(
+      'Publishability matches the directory layout: packages/9-public/ and nothing else.',
+    );
+    return 0;
+  }
+  for (const v of violations) {
+    console.error(`${v.file}: ${v.name} — ${v.rule}`);
+  }
+  console.error(`\nlint-publishability: ${violations.length} violation(s).`);
+  return 1;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  process.exit(main());
+}

--- a/skills/extension-author/prisma-8-extension-upgrade/upgrades/0.16-to-0.17/instructions.md
+++ b/skills/extension-author/prisma-8-extension-upgrade/upgrades/0.16-to-0.17/instructions.md
@@ -539,8 +539,9 @@ changes:
       workspace package published, so a pack could depend on `@internal/contract`,
       `@internal/sql-contract`, `@internal/framework-components` and the rest
       directly — and many do. From 0.17 the published surface is 17 `@prisma/*`
-      packages and everything else is private and renamed, so those dependencies no
-      longer resolve.
+      packages and everything else carries `"private": true` in its manifest, so
+      those dependencies no longer resolve anywhere: a stale name fails at install
+      time rather than resolving to an outdated artifact left on the registry.
       Build against the platform packages instead: `@prisma/orm-framework` for contract,
       components, errors and the PSL tooling; `@prisma/orm-family-sql` or
       `@prisma/orm-family-mongo` for the family surfaces; `@prisma/orm-target-<db>` for the


### PR DESCRIPTION
## What this is

The privatization that should have shipped inside #29864. `main` merged with **64 internal packages still publishable** — the flip was scoped to the switchover slice, whose dispatch was cancelled and never revived, and I consolidated the project PR without folding it in or surfacing the omission as a decision. The only thing keeping those packages off the registry was the publish workflow failing at an unrelated gate.

## Changes

- Every package outside `packages/9-public/` is `"private": true` — all 64. `scripts/list-publishable-packages.mjs` now returns exactly the 17 ADR 242 packages.
- **`pnpm lint:publishability`** — fails in both directions: a publishable package outside `9-public`, or a private one inside it. Wired into CI beside `lint:legacy-name` and `lint:consumer-internal-imports`. Verified against a planted violation in each direction.

## Verification

`lint:publishability` green (and red on planted violations both ways) · `lint:manifests`: all 17 publishable packages OK · `check:publish-deps`: 17 packages, declaration deps clean · `lint:legacy-name` · `lint:consumer-internal-imports` · `pnpm build` · `test:scripts` 298/298.

## What this deliberately does not do

The remaining switchover items — the phantom `@internal/*` devDependencies strip at pack time, the shim's mirrored dependencies, and the publish pipeline's missing-stable-tag assumption — are still open and tracked on TML-3124. This PR is the safety flip only, kept minimal so it can merge immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Clarified package visibility so internal components are not published accidentally.
  * Added automated validation to ensure only designated public packages are publishable.
  * Integrated publishability checks into the continuous integration lint workflow.

* **Documentation**
  * Updated extension upgrade guidance to use the corresponding public platform packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->