### PR TITLE
docs(projects): shape affected-row-counts (spec + plan) (TML-3166)

### DIFF
--- a/projects/affected-row-counts/plan.md
+++ b/projects/affected-row-counts/plan.md
@@ -1,0 +1,47 @@
+# affected-row-counts — Plan
+
+**Spec:** `projects/affected-row-counts/spec.md`
+**Linear Project:** [Prisma 8 RC1](https://linear.app/prisma-company/project/prisma-8-rc1-7592265f700c) — tracked under parent issue [TML-3166](https://linear.app/prisma-company/issue/TML-3166), one sub-issue per slice.
+
+## At a glance
+
+Three slices in the repo's standard substrate → consumer → docs shape: a stack of two (reshape the driver execution surface, then let the count reach the caller and delete the pre-`SELECT`), plus a documentation slice that is independent of both because every decision it records was settled at spec time.
+
+## Composition
+
+### Stack (deliver in order)
+
+1. **Slice `query-execute-split`** — Linear: [TML-3167](https://linear.app/prisma-company/issue/TML-3167)
+   - **Outcome:** `SqlQueryable` is two methods wide and named the way Go names them — `query()` streams rows, `execute()` returns `SqlStatementStats { affectedRows: number }`. Prepared-ness rides on the request rather than doubling the surface, so four methods become two; SQLite's connection and transaction classes stop duplicating each other; the runtime's prepared and unprepared execution paths merge into one. **Nothing above the runtime changes behaviour** — the count terminals still run their pre-`SELECT` at the end of this slice.
+   - **Builds on:** None.
+   - **Hands to:** A driver that answers "how many rows did that affect" directly, and a runtime with one execution path instead of two — the substrate slice 2 reads from.
+   - **Focus:** `driver-types.ts`; the postgres queryable base and its connection/transaction/driver subclasses; both sqlite queryable classes plus the abstract base they're missing; the runtime's two near-identical generators (`sql-runtime.ts:386` and `:531`, which differ only in how they build `exec`); and the driver fakes — 18 test files carry one, 12 of them clustered in `packages/2-sql/5-runtime/test/`, with 96 `executePrepared` occurrences repo-wide. The control plane's `SqlControlDriverInstance.query` is a different interface and does not move. Postgres's `execute()` reads `rowCount` off the buffered result; sqlite's is `stmt.run()`, with `columns().length === 0` kept as a guard so a misrouted `RETURNING` plan fails loudly instead of silently discarding rows. Also lands the ADR 210 conformance fix this slice's code sits on top of: a failed stale-handle retry must surface `ADAPTER.PREPARE_FAILED`, which today is emitted nowhere. Deliberately out of scope: any ORM-visible behaviour change.
+
+2. **Slice `count-terminals`** — Linear: [TML-3168](https://linear.app/prisma-company/issue/TML-3168)
+   - **Outcome:** `updateAndCount` and `deleteAndCount` issue exactly one statement and return the number the engine reported; the pre-`SELECT` is deleted rather than left dormant; a middleware `intercept` on a statistics-shaped execution cannot produce a fabricated count.
+   - **Builds on:** Slice 1's `execute()`.
+   - **Hands to:** The project's purpose, delivered — plus a statistics path `createAndCount` and ADR 023's write budgets could consume later.
+   - **Focus:** The runtime's statistics-returning execution path, present on every `RuntimeScope` implementation (runtime, transaction context `sql-runtime.ts:790`, supabase, mongo — a scope missing it is a compile error, not a silent hole); the two terminals in `collection.ts`; the intercept-result contract. Tests: statement count observed through middleware, and an interleaved-write integration test proving the number came from the write rather than a prior read. Deliberately out of scope: `createAndCount`, and the streaming `RETURNING` terminals.
+
+### Parallel group A (independent of the stack)
+
+- **Slice `count-semantics`** — Linear: [TML-3169](https://linear.app/prisma-company/issue/TML-3169)
+  - **Outcome:** ADR 210 describes the two-method driver surface, and each target's definition of "affected" is documented where a user of that target will find it — Postgres's matched-rows command tag, SQLite's `sqlite3_changes64()`, Mongo's `modifiedCount`.
+  - **Builds on:** None. Every decision it records was settled in the spec; it does not need either code slice to have landed.
+  - **Hands to:** The project-DoD's ADR and documentation conditions, and the vocabulary the other two slices' PR descriptions use.
+  - **Focus:** An **amendment** to [ADR 210](../../docs/architecture%20docs/adrs/ADR%20210%20-%20Prepared%20Statements%20-%20Author%20Surface%20and%20Driver%20SPI.md) — not a new ADR — restating its unchanged principles (opaque slot, lazy synchronous allocation, driver may ignore the slot, `preparedStatements: false` leaves it unset) over the two-method surface; per-target semantics documentation; [`scorecard/06-sql-orm-client.md`](../../scorecard/06-sql-orm-client.md) and [`scorecard/07-mongodb-query-and-orm.md`](../../scorecard/07-mongodb-query-and-orm.md). No code — the `ADAPTER.PREPARE_FAILED` conformance fix lives in slice 1 with the driver.
+
+## Dependencies (external)
+
+- [x] **Linear sync** — done. This project rides the existing [Prisma 8 RC1](https://linear.app/prisma-company/project/prisma-8-rc1-7592265f700c) Linear Project rather than getting one of its own, matching the codec-json-projections precedent (TML-3060 with its slice stack beneath it). Parent [TML-3166](https://linear.app/prisma-company/issue/TML-3166) with one sub-issue per slice, so the GitHub integration's auto-close fires per-slice instead of on the whole project — the reopen churn [`drive/project/README.md`](../../drive/project/README.md) § Linear conventions warns about. Working branch per slice follows `tml-XXXX-<slug>`.
+- [ ] **Workspace install** — this worktree has no `node_modules`, so no validation gate has been run and Drive trace emission is blocked. `pnpm install` before the first dispatch.
+
+## Sequencing rationale
+
+**Why `query-execute-split` ships on its own**, despite slice-INVEST's warning against slices whose value is "preparation for the next one" ([`drive/calibration/sizing.md`](../../drive/calibration/sizing.md) § Slice INVEST). Folding it into slice 2 would produce one PR spanning a breaking driver SPI change, a prepared/unprepared collapse across both drivers and ~15 fakes, a runtime de-duplication, the ORM terminals and their tests — which trips the explicit mis-sizing signal *"a slice that needs the reviewer to read three unrelated areas of the codebase to verify."* It also carries value of its own beyond enabling slice 2: the driver surface halves, and SQLite's twice-written method bodies and the runtime's two near-identical generators go away. Shipping it alone satisfies the spec's transitional-shape constraint directly — the pre-`SELECT` stays until the drivers report, so slice 1 merges with observable behaviour unchanged.
+
+**Why slice 1 isn't split further, despite its footprint.** It is one atomic compile unit: the moment `SqlQueryable` changes shape, both drivers, the runtime's two generators, and all 18 test fakes stop compiling. There is no ordering of those pieces that leaves a green `main` in between, so any attempt to split produces slices that cannot merge independently — a direct *Independent* failure. Its size is footprint, not incoherence: one interface change with its conforming implementations is the repo's clean **hard-cut migration of one substrate concept** shape, and the calibration is explicit that "a 2000-LoC mechanical migration with one outcome passes" *Small* while a small PR spanning three unrelated ideas does not.
+
+The one item that is genuinely a second outcome is the `ADAPTER.PREPARE_FAILED` conformance fix. It stays in slice 1 because it corrects the very code being rewritten and the ADR being amended, but it should be its own dispatch with its own brief rather than riding inside the SPI change's diff — the calibration's stated remedy for "while I'm in there" work. Deciding that is `drive-plan-slice`'s call at pickup.
+
+**Why `count-semantics` is parallel rather than stacked last.** It records decisions, not behaviour: the semantics are settled in the spec, so the ADR and the per-target documentation can be written and merged at any point without waiting for either code slice. Keeping it out of the stack also gets the ADR in front of a reviewer early, while the design rationale is still live — the repo's project-shape pattern explicitly allows for *"a parallelisable docs/ADR slice."*

--- a/projects/affected-row-counts/spec.md
+++ b/projects/affected-row-counts/spec.md
@@ -1,0 +1,129 @@
+# affected-row-counts
+
+## Purpose
+
+Make the ORM's count-returning write terminals report the number the database itself reports, from the statement that did the work. Today they infer it from a separate read, which is a different question asked at a different moment — so the answer can be wrong, and is always paid for twice.
+
+## At a glance
+
+`updateAndCount` runs two statements ([`collection.ts:2012`](../../packages/3-extensions/sql-orm-client/src/collection.ts)); `deleteAndCount` does the same ([`:2240`](../../packages/3-extensions/sql-orm-client/src/collection.ts)):
+
+```ts
+// 1. read every matching primary key into JS…
+const matchingRows = await executeQueryPlan(this.ctx.runtime, countCompiled).toArray();
+// 2. …then run the write, discarding whatever it reports
+await executeQueryPlan(this.ctx.runtime, compiled).toArray();
+return matchingRows.length;
+```
+
+Three consequences. The pair is not atomic — outside a transaction a concurrent insert is updated but not counted, a concurrent delete is counted but not updated. The filter is evaluated twice, and every matching primary key is materialised in JS purely to call `.length` on it. And the two `WHERE` clauses are built by different code paths (`compileSelect` vs `buildCountMutationWhere`, [`query-plan-mutations.ts:195`](../../packages/3-extensions/sql-orm-client/src/query-plan-mutations.ts)), which already drifted once for MTI variants (#940).
+
+The count exists — we throw it away. Postgres reports it in the `CommandComplete` command tag; `pg-cursor` hands it to us as `read`'s third callback argument, which [`postgres-driver.ts:729`](../../packages/3-targets/7-drivers/postgres/src/postgres-driver.ts) drops. `SqlQueryResult.rowCount` is already in the driver interface ([`driver-types.ts:23`](../../packages/2-sql/4-lanes/relational-core/src/ast/driver-types.ts)) but only on `query()`, which nothing on the ORM path calls. SQLite surfaces `sqlite3_changes64()` only through `StatementSync.run()`.
+
+The gap is structural: `RuntimeScope.execute()` returns `AsyncIterableResult<Row>` ([`runtime-core.ts:110`](../../packages/1-framework/1-core/framework-components/src/execution/runtime-core.ts)) — a row stream with nowhere for statement metadata to live. Every layer between driver and caller consumes its source with `for await`, so nothing survives the trip up.
+
+## Non-goals
+
+- **Streaming write terminals.** `update`, `updateAll`, `createAll`, `deleteAll` keep their `UPDATE … RETURNING` streaming path unchanged. Only the count terminals move.
+- **`createAndCount`.** It returns `data.length` without asking the database ([`collection.ts:1671`](../../packages/3-extensions/sql-orm-client/src/collection.ts)). That is not currently wrong — the insert has no conflict clause, so it either inserts every row or throws — and the split-statement path ([`compileInsertCountSplit`](../../packages/3-extensions/sql-orm-client/src/query-plan-mutations.ts)) would need per-statement summing. Revisit if `ON CONFLICT DO NOTHING` ever reaches that path.
+- **Unifying count semantics across targets.** Each engine defines "affected" differently — Mongo's `modifiedCount` excludes no-op writes ([`2-mongo-family/5-query-builders/orm/src/collection.ts:486`](../../packages/2-mongo-family/5-query-builders/orm/src/collection.ts)), Postgres's command tag does not. No translation layer, no normalized definition, no target changed to match another. The differences get documented, not reconciled.
+- **New targets.** No MySQL work, and no accommodation for targets without `RETURNING` beyond what falls out of the design.
+- **Prepared-statement coverage for count terminals**, if the chosen shape costs it. Named as an accepted loss, not silently dropped.
+
+## Place in the larger world
+
+- **Chosen execution shape — two methods, named the way Go names them.** Rows and statistics are different questions, so they get different calls:
+
+  ```ts
+  query<Row>(req): AsyncIterable<Row>          // rows
+  execute(req):    Promise<SqlStatementStats>  // { affectedRows: number }
+  ```
+
+  `affectedRows` is **not optional**. Postgres always reports it in the `CommandComplete` tag for `INSERT`/`UPDATE`/`DELETE`; SQLite's `run()` always returns `changes`. Absence isn't a state either engine has for the statements this method exists to serve — so nothing downstream branches on `undefined`. `SqlStatementStats` is an object rather than a bare `number` because adding a field later (MySQL's matched-vs-changed) is non-breaking for third-party driver authors, while widening a return type is not.
+
+  Two obligations become contract text rather than optionality: `execute()` takes a **single statement** (multi-statement SQL through pg's simple protocol resolves to `Result[]` and the guarantee dissolves), and **DDL / control statements do not go through it** (they have no row-count tag, and the migration plane has its own interface). Both are free — ORM plans are single DML statements.
+
+  This also means statistics never travel through a row stream, so the seven `for await` re-wrap sites between driver and caller stop being a hazard: there is nothing in flight for them to drop.
+
+- **Prepared-ness is a property of the request, not a separate method.** A naive split yields four methods (`query`/`queryPrepared`/`execute`/`executePrepared`) where prepared-ness contributes exactly one thing. Instead the slot rides on the request, keeping the SPI two methods wide:
+
+  ```ts
+  interface PreparedStatementHandle { get(): unknown; set(value: unknown): void }
+
+  interface SqlExecuteRequest {
+    readonly sql: string;
+    readonly params?: readonly unknown[];
+    readonly preparedStatementHandle?: PreparedStatementHandle;  // absent ⇒ ad-hoc
+  }
+  interface PreparedExecuteRequest extends SqlExecuteRequest {
+    readonly preparedStatementHandle: PreparedStatementHandle;   // required
+  }
+  ```
+
+  The handle's value stays **`unknown`** — ADR 210 principle #3 makes opacity load-bearing ("the driver allocates whatever per-target handle it needs — a name, a statement reference, an integer, anything"). Narrowing it to `string` would encode one target's preparation primitive into a cross-target SPI. Where the driver narrows its own handle, that is the driver's business.
+
+  **Two levels of "unset", and they must not be conflated.** The slot's *presence* marks preparedness; the slot's *value* is the lazily-minted handle. A prepared statement on first execute has a slot whose `get()` returns `undefined` — which is why the marker has to be the slot object and not the handle itself. Flatten it to `preparedStatementHandle?: string` and "prepared, not yet minted" becomes indistinguishable from "ad-hoc".
+
+  **The driver branches on the value, never with `in`.** `'preparedStatementHandle' in req` is a key-presence test, so `{ preparedStatementHandle: undefined }` takes the prepared branch and throws on `.get()`. `exactOptionalPropertyTypes` (on repo-wide, `packages/0-config/tsconfig/base.json`) rejects that literal at compile time, but `SqlQueryable` is a published SPI reachable from untyped callers. `req.preparedStatementHandle === undefined` treats absent and illegally-undefined identically, and needs no cast — which matters, since bare `as` is banned in production code.
+
+  Two independent pieces of evidence that the split method was never carrying weight: SQLite's `executePrepared` is a pure delegate to `execute` ([`sqlite-driver.ts:84`](../../packages/3-targets/7-drivers/sqlite/src/sqlite-driver.ts), [`:157`](../../packages/3-targets/7-drivers/sqlite/src/sqlite-driver.ts)), and postgres's falls through whenever prepared statements are disabled ([`postgres-driver.ts:173`](../../packages/3-targets/7-drivers/postgres/src/postgres-driver.ts)).
+- **Driver SPI.** `SqlQueryable` ([`driver-types.ts:82`](../../packages/2-sql/4-lanes/relational-core/src/ast/driver-types.ts)) is exported from `relational-core/src/exports/ast.ts`, so any shape change is a break for third-party driver authors. At 0.x with no back-compat policy that is acceptable; it gets more expensive every release. The slice that reshapes it also **fixes the `execute`/`query` naming inversion** — every prior art puts `execute` on the non-row side (JDBC `executeQuery`/`executeUpdate`, ADO.NET `ExecuteReader`/`ExecuteNonQuery`, Go `Query`/`Exec`) and ours is inverted on both halves. The chosen shape resolves this by construction rather than as a separate rename — the two methods land already named correctly.
+- **Separate surface, untouched.** The migration/control plane uses `SqlControlDriverInstance.query` ([`sql-contract/src/types.ts:7`](../../packages/2-sql/1-core/contract/src/types.ts)) with its own implementations (`PostgresControlDriver`, `SqliteControlDriver`). None of its ~500 call sites are in scope.
+- **Middleware contract.** `runWithMiddleware`'s `intercept` path serves rows without reaching a driver ([`run-with-middleware.ts:87`](../../packages/1-framework/1-core/framework-components/src/execution/run-with-middleware.ts)). It is the only execution path that can reach a caller without an engine-reported count, which is why the intercept result — not the count's type — is where that case gets closed.
+- **[ADR 210 — Prepared Statements](../../docs/architecture%20docs/adrs/ADR%20210%20-%20Prepared%20Statements%20-%20Author%20Surface%20and%20Driver%20SPI.md) is Accepted and this project changes its SPI shape.** Every principle it states survives: the slot stays opaque to the runtime, allocation stays lazy and synchronous, a driver may still ignore the slot entirely, and `preparedStatements: false` still leaves it unset. What changes is the shape those principles were expressed through — the ADR pins `executePrepared` as its own method on `SqlQueryable` (§Driver SPI) and justifies the surface as "a three-field record" (§Why a slot wrapper). So the project owes ADR 210 an **amendment**, not a fresh ADR; the amendment restates the same guarantees over a two-method surface.
+- **[ADR 023 — Budget Evaluation](../../docs/architecture%20docs/adrs/ADR%20023%20-%20Budget%20Evaluation.md)** already assumes a "post factum rowCount when available" for write budgets. This project is what makes that real.
+- **Prior art.** Kysely splits `executeQuery` (rows + `numAffectedRows`) from `streamQuery`; Drizzle passes the driver's native result through per-dialect; ADO.NET's `DbDataReader` streams rows *and* exposes `RecordsAffected`, documented as valid only after the reader is drained. The "count is a completion-time value" constraint is not ours — it is the wire protocol's.
+
+## Contract impact
+
+None. No contract entity, kind, or capability changes; `contract.json` / `contract.d.ts` output is unaffected. Note that count terminals deliberately do **not** assert the `returning` capability (unlike `updateAll`, [`collection.ts:1955`](../../packages/3-extensions/sql-orm-client/src/collection.ts)) — that stays true.
+
+## Adapter impact
+
+- **postgres driver** — `execute()` is the buffered path; `rowCount` comes straight off pg's result. The cursor stays exactly as it is: because statistics no longer ride the row stream, the count never has to be extracted from `readCursor`'s discarded third callback argument. That work disappears from the project.
+- **sqlite driver** — `execute()` is `stmt.run()`, whose `changes` is `sqlite3_changes64()`. `stmt.columns().length === 0` is retained as a **guard, not a router**: `run()` on a `RETURNING` statement executes it and silently discards the rows, so a misrouted plan must fail loudly rather than lose data. Separately, `SqliteConnectionImpl` ([`:66`](../../packages/3-targets/7-drivers/sqlite/src/sqlite-driver.ts)) and `SqliteTransactionImpl` ([`:139`](../../packages/3-targets/7-drivers/sqlite/src/sqlite-driver.ts)) duplicate every method verbatim; they get the abstract-base treatment postgres already has ([`postgres-driver.ts:150`](../../packages/3-targets/7-drivers/postgres/src/postgres-driver.ts)).
+- **supabase runtime** — implements the scope surface ([`supabase-runtime.ts:154`](../../packages/3-extensions/supabase/src/runtime/supabase-runtime.ts)); gains the statistics method.
+- **mongo runtime** — no behaviour change; in scope only to document the semantic difference and, if the chosen shape makes it free, to retire the `blindCast<{ modifiedCount }>` smuggling a count through as a fake row.
+
+## Cross-cutting requirements
+
+- **No fabricated count.** `execute()` always returns a real number, so the risk is not a driver failing to report — it is a *caller* inventing a number when it never called `execute()` at all. The one place that can happen is middleware `intercept`, which short-circuits execution without touching a driver and whose result carries only `rows` ([`runtime-middleware.ts:115`](../../packages/1-framework/1-core/framework-components/src/execution/runtime-middleware.ts)). A middleware intercepting a statistics-shaped execution must supply the statistics; the contract closes there, not by pushing optionality onto every consumer.
+- **Writes are not second-class.** Whatever path carries the count runs the same `beforeExecute` / `intercept` / `onRow` / `afterExecute` chain, codec encoding, plan validation, abort handling, and telemetry as `execute()` does today.
+- **Transaction scope is preserved.** Count terminals inside `db.transaction(...)` run on the transaction's pinned connection, not a second pooled one.
+- **Each target reports its own engine's count; no normalization layer.** Postgres's command tag counts matched rows (including updates that changed nothing), SQLite's `sqlite3_changes64()` counts rows the statement modified, Mongo's `modifiedCount` excludes no-op writes. The project does not reconcile these into a single definition, and no code translates between them. What it owes instead is documentation: each target's meaning stated where a user reading that target's docs will find it.
+- **Every `RuntimeScope` exposes both methods.** The transaction context ([`sql-runtime.ts:790`](../../packages/2-sql/5-runtime/src/sql-runtime.ts)), supabase, and mongo each implement the scope surface; a scope missing the statistics method is a compile error rather than a silent hole, which is the point of returning statistics directly instead of threading them through a stream.
+- **The prepared/unprepared duplication shrinks, not grows.** The split must not leave four driver methods where there were two, four runtime generators where there were two, or SQLite's connection and transaction classes each carrying their own copy of every method.
+- **The prepared path ends up conformant with the ADR it is amending.** ADR 210 §Stale-handle retry requires that a failed retry surface `ADAPTER.PREPARE_FAILED` with the originating error as `cause` — a code ADR 027 reserves for exactly this. It is currently emitted **nowhere in the codebase**: `withStaleHandleRetry` rethrows a generic normalised error ([`postgres-driver.ts:214`](../../packages/3-targets/7-drivers/postgres/src/postgres-driver.ts)). Rewriting the surrounding code while leaving a known violation of the ADR being amended is incoherent, so closing it is in scope rather than a follow-up.
+
+## Transitional-shape constraints
+
+- The pre-`SELECT` fallback stays in place until **both** shipped drivers report a count. No intermediate slice may ship a terminal whose count silently degrades.
+- A driver-SPI change lands with **both** postgres and sqlite in the same slice. No half-migrated driver on `main`.
+- Every slice keeps `pnpm test:integration` and `pnpm test:e2e` green — these are the only gates that exercise a real driver.
+
+## Project Definition of Done
+
+- [ ] Team-DoD floor items (inherited; see [`drive/calibration/dod.md`](../../drive/calibration/dod.md)).
+- [ ] `updateAndCount` and `deleteAndCount` issue exactly one statement, proven by a test that counts statements through middleware — not by reading the source.
+- [ ] An integration test demonstrates the count comes from the write itself: a row inserted between what *would* have been the read and the write is reflected in the returned number.
+- [ ] Both shipped drivers return a real `affectedRows` from `execute()`, with a test pinning the behaviour each relies on — pg's command-tag count, sqlite's `run()` guard against a misrouted `RETURNING` statement.
+- [ ] The driver SPI is **two** methods wide, not four: a prepared statement is a request with a handle, not a separate call. SQLite's connection and transaction classes no longer carry duplicate method bodies, and the runtime's prepared and unprepared execution paths are one code path.
+- [ ] The pre-`SELECT` fallback is deleted, not left dormant.
+- [ ] `SqlQueryable`'s row-returning and non-row methods are named the way every prior art names them; no call site or fake still references the inverted pair.
+- [ ] ADR 210 is amended to describe the two-method surface, and its principles read true against the shipped code — including the stale-retry contract, whose `ADAPTER.PREPARE_FAILED` envelope is emitted by a driver rather than existing only on paper.
+- [ ] [`scorecard/06-sql-orm-client.md`](../../scorecard/06-sql-orm-client.md) and [`scorecard/07-mongodb-query-and-orm.md`](../../scorecard/07-mongodb-query-and-orm.md) reflect the settled semantics.
+
+## Open Questions
+
+None. Three questions were settled by the operator at spec time and moved into the body:
+
+- **Execution shape: `query()` streams rows, `execute()` returns statistics** — see Place in the larger world § Chosen execution shape. (An earlier position — a single `execute()` yielding row/metadata frames — was considered and reversed: it gave statistics a home inside the stream at the cost of making every layer demux, when the two questions simply want two calls.)
+- **The naming falls out of the shape** rather than being a separate rename: `query` returns rows and `execute` returns a count, as in Go's `Query`/`Exec`.
+- **Count semantics follow each driver; no unification** — see Cross-cutting requirements.
+
+## References
+
+- Linear Project: [Prisma 8 RC1](https://linear.app/prisma-company/project/prisma-8-rc1-7592265f700c) — parent issue [TML-3166](https://linear.app/prisma-company/issue/TML-3166), one sub-issue per slice. See [`plan.md`](./plan.md) § Dependencies.
+- ADRs: [ADR 210 — Prepared Statements](../../docs/architecture%20docs/adrs/ADR%20210%20-%20Prepared%20Statements%20-%20Author%20Surface%20and%20Driver%20SPI.md) (amended by this project); [ADR 027 — Error Envelope Stable Codes](../../docs/architecture%20docs/adrs/ADR%20027%20-%20Error%20Envelope%20Stable%20Codes.md) (reserves `ADAPTER.PREPARE_FAILED`); [ADR 023 — Budget Evaluation](../../docs/architecture%20docs/adrs/ADR%20023%20-%20Budget%20Evaluation.md) (consumer of the new count).
+- Upstream constraint: [nodejs/node#59764](https://github.com/nodejs/node/issues/59764) — Node's position that the caller must know what kind of statement it is running; `sqlite3_changes` has never been requested as a standalone binding, so `run()` is the only route.
+- Sibling surfaces: [`docs/architecture docs/subsystems/`](../../docs/architecture%20docs/subsystems/) — Query Lanes, Runtime & Middleware Framework, Adapters & Targets.


### PR DESCRIPTION
Shaping artifacts for the **affected-row-counts** project — spec and three-slice plan, per the project lifecycle in `projects/README.md`. No code changes.

## What this project does

`updateAndCount` and `deleteAndCount` run two statements: a `SELECT` of every matching primary key, then the write — returning the *read's* row count and discarding whatever the write reported. Three consequences:

- **Not atomic.** Outside a transaction, a concurrent insert gets updated but not counted; a concurrent delete gets counted but not updated. The returned number can be wrong.
- **Paid for twice.** The filter is evaluated twice, and every matching primary key is materialised in JS purely to call `.length` on it.
- **Two `WHERE` builders that can drift.** The count `SELECT` goes through `compileSelect`, the write through `buildCountMutationWhere`. They already diverged once for MTI variants (#940).

Meanwhile the count already exists and is discarded — Postgres reports it in the `CommandComplete` tag, SQLite in `sqlite3_changes64()` via `StatementSync.run()`. The gap is structural: `RuntimeScope.execute()` returns a row stream, which has nowhere for statement metadata to live, and every layer between driver and caller consumes its source with `for await`.

After this project the driver SPI splits along the question being asked, named the way every prior art names it (JDBC `executeQuery`/`executeUpdate`, ADO.NET `ExecuteReader`/`ExecuteNonQuery`, Go `Query`/`Exec`):

```ts
query<Row>(req): AsyncIterable<Row>          // rows
execute(req):    Promise<SqlStatementStats>  // { affectedRows: number }
```

`affectedRows` is not optional — absence is not a state either engine has for the statements `execute()` exists to serve, so nothing downstream branches on `undefined`. Because statistics never travel through a row stream, the seven `for await` re-wrap sites stop being a hazard: there is nothing in flight for them to drop. Prepared-ness rides on the request rather than doubling the method surface, so four driver methods become two.

## Plan shape

Three slices — a stack of two plus an independent docs slice:

1. **`query-execute-split`** (TML-3167) — reshape the driver SPI and the runtime's execution paths. No ORM-visible behaviour change; the pre-`SELECT` is still in place at the end of this slice.
2. **`count-terminals`** (TML-3168) — the terminals consume `execute()`; the pre-`SELECT` is deleted rather than left dormant.
3. **`count-semantics`** (TML-3169, parallel) — amend ADR 210; document each target's definition of "affected".

## Scope boundaries

Streaming write terminals, `createAndCount`, and new targets are out of scope. Count semantics are deliberately **not** unified across targets — Postgres's command tag counts matched rows, SQLite's `sqlite3_changes64()` counts modified rows, Mongo's `modifiedCount` excludes no-op writes. The project documents the difference rather than reconciling it; no translation layer, no normalized definition.

## Decision provenance

Three questions were settled with the operator at spec time and moved into the spec body: the execution shape (an earlier single-`execute()` design yielding row/metadata frames was considered and reversed — it gave statistics a home inside the stream at the cost of making every layer demux), the naming falling out of that shape, and per-driver count semantics.

The project **amends** [ADR 210 — Prepared Statements](https://github.com/prisma/prisma/blob/main/docs/architecture%20docs/adrs/ADR%20210%20-%20Prepared%20Statements%20-%20Author%20Surface%20and%20Driver%20SPI.md) rather than adding a new ADR: every principle it states survives (opaque slot, lazy synchronous allocation, a driver may ignore the slot, `preparedStatements: false` leaves it unset) — only the shape they were expressed through changes. ADR 210's stale-retry contract requires `ADAPTER.PREPARE_FAILED`, currently emitted nowhere in the codebase; closing that is in scope for slice 1 rather than deferred, since rewriting the surrounding code while leaving a known violation of the ADR being amended would be incoherent.

Refs: TML-3166

🤖 Generated with [Claude Code](https://claude.com/claude-code)