### PR TITLE
fix(cli): secure Prisma Studio's local HTTP server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@
 - **CLI commands**: Most commands already accept `--config` for custom config paths. Upcoming work removes `--schema` / `--url` in favour of config-based resolution. When editing CLI help text, keep examples aligned with new config-first workflow.
   - For isolated Studio verification, you can run `packages/cli/src/Studio.ts` directly via `pnpm exec tsx` and pass a config object that preserves `loadedFromFile`; this keeps SQLite URLs resolving relative to the config file while avoiding unrelated `packages/cli/src/bin.ts` imports.
   - Studio is now pre-bundled into `packages/cli/build/studio.js` and `packages/cli/build/studio.css`, served only through explicit routes in `packages/cli/src/Studio.ts` via the runtime-specific `packages/cli/src/studio-server.ts` bindings, and should keep listener-level coverage in `packages/cli/src/__tests__/studio-server.vitest.ts` because a past Node regression dropped `GET` bodies by treating them like `HEAD`.
+  - Studio's local HTTP server must bind explicitly to `127.0.0.1`. Its request handler must reject browser requests whose `Origin` is not the active localhost or loopback URL before routing `/bff` or `/telemetry`; removing CORS response headers alone does not prevent cross-origin writes.
   - If Enter or click does not open a cell editor in Studio, verify that the current table and column are writable before assuming a keyboard regression; views/system tables and read-only columns legitimately stay non-editable.
 
 - **Driver adapters datasource**:

--- a/packages/cli/src/Studio.ts
+++ b/packages/cli/src/Studio.ts
@@ -280,8 +280,11 @@ ${bold('Examples')}
 
     const requestedPort = args['--port']
 
-    if (requestedPort === 0) {
-      return new UserFacingError('The Studio port must be greater than 0.')
+    if (
+      requestedPort !== undefined &&
+      (!Number.isInteger(requestedPort) || requestedPort < 1 || requestedPort > 65_535)
+    ) {
+      return new UserFacingError('The Studio port must be an integer between 1 and 65535.')
     }
 
     const connectionString = args['--url'] || config.datasource?.url

--- a/packages/cli/src/Studio.ts
+++ b/packages/cli/src/Studio.ts
@@ -18,7 +18,7 @@ import { runtime } from 'std-env'
 
 import packageJson from '../package.json' assert { type: 'json' }
 import { STUDIO_CSS_FILE_NAME, STUDIO_JS_FILE_NAME, type StudioAdapterType } from './studio-frontend-shared'
-import { startStudioServer } from './studio-server'
+import { startStudioServer, STUDIO_SERVER_HOST } from './studio-server'
 import { UserFacingError } from './utils/errors'
 import { getPpgInfo } from './utils/ppgInfo'
 
@@ -308,7 +308,7 @@ ${bold('Examples')}
     )
     const version = packageJson.dependencies['@prisma/studio-core']
     const ppgDbInfo = await getPpgInfo(connectionString)
