### PR TITLE
chore: remove stale marker.ts coverage exclude entry

### DIFF
--- a/packages/2-sql/5-runtime/vitest.config.ts
+++ b/packages/2-sql/5-runtime/vitest.config.ts
@@ -22,7 +22,6 @@ export default defineConfig({
         'src/codecs/encoding.ts', // TODO(TML-1786): Add tests - currently 6% coverage
         'src/codecs/decoding.ts', // TODO(TML-1786): Add tests - currently 33% coverage
         'src/codecs/validation.ts', // TODO(TML-1786): Add tests - currently 50% coverage
-        'src/marker.ts', // TODO(TML-1786): Add tests - relocated from runtime-executor in TML-2242, currently 10% coverage
         'src/guardrails/raw.ts', // TODO(TML-1786): Add tests - relocated from runtime-executor in TML-2242, currently 8% coverage
         'src/runtime-spi.ts', // SPI type declarations only (interfaces) - no executable statements to cover
         'src/middleware/sql-middleware.ts', // SqlMiddleware interface declarations only - no executable statements to cover


### PR DESCRIPTION
## Linked issue
n/a — small change

## Summary
Removes a stale `src/marker.ts` entry from the vitest coverage exclude list in `packages/2-sql/5-runtime/vitest.config.ts`. The file no longer exists in this package — it was relocated during the TML-2242 refactor, but the exclude entry was never cleaned up, so it currently has no effect and is misleading to anyone reading the config.

## Testing performed
- `pnpm test` in `packages/2-sql/5-runtime` — all 34 test files / 308 tests pass

## Skill update
n/a — internal only

## Checklist
- [x] All commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco). The DCO status check will block merge if any commit is missing a `Signed-off-by:` trailer.
- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and the change is scoped to one logical concern.
- [x] Tests are updated (or `n/a` if the change is doc-only / refactor with no behavioural delta). — n/a, config-only change; existing test suite verifies no regression.
- [ ] The PR title is in `TML-NNNN: <sentence-case title>` form (Linear ticket prefix + concise title naming the concrete deliverable). See `.claude/skills/create-pr/SKILL.md` for the full convention.
- [x] The **Skill update** section above is filled in (or stated `n/a — internal only`).

## Notes for the reviewer
No code changes — just a config cleanup. `src/marker.ts` doesn't exist anywhere in this package, so the exclude entry was never actually excluding anything from coverage. Ran the full package test suite to confirm removing it doesn't break coverage thresholds. As an external first-time contributor I don't have access to Linear, so I couldn't attach a TML ticket number to the PR title — happy to adjust if there's a preferred convention for small housekeeping fixes like this one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test coverage configuration to include marker functionality in coverage reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->