### PR TITLE
docs(sql-orm-client): update()/delete() JSDoc states single-row semantics

### DIFF
--- a/packages/3-extensions/sql-orm-client/src/collection.ts
+++ b/packages/3-extensions/sql-orm-client/src/collection.ts
@@ -1837,9 +1837,10 @@ export class Collection<
   }
 
   /**
-   * Write terminal: update matching rows and return the first one (or
-   * `null` when no row matched). Requires a prior `.where(...)` —
-   * calling `update(...)` on an unfiltered collection is a type error.
+   * Write terminal: update a single matching row — the first one the
+   * filter matches — and return it (or `null` when no row matched).
+   * Requires a prior `.where(...)` — calling `update(...)` on an
+   * unfiltered collection is a type error.
    *
    * Related rows can be created or relinked through relation
    * callbacks on parent/child-owned relations (one-to-one or
@@ -2098,9 +2099,10 @@ export class Collection<
   }
 
   /**
-   * Write terminal: delete matching rows and return the first deleted
-   * row (or `null` when no row matched). Requires a prior `.where(...)`
-   * — calling `delete()` on an unfiltered collection is a type error.
+   * Write terminal: delete a single matching row — the first one the
+   * filter matches — and return it (or `null` when no row matched).
+   * Requires a prior `.where(...)` — calling `delete()` on an
+   * unfiltered collection is a type error.
    *
    * ```typescript
    * const deleted = await db.orm.User.where({ id: 1 }).delete();


### PR DESCRIPTION
## Linked issue

n/a — small change. Prompted by a bug report claiming ORM `update()` writes every matching row and only reports the first; the report turned out to be a doc defect, not a behavior defect.

## At a glance

`update()` against a filter matching three rows executes exactly two statements — an identity pre-select, then a write scoped to that identity:

```sql
SELECT "users"."id" AS "id" FROM "public"."users" WHERE "users"."name" = $1 LIMIT 1
UPDATE "public"."users" SET "name" = $1 WHERE "users"."id" = 1 RETURNING "users"."address", "users"."email", "users"."id", "users"."invited_by_id", "users"."name"
```

The JSDoc, however, read "update matching rows and return the first one" — a description of `updateAll()` semantics, which is what led a reader to file the bug.

## Decision

Doc-only change to two JSDoc blocks in `packages/3-extensions/sql-orm-client/src/collection.ts`: `update()` and `delete()` now say they act on **a single matching row — the first one the filter matches** — instead of "matching rows". No behavior change, no test change, nothing else touched.

## Reviewer notes

- **The bug report is not reproducible; the implementation is unchanged.** I verified two ways before concluding the wording was the only defect. `test/integration/test/sql-orm-client/update.test.ts` already carries "update() affects only one row even when where() matches several", and it passes. I also ran a throwaway integration test against the PGlite-backed Postgres that dumped the executed SQL — that's where the `## At a glance` statements come from. The throwaway test is not part of this PR.
- **Two independent code paths, both already correct.** The scalar path resolves identity columns via `Collection.#findFirstMatchingRowIdentityWhere` and replaces the user's filters with that identity before delegating to the shared update-returning compile. The nested-relation-callback path resolves the row through `findFirstByFilters` in `mutation-executor.ts` and writes by primary key. I verified the nested path with a multi-match parent as well.

## Compatibility / migration / risk

None. Comments only; no emitted artefact, signature, or runtime path changes.

## Testing performed

- `pnpm test test/sql-orm-client/update.test.ts test/sql-orm-client/delete.test.ts` from `test/integration` — 14/14 passing, no type errors.
- `pnpm lint` in `packages/3-extensions/sql-orm-client` — exit 0.

## Skill update

n/a — internal only. The change corrects prose in an existing JSDoc block; no CLI, config, error code, or public API surface changes.

## Alternatives considered

- **Change the behavior to match the old comment** (make `update()` write every match). Rejected: `updateAll()` already occupies that slot, and single-row `update()` is the Prisma-compatible semantic. The comment was wrong, not the code.
- **Leave the JSDoc and reply to the report.** Rejected: the wording is what generated the report, so it will generate the next one too.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the DCO.
- [x] I read CONTRIBUTING.md and the change is scoped to one logical concern.
- [x] Tests are updated — n/a, doc-only with no behavioural delta; existing coverage already asserts the documented semantics.
- [ ] The PR title is in `TML-NNNN: <sentence-case title>` form. No Linear ticket exists for this; using the conventional-commit form that matches the recent history on `main`.
- [x] The **Skill update** section above is filled in.
