### PR TITLE
TML-3167: Split SQL query and execute driver SPI

### DIFF
--- a/packages/2-sql/4-lanes/relational-core/src/ast/driver-types.ts
+++ b/packages/2-sql/4-lanes/relational-core/src/ast/driver-types.ts
@@ -6,24 +6,23 @@
  * clauses) carry no param; `params` holds the wire values for the `$N`/`?`
  * positions, in order.
  */
+export interface PreparedStatementHandle {
+  get(): unknown;
+  set(value: unknown): void;
+}
+
 export interface SqlExecuteRequest {
   readonly sql: string;
   readonly params?: readonly unknown[];
+  readonly preparedStatementHandle?: PreparedStatementHandle;
 }
 
-export interface PreparedExecuteRequest {
-  readonly sql: string;
-  readonly params: readonly unknown[];
-  readonly handle: {
-    get(): unknown;
-    set(value: unknown): void;
-  };
+export interface PreparedExecuteRequest extends SqlExecuteRequest {
+  readonly preparedStatementHandle: PreparedStatementHandle;
 }
 
-export interface SqlQueryResult<Row = Record<string, unknown>> {
-  readonly rows: ReadonlyArray<Row>;
-  readonly rowCount?: number | null;
-  readonly [key: string]: unknown;
+export interface SqlStatementStats {
+  readonly affectedRows: number;
 }
 
 export interface SqlExplainResult<Row = Record<string, unknown>> {
@@ -80,13 +79,7 @@ export interface SqlTransaction extends SqlQueryable {
 }
 
 export interface SqlQueryable {
-  execute<Row = Record<string, unknown>>(request: SqlExecuteRequest): AsyncIterable<Row>;
-  executePrepared<Row = Record<string, unknown>>(
-    request: PreparedExecuteRequest,
-  ): AsyncIterable<Row>;
+  query<Row = Record<string, unknown>>(request: SqlExecuteRequest): AsyncIterable<Row>;
+  execute(request: SqlExecuteRequest): Promise<SqlStatementStats>;
   explain?(request: SqlExecuteRequest): Promise<SqlExplainResult>;
-  query<Row = Record<string, unknown>>(
-    sql: string,
-    params?: readonly unknown[],
-  ): Promise<SqlQueryResult<Row>>;
 }

--- a/packages/2-sql/4-lanes/relational-core/test/ast/driver-types.test.ts
+++ b/packages/2-sql/4-lanes/relational-core/test/ast/driver-types.test.ts
@@ -3,13 +3,10 @@ import type { SqlConnection, SqlDriver, SqlExecuteRequest } from '../../src/ast/
 
 function createMockDriverWithVoidBinding(): SqlDriver {
   const queryable = {
-    async *execute(_request: SqlExecuteRequest) {
+    execute: async () => ({ affectedRows: 0 }),
+    async *query(_request: SqlExecuteRequest) {
       yield { id: 1 };
     },
-    async *executePrepared(_request: { sql: string; params: readonly unknown[] }) {
-      yield { id: 1 };
-    },
-    query: async () => ({ rows: [] as ReadonlyArray<Record<string, unknown>>, rowCount: 0 }),
   };
 
   const transaction = {

--- a/packages/2-sql/5-runtime/src/prepared/prepared-statement.ts
+++ b/packages/2-sql/5-runtime/src/prepared/prepared-statement.ts
@@ -18,7 +18,7 @@ export interface PreparedStatementInternals {
   readonly paramMetadata: readonly ParamMetadata[];
 }
 
-export class PreparedStatementImpl<Params extends Record<string, unknown>, Row>
+export class PreparedStatementImpl<Params, Row>
   implements PreparedStatement<Params, Row>, PreparedStatementInternals
 {
   readonly sql: string;
@@ -43,7 +43,7 @@ export class PreparedStatementImpl<Params extends Record<string, unknown>, Row>
     params: Params,
     options?: RuntimeExecuteOptions,
   ): AsyncIterableResult<Row> {
-    return target.execute(this, params, options);
+    return target.executePrepared(this, params, options);
   }
 }
 

--- a/packages/2-sql/5-runtime/src/prepared/prepared-statement.ts
+++ b/packages/2-sql/5-runtime/src/prepared/prepared-statement.ts
@@ -18,7 +18,7 @@ export interface PreparedStatementInternals {
   readonly paramMetadata: readonly ParamMetadata[];
 }
 
-export class PreparedStatementImpl<Params, Row>
+export class PreparedStatementImpl<Params extends Record<string, unknown>, Row>
   implements PreparedStatement<Params, Row>, PreparedStatementInternals
 {
   readonly sql: string;
@@ -43,7 +43,7 @@ export class PreparedStatementImpl<Params, Row>
     params: Params,
     options?: RuntimeExecuteOptions,
   ): AsyncIterableResult<Row> {
-    return target.executePrepared(this, params, options);
+    return target.execute(this, params, options);
   }
 }
 

--- a/packages/2-sql/5-runtime/src/prepared/types.ts
+++ b/packages/2-sql/5-runtime/src/prepared/types.ts
@@ -45,7 +45,7 @@ export type ParamsFromDeclaration<D, CT extends CodecTypesBase> = {
 
 export type PrepareCallback<D, Row> = (params: BindSiteParams<D>) => SqlQueryPlan<Row>;
 
-export interface PreparedStatement<Params extends Record<string, unknown>, Row> {
+export interface PreparedStatement<Params, Row> {
   readonly sql: string;
   readonly ast: AnyQueryAst;
   readonly meta: PlanMeta;

--- a/packages/2-sql/5-runtime/src/prepared/types.ts
+++ b/packages/2-sql/5-runtime/src/prepared/types.ts
@@ -45,7 +45,7 @@ export type ParamsFromDeclaration<D, CT extends CodecTypesBase> = {
 
 export type PrepareCallback<D, Row> = (params: BindSiteParams<D>) => SqlQueryPlan<Row>;
 
-export interface PreparedStatement<Params, Row> {
+export interface PreparedStatement<Params extends Record<string, unknown>, Row> {
   readonly sql: string;
   readonly ast: AnyQueryAst;
   readonly meta: PlanMeta;

--- a/packages/2-sql/5-runtime/src/sql-runtime.ts
+++ b/packages/2-sql/5-runtime/src/sql-runtime.ts
@@ -582,18 +582,18 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
    * Execute a prepared statement against a caller-supplied queryable, running
    * the full middleware/codec/telemetry pipeline.
    */
-  protected executeBoundStatementAgainstQueryable<Params extends Record<string, unknown>, Row>(
+  protected executePreparedStatementAgainstQueryable<Params extends Record<string, unknown>, Row>(
     ps: PreparedStatementImpl<Params, Row>,
     userParams: Params,
     queryable: SqlQueryable,
     options?: RuntimeExecuteOptions,
   ): AsyncIterableResult<Row> {
     return this.executeWithRequestBuilder<Row>(queryable, options, (codecCtx, execMiddlewareCtx) =>
-      this.buildBoundStatementExecutionRequest(ps, userParams, codecCtx, execMiddlewareCtx),
+      this.buildPreparedStatementExecutionRequest(ps, userParams, codecCtx, execMiddlewareCtx),
     );
   }
 
-  private async buildBoundStatementExecutionRequest<Params extends Record<string, unknown>, Row>(
+  private async buildPreparedStatementExecutionRequest<Params extends Record<string, unknown>, Row>(
     ps: PreparedStatementImpl<Params, Row>,
     userParams: Params,
     codecCtx: SqlCodecCallContext,
@@ -651,7 +651,7 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
   ): AsyncIterableResult<Row> {
     if (planOrStatement instanceof PreparedStatementImpl) {
       const options = scope === undefined ? preparedOptions : { ...preparedOptions, scope };
-      return this.executeBoundStatementAgainstQueryable(
+      return this.executePreparedStatementAgainstQueryable(
         planOrStatement,
         blindCast<Params, 'prepared execute overload always receives statement parameters'>(
           paramsOrOptions,

--- a/packages/2-sql/5-runtime/src/sql-runtime.ts
+++ b/packages/2-sql/5-runtime/src/sql-runtime.ts
@@ -34,6 +34,7 @@ import {
 import type { SqlExecutionPlan, SqlQueryPlan } from '@internal/sql-relational-core/plan';
 import type { CodecDescriptorRegistry } from '@internal/sql-relational-core/query-lane-context';
 import type { RuntimeScope } from '@internal/sql-relational-core/types';
+import { blindCast } from '@internal/utils/casts';
 import { ifDefined } from '@internal/utils/defined';
 import { buildDecodeContext, type DecodeContext, decodeRow } from './codecs/decoding';
 import { deriveParamMetadata, encodeParams, encodeParamsWithMetadata } from './codecs/encoding';
@@ -124,13 +125,16 @@ export interface RuntimeTransaction extends RuntimeQueryable {
 }
 
 export interface RuntimeQueryable extends RuntimeScope {
+  execute<Row>(
+    plan: (SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row },
+    options?: RuntimeExecuteOptions,
+  ): AsyncIterableResult<Row>;
   /**
-   * Run a prepared statement against this scope. Required for the explicit
-   * `PreparedStatement.execute(target, params)` API — every scope (top-level
-   * runtime, connection, transaction) routes prepared executions through the
-   * `SqlQueryable` it is backed by.
+   * Run a prepared statement against this scope. The existing `execute` entry
+   * point carries preparedness on the statement request rather than exposing a
+   * second runtime method.
    */
-  executePrepared<Params, Row>(
+  execute<Params extends Record<string, unknown>, Row>(
     ps: PreparedStatement<Params, Row>,
     params: Params,
     options?: RuntimeExecuteOptions,
@@ -189,7 +193,10 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
       now: () => Date.now(),
       log: log ?? noopLog,
       // ctx is only invoked by runWithMiddleware with execs this runtime lowered; the framework parameter type is the cross-family base.
-      contentHash: (exec) => computeSqlContentHash(exec as SqlExecutionPlan),
+      contentHash: (exec) =>
+        computeSqlContentHash(
+          blindCast<SqlExecutionPlan, 'framework execution is lowered by this SQL runtime'>(exec),
+        ),
       scope: 'runtime',
       // Placeholder satisfying the required field on the cross-family base. The
       // stored ctx is a runtime-level template; the per-execute ctxs constructed
@@ -297,20 +304,25 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
   override execute<Row>(
     plan: (SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row },
     options?: RuntimeExecuteOptions,
-  ): AsyncIterableResult<Row> {
-    return this.executeAgainstQueryable<Row>(plan, this.driver, options);
-  }
-
-  executePrepared<Params, Row>(
+  ): AsyncIterableResult<Row>;
+  override execute<Params extends Record<string, unknown>, Row>(
     ps: PreparedStatement<Params, Row>,
     params: Params,
     options?: RuntimeExecuteOptions,
+  ): AsyncIterableResult<Row>;
+  override execute<Params extends Record<string, unknown>, Row>(
+    planOrStatement:
+      | ((SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row })
+      | PreparedStatement<Params, Row>,
+    paramsOrOptions?: Params | RuntimeExecuteOptions,
+    preparedOptions?: RuntimeExecuteOptions,
   ): AsyncIterableResult<Row> {
-    return this.executePreparedAgainstQueryable<Params, Row>(
-      ps as PreparedStatementImpl<Params, Row>,
-      params as Record<string, unknown>,
+    return this.executeOnQueryable(
       this.driver,
-      options,
+      undefined,
+      planOrStatement,
+      paramsOrOptions,
+      preparedOptions,
     );
   }
 
@@ -364,7 +376,7 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
             break;
           }
           const decodedRow = await decodeRow(next.value, decodeContext, codecCtx);
-          yield decodedRow as Row;
+          yield blindCast<Row, 'decoded row is shaped by the plan row type'>(decodedRow);
         }
       } finally {
         // Best-effort iterator cleanup so the driver can release its
@@ -558,20 +570,20 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
    * Execute a prepared statement against a caller-supplied queryable, running
    * the full middleware/codec/telemetry pipeline.
    */
-  protected executePreparedAgainstQueryable<P, Row>(
-    ps: PreparedStatementImpl<P, Row>,
-    userParams: Record<string, unknown>,
+  protected executeBoundStatementAgainstQueryable<Params extends Record<string, unknown>, Row>(
+    ps: PreparedStatementImpl<Params, Row>,
+    userParams: Params,
     queryable: SqlQueryable,
     options?: RuntimeExecuteOptions,
   ): AsyncIterableResult<Row> {
     return this.executeWithRequestBuilder<Row>(queryable, options, (codecCtx, execMiddlewareCtx) =>
-      this.buildPreparedExecutionRequest(ps, userParams, codecCtx, execMiddlewareCtx),
+      this.buildBoundStatementExecutionRequest(ps, userParams, codecCtx, execMiddlewareCtx),
     );
   }
 
-  private async buildPreparedExecutionRequest<P, Row>(
-    ps: PreparedStatementImpl<P, Row>,
-    userParams: Record<string, unknown>,
+  private async buildBoundStatementExecutionRequest<Params extends Record<string, unknown>, Row>(
+    ps: PreparedStatementImpl<Params, Row>,
+    userParams: Params,
     codecCtx: SqlCodecCallContext,
     execMiddlewareCtx: RuntimeMiddlewareContext,
   ): Promise<ExecutionRequest> {
@@ -624,6 +636,75 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
     };
   }
 
+  private executeOnQueryable<Params extends Record<string, unknown>, Row>(
+    queryable: SqlQueryable,
+    scope: RuntimeExecuteOptions['scope'] | undefined,
+    planOrStatement:
+      | ((SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row })
+      | PreparedStatement<Params, Row>,
+    paramsOrOptions: Params | RuntimeExecuteOptions | undefined,
+    preparedOptions: RuntimeExecuteOptions | undefined,
+  ): AsyncIterableResult<Row> {
+    if (planOrStatement instanceof PreparedStatementImpl) {
+      const options = scope === undefined ? preparedOptions : { ...preparedOptions, scope };
+      return this.executeBoundStatementAgainstQueryable(
+        planOrStatement,
+        blindCast<Params, 'prepared execute overload always receives statement parameters'>(
+          paramsOrOptions,
+        ),
+        queryable,
+        options,
+      );
+    }
+
+    const options = blindCast<
+      RuntimeExecuteOptions | undefined,
+      'plan execute overload always receives execution options'
+    >(paramsOrOptions);
+    return this.executeAgainstQueryable(
+      blindCast<
+        (SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row },
+        'plan execute overload always receives a SQL plan'
+      >(planOrStatement),
+      queryable,
+      scope === undefined ? options : { ...options, scope },
+    );
+  }
+
+  protected createScopedExecutor(
+    queryable: SqlQueryable,
+    scope: NonNullable<RuntimeExecuteOptions['scope']>,
+  ): RuntimeQueryable['execute'] {
+    const self = this;
+
+    function execute<Row>(
+      plan: (SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row },
+      options?: RuntimeExecuteOptions,
+    ): AsyncIterableResult<Row>;
+    function execute<Params extends Record<string, unknown>, Row>(
+      ps: PreparedStatement<Params, Row>,
+      params: Params,
+      options?: RuntimeExecuteOptions,
+    ): AsyncIterableResult<Row>;
+    function execute<Params extends Record<string, unknown>, Row>(
+      planOrStatement:
+        | ((SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row })
+        | PreparedStatement<Params, Row>,
+      paramsOrOptions?: Params | RuntimeExecuteOptions,
+      preparedOptions?: RuntimeExecuteOptions,
+    ): AsyncIterableResult<Row> {
+      return self.executeOnQueryable(
+        queryable,
+        scope,
+        planOrStatement,
+        paramsOrOptions,
+        preparedOptions,
+      );
+    }
+
+    return execute;
+  }
+
   async connection(): Promise<RuntimeConnection> {
     const driverConn = await this.driver.acquireConnection();
     const self = this;
@@ -639,34 +720,13 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
       async destroy(reason?: unknown): Promise<void> {
         await driverConn.destroy(reason);
       },
-      execute<Row>(
-        plan: (SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row },
-        options?: RuntimeExecuteOptions,
-      ): AsyncIterableResult<Row> {
-        return self.executeAgainstQueryable<Row>(plan, driverConn, {
-          ...options,
-          scope: 'connection',
-        });
-      },
-      executePrepared<Params, Row>(
-        ps: PreparedStatement<Params, Row>,
-        params: Params,
-        options?: RuntimeExecuteOptions,
-      ): AsyncIterableResult<Row> {
-        return self.executePreparedAgainstQueryable<Params, Row>(
-          ps as PreparedStatementImpl<Params, Row>,
-          params as Record<string, unknown>,
-          driverConn,
-          { ...options, scope: 'connection' },
-        );
-      },
+      execute: self.createScopedExecutor(driverConn, 'connection'),
     };
 
     return wrappedConnection;
   }
 
   private wrapTransaction(driverTx: SqlTransaction): RuntimeTransaction {
-    const self = this;
     return {
       async commit(): Promise<void> {
         await driverTx.commit();
@@ -674,27 +734,7 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
       async rollback(): Promise<void> {
         await driverTx.rollback();
       },
-      execute<Row>(
-        plan: (SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row },
-        options?: RuntimeExecuteOptions,
-      ): AsyncIterableResult<Row> {
-        return self.executeAgainstQueryable<Row>(plan, driverTx, {
-          ...options,
-          scope: 'transaction',
-        });
-      },
-      executePrepared<Params, Row>(
-        ps: PreparedStatement<Params, Row>,
-        params: Params,
-        options?: RuntimeExecuteOptions,
-      ): AsyncIterableResult<Row> {
-        return self.executePreparedAgainstQueryable<Params, Row>(
-          ps as PreparedStatementImpl<Params, Row>,
-          params as Record<string, unknown>,
-          driverTx,
-          { ...options, scope: 'transaction' },
-        );
-      },
+      execute: this.createScopedExecutor(driverTx, 'transaction'),
     };
   }
 
@@ -752,7 +792,9 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
     outcome: TelemetryOutcome,
     durationMs?: number,
   ): void {
-    const contract = this.contract as { target: string };
+    const contract = blindCast<{ target: string }, 'contract target is required by RuntimeOptions'>(
+      this.contract,
+    );
     this._telemetry = Object.freeze({
       lane: plan.meta.lane,
       target: contract.target,
@@ -799,31 +841,59 @@ export async function withTransaction<R>(
     }
   }
 
+  function execute<Row>(
+    plan: (SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row },
+    options?: RuntimeExecuteOptions,
+  ): AsyncIterableResult<Row>;
+  function execute<Params extends Record<string, unknown>, Row>(
+    ps: PreparedStatement<Params, Row>,
+    params: Params,
+    options?: RuntimeExecuteOptions,
+  ): AsyncIterableResult<Row>;
+  function execute<Params extends Record<string, unknown>, Row>(
+    planOrStatement:
+      | ((SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row })
+      | PreparedStatement<Params, Row>,
+    paramsOrOptions?: Params | RuntimeExecuteOptions,
+    preparedOptions?: RuntimeExecuteOptions,
+  ): AsyncIterableResult<Row> {
+    if (invalidated) {
+      throw transactionClosedError();
+    }
+    if (planOrStatement instanceof PreparedStatementImpl) {
+      return new AsyncIterableResult(
+        guardedStream(
+          transaction.execute(
+            planOrStatement,
+            blindCast<Params, 'prepared execute overload always receives statement parameters'>(
+              paramsOrOptions,
+            ),
+            preparedOptions,
+          ),
+        ),
+      );
+    }
+    return new AsyncIterableResult(
+      guardedStream(
+        transaction.execute<Row>(
+          blindCast<
+            (SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row },
+            'plan execute overload always receives a SQL plan'
+          >(planOrStatement),
+          blindCast<
+            RuntimeExecuteOptions | undefined,
+            'plan execute overload always receives execution options'
+          >(paramsOrOptions),
+        ),
+      ),
+    );
+  }
+
   const txContext: TransactionContext = {
     get invalidated() {
       return invalidated;
     },
-    execute<Row>(
-      plan: (SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row },
-      options?: RuntimeExecuteOptions,
-    ): AsyncIterableResult<Row> {
-      if (invalidated) {
-        throw transactionClosedError();
-      }
-      return new AsyncIterableResult(guardedStream(transaction.execute(plan, options)));
-    },
-    executePrepared<Params, Row>(
-      ps: PreparedStatement<Params, Row>,
-      params: Params,
-      options?: RuntimeExecuteOptions,
-    ): AsyncIterableResult<Row> {
-      if (invalidated) {
-        throw transactionClosedError();
-      }
-      return new AsyncIterableResult(
-        guardedStream(transaction.executePrepared(ps, params, options)),
-      );
-    },
+    execute,
   };
 
   let connectionDisposed = false;

--- a/packages/2-sql/5-runtime/src/sql-runtime.ts
+++ b/packages/2-sql/5-runtime/src/sql-runtime.ts
@@ -17,10 +17,10 @@ import type {
   AnyQueryAst,
   ContractCodecRegistry,
   LoweredStatement,
-  PreparedExecuteRequest,
   SqlCodecCallContext,
   SqlConnection,
   SqlDriver,
+  SqlExecuteRequest,
   SqlQueryable,
   SqlTransaction,
 } from '@internal/sql-relational-core/ast';
@@ -63,6 +63,12 @@ import type {
 } from './runtime-spi';
 import type { ExecutionContext } from './sql-context';
 import { SqlFamilyAdapter } from './sql-family-adapter';
+
+interface ExecutionRequest {
+  readonly exec: SqlExecutionPlan;
+  readonly decodeContext: DecodeContext;
+  readonly request: SqlExecuteRequest;
+}
 
 export type Log = RuntimeLog;
 
@@ -187,8 +193,8 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
       scope: 'runtime',
       // Placeholder satisfying the required field on the cross-family base. The
       // stored ctx is a runtime-level template; the per-execute ctxs constructed
-      // in `executeAgainstQueryable` / `executePreparedAgainstQueryable` spread
-      // this template and override `planExecutionId` with a fresh UUID. ADR 220.
+      // in `executeWithRequestBuilder` spread this template and override
+      // `planExecutionId` with a fresh UUID. ADR 220.
       planExecutionId: '',
     };
 
@@ -267,7 +273,7 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
    */
   // v8 ignore next 6
   protected override runDriver(exec: SqlExecutionPlan): AsyncIterable<Record<string, unknown>> {
-    return this.driver.execute<Record<string, unknown>>({
+    return this.driver.query<Record<string, unknown>>({
       sql: exec.sql,
       params: exec.params,
     });
@@ -388,6 +394,19 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
     queryable: SqlQueryable,
     options?: RuntimeExecuteOptions,
   ): AsyncIterableResult<Row> {
+    return this.executeWithRequestBuilder<Row>(queryable, options, (codecCtx, execMiddlewareCtx) =>
+      this.buildPlanExecutionRequest(plan, codecCtx, execMiddlewareCtx),
+    );
+  }
+
+  private executeWithRequestBuilder<Row>(
+    queryable: SqlQueryable,
+    options: RuntimeExecuteOptions | undefined,
+    buildRequest: (
+      codecCtx: SqlCodecCallContext,
+      execMiddlewareCtx: RuntimeMiddlewareContext,
+    ) => Promise<ExecutionRequest>,
+  ): AsyncIterableResult<Row> {
     this.ensureCodecRegistryValidated();
 
     const self = this;
@@ -409,9 +428,9 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
     // see the right value without any out-of-band signaling.
     //
     // `planExecutionId` is minted here too: every execute() call — top-level,
-    // connection-scoped, or transaction-scoped — flows through this helper and
-    // gets its own fresh UUID. Hooks for one call see the same value; two
-    // calls (even with the same plan) see distinct values. ADR 220.
+    // connection-scoped, transaction-scoped, or prepared — flows through this
+    // helper and gets its own fresh UUID. Hooks for one call see the same
+    // value; two calls (even with the same plan) see distinct values. ADR 220.
     const execMiddlewareCtx: RuntimeMiddlewareContext = {
       ...self.ctx,
       ...ifDefined('signal', signal),
@@ -422,60 +441,71 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
     const generator = async function* (): AsyncGenerator<Row, void, unknown> {
       checkAborted(codecCtx, 'stream');
 
-      let exec: SqlExecutionPlan;
-      if (isExecutionPlan(plan)) {
-        // Pre-lowered fixture path. The plan's params are typically
-        // already encoded; we still fire `beforeExecute` so middleware
-        // that mutates ParamRef values (e.g. cipherstash bulk-encrypt)
-        // gets a chance to run, then re-encode so any mutations land.
-        const preEncodeMutator: SqlParamRefMutatorInternal = createSqlParamRefMutator(plan);
-        await runBeforeExecuteChain<SqlExecutionPlan, SqlParamRefMutator>(
-          plan,
-          self.middleware,
-          execMiddlewareCtx,
-          preEncodeMutator,
-        );
-        exec = Object.freeze({
-          ...plan,
-          params: await encodeParams(
-            { ...plan, params: preEncodeMutator.currentParams() },
-            codecCtx,
-            self.contractCodecs,
-          ),
-        });
-      } else {
-        // Standard AST → exec path. Split lower from encode so the
-        // `beforeExecute` chain fires between them with a mutator built
-        // over the pre-encode draft params; encode then renders the
-        // (possibly mutated) values through the column codecs.
-        const compiled = await self.runBeforeCompile(plan);
-        const draft = self.lowerToDraft(compiled);
-        const preEncodeMutator: SqlParamRefMutatorInternal = createSqlParamRefMutator(draft);
-        await runBeforeExecuteChain<SqlExecutionPlan, SqlParamRefMutator>(
-          draft,
-          self.middleware,
-          execMiddlewareCtx,
-          preEncodeMutator,
-        );
-        const draftWithMutations: SqlExecutionPlan = Object.freeze({
-          ...draft,
-          params: preEncodeMutator.currentParams(),
-        });
-        exec = await self.encodeDraftParams(draftWithMutations, codecCtx);
-      }
-
-      const decodeContext = buildDecodeContext(exec.ast, self.contractCodecs);
-
+      const execution = await buildRequest(codecCtx, execMiddlewareCtx);
       yield* self.streamRows<Row>(
-        exec,
-        decodeContext,
-        () => queryable.execute<Record<string, unknown>>({ sql: exec.sql, params: exec.params }),
+        execution.exec,
+        execution.decodeContext,
+        () => queryable.query<Record<string, unknown>>(execution.request),
         codecCtx,
         execMiddlewareCtx,
       );
     };
 
     return new AsyncIterableResult(generator());
+  }
+
+  private async buildPlanExecutionRequest(
+    plan: SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>,
+    codecCtx: SqlCodecCallContext,
+    execMiddlewareCtx: RuntimeMiddlewareContext,
+  ): Promise<ExecutionRequest> {
+    let exec: SqlExecutionPlan;
+    if (isExecutionPlan(plan)) {
+      // Pre-lowered fixture path. The plan's params are typically
+      // already encoded; we still fire `beforeExecute` so middleware
+      // that mutates ParamRef values (e.g. cipherstash bulk-encrypt)
+      // gets a chance to run, then re-encode so any mutations land.
+      const preEncodeMutator: SqlParamRefMutatorInternal = createSqlParamRefMutator(plan);
+      await runBeforeExecuteChain<SqlExecutionPlan, SqlParamRefMutator>(
+        plan,
+        this.middleware,
+        execMiddlewareCtx,
+        preEncodeMutator,
+      );
+      exec = Object.freeze({
+        ...plan,
+        params: await encodeParams(
+          { ...plan, params: preEncodeMutator.currentParams() },
+          codecCtx,
+          this.contractCodecs,
+        ),
+      });
+    } else {
+      // Standard AST → exec path. Split lower from encode so the
+      // `beforeExecute` chain fires between them with a mutator built
+      // over the pre-encode draft params; encode then renders the
+      // (possibly mutated) values through the column codecs.
+      const compiled = await this.runBeforeCompile(plan);
+      const draft = this.lowerToDraft(compiled);
+      const preEncodeMutator: SqlParamRefMutatorInternal = createSqlParamRefMutator(draft);
+      await runBeforeExecuteChain<SqlExecutionPlan, SqlParamRefMutator>(
+        draft,
+        this.middleware,
+        execMiddlewareCtx,
+        preEncodeMutator,
+      );
+      const draftWithMutations: SqlExecutionPlan = Object.freeze({
+        ...draft,
+        params: preEncodeMutator.currentParams(),
+      });
+      exec = await this.encodeDraftParams(draftWithMutations, codecCtx);
+    }
+
+    return {
+      exec,
+      decodeContext: buildDecodeContext(exec.ast, this.contractCodecs),
+      request: { sql: exec.sql, params: exec.params },
+    };
   }
 
   async prepare<D extends Declaration<CT>, Row, CT extends CodecTypesBase = CodecTypesBase>(
@@ -534,78 +564,64 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
     queryable: SqlQueryable,
     options?: RuntimeExecuteOptions,
   ): AsyncIterableResult<Row> {
-    this.ensureCodecRegistryValidated();
+    return this.executeWithRequestBuilder<Row>(queryable, options, (codecCtx, execMiddlewareCtx) =>
+      this.buildPreparedExecutionRequest(ps, userParams, codecCtx, execMiddlewareCtx),
+    );
+  }
 
-    const self = this;
-    const signal = options?.signal;
-    const scope = options?.scope ?? 'runtime';
-    const codecCtx: SqlCodecCallContext = signal === undefined ? {} : { signal };
-    // `executePrepared` is a parallel entry point to `executeAgainstQueryable`
-    // and mints its own fresh `planExecutionId` per call. ADR 220.
-    const execMiddlewareCtx: RuntimeMiddlewareContext = {
-      ...self.ctx,
-      ...ifDefined('signal', signal),
-      ...(scope !== 'runtime' ? { scope } : {}),
-      planExecutionId: crypto.randomUUID(),
+  private async buildPreparedExecutionRequest<P, Row>(
+    ps: PreparedStatementImpl<P, Row>,
+    userParams: Record<string, unknown>,
+    codecCtx: SqlCodecCallContext,
+    execMiddlewareCtx: RuntimeMiddlewareContext,
+  ): Promise<ExecutionRequest> {
+    // Resolve slot order to unencoded values so `beforeExecute`'s
+    // mutator sees pre-encode user values for prepared-param slots
+    // and can override them before encode runs.
+    const preEncodeValues = resolvePreparedSlotValues(ps, userParams);
+    const preEncodeExec: SqlExecutionPlan = {
+      sql: ps.sql,
+      params: preEncodeValues,
+      ast: ps.ast,
+      meta: ps.meta,
     };
 
-    const generator = async function* (): AsyncGenerator<Row, void, unknown> {
-      checkAborted(codecCtx, 'stream');
+    const mutator: SqlParamRefMutatorInternal = createSqlParamRefMutator(preEncodeExec);
+    await runBeforeExecuteChain<SqlExecutionPlan, SqlParamRefMutator>(
+      preEncodeExec,
+      this.middleware,
+      execMiddlewareCtx,
+      mutator,
+    );
 
-      // Resolve slot order to unencoded values so `beforeExecute`'s
-      // mutator sees pre-encode user values for prepared-param slots
-      // and can override them before encode runs.
-      const preEncodeValues = resolvePreparedSlotValues(ps, userParams);
-      const preEncodeExec: SqlExecutionPlan = {
-        sql: ps.sql,
-        params: preEncodeValues,
-        ast: ps.ast,
-        meta: ps.meta,
-      };
+    const encodedParams = await encodeParamsWithMetadata(
+      mutator.currentParams(),
+      ps.paramMetadata,
+      codecCtx,
+      this.contractCodecs,
+    );
+    const exec: SqlExecutionPlan = {
+      sql: ps.sql,
+      params: encodedParams,
+      ast: ps.ast,
+      meta: ps.meta,
+    };
 
-      const mutator: SqlParamRefMutatorInternal = createSqlParamRefMutator(preEncodeExec);
-      await runBeforeExecuteChain<SqlExecutionPlan, SqlParamRefMutator>(
-        preEncodeExec,
-        self.middleware,
-        execMiddlewareCtx,
-        mutator,
-      );
-
-      const encodedParams = await encodeParamsWithMetadata(
-        mutator.currentParams(),
-        ps.paramMetadata,
-        codecCtx,
-        self.contractCodecs,
-      );
-      const exec: SqlExecutionPlan = {
-        sql: ps.sql,
-        params: encodedParams,
-        ast: ps.ast,
-        meta: ps.meta,
-      };
-
-      const handles = self.#preparedStatementHandles;
-      const request: PreparedExecuteRequest = {
+    const handles = this.#preparedStatementHandles;
+    return {
+      exec,
+      decodeContext: ps.decodeContext,
+      request: {
         sql: exec.sql,
         params: exec.params,
-        handle: {
+        preparedStatementHandle: {
           get: () => handles.get(ps),
           set: (value) => {
             handles.set(ps, value);
           },
         },
-      };
-
-      yield* self.streamRows<Row>(
-        exec,
-        ps.decodeContext,
-        () => queryable.executePrepared<Record<string, unknown>>(request),
-        codecCtx,
-        execMiddlewareCtx,
-      );
+      },
     };
-
-    return new AsyncIterableResult(generator());
   }
 
   async connection(): Promise<RuntimeConnection> {

--- a/packages/2-sql/5-runtime/src/sql-runtime.ts
+++ b/packages/2-sql/5-runtime/src/sql-runtime.ts
@@ -17,10 +17,10 @@ import type {
   AnyQueryAst,
   ContractCodecRegistry,
   LoweredStatement,
+  PreparedExecuteRequest,
   SqlCodecCallContext,
   SqlConnection,
   SqlDriver,
-  SqlExecuteRequest,
   SqlQueryable,
   SqlTransaction,
 } from '@internal/sql-relational-core/ast';
@@ -34,7 +34,6 @@ import {
 import type { SqlExecutionPlan, SqlQueryPlan } from '@internal/sql-relational-core/plan';
 import type { CodecDescriptorRegistry } from '@internal/sql-relational-core/query-lane-context';
 import type { RuntimeScope } from '@internal/sql-relational-core/types';
-import { blindCast } from '@internal/utils/casts';
 import { ifDefined } from '@internal/utils/defined';
 import { buildDecodeContext, type DecodeContext, decodeRow } from './codecs/decoding';
 import { deriveParamMetadata, encodeParams, encodeParamsWithMetadata } from './codecs/encoding';
@@ -64,12 +63,6 @@ import type {
 } from './runtime-spi';
 import type { ExecutionContext } from './sql-context';
 import { SqlFamilyAdapter } from './sql-family-adapter';
-
-interface ExecutionRequest {
-  readonly exec: SqlExecutionPlan;
-  readonly decodeContext: DecodeContext;
-  readonly request: SqlExecuteRequest;
-}
 
 export type Log = RuntimeLog;
 
@@ -125,16 +118,13 @@ export interface RuntimeTransaction extends RuntimeQueryable {
 }
 
 export interface RuntimeQueryable extends RuntimeScope {
-  execute<Row>(
-    plan: (SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row },
-    options?: RuntimeExecuteOptions,
-  ): AsyncIterableResult<Row>;
   /**
-   * Run a prepared statement against this scope. The existing `execute` entry
-   * point carries preparedness on the statement request rather than exposing a
-   * second runtime method.
+   * Run a prepared statement against this scope. Required for the explicit
+   * `PreparedStatement.execute(target, params)` API — every scope (top-level
+   * runtime, connection, transaction) routes prepared executions through the
+   * `SqlQueryable` it is backed by.
    */
-  execute<Params extends Record<string, unknown>, Row>(
+  executePrepared<Params, Row>(
     ps: PreparedStatement<Params, Row>,
     params: Params,
     options?: RuntimeExecuteOptions,
@@ -193,15 +183,12 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
       now: () => Date.now(),
       log: log ?? noopLog,
       // ctx is only invoked by runWithMiddleware with execs this runtime lowered; the framework parameter type is the cross-family base.
-      contentHash: (exec) =>
-        computeSqlContentHash(
-          blindCast<SqlExecutionPlan, 'framework execution is lowered by this SQL runtime'>(exec),
-        ),
+      contentHash: (exec) => computeSqlContentHash(exec as SqlExecutionPlan),
       scope: 'runtime',
       // Placeholder satisfying the required field on the cross-family base. The
       // stored ctx is a runtime-level template; the per-execute ctxs constructed
-      // in `executeWithRequestBuilder` spread this template and override
-      // `planExecutionId` with a fresh UUID. ADR 220.
+      // in `executeAgainstQueryable` / `executePreparedAgainstQueryable` spread
+      // this template and override `planExecutionId` with a fresh UUID. ADR 220.
       planExecutionId: '',
     };
 
@@ -304,25 +291,20 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
   override execute<Row>(
     plan: (SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row },
     options?: RuntimeExecuteOptions,
-  ): AsyncIterableResult<Row>;
-  override execute<Params extends Record<string, unknown>, Row>(
+  ): AsyncIterableResult<Row> {
+    return this.executeAgainstQueryable<Row>(plan, this.driver, options);
+  }
+
+  executePrepared<Params, Row>(
     ps: PreparedStatement<Params, Row>,
     params: Params,
     options?: RuntimeExecuteOptions,
-  ): AsyncIterableResult<Row>;
-  override execute<Params extends Record<string, unknown>, Row>(
-    planOrStatement:
-      | ((SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row })
-      | PreparedStatement<Params, Row>,
-    paramsOrOptions?: Params | RuntimeExecuteOptions,
-    preparedOptions?: RuntimeExecuteOptions,
   ): AsyncIterableResult<Row> {
-    return this.executeOnQueryable(
+    return this.executePreparedAgainstQueryable<Params, Row>(
+      ps as PreparedStatementImpl<Params, Row>,
+      params as Record<string, unknown>,
       this.driver,
-      undefined,
-      planOrStatement,
-      paramsOrOptions,
-      preparedOptions,
+      options,
     );
   }
 
@@ -376,7 +358,7 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
             break;
           }
           const decodedRow = await decodeRow(next.value, decodeContext, codecCtx);
-          yield blindCast<Row, 'decoded row is shaped by the plan row type'>(decodedRow);
+          yield decodedRow as Row;
         }
       } finally {
         // Best-effort iterator cleanup so the driver can release its
@@ -406,19 +388,6 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
     queryable: SqlQueryable,
     options?: RuntimeExecuteOptions,
   ): AsyncIterableResult<Row> {
-    return this.executeWithRequestBuilder<Row>(queryable, options, (codecCtx, execMiddlewareCtx) =>
-      this.buildPlanExecutionRequest(plan, codecCtx, execMiddlewareCtx),
-    );
-  }
-
-  private executeWithRequestBuilder<Row>(
-    queryable: SqlQueryable,
-    options: RuntimeExecuteOptions | undefined,
-    buildRequest: (
-      codecCtx: SqlCodecCallContext,
-      execMiddlewareCtx: RuntimeMiddlewareContext,
-    ) => Promise<ExecutionRequest>,
-  ): AsyncIterableResult<Row> {
     this.ensureCodecRegistryValidated();
 
     const self = this;
@@ -440,9 +409,9 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
     // see the right value without any out-of-band signaling.
     //
     // `planExecutionId` is minted here too: every execute() call — top-level,
-    // connection-scoped, transaction-scoped, or prepared — flows through this
-    // helper and gets its own fresh UUID. Hooks for one call see the same
-    // value; two calls (even with the same plan) see distinct values. ADR 220.
+    // connection-scoped, or transaction-scoped — flows through this helper and
+    // gets its own fresh UUID. Hooks for one call see the same value; two
+    // calls (even with the same plan) see distinct values. ADR 220.
     const execMiddlewareCtx: RuntimeMiddlewareContext = {
       ...self.ctx,
       ...ifDefined('signal', signal),
@@ -453,83 +422,60 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
     const generator = async function* (): AsyncGenerator<Row, void, unknown> {
       checkAborted(codecCtx, 'stream');
 
-      const execution = await buildRequest(codecCtx, execMiddlewareCtx);
+      let exec: SqlExecutionPlan;
+      if (isExecutionPlan(plan)) {
+        // Pre-lowered fixture path. The plan's params are typically
+        // already encoded; we still fire `beforeExecute` so middleware
+        // that mutates ParamRef values (e.g. cipherstash bulk-encrypt)
+        // gets a chance to run, then re-encode so any mutations land.
+        const preEncodeMutator: SqlParamRefMutatorInternal = createSqlParamRefMutator(plan);
+        await runBeforeExecuteChain<SqlExecutionPlan, SqlParamRefMutator>(
+          plan,
+          self.middleware,
+          execMiddlewareCtx,
+          preEncodeMutator,
+        );
+        exec = Object.freeze({
+          ...plan,
+          params: await encodeParams(
+            { ...plan, params: preEncodeMutator.currentParams() },
+            codecCtx,
+            self.contractCodecs,
+          ),
+        });
+      } else {
+        // Standard AST → exec path. Split lower from encode so the
+        // `beforeExecute` chain fires between them with a mutator built
+        // over the pre-encode draft params; encode then renders the
+        // (possibly mutated) values through the column codecs.
+        const compiled = await self.runBeforeCompile(plan);
+        const draft = self.lowerToDraft(compiled);
+        const preEncodeMutator: SqlParamRefMutatorInternal = createSqlParamRefMutator(draft);
+        await runBeforeExecuteChain<SqlExecutionPlan, SqlParamRefMutator>(
+          draft,
+          self.middleware,
+          execMiddlewareCtx,
+          preEncodeMutator,
+        );
+        const draftWithMutations: SqlExecutionPlan = Object.freeze({
+          ...draft,
+          params: preEncodeMutator.currentParams(),
+        });
+        exec = await self.encodeDraftParams(draftWithMutations, codecCtx);
+      }
+
+      const decodeContext = buildDecodeContext(exec.ast, self.contractCodecs);
+
       yield* self.streamRows<Row>(
-        execution.exec,
-        execution.decodeContext,
-        () => queryable.query<Record<string, unknown>>(execution.request),
+        exec,
+        decodeContext,
+        () => queryable.query<Record<string, unknown>>({ sql: exec.sql, params: exec.params }),
         codecCtx,
         execMiddlewareCtx,
       );
     };
 
     return new AsyncIterableResult(generator());
-  }
-
-  private async buildPlanExecutionRequest(
-    plan: SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>,
-    codecCtx: SqlCodecCallContext,
-    execMiddlewareCtx: RuntimeMiddlewareContext,
-  ): Promise<ExecutionRequest> {
-    let exec: SqlExecutionPlan;
-    if (isExecutionPlan(plan)) {
-      // Pre-lowered fixture path. The plan's params are typically
-      // already encoded; we still fire `beforeExecute` so middleware
-      // that mutates ParamRef values (e.g. cipherstash bulk-encrypt)
-      // gets a chance to run, then re-encode so any mutations land.
-      const preEncodeMutator: SqlParamRefMutatorInternal = createSqlParamRefMutator(plan);
-      await runBeforeExecuteChain<SqlExecutionPlan, SqlParamRefMutator>(
-        plan,
-        this.middleware,
-        execMiddlewareCtx,
-        preEncodeMutator,
-      );
-      exec = Object.freeze({
-        ...plan,
-        params: await encodeParams(
-          { ...plan, params: preEncodeMutator.currentParams() },
-          codecCtx,
-          this.contractCodecs,
-        ),
-      });
-    } else {
-      // Standard AST → exec path. Split lower from encode so the
-      // `beforeExecute` chain fires between them with a mutator built
-      // over the pre-encode draft params; encode then renders the
-      // (possibly mutated) values through the column codecs.
-      const compiled = await this.runBeforeCompile(plan);
-      const draft = this.lowerToDraft(compiled);
-      const preEncodeMutator: SqlParamRefMutatorInternal = createSqlParamRefMutator(draft);
-      await runBeforeExecuteChain<SqlExecutionPlan, SqlParamRefMutator>(
-        draft,
-        this.middleware,
-        execMiddlewareCtx,
-        preEncodeMutator,
-      );
-      const draftWithMutations: SqlExecutionPlan = Object.freeze({
-        ...draft,
-        params: preEncodeMutator.currentParams(),
-      });
-      exec = await this.encodeDraftParams(draftWithMutations, codecCtx);
-    }
-
-    return this.createExecutionRequest(exec);
-  }
-
-  private createExecutionRequest(
-    exec: SqlExecutionPlan,
-    decodeContext = buildDecodeContext(exec.ast, this.contractCodecs),
-    preparedStatementHandle?: SqlExecuteRequest['preparedStatementHandle'],
-  ): ExecutionRequest {
-    return {
-      exec,
-      decodeContext,
-      request: {
-        sql: exec.sql,
-        params: exec.params,
-        ...ifDefined('preparedStatementHandle', preparedStatementHandle),
-      },
-    };
   }
 
   async prepare<D extends Declaration<CT>, Row, CT extends CodecTypesBase = CodecTypesBase>(
@@ -582,131 +528,84 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
    * Execute a prepared statement against a caller-supplied queryable, running
    * the full middleware/codec/telemetry pipeline.
    */
-  protected executePreparedAgainstQueryable<Params extends Record<string, unknown>, Row>(
-    ps: PreparedStatementImpl<Params, Row>,
-    userParams: Params,
+  protected executePreparedAgainstQueryable<P, Row>(
+    ps: PreparedStatementImpl<P, Row>,
+    userParams: Record<string, unknown>,
     queryable: SqlQueryable,
     options?: RuntimeExecuteOptions,
   ): AsyncIterableResult<Row> {
-    return this.executeWithRequestBuilder<Row>(queryable, options, (codecCtx, execMiddlewareCtx) =>
-      this.buildPreparedExecutionRequest(ps, userParams, codecCtx, execMiddlewareCtx),
-    );
-  }
+    this.ensureCodecRegistryValidated();
 
-  private async buildPreparedExecutionRequest<Params extends Record<string, unknown>, Row>(
-    ps: PreparedStatementImpl<Params, Row>,
-    userParams: Params,
-    codecCtx: SqlCodecCallContext,
-    execMiddlewareCtx: RuntimeMiddlewareContext,
-  ): Promise<ExecutionRequest> {
-    // Resolve slot order to unencoded values so `beforeExecute`'s
-    // mutator sees pre-encode user values for prepared-param slots
-    // and can override them before encode runs.
-    const preEncodeValues = resolvePreparedSlotValues(ps, userParams);
-    const preEncodeExec: SqlExecutionPlan = {
-      sql: ps.sql,
-      params: preEncodeValues,
-      ast: ps.ast,
-      meta: ps.meta,
-    };
-
-    const mutator: SqlParamRefMutatorInternal = createSqlParamRefMutator(preEncodeExec);
-    await runBeforeExecuteChain<SqlExecutionPlan, SqlParamRefMutator>(
-      preEncodeExec,
-      this.middleware,
-      execMiddlewareCtx,
-      mutator,
-    );
-
-    const encodedParams = await encodeParamsWithMetadata(
-      mutator.currentParams(),
-      ps.paramMetadata,
-      codecCtx,
-      this.contractCodecs,
-    );
-    const exec: SqlExecutionPlan = {
-      sql: ps.sql,
-      params: encodedParams,
-      ast: ps.ast,
-      meta: ps.meta,
-    };
-
-    const handles = this.#preparedStatementHandles;
-    return this.createExecutionRequest(exec, ps.decodeContext, {
-      get: () => handles.get(ps),
-      set: (value) => {
-        handles.set(ps, value);
-      },
-    });
-  }
-
-  private executeOnQueryable<Params extends Record<string, unknown>, Row>(
-    queryable: SqlQueryable,
-    scope: RuntimeExecuteOptions['scope'] | undefined,
-    planOrStatement:
-      | ((SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row })
-      | PreparedStatement<Params, Row>,
-    paramsOrOptions: Params | RuntimeExecuteOptions | undefined,
-    preparedOptions: RuntimeExecuteOptions | undefined,
-  ): AsyncIterableResult<Row> {
-    if (planOrStatement instanceof PreparedStatementImpl) {
-      const options = scope === undefined ? preparedOptions : { ...preparedOptions, scope };
-      return this.executePreparedAgainstQueryable(
-        planOrStatement,
-        blindCast<Params, 'prepared execute overload always receives statement parameters'>(
-          paramsOrOptions,
-        ),
-        queryable,
-        options,
-      );
-    }
-
-    const options = blindCast<
-      RuntimeExecuteOptions | undefined,
-      'plan execute overload always receives execution options'
-    >(paramsOrOptions);
-    return this.executeAgainstQueryable(
-      blindCast<
-        (SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row },
-        'plan execute overload always receives a SQL plan'
-      >(planOrStatement),
-      queryable,
-      scope === undefined ? options : { ...options, scope },
-    );
-  }
-
-  protected createScopedExecutor(
-    queryable: SqlQueryable,
-    scope: NonNullable<RuntimeExecuteOptions['scope']>,
-  ): RuntimeQueryable['execute'] {
     const self = this;
+    const signal = options?.signal;
+    const scope = options?.scope ?? 'runtime';
+    const codecCtx: SqlCodecCallContext = signal === undefined ? {} : { signal };
+    // `executePrepared` is a parallel entry point to `executeAgainstQueryable`
+    // and mints its own fresh `planExecutionId` per call. ADR 220.
+    const execMiddlewareCtx: RuntimeMiddlewareContext = {
+      ...self.ctx,
+      ...ifDefined('signal', signal),
+      ...(scope !== 'runtime' ? { scope } : {}),
+      planExecutionId: crypto.randomUUID(),
+    };
 
-    function execute<Row>(
-      plan: (SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row },
-      options?: RuntimeExecuteOptions,
-    ): AsyncIterableResult<Row>;
-    function execute<Params extends Record<string, unknown>, Row>(
-      ps: PreparedStatement<Params, Row>,
-      params: Params,
-      options?: RuntimeExecuteOptions,
-    ): AsyncIterableResult<Row>;
-    function execute<Params extends Record<string, unknown>, Row>(
-      planOrStatement:
-        | ((SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row })
-        | PreparedStatement<Params, Row>,
-      paramsOrOptions?: Params | RuntimeExecuteOptions,
-      preparedOptions?: RuntimeExecuteOptions,
-    ): AsyncIterableResult<Row> {
-      return self.executeOnQueryable(
-        queryable,
-        scope,
-        planOrStatement,
-        paramsOrOptions,
-        preparedOptions,
+    const generator = async function* (): AsyncGenerator<Row, void, unknown> {
+      checkAborted(codecCtx, 'stream');
+
+      // Resolve slot order to unencoded values so `beforeExecute`'s
+      // mutator sees pre-encode user values for prepared-param slots
+      // and can override them before encode runs.
+      const preEncodeValues = resolvePreparedSlotValues(ps, userParams);
+      const preEncodeExec: SqlExecutionPlan = {
+        sql: ps.sql,
+        params: preEncodeValues,
+        ast: ps.ast,
+        meta: ps.meta,
+      };
+
+      const mutator: SqlParamRefMutatorInternal = createSqlParamRefMutator(preEncodeExec);
+      await runBeforeExecuteChain<SqlExecutionPlan, SqlParamRefMutator>(
+        preEncodeExec,
+        self.middleware,
+        execMiddlewareCtx,
+        mutator,
       );
-    }
 
-    return execute;
+      const encodedParams = await encodeParamsWithMetadata(
+        mutator.currentParams(),
+        ps.paramMetadata,
+        codecCtx,
+        self.contractCodecs,
+      );
+      const exec: SqlExecutionPlan = {
+        sql: ps.sql,
+        params: encodedParams,
+        ast: ps.ast,
+        meta: ps.meta,
+      };
+
+      const handles = self.#preparedStatementHandles;
+      const request: PreparedExecuteRequest = {
+        sql: exec.sql,
+        params: exec.params,
+        preparedStatementHandle: {
+          get: () => handles.get(ps),
+          set: (value) => {
+            handles.set(ps, value);
+          },
+        },
+      };
+
+      yield* self.streamRows<Row>(
+        exec,
+        ps.decodeContext,
+        () => queryable.query<Record<string, unknown>>(request),
+        codecCtx,
+        execMiddlewareCtx,
+      );
+    };
+
+    return new AsyncIterableResult(generator());
   }
 
   async connection(): Promise<RuntimeConnection> {
@@ -724,13 +623,34 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
       async destroy(reason?: unknown): Promise<void> {
         await driverConn.destroy(reason);
       },
-      execute: self.createScopedExecutor(driverConn, 'connection'),
+      execute<Row>(
+        plan: (SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row },
+        options?: RuntimeExecuteOptions,
+      ): AsyncIterableResult<Row> {
+        return self.executeAgainstQueryable<Row>(plan, driverConn, {
+          ...options,
+          scope: 'connection',
+        });
+      },
+      executePrepared<Params, Row>(
+        ps: PreparedStatement<Params, Row>,
+        params: Params,
+        options?: RuntimeExecuteOptions,
+      ): AsyncIterableResult<Row> {
+        return self.executePreparedAgainstQueryable<Params, Row>(
+          ps as PreparedStatementImpl<Params, Row>,
+          params as Record<string, unknown>,
+          driverConn,
+          { ...options, scope: 'connection' },
+        );
+      },
     };
 
     return wrappedConnection;
   }
 
   private wrapTransaction(driverTx: SqlTransaction): RuntimeTransaction {
+    const self = this;
     return {
       async commit(): Promise<void> {
         await driverTx.commit();
@@ -738,7 +658,27 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
       async rollback(): Promise<void> {
         await driverTx.rollback();
       },
-      execute: this.createScopedExecutor(driverTx, 'transaction'),
+      execute<Row>(
+        plan: (SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row },
+        options?: RuntimeExecuteOptions,
+      ): AsyncIterableResult<Row> {
+        return self.executeAgainstQueryable<Row>(plan, driverTx, {
+          ...options,
+          scope: 'transaction',
+        });
+      },
+      executePrepared<Params, Row>(
+        ps: PreparedStatement<Params, Row>,
+        params: Params,
+        options?: RuntimeExecuteOptions,
+      ): AsyncIterableResult<Row> {
+        return self.executePreparedAgainstQueryable<Params, Row>(
+          ps as PreparedStatementImpl<Params, Row>,
+          params as Record<string, unknown>,
+          driverTx,
+          { ...options, scope: 'transaction' },
+        );
+      },
     };
   }
 
@@ -796,9 +736,7 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
     outcome: TelemetryOutcome,
     durationMs?: number,
   ): void {
-    const contract = blindCast<{ target: string }, 'contract target is required by RuntimeOptions'>(
-      this.contract,
-    );
+    const contract = this.contract as { target: string };
     this._telemetry = Object.freeze({
       lane: plan.meta.lane,
       target: contract.target,
@@ -845,59 +783,31 @@ export async function withTransaction<R>(
     }
   }
 
-  function execute<Row>(
-    plan: (SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row },
-    options?: RuntimeExecuteOptions,
-  ): AsyncIterableResult<Row>;
-  function execute<Params extends Record<string, unknown>, Row>(
-    ps: PreparedStatement<Params, Row>,
-    params: Params,
-    options?: RuntimeExecuteOptions,
-  ): AsyncIterableResult<Row>;
-  function execute<Params extends Record<string, unknown>, Row>(
-    planOrStatement:
-      | ((SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row })
-      | PreparedStatement<Params, Row>,
-    paramsOrOptions?: Params | RuntimeExecuteOptions,
-    preparedOptions?: RuntimeExecuteOptions,
-  ): AsyncIterableResult<Row> {
-    if (invalidated) {
-      throw transactionClosedError();
-    }
-    if (planOrStatement instanceof PreparedStatementImpl) {
-      return new AsyncIterableResult(
-        guardedStream(
-          transaction.execute(
-            planOrStatement,
-            blindCast<Params, 'prepared execute overload always receives statement parameters'>(
-              paramsOrOptions,
-            ),
-            preparedOptions,
-          ),
-        ),
-      );
-    }
-    return new AsyncIterableResult(
-      guardedStream(
-        transaction.execute<Row>(
-          blindCast<
-            (SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row },
-            'plan execute overload always receives a SQL plan'
-          >(planOrStatement),
-          blindCast<
-            RuntimeExecuteOptions | undefined,
-            'plan execute overload always receives execution options'
-          >(paramsOrOptions),
-        ),
-      ),
-    );
-  }
-
   const txContext: TransactionContext = {
     get invalidated() {
       return invalidated;
     },
-    execute,
+    execute<Row>(
+      plan: (SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row },
+      options?: RuntimeExecuteOptions,
+    ): AsyncIterableResult<Row> {
+      if (invalidated) {
+        throw transactionClosedError();
+      }
+      return new AsyncIterableResult(guardedStream(transaction.execute(plan, options)));
+    },
+    executePrepared<Params, Row>(
+      ps: PreparedStatement<Params, Row>,
+      params: Params,
+      options?: RuntimeExecuteOptions,
+    ): AsyncIterableResult<Row> {
+      if (invalidated) {
+        throw transactionClosedError();
+      }
+      return new AsyncIterableResult(
+        guardedStream(transaction.executePrepared(ps, params, options)),
+      );
+    },
   };
 
   let connectionDisposed = false;

--- a/packages/2-sql/5-runtime/src/sql-runtime.ts
+++ b/packages/2-sql/5-runtime/src/sql-runtime.ts
@@ -513,10 +513,22 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
       exec = await this.encodeDraftParams(draftWithMutations, codecCtx);
     }
 
+    return this.createExecutionRequest(exec);
+  }
+
+  private createExecutionRequest(
+    exec: SqlExecutionPlan,
+    decodeContext = buildDecodeContext(exec.ast, this.contractCodecs),
+    preparedStatementHandle?: SqlExecuteRequest['preparedStatementHandle'],
+  ): ExecutionRequest {
     return {
       exec,
-      decodeContext: buildDecodeContext(exec.ast, this.contractCodecs),
-      request: { sql: exec.sql, params: exec.params },
+      decodeContext,
+      request: {
+        sql: exec.sql,
+        params: exec.params,
+        ...ifDefined('preparedStatementHandle', preparedStatementHandle),
+      },
     };
   }
 
@@ -620,20 +632,12 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
     };
 
     const handles = this.#preparedStatementHandles;
-    return {
-      exec,
-      decodeContext: ps.decodeContext,
-      request: {
-        sql: exec.sql,
-        params: exec.params,
-        preparedStatementHandle: {
-          get: () => handles.get(ps),
-          set: (value) => {
-            handles.set(ps, value);
-          },
-        },
+    return this.createExecutionRequest(exec, ps.decodeContext, {
+      get: () => handles.get(ps),
+      set: (value) => {
+        handles.set(ps, value);
       },
-    };
+    });
   }
 
   private executeOnQueryable<Params extends Record<string, unknown>, Row>(

--- a/packages/2-sql/5-runtime/src/sql-runtime.ts
+++ b/packages/2-sql/5-runtime/src/sql-runtime.ts
@@ -582,18 +582,18 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
    * Execute a prepared statement against a caller-supplied queryable, running
    * the full middleware/codec/telemetry pipeline.
    */
-  protected executePreparedStatementAgainstQueryable<Params extends Record<string, unknown>, Row>(
+  protected executePreparedAgainstQueryable<Params extends Record<string, unknown>, Row>(
     ps: PreparedStatementImpl<Params, Row>,
     userParams: Params,
     queryable: SqlQueryable,
     options?: RuntimeExecuteOptions,
   ): AsyncIterableResult<Row> {
     return this.executeWithRequestBuilder<Row>(queryable, options, (codecCtx, execMiddlewareCtx) =>
-      this.buildPreparedStatementExecutionRequest(ps, userParams, codecCtx, execMiddlewareCtx),
+      this.buildPreparedExecutionRequest(ps, userParams, codecCtx, execMiddlewareCtx),
     );
   }
 
-  private async buildPreparedStatementExecutionRequest<Params extends Record<string, unknown>, Row>(
+  private async buildPreparedExecutionRequest<Params extends Record<string, unknown>, Row>(
     ps: PreparedStatementImpl<Params, Row>,
     userParams: Params,
     codecCtx: SqlCodecCallContext,
@@ -651,7 +651,7 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
   ): AsyncIterableResult<Row> {
     if (planOrStatement instanceof PreparedStatementImpl) {
       const options = scope === undefined ? preparedOptions : { ...preparedOptions, scope };
-      return this.executePreparedStatementAgainstQueryable(
+      return this.executePreparedAgainstQueryable(
         planOrStatement,
         blindCast<Params, 'prepared execute overload always receives statement parameters'>(
           paramsOrOptions,

--- a/packages/2-sql/5-runtime/test/async-iterable-result.test.ts
+++ b/packages/2-sql/5-runtime/test/async-iterable-result.test.ts
@@ -23,7 +23,7 @@ class MockDriver {
 
   async *query<Row = Record<string, unknown>>(_options: {
     sql: string;
-    params?: readonly unknown[];
+    params: readonly unknown[];
   }): AsyncIterable<Row> {
     for (const row of this.rows) {
       yield row as Row;

--- a/packages/2-sql/5-runtime/test/async-iterable-result.test.ts
+++ b/packages/2-sql/5-runtime/test/async-iterable-result.test.ts
@@ -21,7 +21,7 @@ class MockDriver {
     this.rows = rows;
   }
 
-  async *query<Row = Record<string, unknown>>(_request: {
+  async *query<Row = Record<string, unknown>>(_options: {
     sql: string;
     params?: readonly unknown[];
   }): AsyncIterable<Row> {
@@ -30,10 +30,7 @@ class MockDriver {
     }
   }
 
-  async execute(_request: {
-    sql: string;
-    params?: readonly unknown[];
-  }): Promise<{ affectedRows: number }> {
+  async execute(): Promise<{ affectedRows: number }> {
     return { affectedRows: 0 };
   }
 

--- a/packages/2-sql/5-runtime/test/async-iterable-result.test.ts
+++ b/packages/2-sql/5-runtime/test/async-iterable-result.test.ts
@@ -21,29 +21,20 @@ class MockDriver {
     this.rows = rows;
   }
 
-  async query<Row = Record<string, unknown>>(
-    _sql: string,
-    _params?: readonly unknown[],
-  ): Promise<{ rows: ReadonlyArray<Row> }> {
-    return { rows: [] };
-  }
-
-  async *execute<Row = Record<string, unknown>>(_options: {
+  async *query<Row = Record<string, unknown>>(_request: {
     sql: string;
-    params: readonly unknown[];
+    params?: readonly unknown[];
   }): AsyncIterable<Row> {
     for (const row of this.rows) {
       yield row as Row;
     }
   }
 
-  async *executePrepared<Row = Record<string, unknown>>(_options: {
+  async execute(_request: {
     sql: string;
-    params: readonly unknown[];
-  }): AsyncIterable<Row> {
-    for (const row of this.rows) {
-      yield row as Row;
-    }
+    params?: readonly unknown[];
+  }): Promise<{ affectedRows: number }> {
+    return { affectedRows: 0 };
   }
 
   async acquireConnection(): Promise<never> {

--- a/packages/2-sql/5-runtime/test/intercept-decoding.test.ts
+++ b/packages/2-sql/5-runtime/test/intercept-decoding.test.ts
@@ -92,14 +92,14 @@ function createStubAdapter(codecs: ReadonlyArray<Codec<string>>) {
 }
 
 function createMockDriver(): SqlDriver {
-  const query = vi.fn().mockImplementation(async function* (_request: SqlExecuteRequest) {
+  const rootExecute = vi.fn().mockImplementation(async function* (_request: SqlExecuteRequest) {
     // Default driver path; real test cases below either intercept (skipping this) or assert it was called.
     yield {} as Record<string, unknown>;
   });
 
   return {
     execute: vi.fn().mockResolvedValue({ affectedRows: 0 }),
-    query,
+    query: rootExecute,
     connect: vi.fn().mockImplementation(async (_binding?: undefined) => undefined),
     acquireConnection: vi.fn().mockRejectedValue(new Error('not used in this test')),
     close: vi.fn().mockResolvedValue(undefined),
@@ -219,7 +219,7 @@ describe('intercepted rows go through codec decoding', () => {
 
     // The consumer must see the *decoded* value (a parsed object), not the raw wire string.
     expect(out).toEqual([{ profile: { name: 'Alice', tags: ['admin', 'staff'] } }]);
-    expect(driver.query).not.toHaveBeenCalled();
+    expect(driver.execute).not.toHaveBeenCalled();
   });
 
   it('decodes multiple intercepted rows independently', async () => {
@@ -243,7 +243,7 @@ describe('intercepted rows go through codec decoding', () => {
     const out = await runtime.execute(plan).toArray();
 
     expect(out).toEqual([{ profile: { id: 1 } }, { profile: { id: 2 } }, { profile: { id: 3 } }]);
-    expect(driver.query).not.toHaveBeenCalled();
+    expect(driver.execute).not.toHaveBeenCalled();
   });
 
   it('decodes intercepted rows yielded from an AsyncIterable', async () => {

--- a/packages/2-sql/5-runtime/test/intercept-decoding.test.ts
+++ b/packages/2-sql/5-runtime/test/intercept-decoding.test.ts
@@ -92,16 +92,13 @@ function createStubAdapter(codecs: ReadonlyArray<Codec<string>>) {
 }
 
 function createMockDriver(): SqlDriver {
-  const rootExecute = vi.fn().mockImplementation(async function* (_request: SqlExecuteRequest) {
+  const query = vi.fn().mockImplementation(async function* (_request: SqlExecuteRequest) {
     // Default driver path; real test cases below either intercept (skipping this) or assert it was called.
     yield {} as Record<string, unknown>;
   });
 
-  const query = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 });
-
   return {
-    execute: rootExecute,
-    executePrepared: vi.fn().mockRejectedValue(new Error('executePrepared not used in this test')),
+    execute: vi.fn().mockResolvedValue({ affectedRows: 0 }),
     query,
     connect: vi.fn().mockImplementation(async (_binding?: undefined) => undefined),
     acquireConnection: vi.fn().mockRejectedValue(new Error('not used in this test')),
@@ -222,7 +219,7 @@ describe('intercepted rows go through codec decoding', () => {
 
     // The consumer must see the *decoded* value (a parsed object), not the raw wire string.
     expect(out).toEqual([{ profile: { name: 'Alice', tags: ['admin', 'staff'] } }]);
-    expect(driver.execute).not.toHaveBeenCalled();
+    expect(driver.query).not.toHaveBeenCalled();
   });
 
   it('decodes multiple intercepted rows independently', async () => {
@@ -246,7 +243,7 @@ describe('intercepted rows go through codec decoding', () => {
     const out = await runtime.execute(plan).toArray();
 
     expect(out).toEqual([{ profile: { id: 1 } }, { profile: { id: 2 } }, { profile: { id: 3 } }]);
-    expect(driver.execute).not.toHaveBeenCalled();
+    expect(driver.query).not.toHaveBeenCalled();
   });
 
   it('decodes intercepted rows yielded from an AsyncIterable', async () => {
@@ -269,7 +266,7 @@ describe('intercepted rows go through codec decoding', () => {
     const out = await runtime.execute(plan).toArray();
 
     expect(out).toEqual([{ profile: { kind: 'first' } }, { profile: { kind: 'second' } }]);
-    expect(driver.execute).not.toHaveBeenCalled();
+    expect(driver.query).not.toHaveBeenCalled();
   });
 
   it('decodes driver rows and intercepted rows the same way (round-trip via the same codec path)', async () => {
@@ -281,7 +278,7 @@ describe('intercepted rows go through codec decoding', () => {
       const { runtime, driver } = createTestSetup([]);
 
       // Override the driver to produce the wire value.
-      (driver.execute as ReturnType<typeof vi.fn>).mockImplementation(async function* (
+      (driver.query as ReturnType<typeof vi.fn>).mockImplementation(async function* (
         _request: SqlExecuteRequest,
       ) {
         yield { profile: wireValue };

--- a/packages/2-sql/5-runtime/test/marker-verification.test.ts
+++ b/packages/2-sql/5-runtime/test/marker-verification.test.ts
@@ -106,16 +106,11 @@ function createStubAdapter(
 }
 
 function createDriver(): SqlDriver {
-  const query = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 });
-  const execute = vi.fn().mockImplementation(async function* (_request: SqlExecuteRequest) {
-    yield {} as Record<string, unknown>;
-  });
-  const executePrepared = vi.fn().mockImplementation(async function* () {
+  const query = vi.fn().mockImplementation(async function* (_request: SqlExecuteRequest) {
     yield {} as Record<string, unknown>;
   });
   return {
-    execute,
-    executePrepared,
+    execute: vi.fn().mockResolvedValue({ affectedRows: 0 }),
     query,
     connect: vi.fn().mockImplementation(async (_binding?: undefined) => undefined),
     acquireConnection: vi.fn().mockRejectedValue(new Error('not used in this test')),

--- a/packages/2-sql/5-runtime/test/marker-vs-intercept-ordering.test.ts
+++ b/packages/2-sql/5-runtime/test/marker-vs-intercept-ordering.test.ts
@@ -229,7 +229,7 @@ describe('marker verification runs before intercept', () => {
       }),
     );
     expect(intercept).toHaveBeenCalled();
-    expect(driver.query).not.toHaveBeenCalled();
+    expect(driver.execute).not.toHaveBeenCalled();
     expect(callOrder).toEqual(['verify', 'intercept']);
   });
 });

--- a/packages/2-sql/5-runtime/test/marker-vs-intercept-ordering.test.ts
+++ b/packages/2-sql/5-runtime/test/marker-vs-intercept-ordering.test.ts
@@ -95,14 +95,12 @@ function createStubAdapter(codecs: ReadonlyArray<Codec<string>>) {
 }
 
 function createStubDriver(): SqlDriver {
-  const query = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 });
-  const execute = vi.fn().mockImplementation(async function* (_request: SqlExecuteRequest) {
+  const query = vi.fn().mockImplementation(async function* (_request: SqlExecuteRequest) {
     yield {} as Record<string, unknown>;
   });
 
   return {
-    execute,
-    executePrepared: vi.fn().mockRejectedValue(new Error('executePrepared not used in this test')),
+    execute: vi.fn().mockResolvedValue({ affectedRows: 0 }),
     query,
     connect: vi.fn().mockImplementation(async (_binding?: undefined) => undefined),
     acquireConnection: vi.fn().mockRejectedValue(new Error('not used in this test')),
@@ -231,7 +229,7 @@ describe('marker verification runs before intercept', () => {
       }),
     );
     expect(intercept).toHaveBeenCalled();
-    expect(driver.execute).not.toHaveBeenCalled();
+    expect(driver.query).not.toHaveBeenCalled();
     expect(callOrder).toEqual(['verify', 'intercept']);
   });
 });

--- a/packages/2-sql/5-runtime/test/plan-execution-id.test.ts
+++ b/packages/2-sql/5-runtime/test/plan-execution-id.test.ts
@@ -1,9 +1,5 @@
 import { instantiateExecutionStack } from '@internal/framework-components/execution';
-import type {
-  PreparedExecuteRequest,
-  SqlDriver,
-  SqlExecuteRequest,
-} from '@internal/sql-relational-core/ast';
+import type { SqlDriver, SqlExecuteRequest } from '@internal/sql-relational-core/ast';
 import {
   BinaryExpr,
   ColumnRef,
@@ -27,8 +23,8 @@ import {
 } from './utils';
 
 /**
- * Pins ADR 220 semantics for the SQL runtime: every `execute()` and every
- * `executePrepared()` call mints a fresh `ctx.planExecutionId` for the
+ * Pins ADR 220 semantics for the SQL runtime: every ad-hoc and prepared
+ * execution mints a fresh `ctx.planExecutionId` for the
  * per-execute middleware context. Hooks within one call observe the same
  * ID; hooks across two calls of the same plan/prepared-statement observe
  * distinct IDs.
@@ -37,18 +33,12 @@ import {
 const testContract = createTestContract({ targetFamily: 'sql', target: 'postgres' });
 
 function createMockDriver(rows: ReadonlyArray<Record<string, unknown>> = []): SqlDriver {
-  const execute = vi.fn().mockImplementation(async function* (_request: SqlExecuteRequest) {
-    for (const row of rows) yield row;
-  });
-  const executePrepared = vi.fn().mockImplementation(async function* (
-    _request: PreparedExecuteRequest,
-  ) {
+  const query = vi.fn().mockImplementation(async function* (_request: SqlExecuteRequest) {
     for (const row of rows) yield row;
   });
   return {
-    execute,
-    executePrepared,
-    query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+    execute: vi.fn().mockResolvedValue({ affectedRows: 0 }),
+    query,
     connect: vi.fn().mockResolvedValue(undefined),
     acquireConnection: vi.fn(),
     close: vi.fn().mockResolvedValue(undefined),
@@ -163,8 +153,8 @@ describe('SqlRuntime.execute planExecutionId (ADR 220)', () => {
   });
 });
 
-describe('SqlRuntime.executePrepared planExecutionId (ADR 220)', () => {
-  it('assigns the same planExecutionId to beforeExecute and afterExecute within one executePrepared call', async () => {
+describe('SqlRuntime prepared execution planExecutionId (ADR 220)', () => {
+  it('assigns the same planExecutionId to beforeExecute and afterExecute within one prepared execution', async () => {
     const log: Observation[] = [];
     const { runtime } = createSetup([observerMiddleware(log)]);
     const ps = await runtime.prepare({ userId: 'pg/int4@1' as const }, (params) =>
@@ -178,7 +168,7 @@ describe('SqlRuntime.executePrepared planExecutionId (ADR 220)', () => {
     expect(log[0]?.planExecutionId).toBe(log[1]?.planExecutionId);
   });
 
-  it('assigns distinct planExecutionIds to two executePrepared calls on the same prepared statement', async () => {
+  it('assigns distinct planExecutionIds to two calls on the same prepared statement', async () => {
     const log: Observation[] = [];
     const { runtime } = createSetup([observerMiddleware(log)]);
     const ps = await runtime.prepare({ userId: 'pg/int4@1' as const }, (params) =>

--- a/packages/2-sql/5-runtime/test/plan-execution-id.test.ts
+++ b/packages/2-sql/5-runtime/test/plan-execution-id.test.ts
@@ -23,8 +23,8 @@ import {
 } from './utils';
 
 /**
- * Pins ADR 220 semantics for the SQL runtime: every ad-hoc and prepared
- * execution mints a fresh `ctx.planExecutionId` for the
+ * Pins ADR 220 semantics for the SQL runtime: every `execute()` and every
+ * `executePrepared()` call mints a fresh `ctx.planExecutionId` for the
  * per-execute middleware context. Hooks within one call observe the same
  * ID; hooks across two calls of the same plan/prepared-statement observe
  * distinct IDs.
@@ -153,8 +153,8 @@ describe('SqlRuntime.execute planExecutionId (ADR 220)', () => {
   });
 });
 
-describe('SqlRuntime prepared execution planExecutionId (ADR 220)', () => {
-  it('assigns the same planExecutionId to beforeExecute and afterExecute within one prepared execution', async () => {
+describe('SqlRuntime.executePrepared planExecutionId (ADR 220)', () => {
+  it('assigns the same planExecutionId to beforeExecute and afterExecute within one executePrepared call', async () => {
     const log: Observation[] = [];
     const { runtime } = createSetup([observerMiddleware(log)]);
     const ps = await runtime.prepare({ userId: 'pg/int4@1' as const }, (params) =>
@@ -168,7 +168,7 @@ describe('SqlRuntime prepared execution planExecutionId (ADR 220)', () => {
     expect(log[0]?.planExecutionId).toBe(log[1]?.planExecutionId);
   });
 
-  it('assigns distinct planExecutionIds to two calls on the same prepared statement', async () => {
+  it('assigns distinct planExecutionIds to two executePrepared calls on the same prepared statement', async () => {
     const log: Observation[] = [];
     const { runtime } = createSetup([observerMiddleware(log)]);
     const ps = await runtime.prepare({ userId: 'pg/int4@1' as const }, (params) =>

--- a/packages/2-sql/5-runtime/test/prepared.test.ts
+++ b/packages/2-sql/5-runtime/test/prepared.test.ts
@@ -1,9 +1,5 @@
 import { instantiateExecutionStack } from '@internal/framework-components/execution';
-import type {
-  PreparedExecuteRequest,
-  SqlDriver,
-  SqlExecuteRequest,
-} from '@internal/sql-relational-core/ast';
+import type { SqlDriver, SqlExecuteRequest } from '@internal/sql-relational-core/ast';
 import {
   BinaryExpr,
   ColumnRef,
@@ -34,7 +30,6 @@ const testContract = createTestContract({
 
 interface DriverSpies {
   execute: ReturnType<typeof vi.fn>;
-  executePrepared: ReturnType<typeof vi.fn>;
   query: ReturnType<typeof vi.fn>;
   acquireConnection: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
@@ -43,28 +38,22 @@ interface DriverSpies {
 function createMockDriver(rows: ReadonlyArray<Record<string, unknown>>): SqlDriver & {
   __spies: DriverSpies;
 } {
-  const execute = vi.fn().mockImplementation(async function* (_request: SqlExecuteRequest) {
+  const execute = vi.fn().mockResolvedValue({ affectedRows: 0 });
+  const query = vi.fn().mockImplementation(async function* (_request: SqlExecuteRequest) {
     for (const row of rows) yield row;
   });
-  const executePrepared = vi.fn().mockImplementation(async function* (
-    _request: PreparedExecuteRequest,
-  ) {
-    for (const row of rows) yield row;
-  });
-  const query = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 });
   const close = vi.fn().mockResolvedValue(undefined);
   const acquireConnection = vi.fn();
 
   const driver: SqlDriver = {
     execute,
-    executePrepared,
     query,
     connect: vi.fn().mockResolvedValue(undefined),
     acquireConnection,
     close,
   };
   return Object.assign(driver, {
-    __spies: { execute, executePrepared, query, acquireConnection, close },
+    __spies: { execute, query, acquireConnection, close },
   });
 }
 
@@ -134,7 +123,6 @@ describe('runtime.prepare', () => {
       buildEqUserIdPlan((params as Params<{ userId: unknown }>).userId),
     );
     expect(driver.__spies.execute).not.toHaveBeenCalled();
-    expect(driver.__spies.executePrepared).not.toHaveBeenCalled();
     expect(driver.__spies.query).not.toHaveBeenCalled();
     expect(driver.__spies.acquireConnection).not.toHaveBeenCalled();
   });
@@ -150,10 +138,8 @@ describe('runtime.prepare', () => {
   it('hands the driver an initially-unset handle slot on first execute', async () => {
     const { runtime, driver } = createSetup({ rows: [] });
     let firstHandleGet: unknown = 'unobserved';
-    driver.__spies.executePrepared.mockImplementation(async function* (
-      req: PreparedExecuteRequest,
-    ) {
-      firstHandleGet = req.handle.get();
+    driver.__spies.query.mockImplementation(async function* (req: SqlExecuteRequest) {
+      firstHandleGet = req.preparedStatementHandle?.get();
       yield* [];
     });
     const ps = await runtime.prepare({ userId: 'pg/int4@1' as const }, (params) =>
@@ -227,7 +213,7 @@ describe('runtime.prepare', () => {
     expect(beforeExecute).toHaveBeenCalledTimes(2);
   });
 
-  it('routes .execute() through driver.executePrepared and reuses lowered SQL', async () => {
+  it('routes prepared reads through driver.query and reuses lowered SQL', async () => {
     const { runtime, driver, adapter } = createSetup({ rows: [{ id: 1 }] });
     const ps = await runtime.prepare({ userId: 'pg/int4@1' as const }, (params) =>
       buildEqUserIdPlan((params as Params<{ userId: unknown }>).userId),
@@ -239,7 +225,7 @@ describe('runtime.prepare', () => {
 
     // No additional lower() calls — the lowered SQL is reused.
     expect(adapter.lower).toHaveBeenCalledTimes(1);
-    expect(driver.__spies.executePrepared).toHaveBeenCalledTimes(2);
+    expect(driver.__spies.query).toHaveBeenCalledTimes(2);
     expect(driver.__spies.execute).not.toHaveBeenCalled();
   });
 
@@ -249,12 +235,12 @@ describe('runtime.prepare', () => {
       buildEqUserIdPlan((params as Params<{ userId: unknown }>).userId),
     );
     await ps.execute(runtime, { userId: 42 }).toArray();
-    const lastCall = driver.__spies.executePrepared.mock.calls.at(-1);
+    const lastCall = driver.__spies.query.mock.calls.at(-1);
     expect(lastCall).toBeDefined();
-    const req = lastCall?.[0] as PreparedExecuteRequest;
+    const req = lastCall?.[0] as SqlExecuteRequest;
     expect(req.params).toEqual([42]);
     // No slot markers leak into the wire-format params.
-    for (const p of req.params) {
+    for (const p of req.params ?? []) {
       expect(p).not.toMatchObject({ __preparedSlotMarker: true });
     }
   });
@@ -262,14 +248,13 @@ describe('runtime.prepare', () => {
   it('persists handle.set(value) across executes (round-trip via the slot wrapper)', async () => {
     const { runtime, driver } = createSetup({ rows: [] });
     const observed: unknown[] = [];
-    driver.__spies.executePrepared.mockImplementation(async function* (
-      req: PreparedExecuteRequest,
-    ) {
+    driver.__spies.query.mockImplementation(async function* (req: SqlExecuteRequest) {
       // Simulate a driver allocating a handle on first call and observing
       // the persisted value on subsequent calls.
-      observed.push(req.handle.get());
-      if (req.handle.get() === undefined) {
-        req.handle.set('pn_42');
+      const handle = req.preparedStatementHandle;
+      observed.push(handle?.get());
+      if (handle?.get() === undefined) {
+        handle?.set('pn_42');
       }
       yield* [];
     });
@@ -284,11 +269,10 @@ describe('runtime.prepare', () => {
   it('produces independent results for two .execute() calls on the same handle', async () => {
     const { runtime, driver } = createSetup();
     const captured: Array<readonly unknown[]> = [];
-    driver.__spies.executePrepared.mockImplementation(async function* (
-      req: PreparedExecuteRequest,
-    ) {
-      captured.push(req.params);
-      yield { id: req.params[0] };
+    driver.__spies.query.mockImplementation(async function* (req: SqlExecuteRequest) {
+      const params = req.params ?? [];
+      captured.push(params);
+      yield { id: params[0] };
     });
     const ps = await runtime.prepare({ userId: 'pg/int4@1' as const }, (params) =>
       buildEqUserIdPlan((params as Params<{ userId: unknown }>).userId),
@@ -338,12 +322,12 @@ describe('runtime.prepare', () => {
     // The mutator surfaces the pre-encode user value, not the encoded one.
     expect(captured).toEqual([42]);
     // The replacement reaches the driver — encode runs after mutation.
-    const lastCall = driver.__spies.executePrepared.mock.calls.at(-1);
-    const req = lastCall?.[0] as PreparedExecuteRequest;
+    const lastCall = driver.__spies.query.mock.calls.at(-1);
+    const req = lastCall?.[0] as SqlExecuteRequest;
     expect(req.params).toEqual([999]);
   });
 
-  it('does not invoke executePrepared when ad-hoc .execute(plan) is used (regression)', async () => {
+  it('sends ad-hoc reads through query without a prepared handle', async () => {
     const { runtime, driver } = createSetup({ rows: [{ id: 1 }] });
     const ref = ParamRef.of(7, { codec: { codecId: 'pg/int4@1' } });
     const users = TableSource.named('users');
@@ -360,7 +344,7 @@ describe('runtime.prepare', () => {
       meta,
     });
     await runtime.execute(plan).toArray();
-    expect(driver.__spies.execute).toHaveBeenCalledTimes(1);
-    expect(driver.__spies.executePrepared).not.toHaveBeenCalled();
+    expect(driver.__spies.query).toHaveBeenCalledTimes(1);
+    expect(driver.__spies.query.mock.calls[0]?.[0]?.preparedStatementHandle).toBeUndefined();
   });
 });

--- a/packages/2-sql/5-runtime/test/prepared.test.ts
+++ b/packages/2-sql/5-runtime/test/prepared.test.ts
@@ -1,5 +1,9 @@
 import { instantiateExecutionStack } from '@internal/framework-components/execution';
-import type { SqlDriver, SqlExecuteRequest } from '@internal/sql-relational-core/ast';
+import type {
+  PreparedExecuteRequest,
+  SqlDriver,
+  SqlExecuteRequest,
+} from '@internal/sql-relational-core/ast';
 import {
   BinaryExpr,
   ColumnRef,
@@ -38,10 +42,10 @@ interface DriverSpies {
 function createMockDriver(rows: ReadonlyArray<Record<string, unknown>>): SqlDriver & {
   __spies: DriverSpies;
 } {
-  const execute = vi.fn().mockResolvedValue({ affectedRows: 0 });
   const query = vi.fn().mockImplementation(async function* (_request: SqlExecuteRequest) {
     for (const row of rows) yield row;
   });
+  const execute = vi.fn().mockResolvedValue({ affectedRows: 0 });
   const close = vi.fn().mockResolvedValue(undefined);
   const acquireConnection = vi.fn();
 
@@ -138,8 +142,8 @@ describe('runtime.prepare', () => {
   it('hands the driver an initially-unset handle slot on first execute', async () => {
     const { runtime, driver } = createSetup({ rows: [] });
     let firstHandleGet: unknown = 'unobserved';
-    driver.__spies.query.mockImplementation(async function* (req: SqlExecuteRequest) {
-      firstHandleGet = req.preparedStatementHandle?.get();
+    driver.__spies.query.mockImplementation(async function* (req: PreparedExecuteRequest) {
+      firstHandleGet = req.preparedStatementHandle.get();
       yield* [];
     });
     const ps = await runtime.prepare({ userId: 'pg/int4@1' as const }, (params) =>
@@ -213,7 +217,7 @@ describe('runtime.prepare', () => {
     expect(beforeExecute).toHaveBeenCalledTimes(2);
   });
 
-  it('routes prepared reads through driver.query and reuses lowered SQL', async () => {
+  it('routes .execute() through driver.query with a prepared handle and reuses lowered SQL', async () => {
     const { runtime, driver, adapter } = createSetup({ rows: [{ id: 1 }] });
     const ps = await runtime.prepare({ userId: 'pg/int4@1' as const }, (params) =>
       buildEqUserIdPlan((params as Params<{ userId: unknown }>).userId),
@@ -237,10 +241,12 @@ describe('runtime.prepare', () => {
     await ps.execute(runtime, { userId: 42 }).toArray();
     const lastCall = driver.__spies.query.mock.calls.at(-1);
     expect(lastCall).toBeDefined();
-    const req = lastCall?.[0] as SqlExecuteRequest;
+    const req = lastCall?.[0] as PreparedExecuteRequest;
     expect(req.params).toEqual([42]);
+    const params = req.params;
+    if (params === undefined) throw new Error('expected params');
     // No slot markers leak into the wire-format params.
-    for (const p of req.params ?? []) {
+    for (const p of params) {
       expect(p).not.toMatchObject({ __preparedSlotMarker: true });
     }
   });
@@ -248,13 +254,12 @@ describe('runtime.prepare', () => {
   it('persists handle.set(value) across executes (round-trip via the slot wrapper)', async () => {
     const { runtime, driver } = createSetup({ rows: [] });
     const observed: unknown[] = [];
-    driver.__spies.query.mockImplementation(async function* (req: SqlExecuteRequest) {
+    driver.__spies.query.mockImplementation(async function* (req: PreparedExecuteRequest) {
       // Simulate a driver allocating a handle on first call and observing
       // the persisted value on subsequent calls.
-      const handle = req.preparedStatementHandle;
-      observed.push(handle?.get());
-      if (handle?.get() === undefined) {
-        handle?.set('pn_42');
+      observed.push(req.preparedStatementHandle.get());
+      if (req.preparedStatementHandle.get() === undefined) {
+        req.preparedStatementHandle.set('pn_42');
       }
       yield* [];
     });
@@ -269,8 +274,9 @@ describe('runtime.prepare', () => {
   it('produces independent results for two .execute() calls on the same handle', async () => {
     const { runtime, driver } = createSetup();
     const captured: Array<readonly unknown[]> = [];
-    driver.__spies.query.mockImplementation(async function* (req: SqlExecuteRequest) {
-      const params = req.params ?? [];
+    driver.__spies.query.mockImplementation(async function* (req: PreparedExecuteRequest) {
+      const params = req.params;
+      if (params === undefined) throw new Error('expected params');
       captured.push(params);
       yield { id: params[0] };
     });
@@ -323,11 +329,11 @@ describe('runtime.prepare', () => {
     expect(captured).toEqual([42]);
     // The replacement reaches the driver — encode runs after mutation.
     const lastCall = driver.__spies.query.mock.calls.at(-1);
-    const req = lastCall?.[0] as SqlExecuteRequest;
+    const req = lastCall?.[0] as PreparedExecuteRequest;
     expect(req.params).toEqual([999]);
   });
 
-  it('sends ad-hoc reads through query without a prepared handle', async () => {
+  it('does not supply a prepared handle when ad-hoc .execute(plan) is used (regression)', async () => {
     const { runtime, driver } = createSetup({ rows: [{ id: 1 }] });
     const ref = ParamRef.of(7, { codec: { codecId: 'pg/int4@1' } });
     const users = TableSource.named('users');
@@ -345,6 +351,9 @@ describe('runtime.prepare', () => {
     });
     await runtime.execute(plan).toArray();
     expect(driver.__spies.query).toHaveBeenCalledTimes(1);
-    expect(driver.__spies.query.mock.calls[0]?.[0]?.preparedStatementHandle).toBeUndefined();
+    expect(driver.__spies.query).toHaveBeenCalledWith(
+      expect.not.objectContaining({ preparedStatementHandle: expect.anything() }),
+    );
+    expect(driver.__spies.execute).not.toHaveBeenCalled();
   });
 });

--- a/packages/2-sql/5-runtime/test/raw-connection-seam.test.ts
+++ b/packages/2-sql/5-runtime/test/raw-connection-seam.test.ts
@@ -73,7 +73,6 @@ function createStubAdapter() {
 
 interface RecordingConnection {
   readonly execute: ReturnType<typeof vi.fn>;
-  readonly executePrepared: ReturnType<typeof vi.fn>;
   readonly query: ReturnType<typeof vi.fn>;
   readonly release: ReturnType<typeof vi.fn>;
   readonly destroy: ReturnType<typeof vi.fn>;
@@ -91,13 +90,10 @@ function createRecordingDriver(): {
     get queryCalls() {
       return queryCalls;
     },
-    execute: vi.fn().mockImplementation(async function* (_req: SqlExecuteRequest) {
+    execute: vi.fn().mockResolvedValue({ affectedRows: 0 }),
+    query: vi.fn().mockImplementation(async function* (request: SqlExecuteRequest) {
+      queryCalls.push({ sql: request.sql, params: request.params });
       yield { id: 42 };
-    }),
-    executePrepared: vi.fn().mockImplementation(async function* () {}),
-    query: vi.fn().mockImplementation(async (sql: string, params?: readonly unknown[]) => {
-      queryCalls.push({ sql, params });
-      return { rows: [], rowCount: 0 };
     }),
     release: vi.fn().mockResolvedValue(undefined),
     destroy: vi.fn().mockResolvedValue(undefined),
@@ -107,9 +103,8 @@ function createRecordingDriver(): {
   const acquireConnectionSpy = vi.fn().mockResolvedValue(connection);
 
   const driver: SqlDriver = {
-    execute: vi.fn().mockImplementation(async function* () {}),
-    executePrepared: vi.fn().mockImplementation(async function* () {}),
-    query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+    execute: vi.fn().mockResolvedValue({ affectedRows: 0 }),
+    query: vi.fn().mockImplementation(async function* () {}),
     connect: vi.fn().mockResolvedValue(undefined),
     acquireConnection: () => acquireConnectionSpy(),
     close: vi.fn().mockResolvedValue(undefined),
@@ -247,7 +242,8 @@ describe('acquireRawConnection', () => {
     const { runtime, connection } = createTestSetup({ middleware: [observer] });
     const raw = await runtime.acquireRawConn();
 
-    await raw.query('SET LOCAL role = $1', ['viewer']);
+    for await (const _row of raw.query({ sql: 'SET LOCAL role = $1', params: ['viewer'] })) {
+    }
 
     expect(connection.queryCalls).toEqual([{ sql: 'SET LOCAL role = $1', params: ['viewer'] }]);
     expect(observedSqls).toHaveLength(0);
@@ -272,7 +268,7 @@ describe('executeAgainstQueryable', () => {
     await runtime.runAgainstQueryable(plan, raw).toArray();
 
     expect(observedSqls).toEqual(['select id from users']);
-    expect(connection.execute).toHaveBeenCalledOnce();
+    expect(connection.query).toHaveBeenCalledOnce();
   });
 
   it('sticks to the connection supplied — not the driver root', async () => {
@@ -281,7 +277,7 @@ describe('executeAgainstQueryable', () => {
 
     await runtime.runAgainstQueryable(rawPlan(), raw).toArray();
 
-    expect(connection.execute).toHaveBeenCalledOnce();
-    expect(driver.execute).not.toHaveBeenCalled();
+    expect(connection.query).toHaveBeenCalledOnce();
+    expect(driver.query).not.toHaveBeenCalled();
   });
 });

--- a/packages/2-sql/5-runtime/test/raw-connection-seam.test.ts
+++ b/packages/2-sql/5-runtime/test/raw-connection-seam.test.ts
@@ -242,7 +242,8 @@ describe('acquireRawConnection', () => {
     const { runtime, connection } = createTestSetup({ middleware: [observer] });
     const raw = await runtime.acquireRawConn();
 
-    for await (const _row of raw.query({ sql: 'SET LOCAL role = $1', params: ['viewer'] })) {
+    for await (const row of raw.query({ sql: 'SET LOCAL role = $1', params: ['viewer'] })) {
+      void row;
     }
 
     expect(connection.queryCalls).toEqual([{ sql: 'SET LOCAL role = $1', params: ['viewer'] }]);

--- a/packages/2-sql/5-runtime/test/runtime-ctx-passthrough.test.ts
+++ b/packages/2-sql/5-runtime/test/runtime-ctx-passthrough.test.ts
@@ -77,13 +77,10 @@ function createStubAdapter() {
 
 function createDriver(): SqlDriver {
   return {
-    execute: vi.fn().mockImplementation(async function* (_request: SqlExecuteRequest) {
+    execute: vi.fn().mockResolvedValue({ affectedRows: 0 }),
+    query: vi.fn().mockImplementation(async function* (_request: SqlExecuteRequest) {
       yield {} as Record<string, unknown>;
     }),
-    executePrepared: vi.fn().mockImplementation(async function* () {
-      yield {} as Record<string, unknown>;
-    }),
-    query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
     connect: vi.fn().mockImplementation(async (_binding?: undefined) => undefined),
     acquireConnection: vi.fn().mockRejectedValue(new Error('not used')),
     close: vi.fn().mockResolvedValue(undefined),

--- a/packages/2-sql/5-runtime/test/scope-plumbing.test.ts
+++ b/packages/2-sql/5-runtime/test/scope-plumbing.test.ts
@@ -90,36 +90,27 @@ function createStubAdapter() {
 
 function createMockDriver(): SqlDriver {
   const transaction = {
-    execute: vi.fn().mockImplementation(async function* (_request: SqlExecuteRequest) {
+    execute: vi.fn().mockResolvedValue({ affectedRows: 0 }),
+    query: vi.fn().mockImplementation(async function* (_request: SqlExecuteRequest) {
       yield { id: 3 } as Record<string, unknown>;
     }),
-    executePrepared: vi.fn().mockImplementation(async function* () {
-      yield { id: 3 } as Record<string, unknown>;
-    }),
-    query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
     commit: vi.fn().mockResolvedValue(undefined),
     rollback: vi.fn().mockResolvedValue(undefined),
   };
   const connection = {
-    execute: vi.fn().mockImplementation(async function* (_request: SqlExecuteRequest) {
+    execute: vi.fn().mockResolvedValue({ affectedRows: 0 }),
+    query: vi.fn().mockImplementation(async function* (_request: SqlExecuteRequest) {
       yield { id: 2 } as Record<string, unknown>;
     }),
-    executePrepared: vi.fn().mockImplementation(async function* () {
-      yield { id: 2 } as Record<string, unknown>;
-    }),
-    query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
     release: vi.fn().mockResolvedValue(undefined),
     destroy: vi.fn().mockResolvedValue(undefined),
     beginTransaction: vi.fn().mockResolvedValue(transaction),
   };
   return {
-    execute: vi.fn().mockImplementation(async function* (_request: SqlExecuteRequest) {
+    execute: vi.fn().mockResolvedValue({ affectedRows: 0 }),
+    query: vi.fn().mockImplementation(async function* (_request: SqlExecuteRequest) {
       yield { id: 1 } as Record<string, unknown>;
     }),
-    executePrepared: vi.fn().mockImplementation(async function* () {
-      yield { id: 1 } as Record<string, unknown>;
-    }),
-    query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
     connect: vi.fn().mockImplementation(async (_binding?: undefined) => undefined),
     acquireConnection: vi.fn().mockResolvedValue(connection),
     close: vi.fn().mockResolvedValue(undefined),

--- a/packages/2-sql/5-runtime/test/sql-family-adapter.test.ts
+++ b/packages/2-sql/5-runtime/test/sql-family-adapter.test.ts
@@ -46,13 +46,8 @@ describe('SqlFamilyAdapter', () => {
   it('delegates readMarker to adapter profile', async () => {
     const adapter = new SqlFamilyAdapter(testContract, testProfile);
     const fakeQueryable = {
-      execute: () => {
-        throw new Error('not used');
-      },
-      executePrepared: () => {
-        throw new Error('not used');
-      },
-      query: async () => ({ rows: [] }),
+      execute: async () => ({ affectedRows: 0 }),
+      async *query() {},
     };
     const result = await adapter.markerReader.readMarker(fakeQueryable);
 

--- a/packages/2-sql/5-runtime/test/sql-runtime-abort.test.ts
+++ b/packages/2-sql/5-runtime/test/sql-runtime-abort.test.ts
@@ -78,7 +78,7 @@ function createControlledDriver(options?: DriverOptions): SqlDriver & {
   const rows = options?.rows ?? [{ id: 1 }];
   const rowGate = options?.rowGate;
 
-  const execute = vi.fn().mockImplementation(async function* (_request: SqlExecuteRequest) {
+  const query = vi.fn().mockImplementation(async function* (_request: SqlExecuteRequest) {
     for (const row of rows) {
       if (rowGate) await rowGate();
       yield row;
@@ -86,14 +86,12 @@ function createControlledDriver(options?: DriverOptions): SqlDriver & {
   });
 
   const driver: SqlDriver = {
-    execute,
-    executePrepared: execute,
-    query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+    execute: vi.fn().mockResolvedValue({ affectedRows: 0 }),
+    query,
     connect: vi.fn().mockResolvedValue(undefined),
     acquireConnection: vi.fn().mockResolvedValue({
-      execute,
-      executePrepared: execute,
-      query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+      execute: vi.fn().mockResolvedValue({ affectedRows: 0 }),
+      query,
       release: vi.fn().mockResolvedValue(undefined),
       destroy: vi.fn().mockResolvedValue(undefined),
       beginTransaction: vi.fn(),
@@ -101,7 +99,7 @@ function createControlledDriver(options?: DriverOptions): SqlDriver & {
     close: vi.fn().mockResolvedValue(undefined),
   };
 
-  return Object.assign(driver, { __executeMock: execute });
+  return Object.assign(driver, { __executeMock: query });
 }
 
 function createStubAdapter(extraCodecs: readonly Codec<string>[] = []) {

--- a/packages/2-sql/5-runtime/test/sql-runtime.test.ts
+++ b/packages/2-sql/5-runtime/test/sql-runtime.test.ts
@@ -118,20 +118,16 @@ function createMockDriver(): MockSqlDriver {
     yield { id: 3 };
   });
 
-  const query = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 });
-
   const transaction = {
-    execute: transactionExecute,
-    executePrepared: transactionExecute,
-    query,
+    execute: vi.fn().mockResolvedValue({ affectedRows: 0 }),
+    query: transactionExecute,
     commit: vi.fn().mockResolvedValue(undefined),
     rollback: vi.fn().mockResolvedValue(undefined),
   };
 
   const connection = {
-    execute: connectionExecute,
-    executePrepared: connectionExecute,
-    query,
+    execute: vi.fn().mockResolvedValue({ affectedRows: 0 }),
+    query: connectionExecute,
     release: vi.fn().mockResolvedValue(undefined),
     destroy: vi.fn().mockResolvedValue(undefined),
     beginTransaction: vi.fn().mockResolvedValue(transaction),
@@ -140,9 +136,8 @@ function createMockDriver(): MockSqlDriver {
   const driverClose = vi.fn().mockResolvedValue(undefined);
 
   const driver: SqlDriver = {
-    execute: rootExecute,
-    executePrepared: rootExecute,
-    query,
+    execute: vi.fn().mockResolvedValue({ affectedRows: 0 }),
+    query: rootExecute,
     connect: vi.fn().mockImplementation(async (_binding?: undefined) => undefined),
     acquireConnection: vi.fn().mockResolvedValue(connection),
     close: driverClose,

--- a/packages/3-extensions/supabase/src/runtime/supabase-runtime.ts
+++ b/packages/3-extensions/supabase/src/runtime/supabase-runtime.ts
@@ -38,11 +38,16 @@ export class SupabaseRuntimeImpl<
     const conn = await this.acquireRawConnection();
 
     try {
-      await conn.query('SELECT set_config($1, $2, false)', ['role', binding.role]);
-      await conn.query('SELECT set_config($1, $2, false)', [
-        'request.jwt.claims',
-        JSON.stringify(binding.claims ?? {}),
-      ]);
+      for await (const _row of conn.query({
+        sql: 'SELECT set_config($1, $2, false)',
+        params: ['role', binding.role],
+      })) {
+      }
+      for await (const _row of conn.query({
+        sql: 'SELECT set_config($1, $2, false)',
+        params: ['request.jwt.claims', JSON.stringify(binding.claims ?? {})],
+      })) {
+      }
     } catch (err) {
       await conn.destroy(err).catch(() => undefined);
       throw err;
@@ -122,7 +127,8 @@ export class SupabaseRuntimeImpl<
        */
       async release(): Promise<void> {
         try {
-          await conn.query('RESET ALL');
+          for await (const _row of conn.query({ sql: 'RESET ALL' })) {
+          }
           await conn.release();
         } catch (resetError) {
           await conn.destroy(resetError).catch(() => undefined);

--- a/packages/3-extensions/supabase/src/runtime/supabase-runtime.ts
+++ b/packages/3-extensions/supabase/src/runtime/supabase-runtime.ts
@@ -32,16 +32,14 @@ export class SupabaseRuntimeImpl<
     const conn = await this.acquireRawConnection();
 
     try {
-      for await (const _row of conn.query({
+      await conn.execute({
         sql: 'SELECT set_config($1, $2, false)',
         params: ['role', binding.role],
-      })) {
-      }
-      for await (const _row of conn.query({
+      });
+      await conn.execute({
         sql: 'SELECT set_config($1, $2, false)',
         params: ['request.jwt.claims', JSON.stringify(binding.claims ?? {})],
-      })) {
-      }
+      });
     } catch (err) {
       await conn.destroy(err).catch(() => undefined);
       throw err;
@@ -71,8 +69,7 @@ export class SupabaseRuntimeImpl<
        */
       async release(): Promise<void> {
         try {
-          for await (const _row of conn.query({ sql: 'RESET ALL' })) {
-          }
+          await conn.execute({ sql: 'RESET ALL' });
           await conn.release();
         } catch (resetError) {
           await conn.destroy(resetError).catch(() => undefined);

--- a/packages/3-extensions/supabase/src/runtime/supabase-runtime.ts
+++ b/packages/3-extensions/supabase/src/runtime/supabase-runtime.ts
@@ -4,13 +4,7 @@ import { AsyncIterableResult } from '@internal/framework-components/runtime';
 import { type PostgresRuntime, PostgresRuntimeImpl } from '@internal/postgres/runtime';
 import type { SqlStorage } from '@internal/sql-contract/types';
 import type { SqlExecutionPlan, SqlQueryPlan } from '@internal/sql-relational-core/plan';
-import type {
-  PreparedStatement,
-  PreparedStatementImpl,
-  RuntimeConnection,
-  RuntimeTransaction,
-} from '@internal/sql-runtime';
-import { blindCast } from '@internal/utils/casts';
+import type { RuntimeConnection, RuntimeTransaction } from '@internal/sql-runtime';
 import type { SupabaseRole } from '../contract/roles';
 
 export interface SupabaseRuntime extends PostgresRuntime {}
@@ -56,31 +50,7 @@ export class SupabaseRuntimeImpl<
     const self = this;
 
     const session: RoleSession = {
-      execute<Row>(
-        plan: (SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row },
-        options?: RuntimeExecuteOptions,
-      ): AsyncIterableResult<Row> {
-        return self.executeAgainstQueryable<Row>(plan, conn, { ...options, scope: 'connection' });
-      },
-
-      executePrepared<Params, Row>(
-        ps: PreparedStatement<Params, Row>,
-        params: Params,
-        options?: RuntimeExecuteOptions,
-      ): AsyncIterableResult<Row> {
-        return self.executePreparedAgainstQueryable(
-          blindCast<
-            PreparedStatementImpl<Params, Row>,
-            'PreparedStatement is PreparedStatementImpl; the impl class is the only concrete form'
-          >(ps),
-          blindCast<
-            Record<string, unknown>,
-            'params are structurally Record<string, unknown> at runtime'
-          >(params),
-          conn,
-          { ...options, scope: 'connection' },
-        );
-      },
+      execute: self.createScopedExecutor(conn, 'connection'),
 
       async transaction(): Promise<RuntimeTransaction> {
         const tx = await conn.beginTransaction();
@@ -91,33 +61,7 @@ export class SupabaseRuntimeImpl<
           async rollback(): Promise<void> {
             await tx.rollback();
           },
-          execute<Row>(
-            plan: (SqlExecutionPlan<unknown> | SqlQueryPlan<unknown>) & { readonly _row?: Row },
-            options?: RuntimeExecuteOptions,
-          ): AsyncIterableResult<Row> {
-            return self.executeAgainstQueryable<Row>(plan, tx, {
-              ...options,
-              scope: 'transaction',
-            });
-          },
-          executePrepared<Params, Row>(
-            ps: PreparedStatement<Params, Row>,
-            params: Params,
-            options?: RuntimeExecuteOptions,
-          ): AsyncIterableResult<Row> {
-            return self.executePreparedAgainstQueryable(
-              blindCast<
-                PreparedStatementImpl<Params, Row>,
-                'PreparedStatement is PreparedStatementImpl; the impl class is the only concrete form'
-              >(ps),
-              blindCast<
-                Record<string, unknown>,
-                'params are structurally Record<string, unknown> at runtime'
-              >(params),
-              tx,
-              { ...options, scope: 'transaction' },
-            );
-          },
+          execute: self.createScopedExecutor(tx, 'transaction'),
         };
       },
 

--- a/packages/3-extensions/supabase/test/supabase-runtime.test.ts
+++ b/packages/3-extensions/supabase/test/supabase-runtime.test.ts
@@ -48,7 +48,6 @@ interface RecordingTransaction {
   readonly id: symbol;
   readonly queryCalls: Array<{ sql: string; params: readonly unknown[] | undefined }>;
   execute: ReturnType<typeof vi.fn>;
-  executePrepared: ReturnType<typeof vi.fn>;
   query: ReturnType<typeof vi.fn>;
   commit: ReturnType<typeof vi.fn>;
   rollback: ReturnType<typeof vi.fn>;
@@ -59,7 +58,6 @@ interface RecordingConnection {
   readonly queryCalls: Array<{ sql: string; params: readonly unknown[] | undefined }>;
   readonly beginTransactionSpy: ReturnType<typeof vi.fn>;
   execute: ReturnType<typeof vi.fn>;
-  executePrepared: ReturnType<typeof vi.fn>;
   query: ReturnType<typeof vi.fn>;
   release: ReturnType<typeof vi.fn>;
   destroy: ReturnType<typeof vi.fn>;
@@ -70,7 +68,6 @@ interface RecordingConnection {
 interface RecordingDriver {
   readonly acquireConnectionSpy: ReturnType<typeof vi.fn>;
   execute: ReturnType<typeof vi.fn>;
-  executePrepared: ReturnType<typeof vi.fn>;
   query: ReturnType<typeof vi.fn>;
   connect: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
@@ -91,13 +88,10 @@ function createRecordingDriver(
     get queryCalls() {
       return txQueryCalls;
     },
-    execute: vi.fn().mockImplementation(async function* (_req: SqlExecuteRequest) {
+    execute: vi.fn().mockResolvedValue({ affectedRows: 0 }),
+    query: vi.fn().mockImplementation(async function* (request: SqlExecuteRequest) {
+      txQueryCalls.push({ sql: request.sql, params: request.params });
       for (const row of executeRows) yield row;
-    }),
-    executePrepared: vi.fn().mockImplementation(async function* () {}),
-    query: vi.fn().mockImplementation(async (sql: string, params?: readonly unknown[]) => {
-      txQueryCalls.push({ sql, params });
-      return { rows: [], rowCount: 0 };
     }),
     commit: vi.fn().mockResolvedValue(undefined),
     rollback: vi.fn().mockResolvedValue(undefined),
@@ -113,13 +107,10 @@ function createRecordingDriver(
     get transaction() {
       return transaction;
     },
-    execute: vi.fn().mockImplementation(async function* (_req: SqlExecuteRequest) {
+    execute: vi.fn().mockResolvedValue({ affectedRows: 0 }),
+    query: vi.fn().mockImplementation(async function* (request: SqlExecuteRequest) {
+      connQueryCalls.push({ sql: request.sql, params: request.params });
       for (const row of executeRows) yield row;
-    }),
-    executePrepared: vi.fn().mockImplementation(async function* () {}),
-    query: vi.fn().mockImplementation(async (sql: string, params?: readonly unknown[]) => {
-      connQueryCalls.push({ sql, params });
-      return { rows: [], rowCount: 0 };
     }),
     release: vi.fn().mockResolvedValue(undefined),
     destroy: vi.fn().mockResolvedValue(undefined),
@@ -132,9 +123,8 @@ function createRecordingDriver(
     get connection() {
       return connection;
     },
-    execute: vi.fn().mockImplementation(async function* () {}),
-    executePrepared: vi.fn().mockImplementation(async function* () {}),
-    query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+    execute: vi.fn().mockResolvedValue({ affectedRows: 0 }),
+    query: vi.fn().mockImplementation(async function* () {}),
     connect: vi.fn().mockResolvedValue(undefined),
     close: vi.fn().mockResolvedValue(undefined),
     acquireConnection: () => acquireConnectionSpy(),
@@ -285,19 +275,17 @@ describe('SupabaseRuntimeImpl', () => {
       const queriedOnConn: symbol[] = [];
       const executedOnConn: symbol[] = [];
 
-      driver.connection.query = vi
-        .fn()
-        .mockImplementation(async (sql: string, params?: readonly unknown[]) => {
-          if (sql.startsWith('SELECT set_config')) {
-            queriedOnConn.push(driver.connection.id);
-          }
-          driver.connection.queryCalls.push({ sql, params });
-          return { rows: [], rowCount: 0 };
-        });
-
-      driver.connection.execute = vi.fn().mockImplementation(async function* () {
-        executedOnConn.push(driver.connection.id);
-        yield { id: 1 };
+      driver.connection.query = vi.fn().mockImplementation(async function* (
+        request: SqlExecuteRequest,
+      ) {
+        if (request.sql.startsWith('SELECT set_config')) {
+          queriedOnConn.push(driver.connection.id);
+        }
+        driver.connection.queryCalls.push({ sql: request.sql, params: request.params });
+        if (request.sql !== 'RESET ALL' && !request.sql.startsWith('SELECT set_config')) {
+          executedOnConn.push(driver.connection.id);
+          yield { id: 1 };
+        }
       });
 
       const session = await runtime.openRoleSession({ role: 'anon' });
@@ -389,15 +377,15 @@ describe('SupabaseRuntimeImpl', () => {
       const { runtime, driver } = createTestSetup();
       const resetCalls: string[] = [];
 
-      driver.connection.query = vi
-        .fn()
-        .mockImplementation(async (sql: string, params?: readonly unknown[]) => {
-          driver.connection.queryCalls.push({ sql, params });
-          if (sql === 'RESET ALL') {
-            resetCalls.push(sql);
-          }
-          return { rows: [], rowCount: 0 };
-        });
+      driver.connection.query = vi.fn().mockImplementation(async function* (
+        request: SqlExecuteRequest,
+      ) {
+        driver.connection.queryCalls.push({ sql: request.sql, params: request.params });
+        if (request.sql === 'RESET ALL') {
+          resetCalls.push(request.sql);
+        }
+        yield* [];
+      });
 
       const session = await runtime.openRoleSession({ role: 'anon' });
       await session.release();
@@ -411,15 +399,15 @@ describe('SupabaseRuntimeImpl', () => {
       const { runtime, driver } = createTestSetup();
       const resetError = new Error('RESET ALL failed');
 
-      driver.connection.query = vi
-        .fn()
-        .mockImplementation(async (sql: string, params?: readonly unknown[]) => {
-          driver.connection.queryCalls.push({ sql, params });
-          if (sql === 'RESET ALL') {
-            throw resetError;
-          }
-          return { rows: [], rowCount: 0 };
-        });
+      driver.connection.query = vi.fn().mockImplementation(async function* (
+        request: SqlExecuteRequest,
+      ) {
+        driver.connection.queryCalls.push({ sql: request.sql, params: request.params });
+        if (request.sql === 'RESET ALL') {
+          throw resetError;
+        }
+        yield* [];
+      });
 
       const session = await runtime.openRoleSession({ role: 'anon' });
       await session.release();
@@ -435,12 +423,12 @@ describe('SupabaseRuntimeImpl', () => {
       const bindError = new Error('set_config denied');
       let callCount = 0;
 
-      driver.connection.query = vi.fn().mockImplementation(async () => {
+      driver.connection.query = vi.fn().mockImplementation(async function* () {
         callCount++;
         if (callCount === 1) {
           throw bindError;
         }
-        return { rows: [], rowCount: 0 };
+        yield* [];
       });
 
       await expect(runtime.openRoleSession({ role: 'anon' })).rejects.toBe(bindError);
@@ -466,7 +454,7 @@ describe('SupabaseRuntimeImpl', () => {
       const { runtime, driver } = createTestSetup();
       const streamError = new Error('mid-stream failure');
 
-      driver.connection.execute = vi.fn().mockReturnValue({
+      driver.connection.query = vi.fn().mockReturnValue({
         [Symbol.asyncIterator]() {
           return {
             next(): Promise<IteratorResult<unknown>> {

--- a/packages/3-extensions/supabase/test/supabase-runtime.test.ts
+++ b/packages/3-extensions/supabase/test/supabase-runtime.test.ts
@@ -55,6 +55,7 @@ interface RecordingTransaction {
 
 interface RecordingConnection {
   readonly id: symbol;
+  readonly executeCalls: Array<{ sql: string; params: readonly unknown[] | undefined }>;
   readonly queryCalls: Array<{ sql: string; params: readonly unknown[] | undefined }>;
   readonly beginTransactionSpy: ReturnType<typeof vi.fn>;
   execute: ReturnType<typeof vi.fn>;
@@ -81,6 +82,7 @@ function createRecordingDriver(
   const txId = Symbol('transaction');
   const connId = Symbol('connection');
   const txQueryCalls: Array<{ sql: string; params: readonly unknown[] | undefined }> = [];
+  const connExecuteCalls: Array<{ sql: string; params: readonly unknown[] | undefined }> = [];
   const connQueryCalls: Array<{ sql: string; params: readonly unknown[] | undefined }> = [];
 
   const transaction: RecordingTransaction = {
@@ -100,6 +102,9 @@ function createRecordingDriver(
   const beginTransactionSpy = vi.fn().mockResolvedValue(transaction);
   const connection: RecordingConnection = {
     id: connId,
+    get executeCalls() {
+      return connExecuteCalls;
+    },
     get queryCalls() {
       return connQueryCalls;
     },
@@ -107,7 +112,10 @@ function createRecordingDriver(
     get transaction() {
       return transaction;
     },
-    execute: vi.fn().mockResolvedValue({ affectedRows: 0 }),
+    execute: vi.fn().mockImplementation(async (request: SqlExecuteRequest) => {
+      connExecuteCalls.push({ sql: request.sql, params: request.params });
+      return { affectedRows: 0 };
+    }),
     query: vi.fn().mockImplementation(async function* (request: SqlExecuteRequest) {
       connQueryCalls.push({ sql: request.sql, params: request.params });
       for (const row of executeRows) yield row;
@@ -258,7 +266,7 @@ describe('SupabaseRuntimeImpl', () => {
       await session.execute(stubPlan()).toArray();
       await session.release();
 
-      const setConfigCalls = driver.connection.queryCalls.filter((c) =>
+      const setConfigCalls = driver.connection.executeCalls.filter((c) =>
         c.sql.startsWith('SELECT set_config'),
       );
       expect(setConfigCalls).toEqual([
@@ -272,29 +280,29 @@ describe('SupabaseRuntimeImpl', () => {
 
     it('set_config and the typed execute land on the same connection', async () => {
       const { runtime, driver } = createTestSetup();
+      const sessionControlOnConn: symbol[] = [];
       const queriedOnConn: symbol[] = [];
-      const executedOnConn: symbol[] = [];
 
+      driver.connection.execute = vi.fn().mockImplementation(async (request: SqlExecuteRequest) => {
+        sessionControlOnConn.push(driver.connection.id);
+        driver.connection.executeCalls.push({ sql: request.sql, params: request.params });
+        return { affectedRows: 0 };
+      });
       driver.connection.query = vi.fn().mockImplementation(async function* (
         request: SqlExecuteRequest,
       ) {
-        if (request.sql.startsWith('SELECT set_config')) {
-          queriedOnConn.push(driver.connection.id);
-        }
+        queriedOnConn.push(driver.connection.id);
         driver.connection.queryCalls.push({ sql: request.sql, params: request.params });
-        if (request.sql !== 'RESET ALL' && !request.sql.startsWith('SELECT set_config')) {
-          executedOnConn.push(driver.connection.id);
-          yield { id: 1 };
-        }
+        yield { id: 1 };
       });
 
       const session = await runtime.openRoleSession({ role: 'anon' });
       await session.execute(stubPlan()).toArray();
       await session.release();
 
-      expect(queriedOnConn).toHaveLength(2);
-      expect(executedOnConn).toHaveLength(1);
-      expect(queriedOnConn[0]).toBe(executedOnConn[0]);
+      expect(sessionControlOnConn).toHaveLength(3);
+      expect(queriedOnConn).toHaveLength(1);
+      expect(sessionControlOnConn[0]).toBe(queriedOnConn[0]);
     });
 
     it('claims default to {} when not provided', async () => {
@@ -304,7 +312,7 @@ describe('SupabaseRuntimeImpl', () => {
       await session.execute(stubPlan()).toArray();
       await session.release();
 
-      const claimsCall = driver.connection.queryCalls.find(
+      const claimsCall = driver.connection.executeCalls.find(
         (c) => (c.params as string[])?.[0] === 'request.jwt.claims',
       );
       expect(claimsCall?.params).toEqual(['request.jwt.claims', '{}']);
@@ -317,7 +325,7 @@ describe('SupabaseRuntimeImpl', () => {
       await session.execute(stubPlan()).toArray();
       await session.release();
 
-      const claimsCall = driver.connection.queryCalls.find(
+      const claimsCall = driver.connection.executeCalls.find(
         (c) => (c.params as string[])?.[0] === 'request.jwt.claims',
       );
       expect(claimsCall?.params).toEqual(['request.jwt.claims', '{}']);
@@ -377,14 +385,12 @@ describe('SupabaseRuntimeImpl', () => {
       const { runtime, driver } = createTestSetup();
       const resetCalls: string[] = [];
 
-      driver.connection.query = vi.fn().mockImplementation(async function* (
-        request: SqlExecuteRequest,
-      ) {
-        driver.connection.queryCalls.push({ sql: request.sql, params: request.params });
+      driver.connection.execute = vi.fn().mockImplementation(async (request: SqlExecuteRequest) => {
+        driver.connection.executeCalls.push({ sql: request.sql, params: request.params });
         if (request.sql === 'RESET ALL') {
           resetCalls.push(request.sql);
         }
-        yield* [];
+        return { affectedRows: 0 };
       });
 
       const session = await runtime.openRoleSession({ role: 'anon' });
@@ -399,14 +405,12 @@ describe('SupabaseRuntimeImpl', () => {
       const { runtime, driver } = createTestSetup();
       const resetError = new Error('RESET ALL failed');
 
-      driver.connection.query = vi.fn().mockImplementation(async function* (
-        request: SqlExecuteRequest,
-      ) {
-        driver.connection.queryCalls.push({ sql: request.sql, params: request.params });
+      driver.connection.execute = vi.fn().mockImplementation(async (request: SqlExecuteRequest) => {
+        driver.connection.executeCalls.push({ sql: request.sql, params: request.params });
         if (request.sql === 'RESET ALL') {
           throw resetError;
         }
-        yield* [];
+        return { affectedRows: 0 };
       });
 
       const session = await runtime.openRoleSession({ role: 'anon' });
@@ -423,12 +427,12 @@ describe('SupabaseRuntimeImpl', () => {
       const bindError = new Error('set_config denied');
       let callCount = 0;
 
-      driver.connection.query = vi.fn().mockImplementation(async function* () {
+      driver.connection.execute = vi.fn().mockImplementation(async () => {
         callCount++;
         if (callCount === 1) {
           throw bindError;
         }
-        yield* [];
+        return { affectedRows: 0 };
       });
 
       await expect(runtime.openRoleSession({ role: 'anon' })).rejects.toBe(bindError);
@@ -444,7 +448,7 @@ describe('SupabaseRuntimeImpl', () => {
       await runtime.executeWithRole(stubPlan(), { role: 'anon' }).toArray();
 
       // RESET ALL sent, then release called
-      const resetCall = driver.connection.queryCalls.find((c) => c.sql === 'RESET ALL');
+      const resetCall = driver.connection.executeCalls.find((c) => c.sql === 'RESET ALL');
       expect(resetCall).toBeDefined();
       expect(driver.connection.release).toHaveBeenCalledOnce();
       expect(driver.connection.destroy).not.toHaveBeenCalled();

--- a/packages/3-targets/6-adapters/postgres/src/core/adapter.ts
+++ b/packages/3-targets/6-adapters/postgres/src/core/adapter.ts
@@ -65,8 +65,14 @@ class PostgresAdapterImpl
               sql: string,
               params?: readonly unknown[],
             ) => {
-              const result = await queryable.query<Row>(sql, params);
-              return { rows: [...result.rows] };
+              const rows: Row[] = [];
+              for await (const row of queryable.query<Row>({
+                sql,
+                ...(params === undefined ? {} : { params }),
+              })) {
+                rows.push(row);
+              }
+              return { rows };
             },
             close: async () => {},
           },

--- a/packages/3-targets/6-adapters/postgres/test/adapter.test.ts
+++ b/packages/3-targets/6-adapters/postgres/test/adapter.test.ts
@@ -31,7 +31,6 @@ import {
   ProjectionItem,
   SelectAst,
   type SqlQueryable,
-  type SqlQueryResult,
   SubqueryExpr,
   TableSource,
   UpdateAst,
@@ -511,15 +510,10 @@ describe('Postgres adapter', () => {
   it('readMarker returns no-table when the information_schema probe yields no rows', async () => {
     const calls: Array<{ sql: string; params: readonly unknown[] | undefined }> = [];
     const queryable: SqlQueryable = {
-      execute() {
-        throw new Error('not used in this test');
-      },
-      executePrepared() {
-        throw new Error('not used in this test');
-      },
-      async query<Row>(sql: string, params?: readonly unknown[]): Promise<SqlQueryResult<Row>> {
-        calls.push({ sql, params });
-        return { rows: [], rowCount: 0 } as SqlQueryResult<Row>;
+      execute: async () => ({ affectedRows: 0 }),
+      async *query<Row>(request: { sql: string; params?: readonly unknown[] }): AsyncIterable<Row> {
+        calls.push({ sql: request.sql, params: request.params });
+        yield* [];
       },
     };
 
@@ -534,17 +528,13 @@ describe('Postgres adapter', () => {
   it('readMarker returns absent when the table exists but holds no row for this space', async () => {
     let call = 0;
     const queryable: SqlQueryable = {
-      execute() {
-        throw new Error('not used in this test');
-      },
-      executePrepared() {
-        throw new Error('not used in this test');
-      },
-      async query<Row>(): Promise<SqlQueryResult<Row>> {
+      execute: async () => ({ affectedRows: 0 }),
+      async *query<Row>() {
         call += 1;
-        const result = call === 1 ? { rows: [{ '1': 1 }], rowCount: 1 } : { rows: [], rowCount: 0 };
-        // Cast through `unknown`: the mock returns concrete row shapes, but the generic `Row` parameter on `SqlQueryable.query` is the caller's choice. The two cannot be unified structurally; the caller (adapter `readMarker`) consumes the result with its own row decoders.
-        return result as unknown as SqlQueryResult<Row>;
+        const rows = call === 1 ? [{ '1': 1 }] : [];
+        for (const row of rows) {
+          yield row as Row;
+        }
       },
     };
 
@@ -680,18 +670,13 @@ describe('Postgres adapter', () => {
     };
     let call = 0;
     const queryable: SqlQueryable = {
-      execute() {
-        throw new Error('not used in this test');
-      },
-      executePrepared() {
-        throw new Error('not used in this test');
-      },
-      async query<Row>(): Promise<SqlQueryResult<Row>> {
+      execute: async () => ({ affectedRows: 0 }),
+      async *query<Row>() {
         call += 1;
-        const result =
-          call === 1 ? { rows: [{ '1': 1 }], rowCount: 1 } : { rows: [markerRow], rowCount: 1 };
-        // Cast through `unknown`: see note in the sibling readMarker test.
-        return result as unknown as SqlQueryResult<Row>;
+        const rows = call === 1 ? [{ '1': 1 }] : [markerRow];
+        for (const row of rows) {
+          yield row as Row;
+        }
       },
     };
 

--- a/packages/3-targets/6-adapters/sqlite/src/core/adapter.ts
+++ b/packages/3-targets/6-adapters/sqlite/src/core/adapter.ts
@@ -107,8 +107,14 @@ class SqliteAdapterImpl implements Adapter<AnyQueryAst, SqliteContract, SqliteLo
               sql: string,
               params?: readonly unknown[],
             ) => {
-              const result = await queryable.query<Row>(sql, params);
-              return { rows: [...result.rows] };
+              const rows: Row[] = [];
+              for await (const row of queryable.query<Row>({
+                sql,
+                ...(params === undefined ? {} : { params }),
+              })) {
+                rows.push(row);
+              }
+              return { rows };
             },
             close: async () => {},
           },

--- a/packages/3-targets/7-drivers/postgres/src/driver-error.ts
+++ b/packages/3-targets/7-drivers/postgres/src/driver-error.ts
@@ -1,0 +1,30 @@
+export interface DriverRuntimeError extends Error {
+  readonly code: 'DRIVER.NOT_CONNECTED' | 'DRIVER.ALREADY_CONNECTED' | 'DRIVER.PREPARE_FAILED';
+  readonly category: 'DRIVER';
+  readonly severity: 'error';
+  readonly details?: Record<string, unknown>;
+}
+
+export function driverError(
+  code: DriverRuntimeError['code'],
+  message: string,
+  details?: Record<string, unknown>,
+): DriverRuntimeError {
+  const error = new Error(message);
+  Object.defineProperty(error, 'name', {
+    value: 'RuntimeError',
+    configurable: true,
+  });
+  return details === undefined
+    ? Object.assign(error, {
+        code,
+        category: 'DRIVER' as const,
+        severity: 'error' as const,
+      })
+    : Object.assign(error, {
+        code,
+        category: 'DRIVER' as const,
+        severity: 'error' as const,
+        details,
+      });
+}

--- a/packages/3-targets/7-drivers/postgres/src/exports/runtime.ts
+++ b/packages/3-targets/7-drivers/postgres/src/exports/runtime.ts
@@ -11,6 +11,7 @@ import type {
   SqlQueryResult,
 } from '@internal/sql-relational-core/ast';
 import { postgresDriverDescriptorMeta } from '../core/descriptor-meta';
+import { driverError } from '../driver-error';
 import {
   createBoundDriverFromBinding,
   type PostgresBinding,
@@ -24,32 +25,6 @@ const USE_BEFORE_CONNECT_MESSAGE =
   'Postgres driver not connected. Call connect(binding) before acquireConnection or execute.';
 const ALREADY_CONNECTED_MESSAGE =
   'Postgres driver already connected. Call close() before reconnecting with a new binding.';
-
-interface DriverRuntimeError extends Error {
-  readonly code: 'DRIVER.NOT_CONNECTED' | 'DRIVER.ALREADY_CONNECTED';
-  readonly category: 'DRIVER';
-  readonly severity: 'error';
-  readonly details?: Record<string, unknown>;
-}
-
-function driverError(
-  code: DriverRuntimeError['code'],
-  message: string,
-  details?: Record<string, unknown>,
-): DriverRuntimeError {
-  const error = new Error(message) as DriverRuntimeError;
-  Object.defineProperty(error, 'name', {
-    value: 'RuntimeError',
-    configurable: true,
-  });
-  return Object.assign(error, {
-    code,
-    category: 'DRIVER' as const,
-    severity: 'error' as const,
-    message,
-    details,
-  });
-}
 
 function unboundExecute<Row>(): AsyncIterable<Row> {
   return {

--- a/packages/3-targets/7-drivers/postgres/src/exports/runtime.ts
+++ b/packages/3-targets/7-drivers/postgres/src/exports/runtime.ts
@@ -3,12 +3,11 @@ import type {
   RuntimeDriverInstance,
 } from '@internal/framework-components/execution';
 import type {
-  PreparedExecuteRequest,
   SqlConnection,
   SqlDriver,
   SqlExecuteRequest,
   SqlExplainResult,
-  SqlQueryResult,
+  SqlStatementStats,
 } from '@internal/sql-relational-core/ast';
 import { postgresDriverDescriptorMeta } from '../core/descriptor-meta';
 import { driverError } from '../driver-error';
@@ -26,7 +25,7 @@ const USE_BEFORE_CONNECT_MESSAGE =
 const ALREADY_CONNECTED_MESSAGE =
   'Postgres driver already connected. Call close() before reconnecting with a new binding.';
 
-function unboundExecute<Row>(): AsyncIterable<Row> {
+function unboundQuery<Row>(): AsyncIterable<Row> {
   return {
     [Symbol.asyncIterator]() {
       return {
@@ -105,9 +104,8 @@ class PostgresUnboundDriverImpl implements PostgresRuntimeDriver {
     };
     const wrapped: SqlConnection = {
       beginTransaction: connection.beginTransaction.bind(connection),
-      execute: connection.execute.bind(connection),
-      executePrepared: connection.executePrepared.bind(connection),
       query: connection.query.bind(connection),
+      execute: connection.execute.bind(connection),
       release: async () => {
         try {
           await connection.release();
@@ -138,22 +136,17 @@ class PostgresUnboundDriverImpl implements PostgresRuntimeDriver {
     this.#closed = true;
   }
 
-  execute<Row = Record<string, unknown>>(request: SqlExecuteRequest): AsyncIterable<Row> {
+  query<Row = Record<string, unknown>>(request: SqlExecuteRequest): AsyncIterable<Row> {
     const delegate = this.#delegate;
-    if (delegate === null) {
-      return unboundExecute<Row>();
-    }
-    return delegate.execute<Row>(request);
+    return delegate === null ? unboundQuery<Row>() : delegate.query<Row>(request);
   }
 
-  executePrepared<Row = Record<string, unknown>>(
-    request: PreparedExecuteRequest,
-  ): AsyncIterable<Row> {
+  async execute(request: SqlExecuteRequest): Promise<SqlStatementStats> {
     const delegate = this.#delegate;
     if (delegate === null) {
-      return unboundExecute<Row>();
+      throw driverError('DRIVER.NOT_CONNECTED', USE_BEFORE_CONNECT_MESSAGE);
     }
-    return delegate.executePrepared<Row>(request);
+    return delegate.execute(request);
   }
 
   async explain(request: SqlExecuteRequest): Promise<SqlExplainResult> {
@@ -163,14 +156,6 @@ class PostgresUnboundDriverImpl implements PostgresRuntimeDriver {
       throw driverError('DRIVER.NOT_CONNECTED', USE_BEFORE_CONNECT_MESSAGE);
     }
     return explain.call(delegate, request);
-  }
-
-  async query<Row = Record<string, unknown>>(
-    sql: string,
-    params?: readonly unknown[],
-  ): Promise<SqlQueryResult<Row>> {
-    const delegate = this.#requireDelegate();
-    return delegate.query<Row>(sql, params);
   }
 }
 

--- a/packages/3-targets/7-drivers/postgres/src/postgres-driver.ts
+++ b/packages/3-targets/7-drivers/postgres/src/postgres-driver.ts
@@ -169,8 +169,8 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
         yield* this.runQuery<Row>(request);
         return;
       }
-      const handle = this.preparedStatementName(preparedStatementHandle);
-      yield* this.withStaleHandleStreamRetry<Row>(preparedStatementHandle, handle, (name) =>
+      const name = this.preparedStatementName(preparedStatementHandle);
+      yield* this.withStaleHandleStreamRetry<Row>(preparedStatementHandle, name, (name) =>
         this.runQuery<Row>(request, name),
       );
     } catch (error) {
@@ -184,8 +184,8 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
       if (preparedStatementHandle === undefined || !this.options.preparedStatementsEnabled) {
         return await this.runExecute(request);
       }
-      const handle = this.preparedStatementName(preparedStatementHandle);
-      return await this.withStaleHandleRetry(preparedStatementHandle, handle, (name) =>
+      const name = this.preparedStatementName(preparedStatementHandle);
+      return await this.withStaleHandleRetry(preparedStatementHandle, name, (name) =>
         this.runExecute(request, name),
       );
     } catch (error) {
@@ -194,51 +194,47 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
   }
 
   private preparedStatementName(handle: PreparedStatementHandle): string {
-    const existingHandle = handle.get();
-    if (typeof existingHandle === 'string') {
-      return existingHandle;
+    const existingName = handle.get();
+    if (typeof existingName === 'string') {
+      return existingName;
     }
-    const mintedHandle = this.options.handleAllocator.mint();
-    handle.set(mintedHandle);
-    return mintedHandle;
+    const mintedName = this.options.handleAllocator.mint();
+    handle.set(mintedName);
+    return mintedName;
   }
 
   private async withStaleHandleRetry<Result>(
     preparedStatementHandle: PreparedStatementHandle,
-    handle: string,
-    attempt: (handle: string) => Promise<Result>,
+    name: string,
+    attempt: (name: string) => Promise<Result>,
   ): Promise<Result> {
     try {
-      return await attempt(handle);
+      return await attempt(name);
     } catch (error) {
       if (!isStalePreparedStatementError(error)) {
         throw error;
       }
       // pg's parsedStatements still records the old name; only a fresh name
       // forces pg to re-Parse on this Client.
-      const retryHandle = this.options.handleAllocator.mint();
-      preparedStatementHandle.set(retryHandle);
+      const retryName = this.options.handleAllocator.mint();
+      preparedStatementHandle.set(retryName);
       try {
-        return await attempt(retryHandle);
+        return await attempt(retryName);
       } catch (retryError) {
-        throw prepareFailedError(retryError, retryHandle);
+        throw prepareFailedError(retryError, retryName);
       }
     }
   }
 
   private async *withStaleHandleStreamRetry<Row>(
     preparedStatementHandle: PreparedStatementHandle,
-    handle: string,
-    attempt: (handle: string) => AsyncIterable<Row>,
+    name: string,
+    attempt: (name: string) => AsyncIterable<Row>,
   ): AsyncIterable<Row> {
-    const stream = await this.withStaleHandleRetry(
-      preparedStatementHandle,
-      handle,
-      async (name) => {
-        const iterator = attempt(name)[Symbol.asyncIterator]();
-        return { iterator, first: await iterator.next() };
-      },
-    );
+    const stream = await this.withStaleHandleRetry(preparedStatementHandle, name, async (name) => {
+      const iterator = attempt(name)[Symbol.asyncIterator]();
+      return { iterator, first: await iterator.next() };
+    });
 
     if (stream.first.done) {
       return;
@@ -270,7 +266,10 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
         const result = await client.query({
           name,
           text: request.sql,
-          values: [...(request.params ?? [])],
+          values: blindCast<
+            unknown[],
+            'pg query types require a mutable array but pg does not mutate execution params'
+          >(request.params ?? []),
         });
         return { affectedRows: result.rowCount ?? 0 };
       } finally {

--- a/packages/3-targets/7-drivers/postgres/src/postgres-driver.ts
+++ b/packages/3-targets/7-drivers/postgres/src/postgres-driver.ts
@@ -416,7 +416,10 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
     cursorBatchSize: number,
     name?: string,
   ): AsyncIterable<Record<string, unknown>> {
-    const values = [...(params ?? [])];
+    const values = blindCast<
+      unknown[],
+      'pg cursor types require a mutable array but pg does not mutate execution params'
+    >(params ?? []);
     const cursor = client.query(
       name === undefined ? new Cursor(sql, values) : new NamedCursor({ name, text: sql, values }),
     );

--- a/packages/3-targets/7-drivers/postgres/src/postgres-driver.ts
+++ b/packages/3-targets/7-drivers/postgres/src/postgres-driver.ts
@@ -9,6 +9,7 @@ import type {
   SqlStatementStats,
   SqlTransaction,
 } from '@internal/sql-relational-core/ast';
+import { blindCast } from '@internal/utils/casts';
 import type {
   Client,
   ClientBase,
@@ -104,10 +105,10 @@ function buildConnectionOptions(options: PostgresDriverOptions): ConnectionOptio
 }
 
 function isStalePreparedStatementError(error: unknown): boolean {
-  if (!(error instanceof Error)) {
+  if (!(error instanceof Error) || !('code' in error) || typeof error.code !== 'string') {
     return false;
   }
-  const code = (error as { code?: string }).code;
+  const code = error.code;
   // 26000 — invalid_sql_statement_name (server lost the named statement,
   //         e.g. after DEALLOCATE ALL).
   // 0A000 — cached plan invalidated by DDL (row shape changed).
@@ -169,7 +170,7 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
         return;
       }
       const handle = this.preparedStatementName(preparedStatementHandle);
-      yield* this.withStaleHandleRetry<Row>(preparedStatementHandle, handle, (name) =>
+      yield* this.withStaleHandleStreamRetry<Row>(preparedStatementHandle, handle, (name) =>
         this.runQuery<Row>(request, name),
       );
     } catch (error) {
@@ -178,22 +179,17 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
   }
 
   async execute(request: SqlExecuteRequest): Promise<SqlStatementStats> {
-    const client = await this.acquireClient();
     try {
-      const releaseLock = await acquireClientQueryLock(client);
-      try {
-        const result = await client.query({
-          text: request.sql,
-          values: [...(request.params ?? [])],
-        });
-        return { affectedRows: result.rowCount ?? 0 };
-      } finally {
-        releaseLock();
+      const preparedStatementHandle = request.preparedStatementHandle;
+      if (preparedStatementHandle === undefined || !this.options.preparedStatementsEnabled) {
+        return await this.runExecute(request);
       }
+      const handle = this.preparedStatementName(preparedStatementHandle);
+      return await this.withStaleHandleRetry(preparedStatementHandle, handle, (name) =>
+        this.runExecute(request, name),
+      );
     } catch (error) {
       throw normalizePgError(error);
-    } finally {
-      await this.releaseClient(client);
     }
   }
 
@@ -207,33 +203,81 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
     return mintedHandle;
   }
 
-  private async *withStaleHandleRetry<Row>(
+  private async withStaleHandleRetry<Result>(
     preparedStatementHandle: PreparedStatementHandle,
     handle: string,
-    attempt: (handle: string) => AsyncIterable<Row>,
-  ): AsyncIterable<Row> {
-    let yielded = false;
+    attempt: (handle: string) => Promise<Result>,
+  ): Promise<Result> {
     try {
-      for await (const row of attempt(handle)) {
-        yielded = true;
-        yield row;
-      }
-      return;
+      return await attempt(handle);
     } catch (error) {
-      // If a row was already yielded, the error came from mid-stream and a
-      // retry would re-yield prior rows to the consumer.
-      if (yielded || !isStalePreparedStatementError(error)) {
-        throw normalizePgError(error);
+      if (!isStalePreparedStatementError(error)) {
+        throw error;
       }
       // pg's parsedStatements still records the old name; only a fresh name
       // forces pg to re-Parse on this Client.
       const retryHandle = this.options.handleAllocator.mint();
       preparedStatementHandle.set(retryHandle);
       try {
-        yield* attempt(retryHandle);
+        return await attempt(retryHandle);
       } catch (retryError) {
         throw prepareFailedError(retryError, retryHandle);
       }
+    }
+  }
+
+  private async *withStaleHandleStreamRetry<Row>(
+    preparedStatementHandle: PreparedStatementHandle,
+    handle: string,
+    attempt: (handle: string) => AsyncIterable<Row>,
+  ): AsyncIterable<Row> {
+    const stream = await this.withStaleHandleRetry(
+      preparedStatementHandle,
+      handle,
+      async (name) => {
+        const iterator = attempt(name)[Symbol.asyncIterator]();
+        return { iterator, first: await iterator.next() };
+      },
+    );
+
+    if (stream.first.done) {
+      return;
+    }
+
+    let streamCompleted = false;
+    try {
+      yield stream.first.value;
+      while (true) {
+        const next = await stream.iterator.next();
+        if (next.done) {
+          streamCompleted = true;
+          return;
+        }
+        yield next.value;
+      }
+    } finally {
+      if (!streamCompleted) {
+        await stream.iterator.return?.();
+      }
+    }
+  }
+
+  private async runExecute(request: SqlExecuteRequest, name?: string): Promise<SqlStatementStats> {
+    const client = await this.acquireClient();
+    try {
+      const releaseLock = await acquireClientQueryLock(client);
+      try {
+        const result = await client.query({
+          name,
+          text: request.sql,
+          values: [...(request.params ?? [])],
+        });
+        return { affectedRows: result.rowCount ?? 0 };
+      } finally {
+        releaseLock();
+      }
+    } finally {
+      await this.releaseClient(client);
     }
   }
 
@@ -264,7 +308,7 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
             this.options.cursorBatchSize,
             name,
           )) {
-            yield row as Row;
+            yield blindCast<Row, 'postgres cursor rows are dynamically shaped'>(row);
           }
           return;
         } catch (cursorError) {
@@ -279,7 +323,7 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
       }
 
       for await (const row of this.executeBuffered(client, request.sql, request.params, name)) {
-        yield row as Row;
+        yield blindCast<Row, 'postgres query rows are dynamically shaped'>(row);
       }
     } finally {
       await this.releaseClient(client);
@@ -295,9 +339,13 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
       const releaseLock = await acquireClientQueryLock(client);
       try {
         const result = await client
-          .query(text, request.params as unknown[] | undefined)
+          .query(text, request.params === undefined ? undefined : [...request.params])
           .catch(rethrowNormalizedError);
-        return { rows: result.rows as ReadonlyArray<Record<string, unknown>> };
+        return {
+          rows: blindCast<ReadonlyArray<Record<string, unknown>>, 'pg does not type query rows'>(
+            result.rows,
+          ),
+        };
       } finally {
         releaseLock();
       }
@@ -369,7 +417,7 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
     cursorBatchSize: number,
     name?: string,
   ): AsyncIterable<Record<string, unknown>> {
-    const values = (params ?? []) as unknown[];
+    const values = [...(params ?? [])];
     const cursor = client.query(
       name === undefined ? new Cursor(sql, values) : new NamedCursor({ name, text: sql, values }),
     );
@@ -399,7 +447,7 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
     params: readonly unknown[] | undefined,
     name?: string,
   ): AsyncIterable<Record<string, unknown>> {
-    const config: QueryConfig = { name, text: sql, values: (params ?? []) as unknown[] };
+    const config: QueryConfig = { name, text: sql, values: [...(params ?? [])] };
     const releaseLock = await acquireClientQueryLock(client);
     let result: PgQueryResult;
     try {
@@ -407,7 +455,10 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
     } finally {
       releaseLock();
     }
-    for (const row of result.rows as Record<string, unknown>[]) {
+    for (const row of blindCast<
+      ReadonlyArray<Record<string, unknown>>,
+      'pg does not type query rows'
+    >(result.rows)) {
       yield row;
     }
   }

--- a/packages/3-targets/7-drivers/postgres/src/postgres-driver.ts
+++ b/packages/3-targets/7-drivers/postgres/src/postgres-driver.ts
@@ -1,3 +1,5 @@
+import type { RuntimeErrorEnvelope } from '@internal/framework-components/runtime';
+import { runtimeError } from '@internal/framework-components/runtime';
 import type {
   PreparedExecuteRequest,
   SqlConnection,
@@ -212,7 +214,7 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
       try {
         yield* attempt(retryHandle);
       } catch (retryError) {
-        throw normalizePgError(retryError);
+        throw prepareFailedError(retryError, retryHandle);
       }
     }
   }
@@ -736,4 +738,18 @@ function closeCursor(cursor: Cursor<unknown>): Promise<void> {
 
 function rethrowNormalizedError(error: unknown): never {
   throw normalizePgError(error);
+}
+
+// ADR 210 § Stale-handle retry: a re-prepare that fails again surfaces the
+// stable code reserved for this surface, carrying the driver error as `cause`.
+function prepareFailedError(retryError: unknown, handle: string): RuntimeErrorEnvelope {
+  const cause = normalizePgError(retryError);
+  return Object.assign(
+    runtimeError(
+      'ADAPTER.PREPARE_FAILED',
+      `Prepared statement failed again after re-preparing with a fresh handle: ${cause.message}`,
+      { handle },
+    ),
+    { cause },
+  );
 }

--- a/packages/3-targets/7-drivers/postgres/src/postgres-driver.ts
+++ b/packages/3-targets/7-drivers/postgres/src/postgres-driver.ts
@@ -1,12 +1,12 @@
 import type {
-  PreparedExecuteRequest,
+  PreparedStatementHandle,
   SqlConnection,
   SqlDriver,
   SqlDriverState,
   SqlExecuteRequest,
   SqlExplainResult,
   SqlQueryable,
-  SqlQueryResult,
+  SqlStatementStats,
   SqlTransaction,
 } from '@internal/sql-relational-core/ast';
 import type {
@@ -53,7 +53,8 @@ interface PostgresDriverOptions {
   readonly connect: { client: Client } | { pool: PoolType };
   readonly cursor?: PostgresCursorOptions | undefined;
   /**
-   * Use server-side prepared statements for `executePrepared`. Default
+   * Use server-side prepared statements for `query()` requests with a
+   * prepared-statement handle. Default
    * `true`. Set `false` when running behind a transaction-mode pooler that
    * does not support session-scoped prepared statements (e.g. PgBouncer
    * transaction mode).
@@ -160,36 +161,54 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
     this.options = options;
   }
 
-  async *execute<Row = Record<string, unknown>>(request: SqlExecuteRequest): AsyncIterable<Row> {
+  async *query<Row = Record<string, unknown>>(request: SqlExecuteRequest): AsyncIterable<Row> {
     try {
-      yield* this.runQuery<Row>(request);
+      const preparedStatementHandle = request.preparedStatementHandle;
+      if (preparedStatementHandle === undefined || !this.options.preparedStatementsEnabled) {
+        yield* this.runQuery<Row>(request);
+        return;
+      }
+      const handle = this.preparedStatementName(preparedStatementHandle);
+      yield* this.withStaleHandleRetry<Row>(preparedStatementHandle, handle, (name) =>
+        this.runQuery<Row>(request, name),
+      );
     } catch (error) {
       throw normalizePgError(error);
     }
   }
 
-  async *executePrepared<Row = Record<string, unknown>>(
-    request: PreparedExecuteRequest,
-  ): AsyncIterable<Row> {
-    if (!this.options.preparedStatementsEnabled) {
-      // Skip server-side prepare entirely; route as a regular ad-hoc execute.
-      yield* this.execute<Row>(request);
-      return;
+  async execute(request: SqlExecuteRequest): Promise<SqlStatementStats> {
+    const client = await this.acquireClient();
+    try {
+      const releaseLock = await acquireClientQueryLock(client);
+      try {
+        const result = await client.query({
+          text: request.sql,
+          values: [...(request.params ?? [])],
+        });
+        return { affectedRows: result.rowCount ?? 0 };
+      } finally {
+        releaseLock();
+      }
+    } catch (error) {
+      throw normalizePgError(error);
+    } finally {
+      await this.releaseClient(client);
     }
+  }
 
-    let handle = request.handle.get();
-    if (handle === undefined) {
-      handle = this.options.handleAllocator.mint();
-      request.handle.set(handle);
+  private preparedStatementName(handle: PreparedStatementHandle): string {
+    const existingHandle = handle.get();
+    if (typeof existingHandle === 'string') {
+      return existingHandle;
     }
-
-    yield* this.withStaleHandleRetry<Row>(request, handle as string, (h) =>
-      this.runQuery<Row>(request, h),
-    );
+    const mintedHandle = this.options.handleAllocator.mint();
+    handle.set(mintedHandle);
+    return mintedHandle;
   }
 
   private async *withStaleHandleRetry<Row>(
-    request: PreparedExecuteRequest,
+    preparedStatementHandle: PreparedStatementHandle,
     handle: string,
     attempt: (handle: string) => AsyncIterable<Row>,
   ): AsyncIterable<Row> {
@@ -209,7 +228,7 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
       // pg's parsedStatements still records the old name; only a fresh name
       // forces pg to re-Parse on this Client.
       const retryHandle = this.options.handleAllocator.mint();
-      request.handle.set(retryHandle);
+      preparedStatementHandle.set(retryHandle);
       try {
         yield* attempt(retryHandle);
       } catch (retryError) {
@@ -279,26 +298,6 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
           .query(text, request.params as unknown[] | undefined)
           .catch(rethrowNormalizedError);
         return { rows: result.rows as ReadonlyArray<Record<string, unknown>> };
-      } finally {
-        releaseLock();
-      }
-    } finally {
-      await this.releaseClient(client);
-    }
-  }
-
-  async query<Row = Record<string, unknown>>(
-    sql: string,
-    params?: readonly unknown[],
-  ): Promise<SqlQueryResult<Row>> {
-    const client = await this.acquireClient();
-    try {
-      const releaseLock = await acquireClientQueryLock(client);
-      try {
-        const result = await client
-          .query(sql, params as unknown[] | undefined)
-          .catch(rethrowNormalizedError);
-        return result as unknown as SqlQueryResult<Row>;
       } finally {
         releaseLock();
       }

--- a/packages/3-targets/7-drivers/postgres/src/postgres-driver.ts
+++ b/packages/3-targets/7-drivers/postgres/src/postgres-driver.ts
@@ -1,5 +1,3 @@
-import type { RuntimeErrorEnvelope } from '@internal/framework-components/runtime';
-import { runtimeError } from '@internal/framework-components/runtime';
 import type {
   PreparedExecuteRequest,
   SqlConnection,
@@ -23,6 +21,7 @@ import type {
 import { Pool } from 'pg';
 import Cursor from 'pg-cursor';
 import { callbackToPromise } from './callback-to-promise';
+import { type DriverRuntimeError, driverError } from './driver-error';
 import { NamedCursor } from './named-cursor';
 import { isAlreadyConnectedError, isPostgresError, normalizePgError } from './normalize-error';
 
@@ -740,13 +739,14 @@ function rethrowNormalizedError(error: unknown): never {
   throw normalizePgError(error);
 }
 
-// ADR 210 § Stale-handle retry: a re-prepare that fails again surfaces the
-// stable code reserved for this surface, carrying the driver error as `cause`.
-function prepareFailedError(retryError: unknown, handle: string): RuntimeErrorEnvelope {
+// ADR 210 § Stale-handle retry: a re-prepare that fails again surfaces a
+// stable code, carrying the driver error as `cause`. ADR 239 governs the
+// namespace — `DRIVER` covers driver transport and error normalization.
+function prepareFailedError(retryError: unknown, handle: string): DriverRuntimeError {
   const cause = normalizePgError(retryError);
   return Object.assign(
-    runtimeError(
-      'ADAPTER.PREPARE_FAILED',
+    driverError(
+      'DRIVER.PREPARE_FAILED',
       `Prepared statement failed again after re-preparing with a fresh handle: ${cause.message}`,
       { handle },
     ),

--- a/packages/3-targets/7-drivers/postgres/src/postgres-driver.ts
+++ b/packages/3-targets/7-drivers/postgres/src/postgres-driver.ts
@@ -446,7 +446,14 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
     params: readonly unknown[] | undefined,
     name?: string,
   ): AsyncIterable<Record<string, unknown>> {
-    const config: QueryConfig = { name, text: sql, values: [...(params ?? [])] };
+    const config: QueryConfig = {
+      name,
+      text: sql,
+      values: blindCast<
+        unknown[],
+        'pg query types require a mutable array but pg does not mutate execution params'
+      >(params ?? []),
+    };
     const releaseLock = await acquireClientQueryLock(client);
     let result: PgQueryResult;
     try {

--- a/packages/3-targets/7-drivers/postgres/test/driver.basic.test.ts
+++ b/packages/3-targets/7-drivers/postgres/test/driver.basic.test.ts
@@ -3,8 +3,8 @@ import type { Client, Pool } from 'pg';
 import { Pool as PgPool } from 'pg';
 import { newDb } from 'pg-mem';
 import { afterEach, describe, expect, it } from 'vitest';
-
 import postgresRuntimeDriverDescriptor from '../src/exports/runtime';
+import { executeSql, queryRows } from './sql-queryable-test-utils';
 
 describe('@internal/driver-postgres', () => {
   let cleanup: (() => Promise<void>) | undefined;
@@ -41,11 +41,11 @@ describe('@internal/driver-postgres', () => {
     'streams rows using buffered fallback when cursor disabled',
     async () => {
       const driver = await createMemPoolDriver({ cursor: { disabled: true } });
-      await driver.query('create table items(id serial primary key, name text)');
-      await driver.query('insert into items(name) values ($1), ($2)', ['a', 'b']);
+      await executeSql(driver, 'create table items(id serial primary key, name text)');
+      await executeSql(driver, 'insert into items(name) values ($1), ($2)', ['a', 'b']);
 
       const rows: Array<{ id: number; name: string }> = [];
-      for await (const row of driver.execute<{ id: number; name: string }>({
+      for await (const row of driver.query<{ id: number; name: string }>({
         sql: 'select id, name from items order by id asc',
       })) {
         rows.push(row);
@@ -63,11 +63,11 @@ describe('@internal/driver-postgres', () => {
     'streams rows using cursor mode when enabled',
     async () => {
       const driver = await createMemPoolDriver({ cursor: { batchSize: 1 } });
-      await driver.query('create table items(id serial primary key, name text)');
-      await driver.query('insert into items(name) values ($1), ($2), ($3)', ['a', 'b', 'c']);
+      await executeSql(driver, 'create table items(id serial primary key, name text)');
+      await executeSql(driver, 'insert into items(name) values ($1), ($2), ($3)', ['a', 'b', 'c']);
 
       const rows: Array<{ id: number; name: string }> = [];
-      for await (const row of driver.execute<{ id: number; name: string }>({
+      for await (const row of driver.query<{ id: number; name: string }>({
         sql: 'select id, name from items order by id asc',
       })) {
         rows.push(row);
@@ -86,8 +86,8 @@ describe('@internal/driver-postgres', () => {
     'uses custom cursor batch size',
     async () => {
       const driver = await createMemPoolDriver({ cursor: { batchSize: 2 } });
-      await driver.query('create table items(id serial primary key, name text)');
-      await driver.query('insert into items(name) values ($1), ($2), ($3), ($4)', [
+      await executeSql(driver, 'create table items(id serial primary key, name text)');
+      await executeSql(driver, 'insert into items(name) values ($1), ($2), ($3), ($4)', [
         'a',
         'b',
         'c',
@@ -95,7 +95,7 @@ describe('@internal/driver-postgres', () => {
       ]);
 
       const rows: Array<{ id: number; name: string }> = [];
-      for await (const row of driver.execute<{ id: number; name: string }>({
+      for await (const row of driver.query<{ id: number; name: string }>({
         sql: 'select id, name from items order by id asc',
       })) {
         rows.push(row);
@@ -112,7 +112,7 @@ describe('@internal/driver-postgres', () => {
     'executes explain query',
     async () => {
       const driver = await createMemPoolDriver();
-      await driver.query('create table items(id serial primary key, name text)');
+      await executeSql(driver, 'create table items(id serial primary key, name text)');
 
       // pg-mem doesn't support EXPLAIN (FORMAT JSON), so we test that explain() is callable
       // In a real environment, this would return explain results
@@ -137,16 +137,17 @@ describe('@internal/driver-postgres', () => {
     'executes query with params',
     async () => {
       const driver = await createMemPoolDriver();
-      await driver.query('create table items(id serial primary key, name text)');
-      await driver.query('insert into items(name) values ($1)', ['test']);
+      await executeSql(driver, 'create table items(id serial primary key, name text)');
+      await executeSql(driver, 'insert into items(name) values ($1)', ['test']);
 
-      const result = await driver.query<{ id: number; name: string }>(
+      const result = await queryRows<{ id: number; name: string }>(
+        driver,
         'select id, name from items where name = $1',
         ['test'],
       );
 
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0]?.name).toBe('test');
+      expect(result).toHaveLength(1);
+      expect(result[0]?.name).toBe('test');
     },
     timeouts.spinUpPpgDev,
   );
@@ -165,13 +166,16 @@ describe('@internal/driver-postgres', () => {
       };
 
       await driver.connect({ kind: 'pgClient', client: client as unknown as Client });
-      await driver.query('create table items(id serial primary key, name text)');
-      await driver.query('insert into items(name) values ($1)', ['test']);
+      await executeSql(driver, 'create table items(id serial primary key, name text)');
+      await executeSql(driver, 'insert into items(name) values ($1)', ['test']);
 
-      const result = await driver.query<{ id: number; name: string }>('select id, name from items');
+      const result = await queryRows<{ id: number; name: string }>(
+        driver,
+        'select id, name from items',
+      );
 
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0]?.name).toBe('test');
+      expect(result).toHaveLength(1);
+      expect(result[0]?.name).toBe('test');
     },
     timeouts.spinUpPpgDev,
   );
@@ -196,10 +200,13 @@ describe('@internal/driver-postgres', () => {
         'Postgres driver already connected. Call close() before reconnecting with a new binding.',
       );
 
-      await driver.query('create table items(id serial primary key, name text)');
-      const result = await driver.query<{ id: number; name: string }>('select id, name from items');
+      await executeSql(driver, 'create table items(id serial primary key, name text)');
+      const result = await queryRows<{ id: number; name: string }>(
+        driver,
+        'select id, name from items',
+      );
 
-      expect(result.rows).toBeDefined();
+      expect(result).toBeDefined();
     },
     timeouts.spinUpPpgDev,
   );
@@ -221,10 +228,13 @@ describe('@internal/driver-postgres', () => {
 
       await driver.connect({ kind: 'pgClient', client: client as unknown as Client });
       // acquireClient should detect client is already connected and skip connect()
-      await driver.query('create table items(id serial primary key, name text)');
-      const result = await driver.query<{ id: number; name: string }>('select id, name from items');
+      await executeSql(driver, 'create table items(id serial primary key, name text)');
+      const result = await queryRows<{ id: number; name: string }>(
+        driver,
+        'select id, name from items',
+      );
 
-      expect(result.rows).toBeDefined();
+      expect(result).toBeDefined();
     },
     timeouts.spinUpPpgDev,
   );
@@ -257,10 +267,10 @@ describe('@internal/driver-postgres', () => {
     'handles empty result set',
     async () => {
       const driver = await createMemPoolDriver();
-      await driver.query('create table items(id serial primary key, name text)');
+      await executeSql(driver, 'create table items(id serial primary key, name text)');
 
       const rows: Array<{ id: number; name: string }> = [];
-      for await (const row of driver.execute<{ id: number; name: string }>({
+      for await (const row of driver.query<{ id: number; name: string }>({
         sql: 'select id, name from items',
       })) {
         rows.push(row);
@@ -287,11 +297,15 @@ describe('@internal/driver-postgres', () => {
       };
 
       await driver.connect({ kind: 'pgPool', pool: pool as unknown as Pool });
-      await driver.query('create table cursor_items(id serial primary key, name text)');
-      await driver.query('insert into cursor_items(name) values ($1), ($2), ($3)', ['a', 'b', 'c']);
+      await executeSql(driver, 'create table cursor_items(id serial primary key, name text)');
+      await executeSql(driver, 'insert into cursor_items(name) values ($1), ($2), ($3)', [
+        'a',
+        'b',
+        'c',
+      ]);
 
       const rows: Array<{ id: number; name: string }> = [];
-      for await (const row of driver.execute<{ id: number; name: string }>({
+      for await (const row of driver.query<{ id: number; name: string }>({
         sql: 'select id, name from cursor_items order by id asc',
       })) {
         rows.push(row);
@@ -320,8 +334,8 @@ describe('@internal/driver-postgres', () => {
       };
 
       await driver.connect({ kind: 'pgPool', pool: pool as unknown as Pool });
-      await driver.query('create table explain_items(id serial primary key, name text)');
-      await driver.query('insert into explain_items(name) values ($1)', ['test']);
+      await executeSql(driver, 'create table explain_items(id serial primary key, name text)');
+      await executeSql(driver, 'insert into explain_items(name) values ($1)', ['test']);
 
       const result = await driver.explain!({
         sql: 'select id, name from explain_items where id = $1',
@@ -348,12 +362,15 @@ describe('@internal/driver-postgres', () => {
       };
 
       await driver.connect({ kind: 'url', url: database.connectionString });
-      await driver.query('create table items(id serial primary key, name text)');
-      await driver.query('insert into items(name) values ($1)', ['test']);
+      await executeSql(driver, 'create table items(id serial primary key, name text)');
+      await executeSql(driver, 'insert into items(name) values ($1)', ['test']);
 
-      const result = await driver.query<{ id: number; name: string }>('select id, name from items');
-      expect(result.rows).toHaveLength(1);
-      expect(result.rows[0]?.name).toBe('test');
+      const result = await queryRows<{ id: number; name: string }>(
+        driver,
+        'select id, name from items',
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0]?.name).toBe('test');
     },
     timeouts.spinUpPpgDev,
   );
@@ -363,20 +380,21 @@ describe('@internal/driver-postgres', () => {
       'acquires and releases connections from pool',
       async () => {
         const driver = await createMemPoolDriver();
-        await driver.query('create table items(id serial primary key, name text)');
+        await executeSql(driver, 'create table items(id serial primary key, name text)');
 
         const connection = await driver.acquireConnection();
         expect(connection).toBeDefined();
 
         // Test that the connection can execute queries
-        await connection.query('insert into items(name) values ($1)', ['test-connection']);
-        const result = await connection.query<{ id: number; name: string }>(
+        await executeSql(connection, 'insert into items(name) values ($1)', ['test-connection']);
+        const result = await queryRows<{ id: number; name: string }>(
+          connection,
           'select id, name from items where name = $1',
           ['test-connection'],
         );
 
-        expect(result.rows).toHaveLength(1);
-        expect(result.rows[0]?.name).toBe('test-connection');
+        expect(result).toHaveLength(1);
+        expect(result[0]?.name).toBe('test-connection');
 
         // Release the connection
         await connection.release();
@@ -398,20 +416,21 @@ describe('@internal/driver-postgres', () => {
         };
 
         await driver.connect({ kind: 'pgClient', client: client as unknown as Client });
-        await driver.query('create table items(id serial primary key, name text)');
+        await executeSql(driver, 'create table items(id serial primary key, name text)');
 
         const connection = await driver.acquireConnection();
         expect(connection).toBeDefined();
 
         // Test that the connection can execute queries
-        await connection.query('insert into items(name) values ($1)', ['test-direct']);
-        const result = await connection.query<{ id: number; name: string }>(
+        await executeSql(connection, 'insert into items(name) values ($1)', ['test-direct']);
+        const result = await queryRows<{ id: number; name: string }>(
+          connection,
           'select id, name from items where name = $1',
           ['test-direct'],
         );
 
-        expect(result.rows).toHaveLength(1);
-        expect(result.rows[0]?.name).toBe('test-direct');
+        expect(result).toHaveLength(1);
+        expect(result[0]?.name).toBe('test-direct');
 
         // Release the connection
         await connection.release();
@@ -433,7 +452,7 @@ describe('@internal/driver-postgres', () => {
         };
 
         await driver.connect({ kind: 'pgClient', client: client as unknown as Client });
-        await driver.query('create table items(id serial primary key, name text)');
+        await executeSql(driver, 'create table items(id serial primary key, name text)');
 
         const first = await driver.acquireConnection();
         let secondResolved = false;
@@ -457,13 +476,13 @@ describe('@internal/driver-postgres', () => {
       'connection can stream data with execute method',
       async () => {
         const driver = await createMemPoolDriver({ cursor: { disabled: true } });
-        await driver.query('create table items(id serial primary key, name text)');
-        await driver.query('insert into items(name) values ($1), ($2)', ['a', 'b']);
+        await executeSql(driver, 'create table items(id serial primary key, name text)');
+        await executeSql(driver, 'insert into items(name) values ($1), ($2)', ['a', 'b']);
 
         const connection = await driver.acquireConnection();
 
         const rows: Array<{ id: number; name: string }> = [];
-        for await (const row of connection.execute<{ id: number; name: string }>({
+        for await (const row of connection.query<{ id: number; name: string }>({
           sql: 'select id, name from items order by id asc',
         })) {
           rows.push(row);
@@ -496,7 +515,7 @@ describe('@internal/driver-postgres', () => {
         };
 
         await driver.connect({ kind: 'pgPool', pool: pool as unknown as Pool });
-        await driver.query('create table tx_items(id serial primary key, name text)');
+        await executeSql(driver, 'create table tx_items(id serial primary key, name text)');
 
         const connection = await driver.acquireConnection();
         const transaction = await connection.beginTransaction();
@@ -504,19 +523,20 @@ describe('@internal/driver-postgres', () => {
         expect(transaction).toBeDefined();
 
         // Insert data within the transaction
-        await transaction.query('insert into tx_items(name) values ($1)', ['tx-test']);
+        await executeSql(transaction, 'insert into tx_items(name) values ($1)', ['tx-test']);
 
         // Commit the transaction
         await transaction.commit();
 
         // Verify the data was committed
-        const result = await connection.query<{ id: number; name: string }>(
+        const result = await queryRows<{ id: number; name: string }>(
+          connection,
           'select id, name from tx_items where name = $1',
           ['tx-test'],
         );
 
-        expect(result.rows).toHaveLength(1);
-        expect(result.rows[0]?.name).toBe('tx-test');
+        expect(result).toHaveLength(1);
+        expect(result[0]?.name).toBe('tx-test');
 
         await connection.release();
       },
@@ -538,13 +558,16 @@ describe('@internal/driver-postgres', () => {
         };
 
         await driver.connect({ kind: 'pgPool', pool: pool as unknown as Pool });
-        await driver.query('create table tx_rollback_items(id serial primary key, name text)');
+        await executeSql(
+          driver,
+          'create table tx_rollback_items(id serial primary key, name text)',
+        );
 
         const connection = await driver.acquireConnection();
         const transaction = await connection.beginTransaction();
 
         // Insert data within the transaction
-        await transaction.query('insert into tx_rollback_items(name) values ($1)', [
+        await executeSql(transaction, 'insert into tx_rollback_items(name) values ($1)', [
           'rollback-test',
         ]);
 
@@ -552,12 +575,13 @@ describe('@internal/driver-postgres', () => {
         await transaction.rollback();
 
         // Verify the data was not committed
-        const result = await connection.query<{ id: number; name: string }>(
+        const result = await queryRows<{ id: number; name: string }>(
+          connection,
           'select id, name from tx_rollback_items where name = $1',
           ['rollback-test'],
         );
 
-        expect(result.rows).toHaveLength(0);
+        expect(result).toHaveLength(0);
 
         await connection.release();
       },
@@ -581,14 +605,17 @@ describe('@internal/driver-postgres', () => {
         };
 
         await driver.connect({ kind: 'pgPool', pool: pool as unknown as Pool });
-        await driver.query('create table tx_stream_items(id serial primary key, name text)');
-        await driver.query('insert into tx_stream_items(name) values ($1), ($2)', ['tx-a', 'tx-b']);
+        await executeSql(driver, 'create table tx_stream_items(id serial primary key, name text)');
+        await executeSql(driver, 'insert into tx_stream_items(name) values ($1), ($2)', [
+          'tx-a',
+          'tx-b',
+        ]);
 
         const connection = await driver.acquireConnection();
         const transaction = await connection.beginTransaction();
 
         const rows: Array<{ id: number; name: string }> = [];
-        for await (const row of transaction.execute<{ id: number; name: string }>({
+        for await (const row of transaction.query<{ id: number; name: string }>({
           sql: 'select id, name from tx_stream_items where name like $1 order by id asc',
           params: ['tx-%'],
         })) {
@@ -621,7 +648,7 @@ describe('@internal/driver-postgres', () => {
         };
 
         await driver.connect({ kind: 'pgPool', pool: pool as unknown as Pool });
-        await driver.query('create table tx_explain_items(id serial primary key, name text)');
+        await executeSql(driver, 'create table tx_explain_items(id serial primary key, name text)');
 
         const connection = await driver.acquireConnection();
         const transaction = await connection.beginTransaction();
@@ -655,32 +682,33 @@ describe('@internal/driver-postgres', () => {
         };
 
         await driver.connect({ kind: 'pgPool', pool: pool as unknown as Pool });
-        await driver.query('create table tx_multi_items(id serial primary key, name text)');
+        await executeSql(driver, 'create table tx_multi_items(id serial primary key, name text)');
 
         const connection = await driver.acquireConnection();
 
         // First transaction - commit
         const tx1 = await connection.beginTransaction();
-        await tx1.query('insert into tx_multi_items(name) values ($1)', ['first-tx']);
+        await executeSql(tx1, 'insert into tx_multi_items(name) values ($1)', ['first-tx']);
         await tx1.commit();
 
         // Second transaction - rollback
         const tx2 = await connection.beginTransaction();
-        await tx2.query('insert into tx_multi_items(name) values ($1)', ['second-tx']);
+        await executeSql(tx2, 'insert into tx_multi_items(name) values ($1)', ['second-tx']);
         await tx2.rollback();
 
         // Third transaction - commit
         const tx3 = await connection.beginTransaction();
-        await tx3.query('insert into tx_multi_items(name) values ($1)', ['third-tx']);
+        await executeSql(tx3, 'insert into tx_multi_items(name) values ($1)', ['third-tx']);
         await tx3.commit();
 
         // Verify only committed data is present
-        const result = await connection.query<{ id: number; name: string }>(
+        const result = await queryRows<{ id: number; name: string }>(
+          connection,
           'select name from tx_multi_items order by id',
         );
 
-        expect(result.rows).toHaveLength(2);
-        expect(result.rows.map((r) => r.name)).toEqual(['first-tx', 'third-tx']);
+        expect(result).toHaveLength(2);
+        expect(result.map((r) => r.name)).toEqual(['first-tx', 'third-tx']);
 
         await connection.release();
       },

--- a/packages/3-targets/7-drivers/postgres/test/driver.errors.test.ts
+++ b/packages/3-targets/7-drivers/postgres/test/driver.errors.test.ts
@@ -5,6 +5,7 @@ import { newDb } from 'pg-mem';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import postgresRuntimeDriverDescriptor from '../src/exports/runtime';
 import { createBoundDriverFromBinding } from '../src/postgres-driver';
+import { queryRows } from './sql-queryable-test-utils';
 
 describe('@internal/driver-postgres', () => {
   const cleanups: Array<() => Promise<void>> = [];
@@ -21,12 +22,12 @@ describe('@internal/driver-postgres', () => {
       const db = newDb();
       const { Pool } = db.adapters.createPg();
       const pool = new Pool();
-      const driver = postgresRuntimeDriverDescriptor.create();
+      const driver = postgresRuntimeDriverDescriptor.create({ cursor: { disabled: true } });
       cleanups.push(async () => {
         await driver.close();
       });
       await driver.connect({ kind: 'pgPool', pool: pool as unknown as Pool });
-      await expect(driver.query('select * from nonexistent_table')).rejects.toThrow();
+      await expect(queryRows(driver, 'select * from nonexistent_table')).rejects.toThrow();
     },
     timeouts.spinUpPpgDev,
   );
@@ -54,7 +55,7 @@ describe('@internal/driver-postgres', () => {
     });
 
     const consume = async () => {
-      for await (const _row of driver.execute({ sql: 'select 1' })) {
+      for await (const _row of driver.query({ sql: 'select 1' })) {
         // consume stream
       }
     };
@@ -94,7 +95,7 @@ describe('@internal/driver-postgres', () => {
     });
 
     const rows: Array<{ id: number; name: string }> = [];
-    for await (const row of driver.execute<{ id: number; name: string }>({
+    for await (const row of driver.query<{ id: number; name: string }>({
       sql: 'select id, name from items',
     })) {
       rows.push(row);
@@ -125,7 +126,7 @@ describe('@internal/driver-postgres', () => {
     });
 
     const consume = async () => {
-      for await (const _row of driver.execute({ sql: 'select 1' })) {
+      for await (const _row of driver.query({ sql: 'select 1' })) {
         // consume stream
       }
     };
@@ -145,13 +146,13 @@ describe('@internal/driver-postgres', () => {
     };
     const driver = createBoundDriverFromBinding(
       { kind: 'pgClient', client: mockClient as unknown as Client },
-      undefined,
+      { disabled: true },
     );
     cleanups.push(async () => {
       await driver.close();
     });
 
-    await expect(driver.query('select 1')).rejects.toThrow('Connection failed');
+    await expect(queryRows(driver, 'select 1')).rejects.toThrow('Connection failed');
   });
 
   it('closes pool driver once when close called multiple times', async () => {
@@ -205,15 +206,15 @@ describe('@internal/driver-postgres', () => {
     };
     const driver = createBoundDriverFromBinding(
       { kind: 'pgClient', client: mockClient as unknown as Client },
-      undefined,
+      { disabled: true },
     );
     cleanups.push(async () => {
       await driver.close();
     });
 
-    const result = await driver.query('select 1');
+    const result = await queryRows(driver, 'select 1');
 
-    expect(result.rows).toEqual([]);
+    expect(result).toEqual([]);
     expect(mockClient.connect).toHaveBeenCalledTimes(1);
   });
 
@@ -233,14 +234,14 @@ describe('@internal/driver-postgres', () => {
     };
     const driver = createBoundDriverFromBinding(
       { kind: 'pgClient', client: mockClient as unknown as Client },
-      undefined,
+      { disabled: true },
     );
     cleanups.push(async () => {
       await driver.close();
     });
 
-    const first = driver.query('select 1');
-    const second = driver.query('select 1');
+    const first = queryRows(driver, 'select 1');
+    const second = queryRows(driver, 'select 1');
     resolveConnect?.();
     await Promise.all([first, second]);
 

--- a/packages/3-targets/7-drivers/postgres/test/driver.pinned-client-serialization.integration.test.ts
+++ b/packages/3-targets/7-drivers/postgres/test/driver.pinned-client-serialization.integration.test.ts
@@ -11,6 +11,7 @@ import { timeouts } from '@repo/test-utils';
 import { Client } from 'pg';
 import { afterEach, describe, expect, it } from 'vitest';
 import postgresRuntimeDriverDescriptor from '../src/exports/runtime';
+import { executeSql, queryRows } from './sql-queryable-test-utils';
 
 interface Harness {
   readonly client: Client;
@@ -117,9 +118,9 @@ async function settleWarnings(): Promise<void> {
 }
 
 async function seedRows(h: Harness, count: number): Promise<void> {
-  await h.driver.query('create table items (id int primary key, n int not null)');
+  await executeSql(h.driver, 'create table items (id int primary key, n int not null)');
   const values = Array.from({ length: count }, (_, i) => `(${i}, ${i * 2})`).join(', ');
-  await h.driver.query(`insert into items (id, n) values ${values}`);
+  await executeSql(h.driver, `insert into items (id, n) values ${values}`);
 }
 
 afterEach(async () => {
@@ -140,14 +141,14 @@ describe('pinned-client serialization on a real wire', () => {
       const capture = captureProcessWarnings();
       try {
         const results = await Promise.all([
-          h.driver.query<{ n: number }>('select 1 as n'),
-          h.driver.query<{ n: number }>('select 2 as n'),
-          h.driver.query<{ n: number }>('select 3 as n'),
+          queryRows<{ n: number }>(h.driver, 'select 1 as n'),
+          queryRows<{ n: number }>(h.driver, 'select 2 as n'),
+          queryRows<{ n: number }>(h.driver, 'select 3 as n'),
         ]);
         await settleWarnings();
 
         expect(capture.warnings).toEqual([]);
-        expect(results.map((r) => r.rows[0])).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
+        expect(results.map((r) => r[0])).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
       } finally {
         capture.stop();
       }
@@ -160,12 +161,12 @@ describe('pinned-client serialization on a real wire', () => {
     async () => {
       const h = await createHarness();
       const results = await Promise.all([
-        h.driver.query<{ n: number }>('select 1 as n'),
-        h.driver.query<{ n: number }>('select 2 as n'),
-        h.driver.query<{ n: number }>('select 3 as n'),
+        queryRows<{ n: number }>(h.driver, 'select 1 as n'),
+        queryRows<{ n: number }>(h.driver, 'select 2 as n'),
+        queryRows<{ n: number }>(h.driver, 'select 3 as n'),
       ]);
 
-      expect(results.map((r) => r.rows[0])).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
+      expect(results.map((r) => r[0])).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
       expect(h.maxInFlight()).toBe(1);
     },
     timeouts.spinUpDbServer,
@@ -178,12 +179,12 @@ describe('pinned-client serialization on a real wire', () => {
       const connection = await h.driver.acquireConnection();
       try {
         const results = await Promise.all([
-          connection.query<{ n: number }>('select 1 as n'),
-          connection.query<{ n: number }>('select 2 as n'),
-          connection.query<{ n: number }>('select 3 as n'),
+          queryRows<{ n: number }>(connection, 'select 1 as n'),
+          queryRows<{ n: number }>(connection, 'select 2 as n'),
+          queryRows<{ n: number }>(connection, 'select 3 as n'),
         ]);
 
-        expect(results.map((r) => r.rows[0])).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
+        expect(results.map((r) => r[0])).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
         expect(h.maxInFlight()).toBe(1);
       } finally {
         await connection.release();
@@ -200,13 +201,13 @@ describe('pinned-client serialization on a real wire', () => {
       try {
         const transaction = await connection.beginTransaction();
         const results = await Promise.all([
-          transaction.query<{ n: number }>('select 1 as n'),
-          transaction.query<{ n: number }>('select 2 as n'),
-          transaction.query<{ n: number }>('select 3 as n'),
+          queryRows<{ n: number }>(transaction, 'select 1 as n'),
+          queryRows<{ n: number }>(transaction, 'select 2 as n'),
+          queryRows<{ n: number }>(transaction, 'select 3 as n'),
         ]);
         await transaction.commit();
 
-        expect(results.map((r) => r.rows[0])).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
+        expect(results.map((r) => r[0])).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
         expect(h.maxInFlight()).toBe(1);
       } finally {
         await connection.release();
@@ -224,7 +225,7 @@ describe('pinned-client serialization on a real wire', () => {
 
       const streamed: number[] = [];
       const consumeStream = async (): Promise<void> => {
-        for await (const row of h.driver.execute<{ id: number }>({
+        for await (const row of h.driver.query<{ id: number }>({
           sql: 'select id from items order by id',
         })) {
           streamed.push(row.id);
@@ -233,11 +234,11 @@ describe('pinned-client serialization on a real wire', () => {
 
       const [, other] = await Promise.all([
         consumeStream(),
-        h.driver.query<{ n: number }>('select count(*)::int as n from items'),
+        queryRows<{ n: number }>(h.driver, 'select count(*)::int as n from items'),
       ]);
 
       expect(streamed).toHaveLength(20);
-      expect(other.rows).toEqual([{ n: 20 }]);
+      expect(other).toEqual([{ n: 20 }]);
 
       const begin = h.recordedQueryTexts.indexOf('BEGIN');
       const commit = h.recordedQueryTexts.indexOf('COMMIT');

--- a/packages/3-targets/7-drivers/postgres/test/driver.pinned-client-serialization.test.ts
+++ b/packages/3-targets/7-drivers/postgres/test/driver.pinned-client-serialization.test.ts
@@ -3,6 +3,7 @@ import { timeouts } from '@repo/test-utils';
 import type { Client, Pool } from 'pg';
 import { describe, expect, it } from 'vitest';
 import { createBoundDriverFromBinding } from '../src/postgres-driver';
+import { queryRows } from './sql-queryable-test-utils';
 
 interface ConcurrencyState {
   inFlight: number;
@@ -58,7 +59,7 @@ async function consume<T>(iterable: AsyncIterable<T>): Promise<T[]> {
   return out;
 }
 
-function makeHandleSlot(): PreparedExecuteRequest['handle'] {
+function makeHandleSlot(): PreparedExecuteRequest['preparedStatementHandle'] {
   let value: unknown;
   return {
     get: () => value,
@@ -74,9 +75,9 @@ describe('pinned-client serialization', { timeout: timeouts.databaseOperation },
     const driver = makeDirectDriver(state);
 
     await Promise.all([
-      driver.query('select 1'),
-      driver.query('select 2'),
-      driver.query('select 3'),
+      queryRows(driver, 'select 1'),
+      queryRows(driver, 'select 2'),
+      queryRows(driver, 'select 3'),
     ]);
 
     expect(state.maxInFlight).toBe(1);
@@ -84,7 +85,7 @@ describe('pinned-client serialization', { timeout: timeouts.databaseOperation },
     expect(state.completed).toEqual(['select 1', 'select 2', 'select 3']);
   });
 
-  it('serializes mixed execute/executePrepared/explain/query overlap on a direct driver', async () => {
+  it('serializes mixed query/explain overlap on a direct driver', async () => {
     const state = createConcurrencyState();
     const driver = makeDirectDriver(state);
     const explain = driver.explain;
@@ -93,10 +94,12 @@ describe('pinned-client serialization', { timeout: timeouts.databaseOperation },
     }
 
     await Promise.all([
-      consume(driver.execute({ sql: 'select a' })),
-      consume(driver.executePrepared({ sql: 'select b', params: [], handle: makeHandleSlot() })),
+      consume(driver.query({ sql: 'select a' })),
+      consume(
+        driver.query({ sql: 'select b', params: [], preparedStatementHandle: makeHandleSlot() }),
+      ),
       explain.call(driver, { sql: 'select c' }),
-      driver.query('select d'),
+      queryRows(driver, 'select d'),
     ]);
 
     expect(state.maxInFlight).toBe(1);
@@ -108,7 +111,7 @@ describe('pinned-client serialization', { timeout: timeouts.databaseOperation },
     const driver = makeDirectDriver(state);
     const connection = await driver.acquireConnection();
 
-    await Promise.all([connection.query('select 1'), connection.query('select 2')]);
+    await Promise.all([queryRows(connection, 'select 1'), queryRows(connection, 'select 2')]);
     await connection.release();
 
     expect(state.maxInFlight).toBe(1);
@@ -122,9 +125,9 @@ describe('pinned-client serialization', { timeout: timeouts.databaseOperation },
     const transaction = await connection.beginTransaction();
 
     await Promise.all([
-      transaction.query('select 1'),
-      transaction.query('select 2'),
-      consume(transaction.execute({ sql: 'select 3' })),
+      queryRows(transaction, 'select 1'),
+      queryRows(transaction, 'select 2'),
+      consume(transaction.query({ sql: 'select 3' })),
     ]);
     await transaction.commit();
     await connection.release();
@@ -139,7 +142,7 @@ describe('pinned-client serialization', { timeout: timeouts.databaseOperation },
     const driver = makeDirectDriver(state);
     const connection = await driver.acquireConnection();
 
-    await Promise.all([connection.query('select lease'), driver.query('select driver')]);
+    await Promise.all([queryRows(connection, 'select lease'), queryRows(driver, 'select driver')]);
     await connection.release();
 
     expect(state.maxInFlight).toBe(1);
@@ -151,10 +154,10 @@ describe('pinned-client serialization', { timeout: timeouts.databaseOperation },
     const connection = await driver.acquireConnection();
 
     const nested: unknown[] = [];
-    for await (const row of connection.execute<{ echo: string }>({ sql: 'select outer' })) {
+    for await (const row of connection.query<{ echo: string }>({ sql: 'select outer' })) {
       expect(row).toEqual({ echo: 'select outer' });
-      const inner = await connection.query<{ echo: string }>('select inner');
-      nested.push(inner.rows[0]);
+      const inner = await queryRows<{ echo: string }>(connection, 'select inner');
+      nested.push(inner[0]);
     }
     await connection.release();
 
@@ -169,10 +172,10 @@ describe('pinned-client serialization', { timeout: timeouts.databaseOperation },
     const transaction = await connection.beginTransaction();
 
     const nested: unknown[] = [];
-    for await (const row of transaction.execute<{ echo: string }>({ sql: 'select outer' })) {
+    for await (const row of transaction.query<{ echo: string }>({ sql: 'select outer' })) {
       expect(row).toEqual({ echo: 'select outer' });
-      const inner = await transaction.query<{ echo: string }>('select inner');
-      nested.push(inner.rows[0]);
+      const inner = await queryRows<{ echo: string }>(transaction, 'select inner');
+      nested.push(inner[0]);
     }
     await transaction.commit();
     await connection.release();
@@ -186,13 +189,13 @@ describe('pinned-client serialization', { timeout: timeouts.databaseOperation },
     const driver = makeDirectDriver(state);
 
     const iterator = driver
-      .execute<{ echo: string }>({ sql: 'select abandoned' })
+      .query<{ echo: string }>({ sql: 'select abandoned' })
       [Symbol.asyncIterator]();
     const first = await iterator.next();
     expect(first.done).toBe(false);
 
-    const after = await driver.query<{ echo: string }>('select after');
-    expect(after.rows).toEqual([{ echo: 'select after' }]);
+    const after = await queryRows<{ echo: string }>(driver, 'select after');
+    expect(after).toEqual([{ echo: 'select after' }]);
   });
 
   it('commits a transaction while a buffered stream on it is still open', async () => {
@@ -202,7 +205,7 @@ describe('pinned-client serialization', { timeout: timeouts.databaseOperation },
     const transaction = await connection.beginTransaction();
 
     const iterator = transaction
-      .execute<{ echo: string }>({ sql: 'select open-stream' })
+      .query<{ echo: string }>({ sql: 'select open-stream' })
       [Symbol.asyncIterator]();
     const first = await iterator.next();
     expect(first.done).toBe(false);
@@ -226,7 +229,7 @@ describe('pinned-client serialization', { timeout: timeouts.databaseOperation },
       { disabled: true },
     );
 
-    await Promise.all([driver.query('select 1'), driver.query('select 2')]);
+    await Promise.all([queryRows(driver, 'select 1'), queryRows(driver, 'select 2')]);
 
     expect(state.maxInFlight).toBe(2);
   });

--- a/packages/3-targets/7-drivers/postgres/test/driver.prepared.integration.test.ts
+++ b/packages/3-targets/7-drivers/postgres/test/driver.prepared.integration.test.ts
@@ -2,6 +2,7 @@ import type { SqlConnection, SqlQueryable } from '@internal/sql-relational-core/
 import { createDevDatabase, timeouts } from '@repo/test-utils';
 import { afterEach, describe, expect, it } from 'vitest';
 import { createBoundDriverFromBinding } from '../src/postgres-driver';
+import { executeSql, queryRows } from './sql-queryable-test-utils';
 
 function makeSlot(initial?: unknown) {
   let value: unknown = initial;
@@ -25,10 +26,11 @@ async function consume<T>(iterable: AsyncIterable<T>): Promise<T[]> {
 }
 
 async function preparedNames(queryable: SqlQueryable): Promise<string[]> {
-  const result = await queryable.query<{ name: string }>(
+  const result = await queryRows<{ name: string }>(
+    queryable,
     'select name from pg_prepared_statements order by name',
   );
-  return result.rows.map((r) => r.name);
+  return result.map((row) => row.name);
 }
 
 describe('@internal/driver-postgres prepared statements', () => {
@@ -52,17 +54,17 @@ describe('@internal/driver-postgres prepared statements', () => {
         await database.close();
       });
 
-      await driver.query('create table t (id serial primary key, label text)');
-      await driver.query("insert into t (label) values ('a'), ('b')");
+      await executeSql(driver, 'create table t (id serial primary key, label text)');
+      await executeSql(driver, "insert into t (label) values ('a'), ('b')");
 
       const { slot, snapshot } = makeSlot();
       expect(await preparedNames(driver)).toEqual([]);
 
       const r1 = await consume(
-        driver.executePrepared<{ id: number; label: string }>({
+        driver.query<{ id: number; label: string }>({
           sql: 'select id, label from t where label = $1',
           params: ['a'],
-          handle: slot,
+          preparedStatementHandle: slot,
         }),
       );
       expect(r1).toEqual([{ id: 1, label: 'a' }]);
@@ -72,10 +74,10 @@ describe('@internal/driver-postgres prepared statements', () => {
       expect(await preparedNames(driver)).toEqual([handleName]);
 
       const r2 = await consume(
-        driver.executePrepared<{ id: number; label: string }>({
+        driver.query<{ id: number; label: string }>({
           sql: 'select id, label from t where label = $1',
           params: ['b'],
-          handle: slot,
+          preparedStatementHandle: slot,
         }),
       );
       expect(r2).toEqual([{ id: 2, label: 'b' }]);
@@ -118,7 +120,7 @@ describe('@internal/driver-postgres prepared statements', () => {
         await databaseA.close();
       });
 
-      await consume(driverA.executePrepared({ sql, params: ['a'], handle: slot }));
+      await consume(driverA.query({ sql, params: ['a'], preparedStatementHandle: slot }));
       const name = snapshot() as string;
       expect(name).toMatch(/^pn_\d+$/);
       expect(await preparedNames(driverA)).toEqual([name]);
@@ -133,7 +135,7 @@ describe('@internal/driver-postgres prepared statements', () => {
         await databaseB.close();
       });
 
-      await consume(driverB.executePrepared({ sql, params: ['a'], handle: slot }));
+      await consume(driverB.query({ sql, params: ['a'], preparedStatementHandle: slot }));
       expect(snapshot()).toBe(name);
       expect(await preparedNames(driverB)).toEqual([name]);
     },
@@ -152,22 +154,22 @@ describe('@internal/driver-postgres prepared statements', () => {
         await database.close();
       });
 
-      await driver.query('create table t3 (id serial primary key, label text)');
-      await driver.query("insert into t3 (label) values ('a'), ('b')");
+      await executeSql(driver, 'create table t3 (id serial primary key, label text)');
+      await executeSql(driver, "insert into t3 (label) values ('a'), ('b')");
 
       const { slot, snapshot } = makeSlot();
       const sql = 'select id, label from t3 where label = $1';
 
-      const r1 = await consume(driver.executePrepared({ sql, params: ['a'], handle: slot }));
+      const r1 = await consume(driver.query({ sql, params: ['a'], preparedStatementHandle: slot }));
       expect(r1).toHaveLength(1);
       const firstHandle = snapshot() as string;
 
       // Forget every prepared statement server-side. pg's parsedStatements
       // still records firstHandle, so the next execute under the old name
       // would skip Parse on the wire and surface 26000 from the server.
-      await driver.query('deallocate all');
+      await executeSql(driver, 'deallocate all');
 
-      const r2 = await consume(driver.executePrepared({ sql, params: ['b'], handle: slot }));
+      const r2 = await consume(driver.query({ sql, params: ['b'], preparedStatementHandle: slot }));
       expect(r2).toHaveLength(1);
       expect((r2[0] as { label: string }).label).toBe('b');
 
@@ -191,22 +193,22 @@ describe('@internal/driver-postgres prepared statements', () => {
         await database.close();
       });
 
-      await driver.query('create table t4 (id serial primary key, label text)');
-      await driver.query("insert into t4 (label) values ('a'), ('b')");
+      await executeSql(driver, 'create table t4 (id serial primary key, label text)');
+      await executeSql(driver, "insert into t4 (label) values ('a'), ('b')");
 
       const { slot, snapshot } = makeSlot();
       // SELECT * so a column-shape change invalidates the cached plan.
       const sql = 'select * from t4 where id = $1';
 
-      const r1 = await consume(driver.executePrepared({ sql, params: [1], handle: slot }));
+      const r1 = await consume(driver.query({ sql, params: [1], preparedStatementHandle: slot }));
       expect(r1).toHaveLength(1);
       const firstHandle = snapshot() as string;
 
-      await driver.query('alter table t4 drop column label');
-      await driver.query('alter table t4 add column label varchar(50)');
-      await driver.query("update t4 set label = 'b' where id = 2");
+      await executeSql(driver, 'alter table t4 drop column label');
+      await executeSql(driver, 'alter table t4 add column label varchar(50)');
+      await executeSql(driver, "update t4 set label = 'b' where id = 2");
 
-      const r2 = await consume(driver.executePrepared({ sql, params: [2], handle: slot }));
+      const r2 = await consume(driver.query({ sql, params: [2], preparedStatementHandle: slot }));
       expect(r2).toHaveLength(1);
       const retryHandle = snapshot() as string;
       expect(retryHandle).toMatch(/^pn_\d+$/);
@@ -227,23 +229,23 @@ describe('@internal/driver-postgres prepared statements', () => {
         await database.close();
       });
 
-      await driver.query('create table t5 (id serial primary key, label text)');
+      await executeSql(driver, 'create table t5 (id serial primary key, label text)');
 
       const connection: SqlConnection = await driver.acquireConnection();
       const tx = await connection.beginTransaction();
 
-      await tx.query("insert into t5 (label) values ('a'), ('b'), ('c')");
+      await executeSql(tx, "insert into t5 (label) values ('a'), ('b'), ('c')");
 
       const { slot, snapshot } = makeSlot();
       const sql = 'select id, label from t5 where label = $1';
 
-      const r1 = await consume(tx.executePrepared({ sql, params: ['a'], handle: slot }));
+      const r1 = await consume(tx.query({ sql, params: ['a'], preparedStatementHandle: slot }));
       expect(r1).toEqual([{ id: 1, label: 'a' }]);
 
       const handle = snapshot() as string;
       expect(handle).toMatch(/^pn_\d+$/);
 
-      const r2 = await consume(tx.executePrepared({ sql, params: ['b'], handle: slot }));
+      const r2 = await consume(tx.query({ sql, params: ['b'], preparedStatementHandle: slot }));
       expect(r2).toEqual([{ id: 2, label: 'b' }]);
       expect(snapshot()).toBe(handle);
 
@@ -251,7 +253,9 @@ describe('@internal/driver-postgres prepared statements', () => {
 
       // PREPARE survives the transaction; only DEALLOCATE / end-of-session
       // discards it. The handle still resolves on the parent connection.
-      const r3 = await consume(connection.executePrepared({ sql, params: ['c'], handle: slot }));
+      const r3 = await consume(
+        connection.query({ sql, params: ['c'], preparedStatementHandle: slot }),
+      );
       expect(r3).toEqual([{ id: 3, label: 'c' }]);
       expect(snapshot()).toBe(handle);
 
@@ -272,18 +276,18 @@ describe('@internal/driver-postgres prepared statements', () => {
         await database.close();
       });
 
-      await driver.query('create table t7 (id serial primary key, label text)');
-      await driver.query("insert into t7 (label) values ('a'), ('b')");
+      await executeSql(driver, 'create table t7 (id serial primary key, label text)');
+      await executeSql(driver, "insert into t7 (label) values ('a'), ('b')");
 
       const { slot, snapshot } = makeSlot();
       const sql = 'select id, label from t7 where label = $1';
 
-      const r1 = await consume(driver.executePrepared({ sql, params: ['a'], handle: slot }));
+      const r1 = await consume(driver.query({ sql, params: ['a'], preparedStatementHandle: slot }));
       expect(r1).toEqual([{ id: 1, label: 'a' }]);
       const handle = snapshot() as string;
       expect(handle).toMatch(/^pn_\d+$/);
 
-      const r2 = await consume(driver.executePrepared({ sql, params: ['b'], handle: slot }));
+      const r2 = await consume(driver.query({ sql, params: ['b'], preparedStatementHandle: slot }));
       expect(r2).toEqual([{ id: 2, label: 'b' }]);
 
       expect(await preparedNames(driver)).toEqual([handle]);
@@ -305,14 +309,14 @@ describe('@internal/driver-postgres prepared statements', () => {
         await database.close();
       });
 
-      await driver.query('create table t6 (id serial primary key, label text)');
-      await driver.query("insert into t6 (label) values ('a'), ('b')");
+      await executeSql(driver, 'create table t6 (id serial primary key, label text)');
+      await executeSql(driver, "insert into t6 (label) values ('a'), ('b')");
 
       const { slot, snapshot } = makeSlot();
       const sql = 'select id, label from t6 where label = $1';
 
-      await consume(driver.executePrepared({ sql, params: ['a'], handle: slot }));
-      await consume(driver.executePrepared({ sql, params: ['b'], handle: slot }));
+      await consume(driver.query({ sql, params: ['a'], preparedStatementHandle: slot }));
+      await consume(driver.query({ sql, params: ['b'], preparedStatementHandle: slot }));
 
       expect(snapshot()).toBeUndefined();
       expect(await preparedNames(driver)).toEqual([]);

--- a/packages/3-targets/7-drivers/postgres/test/driver.prepared.test.ts
+++ b/packages/3-targets/7-drivers/postgres/test/driver.prepared.test.ts
@@ -116,4 +116,39 @@ describe('postgres prepared statements', () => {
       expect(invocations).toBe(1);
     });
   });
+
+  describe('stale-handle retry', () => {
+    it('surfaces ADAPTER.PREPARE_FAILED with the originating error as cause when the retry fails', async () => {
+      const retryError = makePgError('26000', 'statement gone after re-prepare');
+      const { client, calls } = makeMockClient({
+        handler: (_call, callIndex) =>
+          callIndex === 0 ? makePgError('26000', 'statement gone') : retryError,
+      });
+      const driver = makeDriver({ kind: 'pgClient', client: client as unknown as Client });
+      cleanups.push(() => driver.close());
+
+      const { slot, snapshot } = makeSlot();
+      const rejection = await consume(
+        driver.executePrepared({ sql: 'select 1', params: [], handle: slot }),
+      ).then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+
+      expect(calls).toHaveLength(2);
+      const envelope = rejection as Error & {
+        code?: unknown;
+        severity?: unknown;
+        details?: Record<string, unknown>;
+      };
+      expect(envelope.code).toBe('ADAPTER.PREPARE_FAILED');
+      expect(envelope.severity).toBe('error');
+      expect(envelope.details).toEqual({ handle: snapshot() });
+
+      const cause = envelope.cause as SqlQueryError;
+      expect(cause).toBeInstanceOf(SqlQueryError);
+      expect(cause.sqlState).toBe('26000');
+      expect(cause.cause).toBe(retryError);
+    });
+  });
 });

--- a/packages/3-targets/7-drivers/postgres/test/driver.prepared.test.ts
+++ b/packages/3-targets/7-drivers/postgres/test/driver.prepared.test.ts
@@ -134,20 +134,6 @@ describe('postgres prepared statements', () => {
     });
   });
 
-  it('passes execute request params to pg without copying', async () => {
-    const { client, calls } = makeMockClient({
-      handler: () => ({ rows: [], rowCount: 1 }),
-    });
-    const driver = makeDriver({ kind: 'pgClient', client: client as unknown as Client });
-    cleanups.push(() => driver.close());
-
-    const params = [42];
-    await driver.execute({ sql: 'update t set x = $1', params });
-
-    const request = calls[0]?.arg as { readonly values: readonly unknown[] };
-    expect(request.values).toBe(params);
-  });
-
   it('uses and reuses a prepared name for execute requests with a handle', async () => {
     const { client, calls } = makeMockClient({
       handler: () => ({ rows: [], rowCount: 1 }),

--- a/packages/3-targets/7-drivers/postgres/test/driver.prepared.test.ts
+++ b/packages/3-targets/7-drivers/postgres/test/driver.prepared.test.ts
@@ -134,6 +134,20 @@ describe('postgres prepared statements', () => {
     });
   });
 
+  it('passes execute request params to pg without copying', async () => {
+    const { client, calls } = makeMockClient({
+      handler: () => ({ rows: [], rowCount: 1 }),
+    });
+    const driver = makeDriver({ kind: 'pgClient', client: client as unknown as Client });
+    cleanups.push(() => driver.close());
+
+    const params = [42];
+    await driver.execute({ sql: 'update t set x = $1', params });
+
+    const request = calls[0]?.arg as { readonly values: readonly unknown[] };
+    expect(request.values).toBe(params);
+  });
+
   it('uses and reuses a prepared name for execute requests with a handle', async () => {
     const { client, calls } = makeMockClient({
       handler: () => ({ rows: [], rowCount: 1 }),

--- a/packages/3-targets/7-drivers/postgres/test/driver.prepared.test.ts
+++ b/packages/3-targets/7-drivers/postgres/test/driver.prepared.test.ts
@@ -118,7 +118,7 @@ describe('postgres prepared statements', () => {
   });
 
   describe('stale-handle retry', () => {
-    it('surfaces ADAPTER.PREPARE_FAILED with the originating error as cause when the retry fails', async () => {
+    it('surfaces DRIVER.PREPARE_FAILED with the originating error as cause when the retry fails', async () => {
       const retryError = makePgError('26000', 'statement gone after re-prepare');
       const { client, calls } = makeMockClient({
         handler: (_call, callIndex) =>
@@ -138,10 +138,12 @@ describe('postgres prepared statements', () => {
       expect(calls).toHaveLength(2);
       const envelope = rejection as Error & {
         code?: unknown;
+        category?: unknown;
         severity?: unknown;
         details?: Record<string, unknown>;
       };
-      expect(envelope.code).toBe('ADAPTER.PREPARE_FAILED');
+      expect(envelope.code).toBe('DRIVER.PREPARE_FAILED');
+      expect(envelope.category).toBe('DRIVER');
       expect(envelope.severity).toBe('error');
       expect(envelope.details).toEqual({ handle: snapshot() });
 

--- a/packages/3-targets/7-drivers/postgres/test/driver.prepared.test.ts
+++ b/packages/3-targets/7-drivers/postgres/test/driver.prepared.test.ts
@@ -134,7 +134,64 @@ describe('postgres prepared statements', () => {
     });
   });
 
+  it('uses and reuses a prepared name for execute requests with a handle', async () => {
+    const { client, calls } = makeMockClient({
+      handler: () => ({ rows: [], rowCount: 1 }),
+    });
+    const driver = makeDriver({ kind: 'pgClient', client: client as unknown as Client });
+    cleanups.push(() => driver.close());
+
+    const { slot, snapshot } = makeSlot();
+    const sql = 'update t set x = $1';
+    await driver.execute({ sql, params: [42], preparedStatementHandle: slot });
+    await driver.execute({ sql, params: [99], preparedStatementHandle: slot });
+
+    expect(snapshot()).toBe('pn_1');
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.arg).toEqual({ name: 'pn_1', text: sql, values: [42] });
+    expect(calls[1]?.arg).toEqual({ name: 'pn_1', text: sql, values: [99] });
+  });
+
   describe('stale-handle retry', () => {
+    it('retries execute with a fresh name and surfaces DRIVER.PREPARE_FAILED if retry fails', async () => {
+      const retryError = makePgError('26000', 'statement gone after re-prepare');
+      const { client, calls } = makeMockClient({
+        handler: (_call, callIndex) =>
+          callIndex === 0 ? makePgError('26000', 'statement gone') : retryError,
+      });
+      const driver = makeDriver({ kind: 'pgClient', client: client as unknown as Client });
+      cleanups.push(() => driver.close());
+
+      const { slot, snapshot } = makeSlot();
+      const rejection = await driver
+        .execute({ sql: 'update t set x = $1', params: [42], preparedStatementHandle: slot })
+        .then(
+          () => undefined,
+          (error: unknown) => error,
+        );
+
+      expect(calls).toHaveLength(2);
+      expect(calls[0]?.arg).toMatchObject({ name: 'pn_1' });
+      expect(calls[1]?.arg).toMatchObject({ name: 'pn_2' });
+      expect(snapshot()).toBe('pn_2');
+
+      const envelope = rejection as Error & {
+        code?: unknown;
+        category?: unknown;
+        severity?: unknown;
+        details?: Record<string, unknown>;
+      };
+      expect(envelope.code).toBe('DRIVER.PREPARE_FAILED');
+      expect(envelope.category).toBe('DRIVER');
+      expect(envelope.severity).toBe('error');
+      expect(envelope.details).toEqual({ handle: 'pn_2' });
+
+      const cause = envelope.cause as SqlQueryError;
+      expect(cause).toBeInstanceOf(SqlQueryError);
+      expect(cause.sqlState).toBe('26000');
+      expect(cause.cause).toBe(retryError);
+    });
+
     it('surfaces DRIVER.PREPARE_FAILED with the originating error as cause when the retry fails', async () => {
       const retryError = makePgError('26000', 'statement gone after re-prepare');
       const { client, calls } = makeMockClient({

--- a/packages/3-targets/7-drivers/postgres/test/driver.prepared.test.ts
+++ b/packages/3-targets/7-drivers/postgres/test/driver.prepared.test.ts
@@ -43,7 +43,7 @@ function makeSlot(initial?: unknown) {
       set: (v: unknown) => {
         value = v;
       },
-    } satisfies PreparedExecuteRequest['handle'],
+    } satisfies PreparedExecuteRequest['preparedStatementHandle'],
     snapshot: () => value,
   };
 }
@@ -89,8 +89,8 @@ describe('postgres prepared statements', () => {
 
       const { slot, snapshot } = makeSlot();
       const sql = 'select id from t where x = $1';
-      await consume(driver.executePrepared({ sql, params: [42], handle: slot }));
-      await consume(driver.executePrepared({ sql, params: [99], handle: slot }));
+      await consume(driver.query({ sql, params: [42], preparedStatementHandle: slot }));
+      await consume(driver.query({ sql, params: [99], preparedStatementHandle: slot }));
 
       expect(snapshot()).toBeUndefined();
       expect(calls).toHaveLength(2);
@@ -111,9 +111,26 @@ describe('postgres prepared statements', () => {
 
       const { slot } = makeSlot();
       await expect(
-        consume(driver.executePrepared({ sql: 'select 1', params: [], handle: slot })),
+        consume(driver.query({ sql: 'select 1', params: [], preparedStatementHandle: slot })),
       ).rejects.toBeInstanceOf(SqlQueryError);
       expect(invocations).toBe(1);
+    });
+  });
+
+  it('maps pg rowCount to affectedRows', async () => {
+    const { client, calls } = makeMockClient({
+      handler: () => ({ rows: [], rowCount: 3 }),
+    });
+    const driver = makeDriver({ kind: 'pgClient', client: client as unknown as Client });
+    cleanups.push(() => driver.close());
+
+    await expect(driver.execute({ sql: 'update t set x = $1', params: [42] })).resolves.toEqual({
+      affectedRows: 3,
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.arg).toEqual({
+      text: 'update t set x = $1',
+      values: [42],
     });
   });
 
@@ -129,7 +146,7 @@ describe('postgres prepared statements', () => {
 
       const { slot, snapshot } = makeSlot();
       const rejection = await consume(
-        driver.executePrepared({ sql: 'select 1', params: [], handle: slot }),
+        driver.query({ sql: 'select 1', params: [], preparedStatementHandle: slot }),
       ).then(
         () => undefined,
         (error: unknown) => error,

--- a/packages/3-targets/7-drivers/postgres/test/driver.stream-portal-protection.integration.test.ts
+++ b/packages/3-targets/7-drivers/postgres/test/driver.stream-portal-protection.integration.test.ts
@@ -14,6 +14,7 @@ import { timeouts } from '@repo/test-utils';
 import { Client } from 'pg';
 import { afterEach, describe, expect, it } from 'vitest';
 import postgresRuntimeDriverDescriptor from '../src/exports/runtime';
+import { executeSql, queryRows } from './sql-queryable-test-utils';
 
 interface SharedSessionHarness {
   readonly db: PGlite;
@@ -119,9 +120,9 @@ async function createSharedSessionHarness(options?: {
 }
 
 async function seedRows(h: SharedSessionHarness, count: number): Promise<void> {
-  await h.driver.query('create table items (id int primary key, n int not null)');
+  await executeSql(h.driver, 'create table items (id int primary key, n int not null)');
   const values = Array.from({ length: count }, (_, i) => `(${i}, ${i * 2})`).join(', ');
-  await h.driver.query(`insert into items (id, n) values ${values}`);
+  await executeSql(h.driver, `insert into items (id, n) values ${values}`);
 }
 
 afterEach(async () => {
@@ -139,7 +140,7 @@ describe('streamed execute on a shared single-session backend', () => {
       await seedRows(h, 30);
 
       const rows: Array<{ id: number }> = [];
-      for await (const row of h.driver.execute<{ id: number }>({
+      for await (const row of h.driver.query<{ id: number }>({
         sql: 'select id from items order by id',
       })) {
         rows.push(row);
@@ -171,7 +172,7 @@ describe('streamed execute on a shared single-session backend', () => {
       h.recordedQueryTexts.length = 0;
 
       const rows: unknown[] = [];
-      for await (const row of h.driver.execute({ sql: 'select id from items order by id' })) {
+      for await (const row of h.driver.query({ sql: 'select id from items order by id' })) {
         rows.push(row);
       }
 
@@ -189,7 +190,7 @@ describe('streamed execute on a shared single-session backend', () => {
       await seedRows(h, 25);
       h.recordedQueryTexts.length = 0;
 
-      for await (const row of h.driver.execute<{ id: number }>({
+      for await (const row of h.driver.query<{ id: number }>({
         sql: 'select id from items order by id',
       })) {
         if (row.id >= 6) {
@@ -201,8 +202,11 @@ describe('streamed execute on a shared single-session backend', () => {
       expect(h.recordedQueryTexts.filter((text) => text === 'COMMIT')).toHaveLength(1);
       expect(h.db.isInTransaction()).toBe(false);
 
-      const after = await h.driver.query<{ n: number }>('select count(*)::int as n from items');
-      expect(after.rows).toEqual([{ n: 25 }]);
+      const after = await queryRows<{ n: number }>(
+        h.driver,
+        'select count(*)::int as n from items',
+      );
+      expect(after).toEqual([{ n: 25 }]);
     },
     timeouts.spinUpDbServer,
   );
@@ -216,7 +220,7 @@ describe('streamed execute on a shared single-session backend', () => {
       const rows: unknown[] = [];
       let caught: unknown;
       try {
-        for await (const row of h.driver.execute({ sql: 'select id from items order by id' })) {
+        for await (const row of h.driver.query({ sql: 'select id from items order by id' })) {
           rows.push(row);
         }
       } catch (error) {
@@ -242,7 +246,7 @@ describe('streamed execute on a shared single-session backend', () => {
       try {
         // Division by zero at id = 3 fails the stream mid-read; the terminating
         // COMMIT then also fails (injected), and must not mask the stream error.
-        for await (const _row of h.driver.execute({
+        for await (const _row of h.driver.query({
           sql: 'select 1 / (id - 3) as x from items order by id',
         })) {
           // drain until the backend raises division_by_zero
@@ -267,7 +271,7 @@ describe('streamed execute on a shared single-session backend', () => {
       const connection = await h.driver.acquireConnection();
       const transaction = await connection.beginTransaction();
       const rows: unknown[] = [];
-      for await (const row of transaction.execute({ sql: 'select id from items order by id' })) {
+      for await (const row of transaction.query({ sql: 'select id from items order by id' })) {
         rows.push(row);
       }
       await transaction.commit();
@@ -292,7 +296,7 @@ describe('streamed execute on a shared single-session backend', () => {
       h.recordedQueryTexts.length = 0;
 
       const rows: unknown[] = [];
-      for await (const row of connection.execute({ sql: 'select id from items order by id' })) {
+      for await (const row of connection.query({ sql: 'select id from items order by id' })) {
         rows.push(row);
       }
       await connection.release();
@@ -311,7 +315,7 @@ describe('streamed execute on a shared single-session backend', () => {
 
       const consume = async (): Promise<number> => {
         let count = 0;
-        for await (const _row of h.driver.execute({ sql: 'select id from items order by id' })) {
+        for await (const _row of h.driver.query({ sql: 'select id from items order by id' })) {
           count++;
         }
         return count;

--- a/packages/3-targets/7-drivers/postgres/test/driver.unbound.test.ts
+++ b/packages/3-targets/7-drivers/postgres/test/driver.unbound.test.ts
@@ -2,8 +2,8 @@ import { createDevDatabase, timeouts } from '@repo/test-utils';
 import type { Client, Pool } from 'pg';
 import { newDb } from 'pg-mem';
 import { afterEach, describe, expect, it } from 'vitest';
-
 import postgresRuntimeDriverDescriptor from '../src/exports/runtime';
+import { executeSql, queryRows } from './sql-queryable-test-utils';
 
 describe('@internal/driver-postgres runtime driver lifecycle', () => {
   let cleanup: (() => Promise<void>) | undefined;
@@ -57,7 +57,7 @@ describe('@internal/driver-postgres runtime driver lifecycle', () => {
 
     it('throws when query is called', async () => {
       const driver = createDriver();
-      await expect(driver.query('select 1')).rejects.toMatchObject({
+      await expect(queryRows(driver, 'select 1')).rejects.toMatchObject({
         code: 'DRIVER.NOT_CONNECTED',
         category: 'DRIVER',
         message: useBeforeConnectMessage,
@@ -66,7 +66,7 @@ describe('@internal/driver-postgres runtime driver lifecycle', () => {
 
     it('throws when execute is iterated', async () => {
       const driver = createDriver();
-      const iter = driver.execute({ sql: 'select 1' });
+      const iter = driver.query({ sql: 'select 1' });
       const iterator = iter[Symbol.asyncIterator]();
       await expect(iterator.next()).rejects.toMatchObject({
         code: 'DRIVER.NOT_CONNECTED',
@@ -119,14 +119,15 @@ describe('@internal/driver-postgres runtime driver lifecycle', () => {
           const driver = createDriver();
           await driver.connect({ kind: 'pgPool', pool: memPool as unknown as Pool });
 
-          await driver.query('create table items(id serial primary key, name text)');
-          await driver.query('insert into items(name) values ($1)', ['test']);
+          await executeSql(driver, 'create table items(id serial primary key, name text)');
+          await executeSql(driver, 'insert into items(name) values ($1)', ['test']);
 
-          const result = await driver.query<{ id: number; name: string }>(
+          const result = await queryRows<{ id: number; name: string }>(
+            driver,
             'select id, name from items',
           );
-          expect(result.rows).toHaveLength(1);
-          expect(result.rows[0]?.name).toBe('test');
+          expect(result).toHaveLength(1);
+          expect(result[0]?.name).toBe('test');
         },
         timeouts.spinUpPpgDev,
       );
@@ -149,11 +150,12 @@ describe('@internal/driver-postgres runtime driver lifecycle', () => {
               'Postgres driver already connected. Call close() before reconnecting with a new binding.',
           });
 
-          await driver.query('create table items(id serial primary key, name text)');
-          const result = await driver.query<{ id: number; name: string }>(
+          await executeSql(driver, 'create table items(id serial primary key, name text)');
+          const result = await queryRows<{ id: number; name: string }>(
+            driver,
             'select id, name from items',
           );
-          expect(result.rows).toBeDefined();
+          expect(result).toBeDefined();
         },
         timeouts.spinUpPpgDev,
       );
@@ -188,14 +190,15 @@ describe('@internal/driver-postgres runtime driver lifecycle', () => {
           const driver = createDriver();
           await driver.connect({ kind: 'pgClient', client: memClient as unknown as Client });
 
-          await driver.query('create table items(id serial primary key, name text)');
-          await driver.query('insert into items(name) values ($1)', ['test']);
+          await executeSql(driver, 'create table items(id serial primary key, name text)');
+          await executeSql(driver, 'insert into items(name) values ($1)', ['test']);
 
-          const result = await driver.query<{ id: number; name: string }>(
+          const result = await queryRows<{ id: number; name: string }>(
+            driver,
             'select id, name from items',
           );
-          expect(result.rows).toHaveLength(1);
-          expect(result.rows[0]?.name).toBe('test');
+          expect(result).toHaveLength(1);
+          expect(result[0]?.name).toBe('test');
         },
         timeouts.spinUpPpgDev,
       );
@@ -241,7 +244,7 @@ describe('@internal/driver-postgres runtime driver lifecycle', () => {
             code: 'DRIVER.NOT_CONNECTED',
             category: 'DRIVER',
           });
-          await expect(driver.query('select 1')).rejects.toMatchObject({
+          await expect(queryRows(driver, 'select 1')).rejects.toMatchObject({
             code: 'DRIVER.NOT_CONNECTED',
             category: 'DRIVER',
           });
@@ -263,15 +266,16 @@ describe('@internal/driver-postgres runtime driver lifecycle', () => {
           };
 
           await driver.connect({ kind: 'url', url: database.connectionString });
-          await driver.query('create table url_items(id serial primary key, name text)');
-          await driver.query('insert into url_items(name) values ($1)', ['url-test']);
+          await executeSql(driver, 'create table url_items(id serial primary key, name text)');
+          await executeSql(driver, 'insert into url_items(name) values ($1)', ['url-test']);
 
-          const result = await driver.query<{ id: number; name: string }>(
+          const result = await queryRows<{ id: number; name: string }>(
+            driver,
             'select id, name from url_items where name = $1',
             ['url-test'],
           );
-          expect(result.rows).toHaveLength(1);
-          expect(result.rows[0]?.name).toBe('url-test');
+          expect(result).toHaveLength(1);
+          expect(result[0]?.name).toBe('url-test');
         },
         timeouts.spinUpPpgDev,
       );

--- a/packages/3-targets/7-drivers/postgres/test/sql-queryable-test-utils.ts
+++ b/packages/3-targets/7-drivers/postgres/test/sql-queryable-test-utils.ts
@@ -1,0 +1,29 @@
+import type {
+  SqlExecuteRequest,
+  SqlQueryable,
+  SqlStatementStats,
+} from '@internal/sql-relational-core/ast';
+
+function request(sql: string, params?: readonly unknown[]): SqlExecuteRequest {
+  return params === undefined ? { sql } : { sql, params };
+}
+
+export async function executeSql(
+  queryable: SqlQueryable,
+  sql: string,
+  params?: readonly unknown[],
+): Promise<SqlStatementStats> {
+  return queryable.execute(request(sql, params));
+}
+
+export async function queryRows<Row>(
+  queryable: SqlQueryable,
+  sql: string,
+  params?: readonly unknown[],
+): Promise<Row[]> {
+  const rows: Row[] = [];
+  for await (const row of queryable.query<Row>(request(sql, params))) {
+    rows.push(row);
+  }
+  return rows;
+}

--- a/packages/3-targets/7-drivers/sqlite/src/sqlite-driver.ts
+++ b/packages/3-targets/7-drivers/sqlite/src/sqlite-driver.ts
@@ -2,15 +2,16 @@ import type { SQLInputValue } from 'node:sqlite';
 import { DatabaseSync } from 'node:sqlite';
 import type { RuntimeDriverInstance } from '@internal/framework-components/execution';
 import type {
-  PreparedExecuteRequest,
   SqlConnection,
   SqlDriver,
   SqlDriverState,
   SqlExecuteRequest,
   SqlExplainResult,
-  SqlQueryResult,
+  SqlQueryable,
+  SqlStatementStats,
   SqlTransaction,
 } from '@internal/sql-relational-core/ast';
+import { InternalError } from '@internal/utils/internal-error';
 import { normalizeSqliteError } from './normalize-error';
 
 export type SqliteBinding = { readonly kind: 'path'; readonly path: string };
@@ -63,16 +64,16 @@ function openConnection(path: string): DatabaseSync {
   }
 }
 
-export class SqliteConnectionImpl implements SqlConnection {
-  readonly #db: DatabaseSync;
+abstract class SqliteQueryable implements SqlQueryable {
+  protected readonly db: DatabaseSync;
 
   constructor(db: DatabaseSync) {
-    this.#db = db;
+    this.db = db;
   }
 
-  async *execute<Row = Record<string, unknown>>(request: SqlExecuteRequest): AsyncIterable<Row> {
+  async *query<Row = Record<string, unknown>>(request: SqlExecuteRequest): AsyncIterable<Row> {
     try {
-      const stmt = this.#db.prepare(request.sql);
+      const stmt = this.db.prepare(request.sql);
       for (const row of stmt.iterate(...toSqliteParams(request.params))) {
         yield row as Row;
       }
@@ -81,113 +82,58 @@ export class SqliteConnectionImpl implements SqlConnection {
     }
   }
 
-  executePrepared<Row = Record<string, unknown>>(
-    request: PreparedExecuteRequest,
-  ): AsyncIterable<Row> {
-    return this.execute<Row>({ sql: request.sql, params: request.params });
+  async execute(request: SqlExecuteRequest): Promise<SqlStatementStats> {
+    try {
+      const stmt = this.db.prepare(request.sql);
+      if (stmt.columns().length !== 0) {
+        throw new InternalError('SQLite cannot execute statements that return rows.');
+      }
+      return { affectedRows: Number(stmt.run(...toSqliteParams(request.params)).changes) };
+    } catch (error) {
+      throw normalizeSqliteError(error);
+    }
   }
 
   async explain(request: SqlExecuteRequest): Promise<SqlExplainResult> {
     try {
-      const stmt = this.#db.prepare(`EXPLAIN QUERY PLAN ${request.sql}`);
+      const stmt = this.db.prepare(`EXPLAIN QUERY PLAN ${request.sql}`);
       const rows = stmt.all(...toSqliteParams(request.params)) as ReadonlyArray<
         Record<string, unknown>
       >;
       return { rows };
-    } catch (error) {
-      throw normalizeSqliteError(error);
-    }
-  }
-
-  async query<Row = Record<string, unknown>>(
-    sql: string,
-    params?: readonly unknown[],
-  ): Promise<SqlQueryResult<Row>> {
-    try {
-      const stmt = this.#db.prepare(sql);
-      const rows = stmt.all(...toSqliteParams(params)) as Row[];
-      return { rows };
-    } catch (error) {
-      throw normalizeSqliteError(error);
-    }
-  }
-
-  async beginTransaction(): Promise<SqlTransaction> {
-    try {
-      this.#db.exec('BEGIN');
-      return new SqliteTransactionImpl(this.#db);
-    } catch (error) {
-      throw normalizeSqliteError(error);
-    }
-  }
-
-  async release(): Promise<void> {
-    // SQLite connections are not pooled — release is equivalent to destroy
-    // (close the underlying DatabaseSync handle).
-    return this.destroy();
-  }
-
-  async destroy(_reason?: unknown): Promise<void> {
-    try {
-      this.#db.close();
     } catch (error) {
       throw normalizeSqliteError(error);
     }
   }
 }
 
-class SqliteTransactionImpl implements SqlTransaction {
-  readonly #db: DatabaseSync;
-
-  constructor(db: DatabaseSync) {
-    this.#db = db;
-  }
-
-  async *execute<Row = Record<string, unknown>>(request: SqlExecuteRequest): AsyncIterable<Row> {
+export class SqliteConnectionImpl extends SqliteQueryable implements SqlConnection {
+  async beginTransaction(): Promise<SqlTransaction> {
     try {
-      const stmt = this.#db.prepare(request.sql);
-      for (const row of stmt.iterate(...toSqliteParams(request.params))) {
-        yield row as Row;
-      }
+      this.db.exec('BEGIN');
+      return new SqliteTransactionImpl(this.db);
     } catch (error) {
       throw normalizeSqliteError(error);
     }
   }
 
-  executePrepared<Row = Record<string, unknown>>(
-    request: PreparedExecuteRequest,
-  ): AsyncIterable<Row> {
-    return this.execute<Row>({ sql: request.sql, params: request.params });
+  async release(): Promise<void> {
+    return this.destroy();
   }
 
-  async explain(request: SqlExecuteRequest): Promise<SqlExplainResult> {
+  async destroy(_reason?: unknown): Promise<void> {
     try {
-      const stmt = this.#db.prepare(`EXPLAIN QUERY PLAN ${request.sql}`);
-      const rows = stmt.all(...toSqliteParams(request.params)) as ReadonlyArray<
-        Record<string, unknown>
-      >;
-      return { rows };
+      this.db.close();
     } catch (error) {
       throw normalizeSqliteError(error);
     }
   }
+}
 
-  async query<Row = Record<string, unknown>>(
-    sql: string,
-    params?: readonly unknown[],
-  ): Promise<SqlQueryResult<Row>> {
-    try {
-      const stmt = this.#db.prepare(sql);
-      const rows = stmt.all(...toSqliteParams(params)) as Row[];
-      return { rows };
-    } catch (error) {
-      throw normalizeSqliteError(error);
-    }
-  }
-
+class SqliteTransactionImpl extends SqliteQueryable implements SqlTransaction {
   async commit(): Promise<void> {
     try {
-      this.#db.exec('COMMIT');
+      this.db.exec('COMMIT');
     } catch (error) {
       throw normalizeSqliteError(error);
     }
@@ -195,7 +141,7 @@ class SqliteTransactionImpl implements SqlTransaction {
 
   async rollback(): Promise<void> {
     try {
-      this.#db.exec('ROLLBACK');
+      this.db.exec('ROLLBACK');
     } catch (error) {
       throw normalizeSqliteError(error);
     }
@@ -209,6 +155,18 @@ interface ConnectedState {
 }
 
 type DriverState = { readonly kind: 'unbound' } | ConnectedState | { readonly kind: 'closed' };
+
+function unboundQuery<Row>(): AsyncIterable<Row> {
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        async next() {
+          throw driverError('DRIVER.NOT_CONNECTED', NOT_CONNECTED_MESSAGE);
+        },
+      };
+    },
+  };
+}
 
 export class SqliteDriver implements SqliteRuntimeDriver {
   readonly familyId = 'sql' as const;
@@ -256,47 +214,19 @@ export class SqliteDriver implements SqliteRuntimeDriver {
     await conn.release();
   }
 
-  execute<Row = Record<string, unknown>>(request: SqlExecuteRequest): AsyncIterable<Row> {
+  query<Row = Record<string, unknown>>(request: SqlExecuteRequest): AsyncIterable<Row> {
     if (this.#state.kind !== 'connected') {
-      return {
-        [Symbol.asyncIterator]() {
-          return {
-            async next() {
-              throw driverError('DRIVER.NOT_CONNECTED', NOT_CONNECTED_MESSAGE);
-            },
-          };
-        },
-      };
+      return unboundQuery<Row>();
     }
-    return this.#state.conn.execute<Row>(request);
+    return this.#state.conn.query<Row>(request);
   }
 
-  executePrepared<Row = Record<string, unknown>>(
-    request: PreparedExecuteRequest,
-  ): AsyncIterable<Row> {
-    if (this.#state.kind !== 'connected') {
-      return {
-        [Symbol.asyncIterator]() {
-          return {
-            async next() {
-              throw driverError('DRIVER.NOT_CONNECTED', NOT_CONNECTED_MESSAGE);
-            },
-          };
-        },
-      };
-    }
-    return this.#state.conn.executePrepared<Row>(request);
+  async execute(request: SqlExecuteRequest): Promise<SqlStatementStats> {
+    return this.#requireConnected().conn.execute(request);
   }
 
   async explain(request: SqlExecuteRequest): Promise<SqlExplainResult> {
     return this.#requireConnected().conn.explain(request);
-  }
-
-  async query<Row = Record<string, unknown>>(
-    sql: string,
-    params?: readonly unknown[],
-  ): Promise<SqlQueryResult<Row>> {
-    return this.#requireConnected().conn.query<Row>(sql, params);
   }
 }
 

--- a/packages/3-targets/7-drivers/sqlite/test/runtime-driver.test.ts
+++ b/packages/3-targets/7-drivers/sqlite/test/runtime-driver.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import sqliteRuntimeDriverDescriptor from '../src/exports/runtime';
+import { executeSql, queryRows } from './sql-queryable-test-utils';
 
 let testDir: string;
 let testPath: string;
@@ -43,7 +44,7 @@ describe('SqliteRuntimeDriverDescriptor', () => {
 
   it('throws on query before connect', async () => {
     const driver = sqliteRuntimeDriverDescriptor.create();
-    await expect(driver.query('SELECT 1')).rejects.toThrow('not connected');
+    await expect(queryRows(driver, 'SELECT 1')).rejects.toThrow('not connected');
   });
 
   it('throws on double connect', async () => {
@@ -55,22 +56,20 @@ describe('SqliteRuntimeDriverDescriptor', () => {
     await driver.close();
   });
 
-  it('execute() throws on unbound driver', async () => {
+  it('execute() throws on an unbound driver', async () => {
     const driver = sqliteRuntimeDriverDescriptor.create();
-    const iter = driver.execute({ sql: 'SELECT 1' });
-    const asyncIter = iter[Symbol.asyncIterator]();
-    await expect(asyncIter.next()).rejects.toThrow('not connected');
+    await expect(driver.execute({ sql: 'SELECT 1' })).rejects.toThrow('not connected');
   });
 
   it('works end-to-end after connect', async () => {
     const driver = sqliteRuntimeDriverDescriptor.create();
     await driver.connect({ kind: 'path', path: testPath });
 
-    await driver.query('CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)');
-    await driver.query('INSERT INTO t VALUES (?, ?)', [1, 'hello']);
-    const result = await driver.query<{ id: number; val: string }>('SELECT * FROM t');
-    expect(result.rows).toHaveLength(1);
-    expect(result.rows[0]).toMatchObject({ id: 1, val: 'hello' });
+    await executeSql(driver, 'CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)');
+    await executeSql(driver, 'INSERT INTO t VALUES (?, ?)', [1, 'hello']);
+    const result = await queryRows<{ id: number; val: string }>(driver, 'SELECT * FROM t');
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: 1, val: 'hello' });
 
     await driver.close();
   });

--- a/packages/3-targets/7-drivers/sqlite/test/sql-queryable-test-utils.ts
+++ b/packages/3-targets/7-drivers/sqlite/test/sql-queryable-test-utils.ts
@@ -1,0 +1,29 @@
+import type {
+  SqlExecuteRequest,
+  SqlQueryable,
+  SqlStatementStats,
+} from '@internal/sql-relational-core/ast';
+
+function request(sql: string, params?: readonly unknown[]): SqlExecuteRequest {
+  return params === undefined ? { sql } : { sql, params };
+}
+
+export async function executeSql(
+  queryable: SqlQueryable,
+  sql: string,
+  params?: readonly unknown[],
+): Promise<SqlStatementStats> {
+  return queryable.execute(request(sql, params));
+}
+
+export async function queryRows<Row>(
+  queryable: SqlQueryable,
+  sql: string,
+  params?: readonly unknown[],
+): Promise<Row[]> {
+  const rows: Row[] = [];
+  for await (const row of queryable.query<Row>(request(sql, params))) {
+    rows.push(row);
+  }
+  return rows;
+}

--- a/packages/3-targets/7-drivers/sqlite/test/sqlite-driver.test.ts
+++ b/packages/3-targets/7-drivers/sqlite/test/sqlite-driver.test.ts
@@ -9,6 +9,7 @@ import {
   type SqliteBinding,
   SqliteConnectionImpl,
 } from '../src/sqlite-driver';
+import { executeSql, queryRows } from './sql-queryable-test-utils';
 
 let testDir: string;
 let testPath: string;
@@ -34,25 +35,25 @@ describe('SqliteBoundDriver', () => {
     await driver.close();
   });
 
-  it('executes CREATE TABLE and INSERT via query()', async () => {
+  it('executes CREATE TABLE and INSERT via execute()', async () => {
     const driver = createDriver();
-    await driver.query('CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT)');
-    await driver.query('INSERT INTO t VALUES (?, ?)', [1, 'alice']);
-    const result = await driver.query<{ id: number; name: string }>('SELECT * FROM t');
-    expect(result.rows).toHaveLength(1);
-    expect(result.rows[0]).toMatchObject({ id: 1, name: 'alice' });
+    await executeSql(driver, 'CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT)');
+    await executeSql(driver, 'INSERT INTO t VALUES (?, ?)', [1, 'alice']);
+    const result = await queryRows<{ id: number; name: string }>(driver, 'SELECT * FROM t');
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: 1, name: 'alice' });
     await driver.close();
   });
 
-  it('executes SELECT via execute() returning AsyncIterable', async () => {
+  it('streams SELECT rows via query()', async () => {
     const driver = createDriver();
-    await driver.query('CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)');
-    await driver.query('INSERT INTO t VALUES (1, ?)', ['a']);
-    await driver.query('INSERT INTO t VALUES (2, ?)', ['b']);
-    await driver.query('INSERT INTO t VALUES (3, ?)', ['c']);
+    await executeSql(driver, 'CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)');
+    await executeSql(driver, 'INSERT INTO t VALUES (1, ?)', ['a']);
+    await executeSql(driver, 'INSERT INTO t VALUES (2, ?)', ['b']);
+    await executeSql(driver, 'INSERT INTO t VALUES (3, ?)', ['c']);
 
     const rows: Array<{ id: number; val: string }> = [];
-    for await (const row of driver.execute<{ id: number; val: string }>({
+    for await (const row of driver.query<{ id: number; val: string }>({
       sql: 'SELECT * FROM t ORDER BY id',
     })) {
       rows.push(row);
@@ -66,9 +67,36 @@ describe('SqliteBoundDriver', () => {
     await driver.close();
   });
 
+  it('reports affected rows from stmt.run().changes', async () => {
+    const run = vi.fn(() => ({ changes: 3, lastInsertRowid: 0 }));
+    const db = {
+      prepare: vi.fn(() => ({ columns: () => [], run })),
+    } as unknown as DatabaseSync;
+    const connection = new SqliteConnectionImpl(db);
+
+    await expect(connection.execute({ sql: 'UPDATE t SET value = ?' })).resolves.toEqual({
+      affectedRows: 3,
+    });
+    expect(run).toHaveBeenCalledOnce();
+  });
+
+  it('rejects RETURNING statements routed through execute()', async () => {
+    const driver = createDriver();
+    await executeSql(driver, 'CREATE TABLE t(id INTEGER PRIMARY KEY, value TEXT)');
+
+    await expect(
+      driver.execute({ sql: "INSERT INTO t(value) VALUES ('lost') RETURNING id" }),
+    ).rejects.toThrow('cannot execute statements that return rows');
+
+    await expect(
+      queryRows<{ id: number; value: string }>(driver, 'SELECT * FROM t'),
+    ).resolves.toEqual([]);
+    await driver.close();
+  });
+
   it('supports EXPLAIN QUERY PLAN', async () => {
     const driver = createDriver();
-    await driver.query('CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)');
+    await executeSql(driver, 'CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)');
 
     const explain = await driver.explain!({ sql: 'SELECT * FROM t WHERE id = 1' });
     expect(explain.rows.length).toBeGreaterThan(0);
@@ -77,13 +105,14 @@ describe('SqliteBoundDriver', () => {
 
   it('enables foreign keys by default', async () => {
     const driver = createDriver();
-    await driver.query('CREATE TABLE parent(id INTEGER PRIMARY KEY)');
-    await driver.query(
+    await executeSql(driver, 'CREATE TABLE parent(id INTEGER PRIMARY KEY)');
+    await executeSql(
+      driver,
       'CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id))',
     );
-    await driver.query('INSERT INTO parent VALUES (?)', [1]);
+    await executeSql(driver, 'INSERT INTO parent VALUES (?)', [1]);
 
-    await expect(driver.query('INSERT INTO child VALUES (?, ?)', [1, 999])).rejects.toThrow(
+    await expect(executeSql(driver, 'INSERT INTO child VALUES (?, ?)', [1, 999])).rejects.toThrow(
       SqlQueryError,
     );
     await driver.close();
@@ -99,11 +128,11 @@ describe('SqliteBoundDriver', () => {
 
   it('normalizes unique constraint errors to SqlQueryError', async () => {
     const driver = createDriver();
-    await driver.query('CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT UNIQUE)');
-    await driver.query('INSERT INTO t VALUES (?, ?)', [1, 'a']);
+    await executeSql(driver, 'CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT UNIQUE)');
+    await executeSql(driver, 'INSERT INTO t VALUES (?, ?)', [1, 'a']);
 
     try {
-      await driver.query('INSERT INTO t VALUES (?, ?)', [2, 'a']);
+      await executeSql(driver, 'INSERT INTO t VALUES (?, ?)', [2, 'a']);
       expect.unreachable('should have thrown');
     } catch (error) {
       expect(SqlQueryError.is(error)).toBe(true);
@@ -114,13 +143,14 @@ describe('SqliteBoundDriver', () => {
 
   it('normalizes foreign key constraint errors to SqlQueryError', async () => {
     const driver = createDriver();
-    await driver.query('CREATE TABLE parent(id INTEGER PRIMARY KEY)');
-    await driver.query(
+    await executeSql(driver, 'CREATE TABLE parent(id INTEGER PRIMARY KEY)');
+    await executeSql(
+      driver,
       'CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id))',
     );
 
     try {
-      await driver.query('INSERT INTO child VALUES (?, ?)', [1, 999]);
+      await executeSql(driver, 'INSERT INTO child VALUES (?, ?)', [1, 999]);
       expect.unreachable('should have thrown');
     } catch (error) {
       expect(SqlQueryError.is(error)).toBe(true);
@@ -133,28 +163,28 @@ describe('SqliteBoundDriver', () => {
 describe('SqliteConnection', () => {
   it('acquireConnection returns a connection that shares database state', async () => {
     const driver = createDriver();
-    await driver.query('CREATE TABLE t(id INTEGER PRIMARY KEY)');
+    await executeSql(driver, 'CREATE TABLE t(id INTEGER PRIMARY KEY)');
     const conn = await driver.acquireConnection();
-    const result = await conn.query<{ id: number }>('SELECT * FROM t');
-    expect(result.rows).toHaveLength(0);
+    const result = await queryRows<{ id: number }>(conn, 'SELECT * FROM t');
+    expect(result).toHaveLength(0);
     await conn.release();
     await driver.close();
   });
 
   it('independent connections have isolated transactions', async () => {
     const driver = createDriver();
-    await driver.query('CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)');
+    await executeSql(driver, 'CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)');
 
     const conn1 = await driver.acquireConnection();
     const conn2 = await driver.acquireConnection();
 
     const tx1 = await conn1.beginTransaction();
-    await tx1.query('INSERT INTO t VALUES (?, ?)', [1, 'from-tx1']);
+    await executeSql(tx1, 'INSERT INTO t VALUES (?, ?)', [1, 'from-tx1']);
     await tx1.commit();
 
     // conn2 sees committed data
-    const after = await conn2.query<{ id: number }>('SELECT * FROM t');
-    expect(after.rows).toHaveLength(1);
+    const after = await queryRows<{ id: number }>(conn2, 'SELECT * FROM t');
+    expect(after).toHaveLength(1);
 
     await conn1.release();
     await conn2.release();
@@ -165,46 +195,46 @@ describe('SqliteConnection', () => {
 describe('SqliteTransaction', () => {
   it('commits a transaction', async () => {
     const driver = createDriver();
-    await driver.query('CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)');
+    await executeSql(driver, 'CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)');
 
     const conn = await driver.acquireConnection();
     const tx = await conn.beginTransaction();
-    await tx.query('INSERT INTO t VALUES (?, ?)', [1, 'a']);
-    await tx.query('INSERT INTO t VALUES (?, ?)', [2, 'b']);
+    await executeSql(tx, 'INSERT INTO t VALUES (?, ?)', [1, 'a']);
+    await executeSql(tx, 'INSERT INTO t VALUES (?, ?)', [2, 'b']);
     await tx.commit();
     await conn.release();
 
-    const result = await driver.query<{ id: number }>('SELECT * FROM t');
-    expect(result.rows).toHaveLength(2);
+    const result = await queryRows<{ id: number }>(driver, 'SELECT * FROM t');
+    expect(result).toHaveLength(2);
     await driver.close();
   });
 
   it('rolls back a transaction', async () => {
     const driver = createDriver();
-    await driver.query('CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)');
-    await driver.query('INSERT INTO t VALUES (?, ?)', [1, 'before']);
+    await executeSql(driver, 'CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)');
+    await executeSql(driver, 'INSERT INTO t VALUES (?, ?)', [1, 'before']);
 
     const conn = await driver.acquireConnection();
     const tx = await conn.beginTransaction();
-    await tx.query('INSERT INTO t VALUES (?, ?)', [2, 'rolled-back']);
+    await executeSql(tx, 'INSERT INTO t VALUES (?, ?)', [2, 'rolled-back']);
     await tx.rollback();
     await conn.release();
 
-    const result = await driver.query<{ id: number }>('SELECT * FROM t');
-    expect(result.rows).toHaveLength(1);
+    const result = await queryRows<{ id: number }>(driver, 'SELECT * FROM t');
+    expect(result).toHaveLength(1);
     await driver.close();
   });
 
   it('supports execute() within a transaction', async () => {
     const driver = createDriver();
-    await driver.query('CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)');
+    await executeSql(driver, 'CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)');
 
     const conn = await driver.acquireConnection();
     const tx = await conn.beginTransaction();
-    await tx.query('INSERT INTO t VALUES (?, ?)', [1, 'a']);
+    await executeSql(tx, 'INSERT INTO t VALUES (?, ?)', [1, 'a']);
 
     const rows: Array<{ id: number; val: string }> = [];
-    for await (const row of tx.execute<{ id: number; val: string }>({
+    for await (const row of tx.query<{ id: number; val: string }>({
       sql: 'SELECT * FROM t',
     })) {
       rows.push(row);

--- a/projects/affected-row-counts/plan.md
+++ b/projects/affected-row-counts/plan.md
@@ -1,0 +1,47 @@
+# affected-row-counts — Plan
+
+**Spec:** `projects/affected-row-counts/spec.md`
+**Linear Project:** [Prisma 8 RC1](https://linear.app/prisma-company/project/prisma-8-rc1-7592265f700c) — tracked under parent issue [TML-3166](https://linear.app/prisma-company/issue/TML-3166), one sub-issue per slice.
+
+## At a glance
+
+Three slices in the repo's standard substrate → consumer → docs shape: a stack of two (reshape the driver execution surface, then let the count reach the caller and delete the pre-`SELECT`), plus a documentation slice that is independent of both because every decision it records was settled at spec time.
+
+## Composition
+
+### Stack (deliver in order)
+
+1. **Slice `query-execute-split`** — Linear: [TML-3167](https://linear.app/prisma-company/issue/TML-3167)
+   - **Outcome:** `SqlQueryable` is two methods wide and named the way Go names them — `query()` streams rows, `execute()` returns `SqlStatementStats { affectedRows: number }`. Prepared-ness rides on the request rather than doubling the surface, so four methods become two; SQLite's connection and transaction classes stop duplicating each other; the runtime's prepared and unprepared execution paths merge into one. **Nothing above the runtime changes behaviour** — the count terminals still run their pre-`SELECT` at the end of this slice.
+   - **Builds on:** None.
+   - **Hands to:** A driver that answers "how many rows did that affect" directly, and a runtime with one execution path instead of two — the substrate slice 2 reads from.
+   - **Focus:** `driver-types.ts`; the postgres queryable base and its connection/transaction/driver subclasses; both sqlite queryable classes plus the abstract base they're missing; the runtime's two near-identical generators (`sql-runtime.ts:386` and `:531`, which differ only in how they build `exec`); and the driver fakes — 18 test files carry one, 12 of them clustered in `packages/2-sql/5-runtime/test/`, with 96 `executePrepared` occurrences repo-wide. The control plane's `SqlControlDriverInstance.query` is a different interface and does not move. Postgres's `execute()` reads `rowCount` off the buffered result; sqlite's is `stmt.run()`, with `columns().length === 0` kept as a guard so a misrouted `RETURNING` plan fails loudly instead of silently discarding rows. Also lands the ADR 210 conformance fix this slice's code sits on top of: a failed stale-handle retry must surface `ADAPTER.PREPARE_FAILED`, which today is emitted nowhere. Deliberately out of scope: any ORM-visible behaviour change.
+
+2. **Slice `count-terminals`** — Linear: [TML-3168](https://linear.app/prisma-company/issue/TML-3168)
+   - **Outcome:** `updateAndCount` and `deleteAndCount` issue exactly one statement and return the number the engine reported; the pre-`SELECT` is deleted rather than left dormant; a middleware `intercept` on a statistics-shaped execution cannot produce a fabricated count.
+   - **Builds on:** Slice 1's `execute()`.
+   - **Hands to:** The project's purpose, delivered — plus a statistics path `createAndCount` and ADR 023's write budgets could consume later.
+   - **Focus:** The runtime's statistics-returning execution path, present on every `RuntimeScope` implementation (runtime, transaction context `sql-runtime.ts:790`, supabase, mongo — a scope missing it is a compile error, not a silent hole); the two terminals in `collection.ts`; the intercept-result contract. Tests: statement count observed through middleware, and an interleaved-write integration test proving the number came from the write rather than a prior read. Deliberately out of scope: `createAndCount`, and the streaming `RETURNING` terminals.
+
+### Parallel group A (independent of the stack)
+
+- **Slice `count-semantics`** — Linear: [TML-3169](https://linear.app/prisma-company/issue/TML-3169)
+  - **Outcome:** ADR 210 describes the two-method driver surface, and each target's definition of "affected" is documented where a user of that target will find it — Postgres's matched-rows command tag, SQLite's `sqlite3_changes64()`, Mongo's `modifiedCount`.
+  - **Builds on:** None. Every decision it records was settled in the spec; it does not need either code slice to have landed.
+  - **Hands to:** The project-DoD's ADR and documentation conditions, and the vocabulary the other two slices' PR descriptions use.
+  - **Focus:** An **amendment** to [ADR 210](../../docs/architecture%20docs/adrs/ADR%20210%20-%20Prepared%20Statements%20-%20Author%20Surface%20and%20Driver%20SPI.md) — not a new ADR — restating its unchanged principles (opaque slot, lazy synchronous allocation, driver may ignore the slot, `preparedStatements: false` leaves it unset) over the two-method surface; per-target semantics documentation; [`scorecard/06-sql-orm-client.md`](../../scorecard/06-sql-orm-client.md) and [`scorecard/07-mongodb-query-and-orm.md`](../../scorecard/07-mongodb-query-and-orm.md). No code — the `ADAPTER.PREPARE_FAILED` conformance fix lives in slice 1 with the driver.
+
+## Dependencies (external)
+
+- [x] **Linear sync** — done. This project rides the existing [Prisma 8 RC1](https://linear.app/prisma-company/project/prisma-8-rc1-7592265f700c) Linear Project rather than getting one of its own, matching the codec-json-projections precedent (TML-3060 with its slice stack beneath it). Parent [TML-3166](https://linear.app/prisma-company/issue/TML-3166) with one sub-issue per slice, so the GitHub integration's auto-close fires per-slice instead of on the whole project — the reopen churn [`drive/project/README.md`](../../drive/project/README.md) § Linear conventions warns about. Working branch per slice follows `tml-XXXX-<slug>`.
+- [ ] **Workspace install** — this worktree has no `node_modules`, so no validation gate has been run and Drive trace emission is blocked. `pnpm install` before the first dispatch.
+
+## Sequencing rationale
+
+**Why `query-execute-split` ships on its own**, despite slice-INVEST's warning against slices whose value is "preparation for the next one" ([`drive/calibration/sizing.md`](../../drive/calibration/sizing.md) § Slice INVEST). Folding it into slice 2 would produce one PR spanning a breaking driver SPI change, a prepared/unprepared collapse across both drivers and ~15 fakes, a runtime de-duplication, the ORM terminals and their tests — which trips the explicit mis-sizing signal *"a slice that needs the reviewer to read three unrelated areas of the codebase to verify."* It also carries value of its own beyond enabling slice 2: the driver surface halves, and SQLite's twice-written method bodies and the runtime's two near-identical generators go away. Shipping it alone satisfies the spec's transitional-shape constraint directly — the pre-`SELECT` stays until the drivers report, so slice 1 merges with observable behaviour unchanged.
+
+**Why slice 1 isn't split further, despite its footprint.** It is one atomic compile unit: the moment `SqlQueryable` changes shape, both drivers, the runtime's two generators, and all 18 test fakes stop compiling. There is no ordering of those pieces that leaves a green `main` in between, so any attempt to split produces slices that cannot merge independently — a direct *Independent* failure. Its size is footprint, not incoherence: one interface change with its conforming implementations is the repo's clean **hard-cut migration of one substrate concept** shape, and the calibration is explicit that "a 2000-LoC mechanical migration with one outcome passes" *Small* while a small PR spanning three unrelated ideas does not.
+
+The one item that is genuinely a second outcome is the `ADAPTER.PREPARE_FAILED` conformance fix. It stays in slice 1 because it corrects the very code being rewritten and the ADR being amended, but it should be its own dispatch with its own brief rather than riding inside the SPI change's diff — the calibration's stated remedy for "while I'm in there" work. Deciding that is `drive-plan-slice`'s call at pickup.
+
+**Why `count-semantics` is parallel rather than stacked last.** It records decisions, not behaviour: the semantics are settled in the spec, so the ADR and the per-target documentation can be written and merged at any point without waiting for either code slice. Keeping it out of the stack also gets the ADR in front of a reviewer early, while the design rationale is still live — the repo's project-shape pattern explicitly allows for *"a parallelisable docs/ADR slice."*

--- a/projects/affected-row-counts/slices/query-execute-split/plan.md
+++ b/projects/affected-row-counts/slices/query-execute-split/plan.md
@@ -1,0 +1,78 @@
+# Slice `query-execute-split` — Dispatch plan
+
+**Slice spec:** `projects/affected-row-counts/slices/query-execute-split/spec.md`
+**Linear:** [TML-3167](https://linear.app/prisma-company/issue/TML-3167)
+
+## Shape
+
+Six dispatches in the repo's **hard-cut migration of one substrate concept** shape (`drive/calibration/sizing.md` § Slice-shape patterns): substrate + reference implementation → second implementation → consumer migration → mechanical fan-out closing the gate. The conformance fix leads, deliberately.
+
+**Expected intermediate state: repo-wide `pnpm typecheck` is red from D2 until D6 closes it.** The moment `SqlQueryable` changes shape, both drivers, the runtime and all 18 test fakes stop compiling — that is the slice's premise, not a defect. Each of D2–D5 gates on its **own package's** typecheck and tests; D6 owns repo-wide green. An implementer who reports "typecheck is red elsewhere" during D2–D5 has observed the plan working, not a failure.
+
+Two calibration patterns drove the boundaries. **"Mechanical fan-out + design judgment in one dispatch"** is why the runtime merge (D4), the supabase judgment (D5), and the 18-file fake migration (D6) are three dispatches rather than one — the judgment sites would otherwise be buried in the fan-out's diff where the reviewer misses them. **"While I'm in there cleanup"** is why the `ADAPTER.PREPARE_FAILED` fix is D1 with its own brief rather than riding inside the SPI diff.
+
+### Dispatch 1: `ADAPTER.PREPARE_FAILED` conformance
+
+- **Outcome:** A failed stale-handle retry surfaces `ADAPTER.PREPARE_FAILED` with the originating error as `cause`, and a test asserts it. The code is currently absent from all source — it appears only in ADR 210, ADR 027, and this project's docs.
+- **Builds on:** None. Runs against today's unmodified SPI.
+- **Hands to:** A `withStaleHandleRetry` that is ADR-210-conformant *before* it gets rewritten — so D2's reshape carries the fix forward rather than being asked to introduce it mid-refactor.
+- **Focus:** `postgres-driver.ts` `withStaleHandleRetry` (currently `:190`; the retry-failure path at `:214` rethrows a generic `normalizePgError`). Read ADR 210 § Stale-handle retry and ADR 027 for the envelope shape — this is a **single-file judgment call**, and the envelope's exact shape is the thing to get right. Deliberately out of scope: any SPI shape change. Gates green throughout; this dispatch does not break the build.
+
+### Dispatch 2: the interface, with postgres as its reference implementation
+
+- **Outcome:** `SqlQueryable` is `query()` (rows, streaming) + `execute()` (`SqlStatementStats`) + `explain?`; `SqlStatementStats` and `PreparedStatementHandle` exist; `SqlExecuteRequest` carries the optional slot and `PreparedExecuteRequest` extends it; `SqlQueryResult` is deleted. The postgres driver conforms, and a test pins that `execute()`'s `affectedRows` comes from pg's command tag.
+- **Builds on:** D1's conformant retry path; the spec's chosen design.
+- **Hands to:** The SPI's final shape plus one complete worked implementation — the reference every later dispatch conforms against.
+- **Focus:** `driver-types.ts`; `postgres-driver.ts` (`PostgresQueryable` base + its four subclasses) and `postgres/src/exports/runtime.ts`. The prepared fall-through (`:173`, prepared-statements-disabled) becomes an internal branch of `query()`. Branch on `req.preparedStatementHandle === undefined`, never `in`. The `handle as string` bare cast (`:185`) should not survive — narrow where the handle is minted. The cursor path is untouched: statistics no longer ride the row stream, so nothing is extracted from `readCursor`. Gate: postgres-driver package typecheck + tests. Deliberately out of scope: sqlite, runtime, fakes.
+
+### Dispatch 3: sqlite conforms, and stops writing every method twice
+
+- **Outcome:** The sqlite driver conforms to the new SPI, with `execute()` as `stmt.run()` (`changes` = `sqlite3_changes64()`). `SqliteConnectionImpl` and `SqliteTransactionImpl` share an abstract base instead of duplicating four method bodies verbatim. Two tests: `run().changes` is the count source, and a `RETURNING` statement routed to `execute()` fails loudly.
+- **Builds on:** D2's SPI shape and the postgres implementation as reference.
+- **Hands to:** Both shipped drivers conforming — the project-DoD condition "both drivers return a real `affectedRows`" is now reachable.
+- **Focus:** `sqlite-driver.ts` (`SqliteConnectionImpl` `:66`, exported; `SqliteTransactionImpl` `:139`, not; the base stays package-private). `columns().length === 0` is retained as a **guard, not a router** — `run()` on a `RETURNING` statement executes it and discards rows silently, so a misrouted plan must fail rather than lose data. Gate: sqlite-driver package typecheck + tests. Deliberately out of scope: runtime, fakes.
+
+### Dispatch 4: one runtime execution path
+
+- **Outcome:** `executeAgainstQueryable` and `executePreparedAgainstQueryable` are one code path parameterised by how `exec` is built. The per-call `planExecutionId` mint (ADR 220) survives for every entry point.
+- **Builds on:** D2's request shape — prepared-ness on the request is what makes the two thunks one call.
+- **Hands to:** A single runtime execution path, so the fakes in D6 have exactly one driver-facing contract to satisfy.
+- **Focus:** `sql-runtime.ts` (`:386` and `:531` — they differ in exactly two places: how `exec` is produced, and `:472` vs `:602` for the driver call) and `prepared/prepared-statement.ts`. `RuntimeScope` (`relational-core/src/runtime-scope.ts:20`) is **not** touched — adding a statistics method to every scope is slice 2. Gate: runtime package typecheck against `src` (its `test/` tree is still red until D6, by design). Deliberately out of scope: the 12 runtime test fakes.
+
+### Dispatch 5: supabase conforms, and its control statements get a home
+
+- **Outcome:** The supabase runtime conforms to the reshaped surface, and `openRoleSession`'s three raw-connection calls — `SELECT set_config($1,$2,false)` twice and `RESET ALL` once — route through `query()` and drain, rather than the deleted buffered `query(sql, params)`.
+- **Builds on:** D2's SPI and D4's single runtime path.
+- **Hands to:** Every production implementation of the surface conforming; only test doubles remain.
+- **Focus:** `supabase-runtime.ts` (`:41`, `:42`, `:125`). This is the **judgment site the project spec missed** — the calls read like control-plane code but run on a raw runtime `SqlConnection`, so the "control plane is a separate interface" boundary does not cover them. `execute()` stays reserved for single DML with a real count, per the spec; `SELECT set_config` legitimately returns a row and `RESET ALL` returns none, so draining is correct for both. If that reasoning does not survive contact with the code, **halt and surface** rather than inventing a third method. Gate: supabase package typecheck + tests.
+
+### Dispatch 6: the fakes follow, and the gate closes
+
+- **Outcome:** Every driver fake implements the new surface; `grep -rn 'executePrepared' --include='*.ts' packages/ test/` returns zero outside `node_modules`/`dist` (baseline: 96 occurrences across 25 files); repo-wide `pnpm typecheck`, `pnpm lint:deps`, and `pnpm test:packages` are green.
+- **Builds on:** D5's state — all production implementations conforming, so the fakes have a settled contract to mirror.
+- **Hands to:** Slice DoD. The SPI is two methods wide end-to-end with no remaining references to the retired pair.
+- **Focus:** 18 test files carrying a fake, 12 clustered in `packages/2-sql/5-runtime/test/`, plus `relational-core/test/ast/driver-types.test.ts`, four postgres/sqlite driver + adapter test files, and `supabase/test/supabase-runtime.test.ts`. A **mechanical fan-out** — uniform transformation, file count irrelevant, verification is one grep plus workspace typecheck. Any fake that needs a *judgment* call rather than a mechanical rewrite is a signal the contract from D2–D5 is underspecified: halt and surface rather than inventing per-fake semantics.
+
+## Handoff linearity
+
+D1 → D2 → D3 → D4 → D5 → D6 is linear; each `builds on` references the immediately-prior `hands to`. Two non-obvious dependencies worth naming for brief assembly:
+
+- **D3, D4 and D5 all build on D2's SPI shape**, not merely on their immediate predecessor. An implementer picking up D4 or D5 needs D2's `driver-types.ts` in context, not just D3's or D4's diff.
+- **D6 depends on the union of D2–D5**, not on D5 alone. Its brief needs the settled contract, which is only complete once every production implementation has landed.
+
+## Slice-DoD reachability
+
+| Slice-DoD condition | Closed by |
+| --- | --- |
+| Zero `executePrepared` occurrences | D6 (grep gate) |
+| `SqlQueryResult` deleted, not orphaned | D2 (deleted) · D6 (verified unreferenced) |
+| `ADAPTER.PREPARE_FAILED` emitted + asserted | D1 |
+| Per-driver count-source tests | D2 (pg command tag) · D3 (sqlite `run().changes` + `RETURNING` guard) |
+| `pnpm lint:deps` clean | D6 |
+| No net increase in bare-`as` casts | D2 (`handle as string` removed) · D6 (repo-wide check) |
+
+Project-DoD floor items and the team-DoD overlay (`drive/calibration/dod.md`) are inherited, not restated.
+
+## Open items
+
+1. **Should D1 land before or after the reshape?** Working position: before, as planned above. It is a self-contained single-file judgment call, and fixing it against stable code produces a cleaner review than introducing it mid-refactor. If D2's rewrite turns out to relocate the retry logic wholesale, D1's test is what proves the behaviour survived the move.

--- a/projects/affected-row-counts/slices/query-execute-split/spec.md
+++ b/projects/affected-row-counts/slices/query-execute-split/spec.md
@@ -1,0 +1,146 @@
+# Slice: query-execute-split
+
+Parent project: `projects/affected-row-counts/`. Contributes the substrate the project's purpose rests on — a driver that can answer "how many rows did that affect" — without changing any ORM-visible behaviour.
+
+## At a glance
+
+`SqlQueryable` stops being four methods that answer two questions badly and becomes two that answer them directly: `query()` streams rows, `execute()` returns `SqlStatementStats`. Prepared-ness moves onto the request, so `executePrepared` disappears from both drivers, the runtime, and 18 test fakes. Nothing above the runtime changes — the count terminals still run their pre-`SELECT` when this merges.
+
+## Chosen design
+
+### The interface, before and after
+
+Today (`packages/2-sql/4-lanes/relational-core/src/ast/driver-types.ts:82`):
+
+```ts
+export interface SqlQueryable {
+  execute<Row>(request: SqlExecuteRequest): AsyncIterable<Row>;          // rows
+  executePrepared<Row>(request: PreparedExecuteRequest): AsyncIterable<Row>;  // rows
+  explain?(request: SqlExecuteRequest): Promise<SqlExplainResult>;
+  query<Row>(sql: string, params?: readonly unknown[]): Promise<SqlQueryResult<Row>>;  // buffered
+}
+```
+
+After:
+
+```ts
+export interface SqlStatementStats {
+  readonly affectedRows: number;
+}
+
+export interface PreparedStatementHandle {
+  get(): unknown;
+  set(value: unknown): void;
+}
+
+export interface SqlExecuteRequest {
+  readonly sql: string;
+  readonly params?: readonly unknown[];
+  readonly preparedStatementHandle?: PreparedStatementHandle;
+}
+
+export interface PreparedExecuteRequest extends SqlExecuteRequest {
+  readonly preparedStatementHandle: PreparedStatementHandle;
+}
+
+export interface SqlQueryable {
+  query<Row>(request: SqlExecuteRequest): AsyncIterable<Row>;
+  execute(request: SqlExecuteRequest): Promise<SqlStatementStats>;
+  explain?(request: SqlExecuteRequest): Promise<SqlExplainResult>;
+}
+```
+
+Three things this does at once, which is why they are one slice:
+
+1. **Fixes the naming inversion.** Today `execute` streams rows and `query` is the buffered one — inverted against every prior art (JDBC `executeQuery`/`executeUpdate`, ADO.NET `ExecuteReader`/`ExecuteNonQuery`, Go `Query`/`Exec`). The new names land correct by construction rather than as a follow-up rename.
+2. **Collapses prepared-ness onto the request.** `PreparedExecuteRequest` gains the slot and *extends* `SqlExecuteRequest` (today it does not — it redeclares `sql` and makes `params` required). Renaming `handle` → `preparedStatementHandle` is what makes the field meaningful on a request type that is no longer prepared-specific.
+3. **Retires the buffered `query(sql, params)`.** Its only ORM-path value was `rowCount`, which is exactly what the new `execute()` returns — as a required `number` rather than `number | null | undefined`.
+
+`SqlQueryResult` is deleted along with the buffered method. Its `readonly [key: string]: unknown` index signature is why `PostgresQueryable.query` can `return result as unknown as SqlQueryResult<Row>` — the new `SqlStatementStats` is a closed two-field shape that the postgres driver populates explicitly.
+
+### Two levels of "unset"
+
+The slot's **presence** marks preparedness; the slot's **value** is the lazily-minted handle. A prepared statement on first execute has a slot whose `get()` returns `undefined` — so the marker must be the slot object, not the handle. Flattening to `preparedStatementHandle?: string` would make "prepared, not yet minted" indistinguishable from "ad-hoc".
+
+Drivers branch on `req.preparedStatementHandle === undefined`, **never** with `in`. Key-presence would send `{ preparedStatementHandle: undefined }` down the prepared path and throw on `.get()`. `exactOptionalPropertyTypes` rejects that literal at compile time, but `SqlQueryable` is exported from `relational-core/src/exports/ast.ts` and reachable from untyped callers. The `=== undefined` form also needs no cast, which matters given the bare-`as` ban.
+
+### Driver-side
+
+**Postgres** (`packages/3-targets/7-drivers/postgres/src/postgres-driver.ts`). The `PostgresQueryable` abstract base already exists (`:150`) with four subclasses; the shape is right, only the methods move. `execute()` is the buffered path — `rowCount` straight off pg's result, no cursor involved. The cursor stays exactly as it is: because statistics no longer ride the row stream, nothing needs extracting from `readCursor`'s discarded third callback argument. That work, which the project spec once scoped, disappears.
+
+The prepared fall-through at `:173` (skip server-side prepare when `preparedStatementsEnabled` is false) becomes an internal branch of `query()` rather than a separate method. The `handle as string` bare cast at `:185` should not survive the rewrite — the driver narrows its own handle, so the narrowing belongs where the handle is minted.
+
+**SQLite** (`packages/3-targets/7-drivers/sqlite/src/sqlite-driver.ts`). `execute()` is `stmt.run()`, whose `changes` is `sqlite3_changes64()`. `stmt.columns().length === 0` is retained as a **guard, not a router**: `run()` on a `RETURNING` statement executes it and silently discards the rows, so a misrouted plan must fail loudly rather than lose data.
+
+`SqliteConnectionImpl` (`:66`) and `SqliteTransactionImpl` (`:139`) currently duplicate `execute`, `executePrepared`, `explain`, and `query` **verbatim** — four method bodies written twice. They get the abstract-base treatment postgres already has. Note `SqliteConnectionImpl` is exported and `SqliteTransactionImpl` is not; the base class stays package-private either way.
+
+### Runtime-side
+
+`executeAgainstQueryable` (`sql-runtime.ts:386`) and `executePreparedAgainstQueryable` (`:531`) are near-identical: same `ensureCodecRegistryValidated`, same `codecCtx`, same `execMiddlewareCtx` with its own minted `planExecutionId`, same terminal `self.streamRows(...)`. They differ in exactly two places — how `exec` is built (AST-lower-and-encode vs. resolve-prepared-slots-and-encode) and which driver method the thunk calls (`:472` vs `:602`). With prepared-ness on the request, the thunk becomes one call and the two generators merge into one path parameterised by how `exec` is produced.
+
+`RuntimeScope` is `Pick<RuntimeExecutor<SqlOrmPlan>, 'execute'>` (`relational-core/src/runtime-scope.ts:20`) — a **runtime-level** surface, distinct from the driver-level `SqlQueryable`. This slice does not touch it. Adding a statistics method to every `RuntimeScope` is slice 2's work.
+
+> **Naming collision, deliberate and temporary.** After this slice `SqlQueryable.execute` returns statistics while `RuntimeScope.execute` still streams rows. Different interfaces at different layers; the reviewer should expect it rather than read it as a mistake.
+
+## Coherence rationale
+
+One interface changes shape and every implementation and fake follows it in the same commit range. The moment `SqlQueryable` changes, both drivers, the runtime's two generators, and all 18 test fakes stop compiling — there is no ordering of those pieces that leaves a green `main` in between, so any split produces slices that cannot merge independently. This is the repo's hard-cut migration shape: one substrate concept, its conforming implementations, and the fakes that stand in for them. Its size is footprint, not incoherence — a reviewer holds one idea ("the SPI splits along the question being asked") and reads the rest as mechanical consequence.
+
+## Scope
+
+**In:**
+
+- `packages/2-sql/4-lanes/relational-core/src/ast/driver-types.ts` — the interface, `SqlStatementStats`, `PreparedStatementHandle`, the reshaped request types; `SqlQueryResult` deleted.
+- `packages/3-targets/7-drivers/postgres/src/postgres-driver.ts` — `PostgresQueryable` + four subclasses; `postgres/src/exports/runtime.ts`.
+- `packages/3-targets/7-drivers/sqlite/src/sqlite-driver.ts` — both queryable classes + the abstract base they're missing.
+- `packages/2-sql/5-runtime/src/sql-runtime.ts` — the two generators merged; `prepared/prepared-statement.ts`.
+- `packages/3-extensions/supabase/src/runtime/supabase-runtime.ts` — the scope surface and its three raw-connection `query()` call sites.
+- The 18 test files carrying a driver fake (12 in `packages/2-sql/5-runtime/test/`), 96 `executePrepared` occurrences repo-wide.
+- The `ADAPTER.PREPARE_FAILED` conformance fix — **its own dispatch**, not folded into the SPI diff.
+
+**Out:**
+
+- Any ORM-visible behaviour change. `updateAndCount` / `deleteAndCount` keep their pre-`SELECT`; no terminal changes.
+- `RuntimeScope` gaining a statistics method — slice 2.
+- The migration/control plane. Verified separate: `packages/3-targets/3-targets/{postgres,sqlite}/src/core/migrations/runner.ts` are typed against `SqlControlDriverInstance` (`@internal/sql-contract/types`), not `SqlQueryable`. Its ~500 `driver.query(...)` call sites do not move.
+- Mongo. No `SqlQueryable` implementation.
+
+## Pre-investigated edge cases
+
+| Edge case | Disposition | Notes |
+| --- | --- | --- |
+| Supabase's three raw-connection `query()` calls | Route to `query()` and drain | `openRoleSession` issues `SELECT set_config($1,$2,false)` twice and `RESET ALL` once against a raw `SqlConnection` (`supabase-runtime.ts:41`, `:42`, `:125`) — the buffered method this slice deletes. These are session-control statements, and the spec reserves `execute()` for single DML with a real count. `SELECT set_config` genuinely returns a row; `RESET ALL` returns none and draining is a no-op. Not discoverable by grepping `SqlQueryable` alone — it looks like control-plane code but runs on the runtime's connection. |
+| `run()` on a `RETURNING` statement | Guard, must fail loudly | Node's `StatementSync.run()` executes the statement and discards rows silently. A misrouted plan would lose data rather than error, so `columns().length === 0` stays as an assertion. Upstream position ([nodejs/node#59764](https://github.com/nodejs/node/issues/59764)): the caller must know what kind of statement it is running; `sqlite3_changes` has never been exposed standalone. |
+| Grounding illustrative snippets | Re-verify before coding | Per `drive/spec/README.md` § Grounding illustrative snippets, TML-2500 hit spec-sketch-vs-shipped-code drift four times. The interface block above is transcribed from today's `driver-types.ts`, but line numbers move — implementers read the file, not this spec. |
+
+## Slice-specific done conditions
+
+- [ ] `grep -rn 'executePrepared' --include='*.ts' packages/ test/` returns zero results outside `node_modules`/`dist` (baseline: 96 occurrences across 25 files).
+- [ ] `SqlQueryResult` is deleted, not left unreferenced.
+- [ ] `ADAPTER.PREPARE_FAILED` is emitted by the postgres driver and asserted by a test — it currently appears only in ADR 210, ADR 027, and this project's docs, never in source.
+- [ ] Both drivers have a test pinning the count source each relies on: pg's command-tag `rowCount`, sqlite's `run().changes` plus the `RETURNING`-misroute guard.
+- [ ] `pnpm lint:deps` clean (the SPI is an exported surface; imports move).
+- [ ] No net increase in bare-`as` casts — the `handle as string` at `postgres-driver.ts:185` should go, not be relocated.
+
+## Contract impact
+
+None. No contract entity, kind, or capability changes; `contract.json` / `contract.d.ts` output is unaffected.
+
+## Adapter impact
+
+- **postgres driver** — reshaped; `execute()` reads `rowCount` off the buffered result. Cursor path untouched.
+- **sqlite driver** — reshaped; `execute()` is `stmt.run()`. Gains the abstract base it lacks.
+- **supabase runtime** — implements the scope surface; three raw-connection call sites rehomed (see edge cases).
+- **mongo** — not touched. No `SqlQueryable` implementation.
+
+## Open Questions
+
+1. **Does `explain?` stay optional on the two-method surface?** Working position: yes, unchanged. It is genuinely optional (postgres and sqlite both implement it; third-party drivers need not), and folding it in would widen the slice for no gain. "Two methods wide" in the project-DoD means the two DML methods, not a literal count including `explain?`.
+
+## References
+
+- Parent project: `projects/affected-row-counts/spec.md`
+- Linear issue: [TML-3167](https://linear.app/prisma-company/issue/TML-3167) (sub-issue of [TML-3166](https://linear.app/prisma-company/issue/TML-3166))
+- [ADR 210 — Prepared Statements](../../../../docs/architecture%20docs/adrs/ADR%20210%20-%20Prepared%20Statements%20-%20Author%20Surface%20and%20Driver%20SPI.md) — amended by this project; principles preserved, shape changed. `§ Stale-handle retry` is the conformance target.
+- [ADR 027 — Error Envelope Stable Codes](../../../../docs/architecture%20docs/adrs/ADR%20027%20-%20Error%20Envelope%20Stable%20Codes.md) — reserves `ADAPTER.PREPARE_FAILED`.
+- [ADR 220](../../../../docs/architecture%20docs/adrs/) — `planExecutionId` minted per execute call; both generators do this independently today and the merged path must preserve it.

--- a/projects/affected-row-counts/spec.md
+++ b/projects/affected-row-counts/spec.md
@@ -1,0 +1,129 @@
+# affected-row-counts
+
+## Purpose
+
+Make the ORM's count-returning write terminals report the number the database itself reports, from the statement that did the work. Today they infer it from a separate read, which is a different question asked at a different moment — so the answer can be wrong, and is always paid for twice.
+
+## At a glance
+
+`updateAndCount` runs two statements ([`collection.ts:2012`](../../packages/3-extensions/sql-orm-client/src/collection.ts)); `deleteAndCount` does the same ([`:2240`](../../packages/3-extensions/sql-orm-client/src/collection.ts)):
+
+```ts
+// 1. read every matching primary key into JS…
+const matchingRows = await executeQueryPlan(this.ctx.runtime, countCompiled).toArray();
+// 2. …then run the write, discarding whatever it reports
+await executeQueryPlan(this.ctx.runtime, compiled).toArray();
+return matchingRows.length;
+```
+
+Three consequences. The pair is not atomic — outside a transaction a concurrent insert is updated but not counted, a concurrent delete is counted but not updated. The filter is evaluated twice, and every matching primary key is materialised in JS purely to call `.length` on it. And the two `WHERE` clauses are built by different code paths (`compileSelect` vs `buildCountMutationWhere`, [`query-plan-mutations.ts:195`](../../packages/3-extensions/sql-orm-client/src/query-plan-mutations.ts)), which already drifted once for MTI variants (#940).
+
+The count exists — we throw it away. Postgres reports it in the `CommandComplete` command tag; `pg-cursor` hands it to us as `read`'s third callback argument, which [`postgres-driver.ts:729`](../../packages/3-targets/7-drivers/postgres/src/postgres-driver.ts) drops. `SqlQueryResult.rowCount` is already in the driver interface ([`driver-types.ts:23`](../../packages/2-sql/4-lanes/relational-core/src/ast/driver-types.ts)) but only on `query()`, which nothing on the ORM path calls. SQLite surfaces `sqlite3_changes64()` only through `StatementSync.run()`.
+
+The gap is structural: `RuntimeScope.execute()` returns `AsyncIterableResult<Row>` ([`runtime-core.ts:110`](../../packages/1-framework/1-core/framework-components/src/execution/runtime-core.ts)) — a row stream with nowhere for statement metadata to live. Every layer between driver and caller consumes its source with `for await`, so nothing survives the trip up.
+
+## Non-goals
+
+- **Streaming write terminals.** `update`, `updateAll`, `createAll`, `deleteAll` keep their `UPDATE … RETURNING` streaming path unchanged. Only the count terminals move.
+- **`createAndCount`.** It returns `data.length` without asking the database ([`collection.ts:1671`](../../packages/3-extensions/sql-orm-client/src/collection.ts)). That is not currently wrong — the insert has no conflict clause, so it either inserts every row or throws — and the split-statement path ([`compileInsertCountSplit`](../../packages/3-extensions/sql-orm-client/src/query-plan-mutations.ts)) would need per-statement summing. Revisit if `ON CONFLICT DO NOTHING` ever reaches that path.
+- **Unifying count semantics across targets.** Each engine defines "affected" differently — Mongo's `modifiedCount` excludes no-op writes ([`2-mongo-family/5-query-builders/orm/src/collection.ts:486`](../../packages/2-mongo-family/5-query-builders/orm/src/collection.ts)), Postgres's command tag does not. No translation layer, no normalized definition, no target changed to match another. The differences get documented, not reconciled.
+- **New targets.** No MySQL work, and no accommodation for targets without `RETURNING` beyond what falls out of the design.
+- **Prepared-statement coverage for count terminals**, if the chosen shape costs it. Named as an accepted loss, not silently dropped.
+
+## Place in the larger world
+
+- **Chosen execution shape — two methods, named the way Go names them.** Rows and statistics are different questions, so they get different calls:
+
+  ```ts
+  query<Row>(req): AsyncIterable<Row>          // rows
+  execute(req):    Promise<SqlStatementStats>  // { affectedRows: number }
+  ```
+
+  `affectedRows` is **not optional**. Postgres always reports it in the `CommandComplete` tag for `INSERT`/`UPDATE`/`DELETE`; SQLite's `run()` always returns `changes`. Absence isn't a state either engine has for the statements this method exists to serve — so nothing downstream branches on `undefined`. `SqlStatementStats` is an object rather than a bare `number` because adding a field later (MySQL's matched-vs-changed) is non-breaking for third-party driver authors, while widening a return type is not.
+
+  Two obligations become contract text rather than optionality: `execute()` takes a **single statement** (multi-statement SQL through pg's simple protocol resolves to `Result[]` and the guarantee dissolves), and **DDL / control statements do not go through it** (they have no row-count tag, and the migration plane has its own interface). Both are free — ORM plans are single DML statements.
+
+  This also means statistics never travel through a row stream, so the seven `for await` re-wrap sites between driver and caller stop being a hazard: there is nothing in flight for them to drop.
+
+- **Prepared-ness is a property of the request, not a separate method.** A naive split yields four methods (`query`/`queryPrepared`/`execute`/`executePrepared`) where prepared-ness contributes exactly one thing. Instead the slot rides on the request, keeping the SPI two methods wide:
+
+  ```ts
+  interface PreparedStatementHandle { get(): unknown; set(value: unknown): void }
+
+  interface SqlExecuteRequest {
+    readonly sql: string;
+    readonly params?: readonly unknown[];
+    readonly preparedStatementHandle?: PreparedStatementHandle;  // absent ⇒ ad-hoc
+  }
+  interface PreparedExecuteRequest extends SqlExecuteRequest {
+    readonly preparedStatementHandle: PreparedStatementHandle;   // required
+  }
+  ```
+
+  The handle's value stays **`unknown`** — ADR 210 principle #3 makes opacity load-bearing ("the driver allocates whatever per-target handle it needs — a name, a statement reference, an integer, anything"). Narrowing it to `string` would encode one target's preparation primitive into a cross-target SPI. Where the driver narrows its own handle, that is the driver's business.
+
+  **Two levels of "unset", and they must not be conflated.** The slot's *presence* marks preparedness; the slot's *value* is the lazily-minted handle. A prepared statement on first execute has a slot whose `get()` returns `undefined` — which is why the marker has to be the slot object and not the handle itself. Flatten it to `preparedStatementHandle?: string` and "prepared, not yet minted" becomes indistinguishable from "ad-hoc".
+
+  **The driver branches on the value, never with `in`.** `'preparedStatementHandle' in req` is a key-presence test, so `{ preparedStatementHandle: undefined }` takes the prepared branch and throws on `.get()`. `exactOptionalPropertyTypes` (on repo-wide, `packages/0-config/tsconfig/base.json`) rejects that literal at compile time, but `SqlQueryable` is a published SPI reachable from untyped callers. `req.preparedStatementHandle === undefined` treats absent and illegally-undefined identically, and needs no cast — which matters, since bare `as` is banned in production code.
+
+  Two independent pieces of evidence that the split method was never carrying weight: SQLite's `executePrepared` is a pure delegate to `execute` ([`sqlite-driver.ts:84`](../../packages/3-targets/7-drivers/sqlite/src/sqlite-driver.ts), [`:157`](../../packages/3-targets/7-drivers/sqlite/src/sqlite-driver.ts)), and postgres's falls through whenever prepared statements are disabled ([`postgres-driver.ts:173`](../../packages/3-targets/7-drivers/postgres/src/postgres-driver.ts)).
+- **Driver SPI.** `SqlQueryable` ([`driver-types.ts:82`](../../packages/2-sql/4-lanes/relational-core/src/ast/driver-types.ts)) is exported from `relational-core/src/exports/ast.ts`, so any shape change is a break for third-party driver authors. At 0.x with no back-compat policy that is acceptable; it gets more expensive every release. The slice that reshapes it also **fixes the `execute`/`query` naming inversion** — every prior art puts `execute` on the non-row side (JDBC `executeQuery`/`executeUpdate`, ADO.NET `ExecuteReader`/`ExecuteNonQuery`, Go `Query`/`Exec`) and ours is inverted on both halves. The chosen shape resolves this by construction rather than as a separate rename — the two methods land already named correctly.
+- **Separate surface, untouched.** The migration/control plane uses `SqlControlDriverInstance.query` ([`sql-contract/src/types.ts:7`](../../packages/2-sql/1-core/contract/src/types.ts)) with its own implementations (`PostgresControlDriver`, `SqliteControlDriver`). None of its ~500 call sites are in scope.
+- **Middleware contract.** `runWithMiddleware`'s `intercept` path serves rows without reaching a driver ([`run-with-middleware.ts:87`](../../packages/1-framework/1-core/framework-components/src/execution/run-with-middleware.ts)). It is the only execution path that can reach a caller without an engine-reported count, which is why the intercept result — not the count's type — is where that case gets closed.
+- **[ADR 210 — Prepared Statements](../../docs/architecture%20docs/adrs/ADR%20210%20-%20Prepared%20Statements%20-%20Author%20Surface%20and%20Driver%20SPI.md) is Accepted and this project changes its SPI shape.** Every principle it states survives: the slot stays opaque to the runtime, allocation stays lazy and synchronous, a driver may still ignore the slot entirely, and `preparedStatements: false` still leaves it unset. What changes is the shape those principles were expressed through — the ADR pins `executePrepared` as its own method on `SqlQueryable` (§Driver SPI) and justifies the surface as "a three-field record" (§Why a slot wrapper). So the project owes ADR 210 an **amendment**, not a fresh ADR; the amendment restates the same guarantees over a two-method surface.
+- **[ADR 023 — Budget Evaluation](../../docs/architecture%20docs/adrs/ADR%20023%20-%20Budget%20Evaluation.md)** already assumes a "post factum rowCount when available" for write budgets. This project is what makes that real.
+- **Prior art.** Kysely splits `executeQuery` (rows + `numAffectedRows`) from `streamQuery`; Drizzle passes the driver's native result through per-dialect; ADO.NET's `DbDataReader` streams rows *and* exposes `RecordsAffected`, documented as valid only after the reader is drained. The "count is a completion-time value" constraint is not ours — it is the wire protocol's.
+
+## Contract impact
+
+None. No contract entity, kind, or capability changes; `contract.json` / `contract.d.ts` output is unaffected. Note that count terminals deliberately do **not** assert the `returning` capability (unlike `updateAll`, [`collection.ts:1955`](../../packages/3-extensions/sql-orm-client/src/collection.ts)) — that stays true.
+
+## Adapter impact
+
+- **postgres driver** — `execute()` is the buffered path; `rowCount` comes straight off pg's result. The cursor stays exactly as it is: because statistics no longer ride the row stream, the count never has to be extracted from `readCursor`'s discarded third callback argument. That work disappears from the project.
+- **sqlite driver** — `execute()` is `stmt.run()`, whose `changes` is `sqlite3_changes64()`. `stmt.columns().length === 0` is retained as a **guard, not a router**: `run()` on a `RETURNING` statement executes it and silently discards the rows, so a misrouted plan must fail loudly rather than lose data. Separately, `SqliteConnectionImpl` ([`:66`](../../packages/3-targets/7-drivers/sqlite/src/sqlite-driver.ts)) and `SqliteTransactionImpl` ([`:139`](../../packages/3-targets/7-drivers/sqlite/src/sqlite-driver.ts)) duplicate every method verbatim; they get the abstract-base treatment postgres already has ([`postgres-driver.ts:150`](../../packages/3-targets/7-drivers/postgres/src/postgres-driver.ts)).
+- **supabase runtime** — implements the scope surface ([`supabase-runtime.ts:154`](../../packages/3-extensions/supabase/src/runtime/supabase-runtime.ts)); gains the statistics method.
+- **mongo runtime** — no behaviour change; in scope only to document the semantic difference and, if the chosen shape makes it free, to retire the `blindCast<{ modifiedCount }>` smuggling a count through as a fake row.
+
+## Cross-cutting requirements
+
+- **No fabricated count.** `execute()` always returns a real number, so the risk is not a driver failing to report — it is a *caller* inventing a number when it never called `execute()` at all. The one place that can happen is middleware `intercept`, which short-circuits execution without touching a driver and whose result carries only `rows` ([`runtime-middleware.ts:115`](../../packages/1-framework/1-core/framework-components/src/execution/runtime-middleware.ts)). A middleware intercepting a statistics-shaped execution must supply the statistics; the contract closes there, not by pushing optionality onto every consumer.
+- **Writes are not second-class.** Whatever path carries the count runs the same `beforeExecute` / `intercept` / `onRow` / `afterExecute` chain, codec encoding, plan validation, abort handling, and telemetry as `execute()` does today.
+- **Transaction scope is preserved.** Count terminals inside `db.transaction(...)` run on the transaction's pinned connection, not a second pooled one.
+- **Each target reports its own engine's count; no normalization layer.** Postgres's command tag counts matched rows (including updates that changed nothing), SQLite's `sqlite3_changes64()` counts rows the statement modified, Mongo's `modifiedCount` excludes no-op writes. The project does not reconcile these into a single definition, and no code translates between them. What it owes instead is documentation: each target's meaning stated where a user reading that target's docs will find it.
+- **Every `RuntimeScope` exposes both methods.** The transaction context ([`sql-runtime.ts:790`](../../packages/2-sql/5-runtime/src/sql-runtime.ts)), supabase, and mongo each implement the scope surface; a scope missing the statistics method is a compile error rather than a silent hole, which is the point of returning statistics directly instead of threading them through a stream.
+- **The prepared/unprepared duplication shrinks, not grows.** The split must not leave four driver methods where there were two, four runtime generators where there were two, or SQLite's connection and transaction classes each carrying their own copy of every method.
+- **The prepared path ends up conformant with the ADR it is amending.** ADR 210 §Stale-handle retry requires that a failed retry surface `ADAPTER.PREPARE_FAILED` with the originating error as `cause` — a code ADR 027 reserves for exactly this. It is currently emitted **nowhere in the codebase**: `withStaleHandleRetry` rethrows a generic normalised error ([`postgres-driver.ts:214`](../../packages/3-targets/7-drivers/postgres/src/postgres-driver.ts)). Rewriting the surrounding code while leaving a known violation of the ADR being amended is incoherent, so closing it is in scope rather than a follow-up.
+
+## Transitional-shape constraints
+
+- The pre-`SELECT` fallback stays in place until **both** shipped drivers report a count. No intermediate slice may ship a terminal whose count silently degrades.
+- A driver-SPI change lands with **both** postgres and sqlite in the same slice. No half-migrated driver on `main`.
+- Every slice keeps `pnpm test:integration` and `pnpm test:e2e` green — these are the only gates that exercise a real driver.
+
+## Project Definition of Done
+
+- [ ] Team-DoD floor items (inherited; see [`drive/calibration/dod.md`](../../drive/calibration/dod.md)).
+- [ ] `updateAndCount` and `deleteAndCount` issue exactly one statement, proven by a test that counts statements through middleware — not by reading the source.
+- [ ] An integration test demonstrates the count comes from the write itself: a row inserted between what *would* have been the read and the write is reflected in the returned number.
+- [ ] Both shipped drivers return a real `affectedRows` from `execute()`, with a test pinning the behaviour each relies on — pg's command-tag count, sqlite's `run()` guard against a misrouted `RETURNING` statement.
+- [ ] The driver SPI is **two** methods wide, not four: a prepared statement is a request with a handle, not a separate call. SQLite's connection and transaction classes no longer carry duplicate method bodies, and the runtime's prepared and unprepared execution paths are one code path.
+- [ ] The pre-`SELECT` fallback is deleted, not left dormant.
+- [ ] `SqlQueryable`'s row-returning and non-row methods are named the way every prior art names them; no call site or fake still references the inverted pair.
+- [ ] ADR 210 is amended to describe the two-method surface, and its principles read true against the shipped code — including the stale-retry contract, whose `ADAPTER.PREPARE_FAILED` envelope is emitted by a driver rather than existing only on paper.
+- [ ] [`scorecard/06-sql-orm-client.md`](../../scorecard/06-sql-orm-client.md) and [`scorecard/07-mongodb-query-and-orm.md`](../../scorecard/07-mongodb-query-and-orm.md) reflect the settled semantics.
+
+## Open Questions
+
+None. Three questions were settled by the operator at spec time and moved into the body:
+
+- **Execution shape: `query()` streams rows, `execute()` returns statistics** — see Place in the larger world § Chosen execution shape. (An earlier position — a single `execute()` yielding row/metadata frames — was considered and reversed: it gave statistics a home inside the stream at the cost of making every layer demux, when the two questions simply want two calls.)
+- **The naming falls out of the shape** rather than being a separate rename: `query` returns rows and `execute` returns a count, as in Go's `Query`/`Exec`.
+- **Count semantics follow each driver; no unification** — see Cross-cutting requirements.
+
+## References
+
+- Linear Project: [Prisma 8 RC1](https://linear.app/prisma-company/project/prisma-8-rc1-7592265f700c) — parent issue [TML-3166](https://linear.app/prisma-company/issue/TML-3166), one sub-issue per slice. See [`plan.md`](./plan.md) § Dependencies.
+- ADRs: [ADR 210 — Prepared Statements](../../docs/architecture%20docs/adrs/ADR%20210%20-%20Prepared%20Statements%20-%20Author%20Surface%20and%20Driver%20SPI.md) (amended by this project); [ADR 027 — Error Envelope Stable Codes](../../docs/architecture%20docs/adrs/ADR%20027%20-%20Error%20Envelope%20Stable%20Codes.md) (reserves `ADAPTER.PREPARE_FAILED`); [ADR 023 — Budget Evaluation](../../docs/architecture%20docs/adrs/ADR%20023%20-%20Budget%20Evaluation.md) (consumer of the new count).
+- Upstream constraint: [nodejs/node#59764](https://github.com/nodejs/node/issues/59764) — Node's position that the caller must know what kind of statement it is running; `sqlite3_changes` has never been requested as a standalone binding, so `run()` is the only route.
+- Sibling surfaces: [`docs/architecture docs/subsystems/`](../../docs/architecture%20docs/subsystems/) — Query Lanes, Runtime & Middleware Framework, Adapters & Targets.

--- a/test/integration/test/sql-orm-client/runtime-helpers.ts
+++ b/test/integration/test/sql-orm-client/runtime-helpers.ts
@@ -3,7 +3,10 @@ import type { Contract } from '@internal/contract/types';
 import postgresDriver from '@internal/driver-postgres/runtime';
 import pgvectorRuntime from '@internal/extension-pgvector/runtime';
 import { instantiateExecutionStack } from '@internal/framework-components/execution';
-import type { AsyncIterableResult } from '@internal/framework-components/runtime';
+import type {
+  AsyncIterableResult,
+  RuntimeExecuteOptions,
+} from '@internal/framework-components/runtime';
 import { PostgresRuntimeImpl } from '@internal/postgres/runtime';
 import type { SqlStorage } from '@internal/sql-contract/types';
 import type { RuntimeQueryable } from '@internal/sql-orm-client';
@@ -11,9 +14,12 @@ import type { SqlExecutionPlan, SqlQueryPlan } from '@internal/sql-relational-co
 import {
   createExecutionContext,
   createSqlExecutionStack,
+  type PreparedStatement,
   type SqlRuntimeExtensionDescriptor,
+  type RuntimeQueryable as SqlRuntimeQueryable,
 } from '@internal/sql-runtime';
 import postgresTarget from '@internal/target-postgres/runtime';
+import { blindCast } from '@internal/utils/casts';
 import { Client } from 'pg';
 import { getTestContract } from './helpers';
 
@@ -177,6 +183,57 @@ export async function createPgIntegrationRuntime(
     return delegate(plan);
   };
 
+  function isPreparedStatement<Params extends Record<string, unknown>, Row>(
+    execution:
+      | ((SqlExecutionPlan | SqlQueryPlan) & { readonly _row?: Row })
+      | PreparedStatement<Params, Row>,
+  ): execution is PreparedStatement<Params, Row> {
+    return 'slots' in execution;
+  }
+
+  function createRecordingExecutor(target: SqlRuntimeQueryable): SqlRuntimeQueryable['execute'] {
+    function execute<Row>(
+      plan: (SqlExecutionPlan | SqlQueryPlan) & { readonly _row?: Row },
+      options?: RuntimeExecuteOptions,
+    ): AsyncIterableResult<Row>;
+    function execute<Params extends Record<string, unknown>, Row>(
+      ps: PreparedStatement<Params, Row>,
+      params: Params,
+      options?: RuntimeExecuteOptions,
+    ): AsyncIterableResult<Row>;
+    function execute<Params extends Record<string, unknown>, Row>(
+      planOrStatement:
+        | ((SqlExecutionPlan | SqlQueryPlan) & { readonly _row?: Row })
+        | PreparedStatement<Params, Row>,
+      paramsOrOptions?: Params | RuntimeExecuteOptions,
+      preparedOptions?: RuntimeExecuteOptions,
+    ): AsyncIterableResult<Row> {
+      if (isPreparedStatement(planOrStatement)) {
+        return target.execute(
+          planOrStatement,
+          blindCast<Params, 'prepared execute overload always receives statement parameters'>(
+            paramsOrOptions,
+          ),
+          preparedOptions,
+        );
+      }
+
+      return recordAndDelegate(
+        (plan) =>
+          target.execute(
+            plan,
+            blindCast<
+              RuntimeExecuteOptions | undefined,
+              'plan execute overload always receives execution options'
+            >(paramsOrOptions),
+          ),
+        planOrStatement,
+      );
+    }
+
+    return execute;
+  }
+
   const runtime: PgIntegrationRuntime = {
     executions,
     async query<Row extends Record<string, unknown> = Record<string, unknown>>(
@@ -209,14 +266,12 @@ export async function createPgIntegrationRuntime(
 
       const recordingConnection: PgConnection = {
         ...conn,
-        execute: <Row>(plan: (SqlExecutionPlan | SqlQueryPlan) & { readonly _row?: Row }) =>
-          recordAndDelegate((p) => conn.execute(p), plan),
+        execute: createRecordingExecutor(conn),
         transaction: async (): Promise<PgTransaction> => {
           const tx = await conn.transaction();
           const recordingTransaction: PgTransaction = {
             ...tx,
-            execute: <Row>(plan: (SqlExecutionPlan | SqlQueryPlan) & { readonly _row?: Row }) =>
-              recordAndDelegate((p) => tx.execute(p), plan),
+            execute: createRecordingExecutor(tx),
           };
           return recordingTransaction;
         },


### PR DESCRIPTION
## Linked issue

Refs [TML-3167](https://linear.app/prisma-company/issue/TML-3167/query-execute-split)

## At a glance

```ts
interface SqlQueryable {
  query<Row>(request: SqlExecuteRequest): AsyncIterable<Row>
  execute(request: SqlExecuteRequest): Promise<SqlStatementStats>
}
```

Drivers now distinguish streaming rows from DML execution statistics instead of exposing separate prepared variants or a buffered query API.

## Decision

This PR ships the Slice 1 driver-SPI split for affected-row counts: `query()` streams rows, `execute()` returns `{ affectedRows }`, and prepared execution is represented by an optional handle on the request. PostgreSQL and SQLite implement the final surface; the SQL runtime, Supabase runtime, adapters, and test doubles use it end to end.

It also makes a failed PostgreSQL stale prepared-statement retry emit the structural `DRIVER.PREPARE_FAILED` envelope required by ADR 239, preserving the normalized driver error as its cause.

## Reviewer notes

- This is a deliberate hard-cut migration. The broad test/fake changes are mechanical consumers of the two-method driver contract, not independent behavior changes.
- PostgreSQL counts `rowCount`; SQLite counts `stmt.run().changes`. Their distinct engine semantics are intentionally preserved.
- SQLite rejects a `RETURNING` statement routed to `execute()` before execution, preventing silent row loss.
- `pnpm test:packages` still has unrelated telemetry/CLI harness failures: `telemetry-backend` cannot locate `prisma-next`, and seven CLI process tests exceed their timeout. The changed packages and workspace typecheck are green.

## How it fits together

1. The relational driver contract exposes one streaming path and one statistics path in `packages/2-sql/4-lanes/relational-core/src/ast/driver-types.ts`.
2. PostgreSQL maps buffered command results to `{ affectedRows }`, while SQLite maps `StatementSync.run().changes` and retains its defensive `RETURNING` guard.
3. Preparedness moves onto the request, letting `packages/2-sql/5-runtime/src/sql-runtime.ts` use one streaming execution pipeline for ad-hoc and prepared plans.
4. Supabase session setup, target adapters, runtime helpers, and all fakes consume the same request-shaped contract.

## Behavior changes & evidence

- **Drivers report write statistics directly** through `execute(request)`.
  - Implementation: `packages/3-targets/7-drivers/postgres/src/postgres-driver.ts`, `packages/3-targets/7-drivers/sqlite/src/sqlite-driver.ts`
  - Evidence: `packages/3-targets/7-drivers/postgres/test/driver.basic.test.ts`, `packages/3-targets/7-drivers/sqlite/test/sqlite-driver.test.ts`
- **Prepared retry failures carry a stable DRIVER error code and original cause.**
  - Implementation: `packages/3-targets/7-drivers/postgres/src/postgres-driver.ts`, `packages/3-targets/7-drivers/postgres/src/driver-error.ts`
  - Evidence: `packages/3-targets/7-drivers/postgres/test/driver.prepared.test.ts`
- **The runtime has one streamed-row execution flow for normal and prepared plans.**
  - Implementation: `packages/2-sql/5-runtime/src/sql-runtime.ts`
  - Evidence: `packages/2-sql/5-runtime/test/prepared.test.ts`, `packages/2-sql/5-runtime/test/plan-execution-id.test.ts`

## Compatibility / migration / risk

This is a breaking internal driver SPI change. All in-repository implementations and fakes are migrated in this PR. ORM-visible count-terminal behavior remains unchanged; the count-terminal behavior change belongs to TML-3168.

## Testing performed

- `pnpm typecheck` — 165/165 tasks passed
- `pnpm lint:deps` passed
- PostgreSQL driver typecheck, test (127 tests), and lint passed
- SQLite driver typecheck, test (29 tests), and lint passed
- Supabase build, typecheck, lint, and test (89 tests) passed
- `executePrepared` and `SqlQueryResult` searches under `packages/` and `test/` returned zero results
- `pnpm test:packages` ran but has the unrelated telemetry/CLI harness failures noted above

## Skill update

n/a — internal SPI refactor; no end-user skill surface changed.

## Alternatives considered

- Keeping a separate `executePrepared()` method was rejected because preparedness is a request property, not a distinct execution operation.
- Returning statistics in the row stream was rejected because count consumers should not need to demultiplex row and metadata frames.
- Normalizing affected-row semantics across engines was rejected; each driver reports its native engine result.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco).
- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and the change is scoped to one logical concern.
- [x] Tests are updated.
- [x] The PR title is in `TML-NNNN: <sentence-case title>` form.
- [x] The **Skill update** section is filled in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - SQL queries now stream rows asynchronously, improving support for large result sets.
  - Statement execution reports affected-row statistics.
  - Prepared statements reuse handles and recover from stale handles.
  - PostgreSQL and SQLite support the unified SQL execution interface.
  - Added structured PostgreSQL driver errors with standardized codes and severity metadata.

- **Breaking Changes**
  - Removed separate prepared-execution methods and the legacy query-result format.
  - Query and execution methods now use request objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->