-    const port = args['--port'] || (await getPort({ port: DEFAULT_PORT, portRange: [MIN_PORT, DEFAULT_PORT - 1] }))
+    const port = await resolveStudioPort(args['--port'])
     const handler = createStudioRequestHandler({
       adapter: studioStuff.adapter,
       executor,
@@ -343,6 +343,18 @@ ${bold('Examples')}
 
 function getUrlBasePath(url: string | undefined, configPath: string | null): string {
   return url ? process.cwd() : configPath ? dirname(configPath) : process.cwd()
+}
+
+async function resolveStudioPort(requestedPort: number | undefined): Promise<number> {
+  if (requestedPort !== undefined) {
+    return requestedPort
+  }
+
+  return getPort({
+    host: STUDIO_SERVER_HOST,
+    port: DEFAULT_PORT,
+    portRange: [MIN_PORT, DEFAULT_PORT - 1],
+  })
 }
 
 function serializeBffError(error: unknown): SerializedError {

--- a/packages/cli/src/Studio.ts
+++ b/packages/cli/src/Studio.ts
@@ -278,6 +278,12 @@ ${bold('Examples')}
       return this.help()
     }
 
+    const requestedPort = args['--port']
+
+    if (requestedPort === 0) {
+      return new UserFacingError('The Studio port must be greater than 0.')
+    }
+
     const connectionString = args['--url'] || config.datasource?.url
 
     if (!connectionString) {
@@ -308,7 +314,7 @@ ${bold('Examples')}
     )
     const version = packageJson.dependencies['@prisma/studio-core']
     const ppgDbInfo = await getPpgInfo(connectionString)
-    const port = await resolveStudioPort(args['--port'])
+    const port = await resolveStudioPort(requestedPort)
     const handler = createStudioRequestHandler({
       adapter: studioStuff.adapter,
       executor,

--- a/packages/cli/src/Studio.ts
+++ b/packages/cli/src/Studio.ts
@@ -308,15 +308,15 @@ ${bold('Examples')}
     )
     const version = packageJson.dependencies['@prisma/studio-core']
     const ppgDbInfo = await getPpgInfo(connectionString)
+    const port = args['--port'] || (await getPort({ port: DEFAULT_PORT, portRange: [MIN_PORT, DEFAULT_PORT - 1] }))
     const handler = createStudioRequestHandler({
       adapter: studioStuff.adapter,
       executor,
       ppgDbInfo,
+      port,
       protocol,
       version,
     })
-
-    const port = args['--port'] || (await getPort({ port: DEFAULT_PORT, portRange: [MIN_PORT, DEFAULT_PORT - 1] }))
 
     const url = `http://localhost:${port}`
 
@@ -474,23 +474,25 @@ function createStudioRequestHandler({
   adapter,
   executor,
   ppgDbInfo,
+  port,
   protocol,
   version,
 }: {
   adapter: StudioAdapterType
   executor: Executor
   ppgDbInfo: Awaited<ReturnType<typeof getPpgInfo>>
+  port: number
   protocol: string
   version: string
 }): (request: Request) => Promise<Response> {
   let projectHash: string | null = null
 
   return async (request) => {
-    const { pathname } = new URL(request.url)
-
-    if (request.method === 'OPTIONS') {
-      return optionsResponse()
+    if (!isAllowedStudioOrigin(request, port)) {
+      return textResponse('Forbidden', 403)
     }
+
+    const { pathname } = new URL(request.url)
 
     if (isGetOrHeadRequest(request.method) && pathname === '/') {
       const contentType = FILE_EXTENSION_TO_CONTENT_TYPE[extname('index.html')]
@@ -630,12 +632,10 @@ async function serveStudioAsset(requestPath: string): Promise<Response> {
   const contentType = FILE_EXTENSION_TO_CONTENT_TYPE[extname(fileName)]
 
   try {
-    return withCors(
-      new Response(await readStudioAsset(fileName), {
-        headers: { 'Content-Type': contentType },
-        status: 200,
-      }),
-    )
+    return new Response(await readStudioAsset(fileName), {
+      headers: { 'Content-Type': contentType },
+      status: 200,
+    })
   } catch (error: unknown) {
     if (isNotFoundError(error)) {
       return textResponse('Not Found', 404)
@@ -676,36 +676,22 @@ function isNotFoundError(error: unknown): error is NodeJS.ErrnoException {
 }
 
 function jsonResponse(payload: unknown): Response {
-  return withCors(Response.json(payload))
+  return Response.json(payload)
 }
 
 function emptyResponse(status: number, headers?: Record<string, string>): Response {
-  return withCors(new Response(null, { headers, status }))
-}
-
-function optionsResponse(): Response {
-  return emptyResponse(204, {
-    'Access-Control-Allow-Headers': 'Content-Type',
-    'Access-Control-Allow-Methods': 'GET, HEAD, POST, OPTIONS',
-  })
+  return new Response(null, { headers, status })
 }
 
 function textResponse(text: string, status: number, headers?: Record<string, string>): Response {
-  return withCors(
-    new Response(text, {
-      headers,
-      status,
-    }),
-  )
+  return new Response(text, {
+    headers,
+    status,
+  })
 }
 
-function withCors(response: Response): Response {
-  const headers = new Headers(response.headers)
-  headers.set('Access-Control-Allow-Origin', '*')
+function isAllowedStudioOrigin(request: Request, port: number): boolean {
+  const origin = request.headers.get('Origin')
 
-  return new Response(response.body, {
-    headers,
-    status: response.status,
-    statusText: response.statusText,
-  })
+  return origin === null || origin === `http://localhost:${port}` || origin === `http://127.0.0.1:${port}`
 }

--- a/packages/cli/src/Studio.ts
+++ b/packages/cli/src/Studio.ts
@@ -714,5 +714,18 @@ function textResponse(text: string, status: number, headers?: Record<string, str
 function isAllowedStudioOrigin(request: Request, port: number): boolean {
   const origin = request.headers.get('Origin')
 
-  return origin === null || origin === `http://localhost:${port}` || origin === `http://127.0.0.1:${port}`
+  if (origin === null) {
+    return true
+  }
+
+  try {
+    const normalizedOrigin = new URL(origin).origin
+
+    return (
+      normalizedOrigin === new URL(`http://localhost:${port}`).origin ||
+      normalizedOrigin === new URL(`http://127.0.0.1:${port}`).origin
+    )
+  } catch {
+    return false
+  }
 }

--- a/packages/cli/src/__tests__/Studio.vitest.ts
+++ b/packages/cli/src/__tests__/Studio.vitest.ts
@@ -185,6 +185,21 @@ describe('Studio port selection', () => {
     expect(getPortMock).not.toHaveBeenCalled()
     expect(startStudioServerMock).toHaveBeenCalledWith(expect.objectContaining({ port: 5_555 }))
   })
+
+  test('rejects an explicitly requested ephemeral port', async () => {
+    const { Studio } = await import('../Studio')
+
+    const result = await Studio.new().parse(
+      ['--browser', 'none', '--port', '0', '--url', 'postgresql://user:password@localhost:5432/db'],
+      defaultTestConfig(),
+    )
+
+    expect(result).toBeInstanceOf(Error)
+    expect((result as Error).name).toBe('UserFacingError')
+    expect((result as Error).message).toContain('The Studio port must be greater than 0.')
+    expect(getPortMock).not.toHaveBeenCalled()
+    expect(startStudioServerMock).not.toHaveBeenCalled()
+  })
 })
 
 describe('Studio MySQL URL compatibility', () => {

--- a/packages/cli/src/__tests__/Studio.vitest.ts
+++ b/packages/cli/src/__tests__/Studio.vitest.ts
@@ -254,7 +254,7 @@ describe('Studio BFF', () => {
       schemaVersion: 'v1',
       sql: 'select 1',
     })
-    expect(response.headers.get('access-control-allow-origin')).toBe('*')
+    expect(response.headers.has('access-control-allow-origin')).toBe(false)
     expect(await response.json()).toEqual([
       null,
       {
@@ -401,6 +401,54 @@ describe('Studio BFF', () => {
     expect(await response.json()).toEqual([null, [[{ id: 1 }], [{ id: 2 }]]])
   })
 
+  test('rejects cross-origin BFF requests before executing a query', async () => {
+    const executeMock = vi.fn()
+
+    await startStudioBff({
+      execute: executeMock,
+    })
+
+    const response = await getServerResponse('http://localhost:5555/bff', {
+      body: JSON.stringify({
+        procedure: 'query',
+        query: { parameters: [], sql: 'delete from User' },
+      }),
+      headers: {
+        'content-type': 'text/plain',
+        origin: 'https://attacker.example',
+      },
+      method: 'POST',
+    })
+
+    expect(response.status).toBe(403)
+    expect(response.headers.has('access-control-allow-origin')).toBe(false)
+    expect(executeMock).not.toHaveBeenCalled()
+  })
+
+  test('allows same-origin BFF requests', async () => {
+    const executeMock = vi.fn(() => Promise.resolve([null, [{ id: 1 }]]))
+
+    await startStudioBff({
+      execute: executeMock,
+    })
+
+    const response = await getServerResponse('http://localhost:5555/bff', {
+      body: JSON.stringify({
+        procedure: 'query',
+        query: { parameters: [], sql: 'select 1 as id' },
+      }),
+      headers: {
+        'content-type': 'application/json',
+        origin: 'http://localhost:5555',
+      },
+      method: 'POST',
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.has('access-control-allow-origin')).toBe(false)
+    expect(executeMock).toHaveBeenCalledWith({ parameters: [], sql: 'select 1 as id' })
+  })
+
   test('returns an explicit error when query insights are unsupported', async () => {
     await startStudioBff({
       execute: vi.fn(),
@@ -440,7 +488,7 @@ describe('Studio BFF', () => {
     const html = await response.text()
 
     expect(response.status).toBe(200)
-    expect(response.headers.get('access-control-allow-origin')).toBe('*')
+    expect(response.headers.has('access-control-allow-origin')).toBe(false)
     expect(html).toContain('<link rel="icon"')
     expect(html).toContain('<link rel="stylesheet" href="/studio.css">')
     expect(html).toContain('<script type="module" src="/studio.js"></script>')
@@ -470,20 +518,21 @@ describe('Studio BFF', () => {
     expect(await cssResponse.text()).toBe('.ps { color: black; }')
   })
 
-  test('responds to OPTIONS requests with CORS preflight headers', async () => {
+  test('rejects cross-origin preflight requests', async () => {
     await startStudioBff({
       execute: vi.fn(),
     })
 
     const response = await getServerResponse('http://localhost:5555/bff', {
+      headers: {
+        'access-control-request-method': 'POST',
+        origin: 'https://attacker.example',
+      },
       method: 'OPTIONS',
     })
 
-    expect(response.status).toBe(204)
-    expect(response.headers.get('access-control-allow-origin')).toBe('*')
-    expect(response.headers.get('access-control-allow-methods')).toBe('GET, HEAD, POST, OPTIONS')
-    expect(response.headers.get('access-control-allow-headers')).toBe('Content-Type')
-    expect(await response.text()).toBe('')
+    expect(response.status).toBe(403)
+    expect(response.headers.has('access-control-allow-origin')).toBe(false)
   })
 
   test('no longer serves adapter.js', async () => {

--- a/packages/cli/src/__tests__/Studio.vitest.ts
+++ b/packages/cli/src/__tests__/Studio.vitest.ts
@@ -2,6 +2,7 @@ import { defaultTestConfig } from '@prisma/config'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 const createPoolMock = vi.fn(() => ({ end: vi.fn() }))
+const getPortMock = vi.fn(() => Promise.resolve(55_555))
 const readFileMock = vi.fn((filePath: string) => {
   if (/[\\/]studio\.js$/.test(filePath)) {
     return Promise.resolve('window.__studioBundle = true;')
@@ -39,6 +40,12 @@ vi.mock('mysql2/promise', () => {
   }
 })
 
+vi.mock('get-port-please', () => {
+  return {
+    getPort: getPortMock,
+  }
+})
+
 vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs/promises')>()
 
@@ -50,6 +57,7 @@ vi.mock('node:fs/promises', async (importOriginal) => {
 
 vi.mock('../studio-server', () => {
   return {
+    STUDIO_SERVER_HOST: '127.0.0.1',
     startStudioServer: startStudioServerMock,
   }
 })
@@ -80,6 +88,11 @@ vi.mock('@prisma/studio-core/data/postgresjs', () => {
   return {
     createPostgresJSExecutor: createPostgresJSExecutorMock,
   }
+})
+
+beforeEach(() => {
+  getPortMock.mockReset()
+  getPortMock.mockResolvedValue(55_555)
 })
 
 describe('Studio URL validation', () => {
@@ -135,6 +148,42 @@ describe('Studio URL validation', () => {
     expect(new URL(createPoolMock.mock.calls[0][0]).protocol).toBe('mysql:')
     expect(new URL(createPoolMock.mock.calls[0][0]).hostname).toBe('aws.connect.psdb.cloud')
     expect(new URL(createPoolMock.mock.calls[0][0]).pathname).toBe('/db')
+  })
+})
+
+describe('Studio port selection', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    createPostgresJSExecutorMock.mockClear()
+    startStudioServerMock.mockClear()
+  })
+
+  test('checks for an available port on the loopback interface when no port is requested', async () => {
+    const { Studio } = await import('../Studio')
+
+    await Studio.new().parse(
+      ['--browser', 'none', '--url', 'postgresql://user:password@localhost:5432/db'],
+      defaultTestConfig(),
+    )
+
+    expect(getPortMock).toHaveBeenCalledWith({
+      host: '127.0.0.1',
+      port: 51_212,
+      portRange: [49_152, 51_211],
+    })
+    expect(startStudioServerMock).toHaveBeenCalledWith(expect.objectContaining({ port: 55_555 }))
+  })
+
+  test('uses a requested port without probing for an available port', async () => {
+    const { Studio } = await import('../Studio')
+
+    await Studio.new().parse(
+      ['--browser', 'none', '--port', '5555', '--url', 'postgresql://user:password@localhost:5432/db'],
+      defaultTestConfig(),
+    )
+
+    expect(getPortMock).not.toHaveBeenCalled()
+    expect(startStudioServerMock).toHaveBeenCalledWith(expect.objectContaining({ port: 5_555 }))
   })
 })
 

--- a/packages/cli/src/__tests__/Studio.vitest.ts
+++ b/packages/cli/src/__tests__/Studio.vitest.ts
@@ -186,20 +186,23 @@ describe('Studio port selection', () => {
     expect(startStudioServerMock).toHaveBeenCalledWith(expect.objectContaining({ port: 5_555 }))
   })
 
-  test('rejects an explicitly requested ephemeral port', async () => {
-    const { Studio } = await import('../Studio')
+  test.each(['0', '-1', '1.5', '65536'])(
+    'rejects an explicitly requested port outside the valid integer range: %s',
+    async (port) => {
+      const { Studio } = await import('../Studio')
 
-    const result = await Studio.new().parse(
-      ['--browser', 'none', '--port', '0', '--url', 'postgresql://user:password@localhost:5432/db'],
-      defaultTestConfig(),
-    )
+      const result = await Studio.new().parse(
+        ['--browser', 'none', '--port', port, '--url', 'postgresql://user:password@localhost:5432/db'],
+        defaultTestConfig(),
+      )
 
-    expect(result).toBeInstanceOf(Error)
-    expect((result as Error).name).toBe('UserFacingError')
-    expect((result as Error).message).toContain('The Studio port must be greater than 0.')
-    expect(getPortMock).not.toHaveBeenCalled()
-    expect(startStudioServerMock).not.toHaveBeenCalled()
-  })
+      expect(result).toBeInstanceOf(Error)
+      expect((result as Error).name).toBe('UserFacingError')
+      expect((result as Error).message).toContain('The Studio port must be an integer between 1 and 65535.')
+      expect(getPortMock).not.toHaveBeenCalled()
+      expect(startStudioServerMock).not.toHaveBeenCalled()
+    },
+  )
 })
 
 describe('Studio MySQL URL compatibility', () => {

--- a/packages/cli/src/__tests__/Studio.vitest.ts
+++ b/packages/cli/src/__tests__/Studio.vitest.ts
@@ -516,6 +516,60 @@ describe('Studio BFF', () => {
     expect(executeMock).toHaveBeenCalledWith({ parameters: [], sql: 'select 1 as id' })
   })
 
+  test.each(['http://localhost', 'http://127.0.0.1'])('allows default-port BFF requests from %s', async (origin) => {
+    const executeMock = vi.fn(() => Promise.resolve([null, [{ id: 1 }]]))
+
+    await startStudioBff(
+      {
+        execute: executeMock,
+      },
+      80,
+    )
+
+    const response = await getServerResponse(`${origin}/bff`, {
+      body: JSON.stringify({
+        procedure: 'query',
+        query: { parameters: [], sql: 'select 1 as id' },
+      }),
+      headers: {
+        'content-type': 'application/json',
+        origin,
+      },
+      method: 'POST',
+    })
+
+    expect(response.status).toBe(200)
+    expect(executeMock).toHaveBeenCalledWith({ parameters: [], sql: 'select 1 as id' })
+  })
+
+  test.each(['http://localhost', 'http://127.0.0.1'])(
+    'allows default-port telemetry requests from %s',
+    async (origin) => {
+      await startStudioBff(
+        {
+          execute: vi.fn(),
+        },
+        80,
+      )
+
+      const response = await getServerResponse(`${origin}/telemetry`, {
+        body: JSON.stringify({
+          eventId: 'event-id',
+          name: 'studio_closed',
+          payload: {},
+          timestamp: '2026-08-05T00:00:00.000Z',
+        }),
+        headers: {
+          'content-type': 'application/json',
+          origin,
+        },
+        method: 'POST',
+      })
+
+      expect(response.status).toBe(200)
+    },
+  )
+
   test('returns an explicit error when query insights are unsupported', async () => {
     await startStudioBff({
       execute: vi.fn(),
@@ -635,17 +689,20 @@ async function getServerResponse(input: string, init?: RequestInit): Promise<Res
   return fetchHandler(new Request(input, init))
 }
 
-async function startStudioBff(executor: {
-  execute: ReturnType<typeof vi.fn>
-  executeTransaction?: ReturnType<typeof vi.fn>
-  lintSql?: ReturnType<typeof vi.fn>
-}) {
+async function startStudioBff(
+  executor: {
+    execute: ReturnType<typeof vi.fn>
+    executeTransaction?: ReturnType<typeof vi.fn>
+    lintSql?: ReturnType<typeof vi.fn>
+  },
+  port = 5555,
+) {
   createPostgresJSExecutorMock.mockReturnValueOnce(executor)
 
   const { Studio } = await import('../Studio')
 
   await Studio.new().parse(
-    ['--browser', 'none', '--port', '5555', '--url', 'postgresql://user:password@localhost:5432/db'],
+    ['--browser', 'none', '--port', String(port), '--url', 'postgresql://user:password@localhost:5432/db'],
     defaultTestConfig(),
   )
 }

--- a/packages/cli/src/__tests__/studio-server.vitest.ts
+++ b/packages/cli/src/__tests__/studio-server.vitest.ts
@@ -1,10 +1,9 @@
-import { connect } from 'node:net'
-import { networkInterfaces } from 'node:os'
+import { Server } from 'node:http'
 
 import { getPort } from 'get-port-please'
 import { afterEach, expect, test, vi } from 'vitest'
 
-import { startStudioServer, type StudioServer } from '../studio-server'
+import { startStudioServer, STUDIO_SERVER_HOST, type StudioServer } from '../studio-server'
 
 const activeServers: StudioServer[] = []
 
@@ -25,17 +24,21 @@ test('streams GET response bodies from the Node Studio server', async () => {
   expect(await response.text()).toBe('hello from studio')
 })
 
-test('only accepts connections on the IPv4 loopback address', async () => {
-  const { port } = await startTestServer(() => new Response('hello from studio', { status: 200 }))
-  const nonLoopbackAddress = Object.values(networkInterfaces())
-    .flat()
-    .find((address) => address?.family === 'IPv4' && !address.internal)?.address
+test('binds the listener to the IPv4 loopback address', async () => {
+  const port = await getPort({ host: STUDIO_SERVER_HOST, random: true })
+  const listenSpy = vi.spyOn(Server.prototype, 'listen')
 
-  if (!nonLoopbackAddress) {
-    throw new Error('Test requires a non-loopback IPv4 address')
-  }
+  await new Promise<void>((resolve) => {
+    const server = startStudioServer({
+      handler: () => new Response('hello from studio', { status: 200 }),
+      onListen: resolve,
+      port,
+    })
 
-  await expect(canConnect(nonLoopbackAddress, port)).resolves.toBe(false)
+    activeServers.push(server)
+  })
+
+  expect(listenSpy).toHaveBeenCalledWith(port, STUDIO_SERVER_HOST, expect.any(Function))
 })
 
 test('preserves HEAD semantics without dropping GET bodies', async () => {
@@ -119,18 +122,4 @@ async function startTestServer(
   })
 
   return { port }
-}
-
-function canConnect(host: string, port: number): Promise<boolean> {
-  return new Promise((resolve) => {
-    const socket = connect({ host, port })
-    const settle = (connected: boolean) => {
-      socket.destroy()
-      resolve(connected)
-    }
-
-    socket.setTimeout(1_000, () => settle(false))
-    socket.once('connect', () => settle(true))
-    socket.once('error', () => settle(false))
-  })
 }

--- a/packages/cli/src/__tests__/studio-server.vitest.ts
+++ b/packages/cli/src/__tests__/studio-server.vitest.ts
@@ -1,3 +1,6 @@
+import { connect } from 'node:net'
+import { networkInterfaces } from 'node:os'
+
 import { getPort } from 'get-port-please'
 import { afterEach, expect, test, vi } from 'vitest'
 
@@ -22,6 +25,19 @@ test('streams GET response bodies from the Node Studio server', async () => {
   expect(await response.text()).toBe('hello from studio')
 })
 
+test('only accepts connections on the IPv4 loopback address', async () => {
+  const { port } = await startTestServer(() => new Response('hello from studio', { status: 200 }))
+  const nonLoopbackAddress = Object.values(networkInterfaces())
+    .flat()
+    .find((address) => address?.family === 'IPv4' && !address.internal)?.address
+
+  if (!nonLoopbackAddress) {
+    throw new Error('Test requires a non-loopback IPv4 address')
+  }
+
+  await expect(canConnect(nonLoopbackAddress, port)).resolves.toBe(false)
+})
+
 test('preserves HEAD semantics without dropping GET bodies', async () => {
   const { port } = await startTestServer(() => new Response('hello from studio', { status: 200 }))
 
@@ -41,7 +57,7 @@ test('logs server errors and returns the error message in the response body', as
   const response = await fetch(`http://127.0.0.1:${port}/`)
 
   expect(response.status).toBe(500)
-  expect(response.headers.get('access-control-allow-origin')).toBe('*')
+  expect(response.headers.has('access-control-allow-origin')).toBe(false)
   expect(await response.text()).toBe('boom')
   expect(consoleErrorSpy).toHaveBeenCalledWith('[Prisma Studio]', error)
 })
@@ -89,7 +105,7 @@ async function startTestServer(
   handler: (request: Request) => Response | Promise<Response>,
   onNodeRequestSettled?: () => void,
 ): Promise<{ port: number }> {
-  const port = await getPort({ host: '127.0.0.1' })
+  const port = await getPort({ host: '127.0.0.1', random: true })
 
   await new Promise<void>((resolve) => {
     const server = startStudioServer({
@@ -103,4 +119,18 @@ async function startTestServer(
   })
 
   return { port }
+}
+
+function canConnect(host: string, port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = connect({ host, port })
+    const settle = (connected: boolean) => {
+      socket.destroy()
+      resolve(connected)
+    }
+
+    socket.setTimeout(1_000, () => settle(false))
+    socket.once('connect', () => settle(true))
+    socket.once('error', () => settle(false))
+  })
 }

--- a/packages/cli/src/studio-server.ts
+++ b/packages/cli/src/studio-server.ts
@@ -4,6 +4,8 @@ import { pipeline } from 'node:stream/promises'
 
 import { runtime } from 'std-env'
 
+const STUDIO_SERVER_HOST = '127.0.0.1'
+
 export type StudioRequestHandler = (request: Request) => Promise<Response> | Response
 
 export interface StudioServer {
@@ -54,14 +56,13 @@ function startNodeStudioServer({
       }
 
       nodeResponse.statusCode = 500
-      nodeResponse.setHeader('Access-Control-Allow-Origin', '*')
       nodeResponse.end(error instanceof Error ? error.message : 'Internal Server Error')
     } finally {
       onNodeRequestSettled?.()
     }
   })
 
-  server.listen(port, onListen)
+  server.listen(port, STUDIO_SERVER_HOST, onListen)
 
   return {
     close() {
@@ -126,7 +127,9 @@ function startBunStudioServer({ handler, onListen, port }: StartStudioServerOpti
   const bun = (
     globalThis as typeof globalThis & {
       Bun?: {
-        serve(options: { fetch: StudioRequestHandler; port: number }): { stop(closeActiveConnections?: boolean): void }
+        serve(options: { fetch: StudioRequestHandler; hostname: string; port: number }): {
+          stop(closeActiveConnections?: boolean): void
+        }
       }
     }
   ).Bun
@@ -137,6 +140,7 @@ function startBunStudioServer({ handler, onListen, port }: StartStudioServerOpti
 
   const server = bun.serve({
     fetch: handler,
+    hostname: STUDIO_SERVER_HOST,
     port,
   })
 
@@ -155,7 +159,7 @@ function startDenoStudioServer({ handler, onListen, port }: StartStudioServerOpt
     globalThis as typeof globalThis & {
       Deno?: {
         serve(
-          options: { port: number; signal: AbortSignal },
+          options: { hostname: string; port: number; signal: AbortSignal },
           handler: StudioRequestHandler,
         ): { shutdown?(): Promise<void> }
       }
@@ -166,7 +170,7 @@ function startDenoStudioServer({ handler, onListen, port }: StartStudioServerOpt
     throw new Error('Deno runtime is not available.')
   }
 
-  deno.serve({ port, signal: abortController.signal }, handler)
+  deno.serve({ hostname: STUDIO_SERVER_HOST, port, signal: abortController.signal }, handler)
   onListen()
 
   return {

--- a/packages/cli/src/studio-server.ts
+++ b/packages/cli/src/studio-server.ts
@@ -4,6 +4,7 @@ import { pipeline } from 'node:stream/promises'
 
 import { runtime } from 'std-env'
 
+/** Must remain the IPv4 loopback host used by Studio's listener and port probing. */
 export const STUDIO_SERVER_HOST = '127.0.0.1'
 
 export type StudioRequestHandler = (request: Request) => Promise<Response> | Response

--- a/packages/cli/src/studio-server.ts
+++ b/packages/cli/src/studio-server.ts
@@ -4,7 +4,7 @@ import { pipeline } from 'node:stream/promises'
 
 import { runtime } from 'std-env'
 
-const STUDIO_SERVER_HOST = '127.0.0.1'
+export const STUDIO_SERVER_HOST = '127.0.0.1'
 
 export type StudioRequestHandler = (request: Request) => Promise<Response> | Response
 


### PR DESCRIPTION
## Linked issue

Private vulnerability report submitted through GitHub PVR.

## Summary

Prisma Studio advertised a localhost URL while its HTTP server listened on every interface and returned wildcard CORS headers. Because `POST /bff` executes database queries, a reachable network client—or a malicious website visited while Studio was open—could read or modify the connected database.

This change binds the Node, Bun, and Deno servers explicitly to `127.0.0.1`, rejects browser requests whose `Origin` is not the active `localhost` or `127.0.0.1` Studio URL before routing, and removes wildcard CORS responses. Origin-less local tooling remains supported.

## Root cause

The Studio rewrite introduced for Prisma 7.0.0 treated the advertised `http://localhost` URL as if it also constrained the listener. It did not specify a host and enabled permissive CORS around a privileged SQL BFF. The later pre-bundled server refactor preserved both behaviors.

## Testing performed

- Dependency-aware CLI build passed across 39 workspace projects.
- Targeted ESLint passed for the affected source and test files.
- Studio request-handler tests passed (20/20).
- Studio listener tests passed (5/5).
- Full CLI Vitest passed all Studio/security coverage; one unrelated existing `Init.vitest.ts` fixture failed.
- Manual built-CLI test confirmed only `127.0.0.1` was listening, the host LAN address refused connections, same-origin SQL succeeded, and hostile-origin SQL returned 403 before execution.
- Headed browser smoke test loaded Studio with no console warnings or errors.

## Skill update

n/a — security hardening only; no user-facing CLI command, flag, API, config field, error code, or terminology changed.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the DCO.
- [x] I read `CONTRIBUTING.md` and the change is scoped to one logical concern.
- [x] Tests are updated.
- [ ] The PR title uses a Linear ticket prefix — n/a, this work comes from a private vulnerability report rather than a Linear issue.
- [x] The **Skill update** section is filled in.

## Notes for the reviewer

The server and BFF are implemented in the maintained `v7` branch of `prisma/prisma`; `studio-core` supplies the bundled frontend and does not own this HTTP trust boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Studio servers now bind exclusively to the local loopback address.
  * Requests from unauthorized origins, including cross-origin preflight requests, return `403 Forbidden`.
  * Permissive cross-origin access and related response headers have been removed.

* **Bug Fixes**
  * Improved protection for Studio backend and telemetry endpoints.
  * Standardized local server behavior across supported runtimes.
  * Same-origin requests continue to work correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->