### PR TITLE
refactor(errors): explicit codes on the generic error path, cause support, namespace remaps (TML-3180)

### DIFF
--- a/docs/architecture docs/adrs/ADR 207 - Family-instance capability views for the framework CLI.md
+++ b/docs/architecture docs/adrs/ADR 207 - Family-instance capability views for the framework CLI.md
@@ -57,7 +57,7 @@ toFooView(input: unknown): FooView | undefined {
 // cli/src/commands/uses-foo.ts
 const view = client.toFooView(schema);
 if (!view) {
-  return notOk(errorRuntime('this command is not supported for this family', {
+  return notOk(errorRuntime('CLI.FAMILY_UNSUPPORTED', 'this command is not supported for this family', {
     why: 'The configured family does not implement the FooCapable capability.',
     fix: 'Use a family that supports this capability.',
   }));
@@ -135,7 +135,7 @@ toSchemaDiagram(schema: unknown): SchemaDiagram | undefined {
 // cli/src/commands/db-schema.ts
 if (flags.diagram) {
   const diagram = client.toSchemaDiagram(value.schema);
-  if (!diagram) return notOk(errorRuntime('--diagram is not supported for this family', { ... }));
+  if (!diagram) return notOk(errorRuntime('CLI.FAMILY_UNSUPPORTED', '--diagram is not supported for this family', { ... }));
   ui.output(diagram.mermaid);
   return;
 }

--- a/docs/architecture docs/adrs/ADR 207 - Family-instance capability views for the framework CLI.md
+++ b/docs/architecture docs/adrs/ADR 207 - Family-instance capability views for the framework CLI.md
@@ -54,12 +54,14 @@ toFooView(input: unknown): FooView | undefined {
   return undefined;
 }
 
-// cli/src/commands/uses-foo.ts
+// cli/src/commands/uses-foo.ts — each capability command registers its own
+// domain `*_UNSUPPORTED` code; the shipped exemplar is `CONTRACT.INFER_UNSUPPORTED`
+// in contract-infer.ts.
 const view = client.toFooView(schema);
 if (!view) {
-  return notOk(errorRuntime('CLI.FAMILY_UNSUPPORTED', 'this command is not supported for this family', {
-    why: 'The configured family does not implement the FooCapable capability.',
-    fix: 'Use a family that supports this capability.',
+  return notOk(errorRuntime('CONTRACT.INFER_UNSUPPORTED', 'contract infer is not supported for this family', {
+    why: 'The configured family does not implement the PslContractInferCapable capability.',
+    fix: 'Use a family that supports contract inference (e.g. SQL/Postgres).',
   }));
 }
 ```
@@ -135,7 +137,9 @@ toSchemaDiagram(schema: unknown): SchemaDiagram | undefined {
 // cli/src/commands/db-schema.ts
 if (flags.diagram) {
   const diagram = client.toSchemaDiagram(value.schema);
-  if (!diagram) return notOk(errorRuntime('CLI.FAMILY_UNSUPPORTED', '--diagram is not supported for this family', { ... }));
+  // A new capability registers a new domain code (like `CONTRACT.INFER_UNSUPPORTED`)
+  // in the error reference before shipping.
+  if (!diagram) return notOk(errorRuntime('CONTRACT.SCHEMA_DIAGRAM_UNSUPPORTED', '--diagram is not supported for this family', { ... }));
   ui.output(diagram.mermaid);
   return;
 }

--- a/docs/architecture docs/adrs/ADR 239 - Errors are structural envelopes with dotted namespace codes.md
+++ b/docs/architecture docs/adrs/ADR 239 - Errors are structural envelopes with dotted namespace codes.md
@@ -109,6 +109,8 @@ The split between "CLI presentation error" and "runtime error" is historical, no
 
 **Extensions.** In-repo extensions are ordinary namespaces named by the extension, uppercased: `SUPABASE`, `POSTGIS`, `PGVECTOR`, `PARADEDB`, … Core namespaces are reserved. Third-party extensions get a documented convention only — namespace = extension name uppercased — and the public code type is widened to the template-literal shape `` `${Uppercase<string>}.${string}` ``. Nothing polices third-party codes at runtime; they are outside the stability promise.
 
+**Targets and adapters.** Target and adapter packages do not get namespaces of their own — there is no `SQLITE.*`, `POSTGRES.*`, or `ADAPTER.*`. A target-specific failure is still a failure of a core concern, and it uses that concern's namespace: rendering or executing a query uses `RUNTIME` (with `meta.target`/`meta.feature` identifying the target-specific condition), transport uses `DRIVER`, migration apply uses `MIGRATION`. The target name is data, not taxonomy. This keeps the namespace an answer to "what went wrong" rather than "which package said so", and keeps codes stable if a check moves between a target pack and shared code.
+
 **SCHEMA** (a reserved `CliErrorDomain` with no producers) is dropped.
 
 ## The foundation surface

--- a/docs/reference/error-reference.md
+++ b/docs/reference/error-reference.md
@@ -71,6 +71,10 @@ The migration-file CLI (`prisma-next migration`) received `--config` without a p
 
 A file the command needs does not exist at the given path. Produced by several commands: the migration command scaffold, `migrate`, `migration plan`, `migration show`, `db sign`, `db verify`, and `ref` all raise it when the emitted `contract.json` (or another required file) is missing from the expected location. The path is carried in `where.path` rather than meta. Meta: none (`where.path` holds the file path).
 
+### CLI.FILE_WRITE_FAILED
+
+Writing a file failed — currently raised when `format` cannot write the formatted PSL source back to disk (e.g. the file is not writable). The underlying failure is attached as `cause`. Meta: none.
+
 ### CLI.INIT_AUTHORING_SCHEMA_PATH_MISMATCH
 
 During `prisma-next init`, `--authoring` and `--schema-path` disagree on file extension — for example `--authoring psl` with a schema path ending in `.ts`. Raised before any scaffold files are written, so the project tree stays untouched. Meta: `authoring`, `schemaPath`, `actualExtension`, `expectedExtension`.
@@ -138,6 +142,14 @@ Reserved: a command was asked for a `--json` sub-format it does not support; the
 ### CLI.OUTPUT_FORMAT_CONFLICT
 
 The main CLI received mutually exclusive output flags: `--format pretty` together with `--json`. Use `--format json` or `--json` alone for JSON output. Meta: none.
+
+### CLI.PROJECT_MANIFEST_INVALID
+
+A `package.json` found while resolving the project import root is not valid JSON, or parses to something other than a JSON object. Emission reads the nearest manifest to decide which package names generated files should import; fix the manifest's JSON and re-run. The parse failure (when there is one) is attached as `cause`. Meta: `path`.
+
+### CLI.PROJECT_MANIFEST_UNREADABLE
+
+A `package.json` found while resolving the project import root exists but could not be read (e.g. a permissions failure). Absent manifests continue the walk up; a read failure stops it, because silently skipping would emit against the wrong project's dependencies. The read failure is attached as `cause`. Meta: `path`.
 
 ### CLI.UNEXPECTED
 
@@ -331,7 +343,7 @@ The TypeScript contract module imports something outside the contract-source imp
 
 ### CONTRACT.SOURCE_LOAD_FAILED
 
-Bundling or evaluating the TypeScript contract module failed (esbuild bundle error, or the module threw on import). Raised by the CLI while loading a TS contract source; the underlying failure is attached as `cause`. Meta: `path`, `stage` (`bundle` or `import`).
+Loading the contract source failed: bundling or evaluating the TypeScript contract module (esbuild bundle error, or the module threw on import), the contract source provider returning a failure or a malformed result during `contract emit`, or `format` failing to read the PSL source file. The underlying failure is attached as `cause` where one exists. Meta: `path`, `stage` (`bundle` or `import`) at the TS-loader site; `diagnostics`, `issues`, `providerMeta` at the emit provider site; none at the format read site.
 
 ### CONTRACT.TABLE_AMBIGUOUS
 
@@ -359,7 +371,7 @@ Aggregate contract validation failed: structural validation of the contract JSON
 
 ### CONTRACT.VERIFY_FAILED
 
-The generic control-plane failure code (`errorRuntime`) used when a CLI operation fails without a more specific code: database connection failures in control drivers, failure to resolve the contract source, contract-source read/write failures during `format`, a resolved hash missing from the migration graph, and similar. Message and fix text vary per site. Meta: varies per site.
+`db verify` failed for a reason the verify result did not classify under a more specific code (marker, target, or schema-verification codes). The summary carries the verify result's own text. Meta: none.
 
 ### CONTRACT.WIRE_NAME_PREFIX_TOO_LONG
 
@@ -653,6 +665,10 @@ A parameterized codec's `paramsSchema` rejected the `typeParams` carried by a co
 
 Calling `connect(binding)` on a driver — or `connect()` on a target facade client (Postgres, SQLite, Mongo) or the CLI control client — that is already connected. Close with `close()` before reconnecting with a new binding. Meta: `bindingKind`.
 
+### DRIVER.CONNECTION_FAILED
+
+A control-plane driver could not establish a database connection (`driver.create(url)` in the SQLite, Postgres, and Mongo control drivers). The `why` carries the underlying driver message and the original error is attached as `cause`; connection URLs in meta are redacted. Meta: `path` (SQLite); `sqlState` plus redacted URL fields (Postgres); redacted URL fields (Mongo).
+
 ### DRIVER.NOT_CONNECTED
 
 Using a driver, a target facade client, or the CLI control client before `connect(...)` has been called (or after it was closed) — surfaces from `execute`, `executePrepared`, `acquireConnection`, `query`, or `explain`, including lazily when iterating an execute result.
@@ -825,7 +841,7 @@ A migration package on disk is corrupt: the `migrationHash` stored in `migration
 
 ### MIGRATION.HASH_NOT_IN_GRAPH
 
-A contract hash the user supplied (or that a ref resolved to) is not a node in the on-disk migration graph — raised during plan resolution (`migration plan --from`) and `ref set`. The envelope lists the reachable hashes and suggests a valid one or running `migration plan` to introduce it. Meta: `hash`/`resolvedHash`, `reachableHashes` or `reachableRefs`, sometimes `graphTipHash`.
+A contract hash the user supplied (or that a ref resolved to) is not a node in the on-disk migration graph — raised during plan resolution (`migration plan --from`), `ref set`, and `migration new --from`. The envelope lists the reachable hashes and suggests a valid one or running `migration plan` to introduce it. Meta: `hash`/`resolvedHash`, `reachableHashes` or `reachableRefs`, sometimes `graphTipHash`; none at the `migration new` site.
 
 ### MIGRATION.INVALID_DEFAULT_EXPORT
 
@@ -903,6 +919,10 @@ Runner-level failure during apply: the plan asserts an origin contract, but the 
 
 A diagnostic in `migration status`: the active ref requires data invariants that the database marker does not record as provided. If no path through the graph can supply them, status escalates to `MIGRATION.NO_INVARIANT_PATH`. Meta: `ref` (when a ref is active), `invariants` (the missing ids).
 
+### MIGRATION.NO_CHANGES
+
+`migration new` found the from and to contract hashes identical — there is nothing to migrate. Change the contract and re-run `prisma-next contract emit` first, or pass `--from <hash>` explicitly to author a data-only migration on the current contract hash. Meta: none.
+
 ### MIGRATION.NO_INITIAL_MIGRATION
 
 While reconstructing the migration graph, no migration starts from the empty contract state, so the history has no entry point. Usually indicates corrupted `migration.json` files. Meta: `nodes` (known hashes).
@@ -910,6 +930,10 @@ While reconstructing the migration graph, no migration starts from the empty con
 ### MIGRATION.NO_INVARIANT_PATH
 
 The target (or named ref) requires data invariants, and no path through the migration graph from the current state covers all of them. Add a migration on the path that runs a `dataTransform` with each missing `invariantId`, or retarget the ref. Meta: `required`, `missing`, `structuralPath` (edges: `dirName`, `migrationHash`, `from`, `to`, `invariants`), `refName` (when applicable).
+
+### MIGRATION.NO_MIGRATIONS
+
+`migration show` was given a non-path reference but the app space has no migration packages at all, so there is nothing to resolve against. Create a migration with `prisma-next migration plan` first. Meta: none.
 
 ### MIGRATION.NO_TARGET
 
@@ -919,9 +943,13 @@ The migration history contains cycles (e.g. after a rollback migration C1→C2�
 
 A Mongo migration check uses a filter feature the check evaluator does not support — an unsupported filter operator, or an aggregation-expression filter. Meta: `operator`.
 
+### MIGRATION.PACKAGE_NOT_FOUND
+
+`migration show` resolved its target (a directory path, or a migration reference) but no loaded on-disk migration package matches it — either no package lives at the given path, or the resolved migration's package failed to load. Pass a directory name, hash prefix, or path to an on-disk app-space migration package, or inspect the migrations directory for corruption. Meta: none.
+
 ### MIGRATION.PATH_UNREACHABLE
 
-An apply command (`migrate`/`db update`) cannot find a path through the on-disk migration graph from the database's current marker to the requested target — the connecting edge was never planned. The fix walks you through `migration plan` (with the right `--from`/`--to`) then `migrate`. Meta: carries the underlying failure's meta (`fromHash`, `targetHash`, `deadEnds`, `kind`) plus the code.
+An apply command (`migrate`/`db update`) cannot find a path through the on-disk migration graph from the database's current marker to the requested target — the connecting edge was never planned. The fix walks you through `migration plan` (with the right `--from`/`--to`) then `migrate`. Meta: carries the underlying failure's meta (`fromHash`, `targetHash`, `deadEnds`, `kind`).
 
 ### MIGRATION.PLANNING_FAILED
 
@@ -951,6 +979,18 @@ Before executing a migration operation, one of its precheck steps (a query expec
 
 The `providedInvariants` stored in `migration.json` disagrees with the canonical value derived from `ops.json` — the manifest was likely hand-edited without re-emitting (a same-ids-different-order case is called out explicitly). Re-emit the package. Meta: `filePath`, `stored`, `derived`, `difference` (`{missing, extra}`).
 
+### MIGRATION.REF_AMBIGUOUS
+
+A contract or migration reference prefix matches more than one candidate (raised by the shared ref-resolution mapper used across CLI commands). Provide a longer prefix or the full hash. Meta: `input`, `candidates`, `grammar`.
+
+### MIGRATION.REF_INVALID_FORMAT
+
+A contract or migration reference is syntactically invalid — it is not a hash, ref name, or migration directory name in any accepted form (raised by the shared ref-resolution mapper). Meta: `input`.
+
+### MIGRATION.REF_NOT_FOUND
+
+A contract or migration reference does not resolve: no matching hash, ref name, or migration directory name exists in the migration graph or refs index (raised by the shared ref-resolution mapper used across CLI commands). Meta: `input`, `grammar`.
+
 ### MIGRATION.REF_NOT_RESOLVABLE
 
 A ref name resolves to nothing: no pointer file with that name exists, and the fallback hash is not a node in the migration graph either, so there is no contract to materialize. Create the ref with `ref set`, advance it via `db update --advance-ref`, or pass a graph-node hash. Meta: `refName`, `identifier`.
@@ -962,6 +1002,10 @@ A ref name resolves to nothing: no pointer file with that name exists, and the f
 ### MIGRATION.REF_SET_EMPTY_SENTINEL
 
 `ref set` was asked to point a ref at the empty-database sentinel hash, which is a planner internal and not a valid ref target. Use a real contract hash from the migration graph. Meta: `hash`.
+
+### MIGRATION.REF_WRONG_GRAMMAR
+
+A reference parsed, but as the wrong kind for the argument position — e.g. a migration-only reference where a contract reference is required (raised by the shared ref-resolution mapper). The message and fix come from the resolver's own diagnosis. Meta: `input`, `expectedGrammar`.
 
 ### MIGRATION.RUNNER_FAILED
 
@@ -990,6 +1034,10 @@ SQLite twin of `MIGRATION.POSTGRES_CONTROL_STACK_MISSING`: a `SqliteMigration` o
 ### MIGRATION.TARGET_MISMATCH
 
 A migration script declares one `targetId` but the loaded `prisma-next.config.ts` declares another; the script can only run against a config targeting the same database. Switch configs or pass `--config <path>`. Meta: `migrationTargetId`, `configTargetId`.
+
+### MIGRATION.TARGET_NOT_APP_SPACE
+
+A filesystem-path target given to a migration command resolves outside the app space's migrations directory — path targets must point at an app-space migration. Pass an app-space migration directory or use a hash prefix. Meta: none.
 
 ### MIGRATION.TARGET_UNSUPPORTED
 

--- a/docs/reference/error-reference.md
+++ b/docs/reference/error-reference.md
@@ -517,11 +517,11 @@ A lane terminal (SQL DSL `.build()`, ORM collection terminal) received an annota
 
 ### RUNTIME.AST_INVALID
 
-A lowered SQL AST is structurally invalid at render time: a subquery projecting other than one column, an INSERT with zero rows, a missing column value, an empty onConflict column list or do-update-set, an UPDATE with no SET assignments, or an INSERT target table absent from contract storage. Raised by the Postgres and SQLite SQL renderers. Meta: `node`, `table`, `column`.
+A lowered SQL AST is structurally invalid: a subquery projecting other than one column, an INSERT with zero rows, a missing column value, an empty onConflict column list or do-update-set, an UPDATE with no SET assignments, an INSERT target table absent from contract storage, or an AST node constructed with invalid arguments (empty FunctionSource column aliases, a CaseExpr with no branches). Raised by the Postgres and SQLite SQL renderers and by AST node construction in relational-core. Meta: `node`, `table`, `column`; construction sites carry node-specific fields.
 
 ### RUNTIME.AST_UNSUPPORTED
 
-The authored SQL AST uses a feature this target cannot render — currently DEFAULT as a value in INSERT … VALUES on SQLite. Meta: `node`.
+The authored SQL AST uses a feature this target cannot render — e.g. DEFAULT as a value in INSERT … VALUES, WITH ORDINALITY on function sources, or returned-column aliases on function sources, all on SQLite. Raised by the target adapters' renderers. Meta: `node` (INSERT DEFAULT site); `target`, `feature` (function-source sites).
 
 ### RUNTIME.BINDING_INVALID
 
@@ -530,6 +530,14 @@ A target facade client (`@internal/postgres`, `@internal/sqlite`, `@internal/mon
 ### RUNTIME.BINDING_MISSING
 
 A target facade client was asked to connect with no binding at all (no connection string, no environment fallback). Meta: `expected`.
+
+### RUNTIME.CODEC_DESCRIPTOR_ARRAY_UNSUPPORTED
+
+A codec projection used `CodecRef.many` against a SQLite codec descriptor — SQLite has no stored scalar-array codec protocol, so projecting the whole stored array would be ambiguous. Use a scalar CodecRef or an explicit target representation. Meta: `codecId`.
+
+### RUNTIME.CODEC_DESCRIPTOR_INVALID
+
+A codec descriptor handed to a target codec-descriptor registry (Postgres, SQLite) is not a valid descriptor for that target: wrong discriminant, missing target descriptor methods, or a malformed params schema. Extend the target's descriptor class or adapt a generic descriptor with the target's wrapper (`postgresCodec()` / `sqliteCodec()`). Meta: `codecId`.
 
 ### RUNTIME.CODEC_DESCRIPTOR_MISSING
 
@@ -573,7 +581,7 @@ Two authoring contributions register the same discriminator key — the same `en
 
 ### RUNTIME.DUPLICATE_CODEC
 
-Two runtime stack contributors (target pack, extension packs) register a codec with the same id while the SQL context or Mongo execution stack collects codecs. Remove the duplicate contribution. Meta: `codecId`; on the Mongo path also `existingOwner`, `incomingOwner`.
+Two runtime stack contributors (target pack, extension packs) register a codec with the same id — while the SQL context or Mongo execution stack collects codecs, or while a target codec-descriptor registry (Postgres, SQLite) is composed. Remove the duplicate contribution. Meta: `codecId`; on the Mongo path also `existingOwner`, `incomingOwner`; on the target registry path also `target`.
 
 ### RUNTIME.DUPLICATE_MUTATION_DEFAULT_GENERATOR
 

--- a/docs/reference/error-reference.md
+++ b/docs/reference/error-reference.md
@@ -59,7 +59,7 @@ Reserved: `db verify` needs `db.queryRunnerFactory` in `prisma-next.config.ts` a
 
 ### CONFIG.VALIDATION_FAILED
 
-`prisma-next.config.ts` loaded but failed validation: a required field is missing or malformed. Raised by the config loader and by framework-component resolution for fields like `frameworkComponents[]`, `frameworkComponents[].kind`/`familyId`/`targetId`, `contract.targetFamily`, and `contract.target`. Meta: none.
+`prisma-next.config.ts` loaded but failed validation: a required field is missing or malformed. Raised by the config loader and by framework-component resolution for fields like `frameworkComponents[]`, `frameworkComponents[].kind`/`familyId`/`targetId`, `contract.targetFamily`, and `contract.target`; also raised by contract-path resolution when `config.contract.output` is absent. Meta: none.
 
 ## CLI
 
@@ -69,7 +69,7 @@ The migration-file CLI (`prisma-next migration`) received `--config` without a p
 
 ### CLI.FILE_NOT_FOUND
 
-A file the command needs does not exist at the given path. Produced by several commands: the migration command scaffold, `migrate`, `migration plan`, `migration show`, `db sign`, `db verify`, and `ref` all raise it when the emitted `contract.json` (or another required file) is missing from the expected location. The path is carried in `where.path` rather than meta. Meta: none (`where.path` holds the file path).
+A file the command needs does not exist at the given path. Produced by several commands: the migration command scaffold, `migrate`, `migration plan`, `migration show`, `db sign`, `db verify`, and `ref` all raise it when the emitted `contract.json` (or another required file) is missing from the expected location. Most sites carry the path in `where.path`; the `migration new` contract-file site carries it in the summary text only. Meta: none.
 
 ### CLI.FILE_WRITE_FAILED
 
@@ -243,7 +243,7 @@ A Mongo variant model declares an index that conflicts with the discriminator sc
 
 ### CONTRACT.INFER_UNSUPPORTED
 
-`contract infer` met a database shape it cannot express yet: duplicate table names across schemas, a column typed by a native enum that an extension pack space already describes in another schema, or native enum adoption with content spanning multiple schemas. Meta: `tableName`, `columnName`, `schemas`.
+`contract infer` is not available: either the configured family does not implement the `PslContractInferCapable` capability (no meta at that site), or the family supports inference but the database shape cannot be expressed yet — duplicate table names across schemas, a column typed by a native enum that an extension pack space already describes in another schema, or native enum adoption with content spanning multiple schemas. Meta at the shape sites: `tableName`, `columnName`, `schemas`.
 
 ### CONTRACT.INTROSPECTION_UNSUPPORTED
 
@@ -367,7 +367,7 @@ The emitted contract file could not be read or parsed while computing `migration
 
 ### CONTRACT.VALIDATION_FAILED
 
-Aggregate contract validation failed: structural validation of the contract JSON (`ContractValidationError` with a `phase` of structural/domain/storage), semantic validation during `buildContract`, or storage/model validators rejecting the built contract. Raised at emit/authoring time and whenever a contract is loaded and validated. Meta: `errors` (aggregate site); the error class also carries `phase`.
+Aggregate contract validation failed: structural validation of the contract JSON (`ContractValidationError` with a `phase` of structural/domain/storage), semantic validation during `buildContract`, or storage/model validators rejecting the built contract. Raised at emit/authoring time and whenever a contract is loaded and validated. Also raised by `migration new` when the emitted contract has no `storageHash`; that site has no meta. Meta: `errors` (aggregate site); the error class also carries `phase`.
 
 ### CONTRACT.VERIFY_FAILED
 
@@ -385,7 +385,7 @@ An authored wire-name prefix (an index name, or an RLS policy prefix) exceeds th
 
 ### PSL.PARSE_FAILED
 
-`format()` was asked to format PSL source that has parse errors; formatting refuses to run on an unparseable document. The message carries the first diagnostic and a count of the rest; the CLI `format` command wraps this into a structured failure telling the user to fix the parse errors. Meta: `diagnostics`.
+`format()` was asked to format PSL source that has parse errors; formatting refuses to run on an unparseable document. The message carries the first diagnostic and a count of the rest; the CLI `format` command wraps this into a structured failure telling the user to fix the parse errors, attaching the parser error as `cause`. Meta: `diagnostics`.
 
 ## ORM
 
@@ -773,7 +773,7 @@ A `migration check` failure row: a migration's `from` hash is not produced by an
 
 ### MIGRATION.CONTRACT_DESERIALIZATION_FAILED
 
-A contract snapshot on disk was found but failed to deserialize into a valid contract while migration tooling resolved a contract at a ref or hash. Re-emit the owning migration package or restore it from version control. Meta: `filePath`, `message`.
+A contract snapshot on disk was found but failed to deserialize into a valid contract while migration tooling resolved a contract at a ref or hash. Re-emit the owning migration package or restore it from version control. Meta: `filePath`, `message`. Also raised by `migration new` when the emitted `contract.json` fails to deserialize; that site has no meta and attaches the deserialization failure as `cause`.
 
 ### MIGRATION.CONTRACT_SNAPSHOT_HASH_MISMATCH
 
@@ -937,7 +937,7 @@ While reconstructing the migration graph, no migration starts from the empty con
 
 ### MIGRATION.NO_INVARIANT_PATH
 
-The target (or named ref) requires data invariants, and no path through the migration graph from the current state covers all of them. Add a migration on the path that runs a `dataTransform` with each missing `invariantId`, or retarget the ref. Meta: `required`, `missing`, `structuralPath` (edges: `dirName`, `migrationHash`, `from`, `to`, `invariants`), `refName` (when applicable).
+The target (or named ref) requires data invariants, and no path through the migration graph from the current state covers all of them. Add a migration on the path that runs a `dataTransform` with each missing `invariantId`, or retarget the ref. Meta: `required`, `missing`, `structuralPath` (edges: `dirName`, `migrationHash`, `from`, `to`, `invariants`), `refName` (when applicable). Also raised per space by `migrate` in show/plan mode when a space's path requires invariants not available on disk; that site's meta is `spaceId`, `missing`.
 
 ### MIGRATION.NO_MIGRATIONS
 
@@ -1017,7 +1017,7 @@ A reference parsed, but as the wrong kind for the argument position — e.g. a m
 
 ### MIGRATION.RUNNER_FAILED
 
-Generic wrapper for a migration runner failure during execution that has no more specific code; the summary/why carry the underlying detail (also used to surface the legacy-marker-shape condition from marker reads, with `meta.runnerErrorCode`). Inspect the reported conflict and reconcile schema drift.
+Generic wrapper for a migration runner failure during execution that has no more specific code; the summary/why carry the underlying detail (also used to surface the legacy-marker-shape condition from marker reads, with `meta.runnerErrorCode`). `migrate` and `db init` map unrecognized apply failures through it, passing the failure's own meta through unchanged. Inspect the reported conflict and reconcile schema drift. Meta: the wrapped failure's meta, when it has any; `runnerErrorCode` at the legacy-marker-shape site.
 
 ### MIGRATION.SAME_SOURCE_AND_TARGET
 
@@ -1029,7 +1029,7 @@ After applying migrations, the runner introspected the database and the resultin
 
 ### MIGRATION.SNAPSHOT_MISSING
 
-A `--from` reference cannot produce a contract: either a ref name has no pointer file and the fallback hash is not a graph node (`viaRef: true`), or an explicit `--from <hash>` was given on an empty migration graph and names no ref (`viaRef: false`). Meta: `identifier`, `viaRef`.
+A `--from` reference cannot produce a contract: either a ref name has no pointer file and the fallback hash is not a graph node (`viaRef: true`), or an explicit `--from <hash>` was given on an empty migration graph and names no ref (`viaRef: false`). Meta: `identifier`, `viaRef`. Also raised by `db sign` when a contract reference resolves to a hash but no migration produces that hash and the emitted contract does not match; that site has no meta.
 
 ### MIGRATION.SPACE_NOT_FOUND
 

--- a/docs/reference/error-reference.md
+++ b/docs/reference/error-reference.md
@@ -1017,7 +1017,7 @@ A reference parsed, but as the wrong kind for the argument position — e.g. a m
 
 ### MIGRATION.RUNNER_FAILED
 
-Generic wrapper for a migration runner failure during execution that has no more specific code; the summary/why carry the underlying detail (also used to surface the legacy-marker-shape condition from marker reads, with `meta.runnerErrorCode`). `migrate` and `db init` map unrecognized apply failures through it, passing the failure's own meta through unchanged. Inspect the reported conflict and reconcile schema drift. Meta: the wrapped failure's meta, when it has any; `runnerErrorCode` at the legacy-marker-shape site.
+Generic wrapper for a migration runner failure during execution that has no more specific code; the summary/why carry the underlying detail (also used to surface the legacy-marker-shape condition from marker reads, with `meta.runnerErrorCode`). `migrate` and `db init` map unrecognized apply failures through it, passing the failure's own meta through unchanged. Inspect the reported summary/why detail and address the underlying failure before re-running the command. Meta: the wrapped failure's meta, when it has any; `runnerErrorCode` at the legacy-marker-shape site.
 
 ### MIGRATION.SAME_SOURCE_AND_TARGET
 
@@ -1045,7 +1045,7 @@ A migration script declares one `targetId` but the loaded `prisma-next.config.ts
 
 ### MIGRATION.TARGET_NOT_APP_SPACE
 
-A filesystem-path target given to a migration command resolves outside the app space's migrations directory — path targets must point at an app-space migration. Pass an app-space migration directory or use a hash prefix. Meta: none.
+A filesystem-path target given to a migration command does not resolve to an app-space migration directory — it points outside the app space's migrations directory, or at that directory's root itself. Pass an app-space migration directory or use a hash prefix. Meta: none.
 
 ### MIGRATION.TARGET_UNSUPPORTED
 

--- a/packages/1-framework/1-core/errors/src/control.ts
+++ b/packages/1-framework/1-core/errors/src/control.ts
@@ -152,6 +152,7 @@ export function errorContractValidationFailed(
   reason: string,
   options?: {
     readonly where?: { readonly path?: string; readonly line?: number };
+    readonly cause?: unknown;
   },
 ): CliStructuredError {
   return new CliStructuredError('CONTRACT.VALIDATION_FAILED', 'Contract validation failed', {
@@ -159,6 +160,7 @@ export function errorContractValidationFailed(
     fix: 'Re-run `prisma-next contract emit`, or fix the contract file and try again',
     docsUrl: docsUrlFor('CONTRACT.VALIDATION_FAILED'),
     ...(options?.where ? { where: options.where } : {}),
+    ...ifDefined('cause', options?.cause),
   });
 }
 
@@ -171,6 +173,7 @@ export function errorFileNotFound(
     readonly why?: string;
     readonly fix?: string;
     readonly docsUrl?: string;
+    readonly cause?: unknown;
   },
 ): CliStructuredError {
   return new CliStructuredError('CLI.FILE_NOT_FOUND', 'File not found', {
@@ -178,6 +181,7 @@ export function errorFileNotFound(
     fix: options?.fix ?? 'Check that the file path is correct',
     where: { path: filePath },
     ...(options?.docsUrl ? { docsUrl: options.docsUrl } : {}),
+    ...ifDefined('cause', options?.cause),
   });
 }
 

--- a/packages/1-framework/1-core/errors/src/control.ts
+++ b/packages/1-framework/1-core/errors/src/control.ts
@@ -57,9 +57,10 @@ export class CliStructuredError extends Error implements StructuredError {
       readonly where?: { readonly path?: string; readonly line?: number };
       readonly meta?: Record<string, unknown>;
       readonly docsUrl?: string;
+      readonly cause?: unknown;
     },
   ) {
-    super(summary);
+    super(summary, options?.cause !== undefined ? { cause: options.cause } : undefined);
     this.name = 'CliStructuredError';
     this.code = code;
     this.severity = options?.severity ?? 'error';
@@ -462,10 +463,12 @@ export function errorUnexpected(
   options?: {
     readonly why?: string;
     readonly fix?: string;
+    readonly cause?: unknown;
   },
 ): CliStructuredError {
   return new CliStructuredError('CLI.UNEXPECTED', 'Unexpected error', {
     why: options?.why ?? message,
     fix: options?.fix ?? 'Check the error message and try again',
+    ...ifDefined('cause', options?.cause),
   });
 }

--- a/packages/1-framework/1-core/errors/src/execution.ts
+++ b/packages/1-framework/1-core/errors/src/execution.ts
@@ -265,19 +265,22 @@ export function errorDestructiveChanges(
 }
 
 /**
- * Generic runtime error.
+ * Generic runtime error carrying a caller-provided dotted code.
  */
 export function errorRuntime(
+  code: `${string}.${string}`,
   summary: string,
   options?: {
     readonly why?: string;
     readonly fix?: string;
     readonly meta?: Record<string, unknown>;
+    readonly cause?: unknown;
   },
 ): CliStructuredError {
-  return new CliStructuredError('CONTRACT.VERIFY_FAILED', summary, {
-    ...(options?.why ? { why: options.why } : { why: 'Verification failed' }),
-    ...(options?.fix ? { fix: options.fix } : { fix: 'Check contract and database state' }),
-    ...(options?.meta ? { meta: options.meta } : {}),
+  return new CliStructuredError(code, summary, {
+    ...ifDefined('why', options?.why),
+    ...ifDefined('fix', options?.fix),
+    ...ifDefined('meta', options?.meta),
+    ...ifDefined('cause', options?.cause),
   });
 }

--- a/packages/1-framework/1-core/errors/src/execution.ts
+++ b/packages/1-framework/1-core/errors/src/execution.ts
@@ -67,6 +67,7 @@ export function errorMarkerRowCorrupt(options: {
   readonly why: string;
   readonly space: string;
   readonly markerLocation: string;
+  readonly cause?: unknown;
 }): CliStructuredError {
   return new CliStructuredError(
     'CONTRACT.MARKER_ROW_CORRUPT',
@@ -75,6 +76,7 @@ export function errorMarkerRowCorrupt(options: {
       why: options.why,
       fix: `The ${options.markerLocation} row for space "${options.space}" contains invalid data. Delete the row, then run \`prisma-next db sign --db <url>\` to write a fresh marker.`,
       meta: { space: options.space },
+      ...ifDefined('cause', options.cause),
     },
   );
 }
@@ -86,6 +88,7 @@ export function errorMarkerReadFailed(options: {
   readonly why: string;
   readonly space: string;
   readonly markerLocation: string;
+  readonly cause?: unknown;
 }): CliStructuredError {
   return new CliStructuredError(
     'CONTRACT.MARKER_READ_FAILED',
@@ -94,6 +97,7 @@ export function errorMarkerReadFailed(options: {
       why: options.why,
       fix: `Could not read marker at ${options.markerLocation} for space "${options.space}". Verify read permissions, connectivity, and locks, then retry.`,
       meta: { space: options.space },
+      ...ifDefined('cause', options.cause),
     },
   );
 }
@@ -117,6 +121,7 @@ function isLegacyMarkerShapeReadError(message: string): boolean {
 function errorLegacyMarkerShape(options: {
   readonly why: string;
   readonly markerLocation: string;
+  readonly cause?: unknown;
 }): CliStructuredError {
   return errorRunnerFailed(
     `Legacy marker-table shape detected on ${options.markerLocation} (no \`space\` column). ` +
@@ -126,6 +131,7 @@ function errorLegacyMarkerShape(options: {
       why: options.why,
       fix: 'Legacy marker-table shape detected. Drop `prisma_contract.marker` (Postgres) or `_prisma_marker` (SQLite) and re-run `prisma-next db init` to recreate it with the current per-space schema.',
       meta: { runnerErrorCode: 'MIGRATION.LEGACY_MARKER_SHAPE' },
+      ...ifDefined('cause', options.cause),
     },
   );
 }
@@ -142,6 +148,7 @@ export function rethrowMarkerReadError(
       why: err.message,
       space: context.space,
       markerLocation: context.markerLocation,
+      cause: err,
     });
   }
   const message = err instanceof Error ? err.message : String(err);
@@ -149,12 +156,14 @@ export function rethrowMarkerReadError(
     throw errorLegacyMarkerShape({
       why: message,
       markerLocation: context.markerLocation,
+      cause: err,
     });
   }
   throw errorMarkerReadFailed({
     why: message,
     space: context.space,
     markerLocation: context.markerLocation,
+    cause: err,
   });
 }
 
@@ -223,12 +232,14 @@ export function errorRunnerFailed(
     readonly why?: string;
     readonly fix?: string;
     readonly meta?: Record<string, unknown>;
+    readonly cause?: unknown;
   },
 ): CliStructuredError {
   return new CliStructuredError('MIGRATION.RUNNER_FAILED', summary, {
     why: options?.why ?? 'Migration runner failed',
     fix: options?.fix ?? 'Inspect the reported conflict and reconcile schema drift',
     ...(options?.meta ? { meta: options.meta } : {}),
+    ...ifDefined('cause', options?.cause),
   });
 }
 

--- a/packages/1-framework/1-core/errors/test/control.test.ts
+++ b/packages/1-framework/1-core/errors/test/control.test.ts
@@ -73,6 +73,27 @@ describe('CliStructuredError', () => {
     expect(envelope.summary).toBe('Test error');
   });
 
+  it('sets cause when provided', () => {
+    const cause = new Error('underlying failure');
+    const error = new CliStructuredError('CONFIG.FILE_NOT_FOUND', 'Test error', { cause });
+
+    expect(error.cause).toBe(cause);
+  });
+
+  it('omits cause as an own property when not provided', () => {
+    const error = new CliStructuredError('CONFIG.FILE_NOT_FOUND', 'Test error');
+
+    expect(Object.hasOwn(error, 'cause')).toBe(false);
+  });
+
+  it('envelope carries no cause key', () => {
+    const error = new CliStructuredError('CONFIG.FILE_NOT_FOUND', 'Test error', {
+      cause: new Error('underlying failure'),
+    });
+
+    expect(Object.keys(error.toEnvelope())).not.toContain('cause');
+  });
+
   it('normalizes fix when fix equals why', () => {
     const error = new CliStructuredError('CONFIG.FILE_NOT_FOUND', 'Test error', {
       why: 'Same message',
@@ -445,5 +466,16 @@ describe('Generic Error', () => {
     });
     expect(error.why).toBe('Custom why');
     expect(error.fix).toBe('Custom fix');
+  });
+
+  it('errorUnexpected forwards cause', () => {
+    const cause = new Error('underlying failure');
+    const error = errorUnexpected('Unexpected error occurred', { cause });
+    expect(error.cause).toBe(cause);
+  });
+
+  it('errorUnexpected without cause leaves no own cause property', () => {
+    const error = errorUnexpected('Unexpected error occurred');
+    expect(Object.hasOwn(error, 'cause')).toBe(false);
   });
 });

--- a/packages/1-framework/1-core/errors/test/execution.test.ts
+++ b/packages/1-framework/1-core/errors/test/execution.test.ts
@@ -100,6 +100,12 @@ describe('Runtime Errors', () => {
     expect(error.meta).toEqual({ key: 'value' });
   });
 
+  it('errorRunnerFailed forwards cause', () => {
+    const cause = new Error('underlying failure');
+    const error = errorRunnerFailed('Runner failed', { cause });
+    expect(error.cause).toBe(cause);
+  });
+
   it('errorDestructiveChanges creates correct error', () => {
     const error = errorDestructiveChanges('Destructive changes detected');
     expect(error.code).toBe('MIGRATION.DESTRUCTIVE_CHANGES');
@@ -210,6 +216,42 @@ describe('Runtime Errors', () => {
       expect(envelope.fix).toContain('Legacy marker-table shape detected');
       expect(envelope.fix).toContain('prisma_contract.marker');
       expect(envelope.fix).toContain('prisma-next db init');
+    }
+  });
+
+  it('rethrowMarkerReadError preserves cause on the corrupt-row path', () => {
+    const original = new Error('Invalid contract marker row: core_hash must be string');
+    try {
+      rethrowMarkerReadError(original, {
+        space: 'app',
+        markerLocation: 'prisma_contract.marker',
+      });
+    } catch (err) {
+      expect((err as CliStructuredError).cause).toBe(original);
+    }
+  });
+
+  it('rethrowMarkerReadError preserves cause on the read-failed path', () => {
+    const original = new Error('permission denied for table marker');
+    try {
+      rethrowMarkerReadError(original, {
+        space: 'app',
+        markerLocation: 'prisma_contract.marker',
+      });
+    } catch (err) {
+      expect((err as CliStructuredError).cause).toBe(original);
+    }
+  });
+
+  it('rethrowMarkerReadError preserves cause on the legacy-shape path', () => {
+    const original = new Error('column "space" does not exist');
+    try {
+      rethrowMarkerReadError(original, {
+        space: 'app',
+        markerLocation: 'prisma_contract.marker',
+      });
+    } catch (err) {
+      expect((err as CliStructuredError).cause).toBe(original);
     }
   });
 

--- a/packages/1-framework/1-core/errors/test/execution.test.ts
+++ b/packages/1-framework/1-core/errors/test/execution.test.ts
@@ -123,21 +123,35 @@ describe('Runtime Errors', () => {
     expect(error.meta).toEqual({ key: 'value' });
   });
 
-  it('errorRuntime creates correct error', () => {
-    const error = errorRuntime('Something failed');
-    expect(error.code).toBe('CONTRACT.VERIFY_FAILED');
+  it('errorRuntime carries the caller-provided code', () => {
+    const error = errorRuntime('MIGRATION.SPACE_NOT_FOUND', 'Something failed');
+    expect(error.code).toBe('MIGRATION.SPACE_NOT_FOUND');
     expect(error.message).toBe('Something failed');
+    expect(error.why).toBeUndefined();
+    expect(error.fix).toBeUndefined();
   });
 
   it('errorRuntime with all options', () => {
-    const error = errorRuntime('Something failed', {
+    const error = errorRuntime('CONTRACT.VERIFY_FAILED', 'Something failed', {
       why: 'Custom why',
       fix: 'Custom fix',
       meta: { key: 'value' },
     });
+    expect(error.code).toBe('CONTRACT.VERIFY_FAILED');
     expect(error.why).toBe('Custom why');
     expect(error.fix).toBe('Custom fix');
     expect(error.meta).toEqual({ key: 'value' });
+  });
+
+  it('errorRuntime forwards cause', () => {
+    const cause = new Error('underlying failure');
+    const error = errorRuntime('DRIVER.CONNECTION_FAILED', 'Something failed', { cause });
+    expect(error.cause).toBe(cause);
+  });
+
+  it('errorRuntime without cause leaves no own cause property', () => {
+    const error = errorRuntime('DRIVER.CONNECTION_FAILED', 'Something failed');
+    expect(Object.hasOwn(error, 'cause')).toBe(false);
   });
 
   it('errorMarkerRowCorrupt creates CONTRACT.MARKER_ROW_CORRUPT envelope', () => {

--- a/packages/1-framework/1-core/errors/test/execution.test.ts
+++ b/packages/1-framework/1-core/errors/test/execution.test.ts
@@ -235,38 +235,32 @@ describe('Runtime Errors', () => {
 
   it('rethrowMarkerReadError preserves cause on the corrupt-row path', () => {
     const original = new Error('Invalid contract marker row: core_hash must be string');
-    try {
+    expect(() =>
       rethrowMarkerReadError(original, {
         space: 'app',
         markerLocation: 'prisma_contract.marker',
-      });
-    } catch (err) {
-      expect((err as CliStructuredError).cause).toBe(original);
-    }
+      }),
+    ).toThrow(expect.objectContaining({ cause: original }));
   });
 
   it('rethrowMarkerReadError preserves cause on the read-failed path', () => {
     const original = new Error('permission denied for table marker');
-    try {
+    expect(() =>
       rethrowMarkerReadError(original, {
         space: 'app',
         markerLocation: 'prisma_contract.marker',
-      });
-    } catch (err) {
-      expect((err as CliStructuredError).cause).toBe(original);
-    }
+      }),
+    ).toThrow(expect.objectContaining({ cause: original }));
   });
 
   it('rethrowMarkerReadError preserves cause on the legacy-shape path', () => {
     const original = new Error('column "space" does not exist');
-    try {
+    expect(() =>
       rethrowMarkerReadError(original, {
         space: 'app',
         markerLocation: 'prisma_contract.marker',
-      });
-    } catch (err) {
-      expect((err as CliStructuredError).cause).toBe(original);
-    }
+      }),
+    ).toThrow(expect.objectContaining({ cause: original }));
   });
 
   it('rethrowMarkerReadError rethrows existing CliStructuredError', () => {

--- a/packages/1-framework/3-tooling/cli/src/commands/contract-infer.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/contract-infer.ts
@@ -57,10 +57,14 @@ async function executeContractInferCommand(
 
   if (!pslContractAst) {
     return notOk(
-      errorRuntime('contract infer is not supported for this family', {
-        why: 'The configured family does not implement the PslContractInferCapable capability, so an inferred PSL contract cannot be produced from the live database schema.',
-        fix: 'Use a family that supports contract inference (e.g. SQL/Postgres).',
-      }),
+      errorRuntime(
+        'CONTRACT.INFER_UNSUPPORTED',
+        'contract infer is not supported for this family',
+        {
+          why: 'The configured family does not implement the PslContractInferCapable capability, so an inferred PSL contract cannot be produced from the live database schema.',
+          fix: 'Use a family that supports contract inference (e.g. SQL/Postgres).',
+        },
+      ),
     );
   }
 

--- a/packages/1-framework/3-tooling/cli/src/commands/db-init.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/db-init.ts
@@ -75,12 +75,12 @@ function mapDbInitFailure(failure: DbInitFailure): CliStructuredError {
     }
 
     return errorRuntime(
+      'MIGRATION.MARKER_ORIGIN_MISMATCH',
       `Existing database signature does not match plan destination.${mismatchParts.length > 0 ? ` Mismatch in ${mismatchParts.join(' and ')}.` : ''}`,
       {
         why: 'Database has an existing signature (marker) that does not match the target contract',
         fix: 'If bootstrapping, drop/reset the database then re-run `prisma-next db init`; otherwise reconcile schema/marker using your migration workflow',
         meta: {
-          code: 'MIGRATION.MARKER_ORIGIN_MISMATCH',
           ...ifDefined('markerStorageHash', failure.marker?.storageHash),
           ...ifDefined('destinationStorageHash', failure.destination?.storageHash),
           ...ifDefined('markerProfileHash', failure.marker?.profileHash),
@@ -102,9 +102,7 @@ function mapDbInitFailure(failure: DbInitFailure): CliStructuredError {
     return errorRunnerFailed(failure.summary, {
       why: failure.why ?? 'Migration runner failed',
       fix,
-      ...(failure.meta
-        ? { meta: { code: 'RUNNER_FAILED', ...failure.meta } }
-        : { meta: { code: 'RUNNER_FAILED' } }),
+      ...ifDefined('meta', failure.meta),
     });
   }
 

--- a/packages/1-framework/3-tooling/cli/src/commands/db-init.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/db-init.ts
@@ -102,6 +102,7 @@ function mapDbInitFailure(failure: DbInitFailure): CliStructuredError {
       why: failure.why ?? 'Migration runner failed',
       fix,
       ...ifDefined('meta', failure.meta),
+      ...ifDefined('cause', failure.cause),
     });
   }
 

--- a/packages/1-framework/3-tooling/cli/src/commands/db-init.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/db-init.ts
@@ -12,7 +12,6 @@ import {
   errorRunnerFailed,
   errorRuntime,
   errorUnexpected,
-  mapMigrationToolsError,
 } from '../utils/cli-errors';
 import type { MigrationCommandOptions } from '../utils/command-helpers';
 import {
@@ -182,7 +181,7 @@ async function executeDbInitCommand(
         });
       } catch (error) {
         if (MigrationToolsError.is(error)) {
-          return notOk(mapMigrationToolsError(error));
+          return notOk(error);
         }
         throw error;
       }

--- a/packages/1-framework/3-tooling/cli/src/commands/db-sign.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/db-sign.ts
@@ -128,10 +128,14 @@ async function executeDbSignCommand(
           contractJson = defaultContract;
         } else {
           return notOk(
-            errorRuntime(`No contract file found for hash "${targetHash}"`, {
-              why: `Resolved contract reference "${effectiveContractArg}" to hash "${targetHash}" but no migration produces that hash and the emitted contract does not match.`,
-              fix: 'Ensure the target contract exists on disk — either as a migration endpoint or as the emitted contract.json.',
-            }),
+            errorRuntime(
+              'MIGRATION.SNAPSHOT_MISSING',
+              `No contract file found for hash "${targetHash}"`,
+              {
+                why: `Resolved contract reference "${effectiveContractArg}" to hash "${targetHash}" but no migration produces that hash and the emitted contract does not match.`,
+                fix: 'Ensure the target contract exists on disk — either as a migration endpoint or as the emitted contract.json.',
+              },
+            ),
           );
         }
       }

--- a/packages/1-framework/3-tooling/cli/src/commands/db-sign.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/db-sign.ts
@@ -20,7 +20,6 @@ import {
   errorFileNotFound,
   errorRuntime,
   errorUnexpected,
-  mapMigrationToolsError,
   mapRefResolutionError,
 } from '../utils/cli-errors';
 import {
@@ -140,7 +139,7 @@ async function executeDbSignCommand(
         }
       }
     } catch (error) {
-      if (MigrationToolsError.is(error)) return notOk(mapMigrationToolsError(error));
+      if (MigrationToolsError.is(error)) return notOk(error);
       if (error instanceof CliStructuredError) return notOk(error);
       return notOk(
         errorUnexpected(error instanceof Error ? error.message : String(error), {

--- a/packages/1-framework/3-tooling/cli/src/commands/db-update.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/db-update.ts
@@ -19,7 +19,6 @@ import {
   errorMigrationPlanningFailed,
   errorRunnerFailed,
   errorUnexpected,
-  mapMigrationToolsError,
   mapRefResolutionError,
 } from '../utils/cli-errors';
 import type { MigrationCommandOptions } from '../utils/command-helpers';
@@ -154,9 +153,6 @@ async function executeDbUpdateCommand(
         'contract.json',
       );
     } catch (error) {
-      if (MigrationToolsError.is(error)) {
-        return notOk(mapMigrationToolsError(error));
-      }
       if (CliStructuredError.is(error)) {
         return notOk(error);
       }
@@ -208,7 +204,7 @@ async function executeDbUpdateCommand(
         });
       } catch (error) {
         if (MigrationToolsError.is(error)) {
-          return notOk(mapMigrationToolsError(error));
+          return notOk(error);
         }
         throw error;
       }

--- a/packages/1-framework/3-tooling/cli/src/commands/db-update.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/db-update.ts
@@ -80,6 +80,7 @@ function mapDbUpdateFailure(failure: DbUpdateFailure): CliStructuredError {
           ? { plannerWarnings: failure.warnings }
           : {}),
       },
+      ...ifDefined('cause', failure.cause),
     });
   }
 

--- a/packages/1-framework/3-tooling/cli/src/commands/db-verify.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/db-verify.ts
@@ -97,7 +97,10 @@ function mapVerifyFailure(verifyResult: VerifyDatabaseResult): CliStructuredErro
     }
     // Unknown code - fall through to runtime error
   }
-  return errorRuntime(verifyResult.summary);
+  return errorRuntime('CONTRACT.VERIFY_FAILED', verifyResult.summary, {
+    why: 'Verification failed',
+    fix: 'Check contract and database state',
+  });
 }
 
 type DbVerifyFailure = CliStructuredError | CombinedVerifyResult;

--- a/packages/1-framework/3-tooling/cli/src/commands/migrate.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/migrate.ts
@@ -32,7 +32,6 @@ import {
   errorRuntime,
   errorTargetMigrationNotSupported,
   errorUnexpected,
-  mapMigrationToolsError,
   mapRefResolutionError,
   requireLiveDatabase,
 } from '../utils/cli-errors';
@@ -191,7 +190,7 @@ async function executeMigrateShowCommand(
     allRefs = await readRefs(refsDir);
   } catch (error) {
     if (MigrationToolsError.is(error)) {
-      return notOk(mapMigrationToolsError(error));
+      return notOk(error);
     }
     throw error;
   }
@@ -342,9 +341,6 @@ async function executeMigrateShowCommand(
     } catch (error) {
       if (CliStructuredError.is(error)) {
         return notOk(error);
-      }
-      if (MigrationToolsError.is(error)) {
-        return notOk(mapMigrationToolsError(error));
       }
       return notOk(
         errorUnexpected(error instanceof Error ? error.message : String(error), {
@@ -770,13 +766,11 @@ async function executeMigrateCommand(
       const unknown = refEntry.invariants.filter((id) => !known.has(id));
       if (unknown.length > 0) {
         return notOk(
-          mapMigrationToolsError(
-            errorUnknownInvariant({
-              ...ifDefined('refName', toArg),
-              unknown,
-              declared: [...declared].sort(),
-            }),
-          ),
+          errorUnknownInvariant({
+            ...ifDefined('refName', toArg),
+            unknown,
+            declared: [...declared].sort(),
+          }),
         );
       }
     }
@@ -842,7 +836,7 @@ async function executeMigrateCommand(
         );
       } catch (error) {
         if (MigrationToolsError.is(error)) {
-          return notOk(mapMigrationToolsError(error));
+          return notOk(error);
         }
         throw error;
       }
@@ -863,9 +857,6 @@ async function executeMigrateCommand(
   } catch (error) {
     if (CliStructuredError.is(error)) {
       return notOk(error);
-    }
-    if (MigrationToolsError.is(error)) {
-      return notOk(mapMigrationToolsError(error));
     }
     return notOk(
       errorUnexpected(error instanceof Error ? error.message : String(error), {

--- a/packages/1-framework/3-tooling/cli/src/commands/migrate.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/migrate.ts
@@ -587,6 +587,7 @@ function mapApplyFailure(failure: MigrateFailure): CliStructuredErrorType {
     why: failure.why ?? 'Migration runner failed',
     fix: 'Fix the issue and re-run `prisma-next migrate --to <contract>` — previously applied migrations are preserved.',
     meta: failure.meta ?? {},
+    ...ifDefined('cause', failure.cause),
   });
 }
 

--- a/packages/1-framework/3-tooling/cli/src/commands/migrate.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/migrate.ts
@@ -28,6 +28,7 @@ import {
   errorFileNotFound,
   errorMarkerMismatch,
   errorPathUnreachable,
+  errorRunnerFailed,
   errorRuntime,
   errorTargetMigrationNotSupported,
   errorUnexpected,
@@ -409,9 +410,14 @@ async function executeMigrateShowCommand(
     }
     if (outcome.kind === 'unsatisfiable') {
       return notOk(
-        errorRuntime(`Missing required invariants for space "${outcome.spaceId}"`, {
-          why: `The path requires invariants not available on disk: ${outcome.missing.join(', ')}`,
-        }),
+        errorRuntime(
+          'MIGRATION.NO_INVARIANT_PATH',
+          `Missing required invariants for space "${outcome.spaceId}"`,
+          {
+            why: `The path requires invariants not available on disk: ${outcome.missing.join(', ')}`,
+            meta: { spaceId: outcome.spaceId, missing: [...outcome.missing] },
+          },
+        ),
       );
     }
 
@@ -580,7 +586,7 @@ function mapApplyFailure(failure: MigrateFailure): CliStructuredErrorType {
   if (failure.code === 'MIGRATION_PATH_NOT_FOUND') {
     return errorPathUnreachable(failure);
   }
-  return errorRuntime(failure.summary, {
+  return errorRunnerFailed(failure.summary, {
     why: failure.why ?? 'Migration runner failed',
     fix: 'Fix the issue and re-run `prisma-next migrate --to <contract>` — previously applied migrations are preserved.',
     meta: failure.meta ?? {},

--- a/packages/1-framework/3-tooling/cli/src/commands/migrate.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/migrate.ts
@@ -415,6 +415,7 @@ async function executeMigrateShowCommand(
           `Missing required invariants for space "${outcome.spaceId}"`,
           {
             why: `The path requires invariants not available on disk: ${outcome.missing.join(', ')}`,
+            fix: 'Add a migration on the path that runs `dataTransform({ invariantId: "<id>", … })` for each missing invariant, or retarget the ref to a hash whose path already provides them.',
             meta: { spaceId: outcome.spaceId, missing: [...outcome.missing] },
           },
         ),

--- a/packages/1-framework/3-tooling/cli/src/commands/migration-check.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/migration-check.ts
@@ -556,7 +556,7 @@ async function checkSingleTarget(
       matchedPkg = hits[0]!.pkg;
     } else if (bestParseFailure !== undefined) {
       // The ref didn't resolve in any in-scope space — surface the most informative
-      // parse failure through the shared ref-resolution envelope (CONTRACT.VERIFY_FAILED) the
+      // parse failure through the shared ref-resolution envelope (MIGRATION.REF_*) the
       // earlier work established, rather than a bespoke string. (Ref-resolved-but-
       // no-package falls through to the "not found on disk" result below.)
       return { error: mapRefResolutionError(bestParseFailure), exitCode: PRECONDITION };

--- a/packages/1-framework/3-tooling/cli/src/commands/migration-log.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/migration-log.ts
@@ -1,16 +1,11 @@
 import { loadConfig } from '@internal/config-loader';
 import type { LedgerEntryRecord } from '@internal/contract/types';
-import { MigrationToolsError } from '@internal/migration-tools/errors';
+
 import { ifDefined } from '@internal/utils/defined';
 import { notOk, ok, type Result } from '@internal/utils/result';
 import { Command } from 'commander';
 import { createControlClient } from '../control-api/client';
-import {
-  CliStructuredError,
-  errorUnexpected,
-  mapMigrationToolsError,
-  requireLiveDatabase,
-} from '../utils/cli-errors';
+import { CliStructuredError, errorUnexpected, requireLiveDatabase } from '../utils/cli-errors';
 import {
   addGlobalOptions,
   maskConnectionUrl,
@@ -93,7 +88,6 @@ export async function executeMigrationLogCommand(
     return ok(ledger);
   } catch (error) {
     if (CliStructuredError.is(error)) return notOk(error);
-    if (MigrationToolsError.is(error)) return notOk(mapMigrationToolsError(error));
     return notOk(
       errorUnexpected(error instanceof Error ? error.message : String(error), {
         why: `Failed to read migration log: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/1-framework/3-tooling/cli/src/commands/migration-new.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/migration-new.ts
@@ -92,7 +92,7 @@ async function executeMigrationNewCommand(
   } catch (error) {
     if (error instanceof Error && (error as { code?: string }).code === 'ENOENT') {
       return notOk(
-        errorRuntime(`Contract file not found at ${contractPathAbsolute}`, {
+        errorRuntime('CLI.FILE_NOT_FOUND', `Contract file not found at ${contractPathAbsolute}`, {
           why: `Contract file not found at ${contractPathAbsolute}`,
           fix: 'Run `prisma-next contract emit` first to generate the contract',
         }),
@@ -107,9 +107,10 @@ async function executeMigrationNewCommand(
     toContract = familyInstance.deserializeContract(parsedContract);
   } catch (error) {
     return notOk(
-      errorRuntime('Contract JSON is invalid', {
+      errorRuntime('MIGRATION.CONTRACT_DESERIALIZATION_FAILED', 'Contract JSON is invalid', {
         why: `Failed to deserialize ${contractPathAbsolute}: ${error instanceof Error ? error.message : String(error)}`,
         fix: 'Run `prisma-next contract emit` to regenerate the contract',
+        cause: error,
       }),
     );
   }
@@ -117,7 +118,7 @@ async function executeMigrationNewCommand(
   const toStorageHash = toContract.storage?.storageHash;
   if (typeof toStorageHash !== 'string') {
     return notOk(
-      errorRuntime('Contract is missing storageHash', {
+      errorRuntime('CONTRACT.VALIDATION_FAILED', 'Contract is missing storageHash', {
         why: `Contract at ${contractPathAbsolute} has no storageHash`,
         fix: 'Run `prisma-next contract emit` to regenerate the contract',
       }),
@@ -144,7 +145,7 @@ async function executeMigrationNewCommand(
       const match = packages.find((p) => p.metadata.to.startsWith(options.from!));
       if (!match) {
         return notOk(
-          errorRuntime('Starting contract not found', {
+          errorRuntime('MIGRATION.HASH_NOT_IN_GRAPH', 'Starting contract not found', {
             why: `No migration with to hash matching "${options.from}" exists in ${appMigrationsRelative}`,
             fix: 'Check that the --from hash matches a known migration target hash.',
           }),
@@ -161,7 +162,7 @@ async function executeMigrationNewCommand(
 
   if (fromHash === toStorageHash && !options.from) {
     return notOk(
-      errorRuntime('No changes detected', {
+      errorRuntime('MIGRATION.NO_CHANGES', 'No changes detected', {
         why: 'The from and to contract hashes are identical — there is nothing to migrate.',
         fix: 'Change the contract and run `prisma-next contract emit` before creating a new migration. To author a data-only migration on the current contract hash, pass `--from <hash>` explicitly.',
       }),

--- a/packages/1-framework/3-tooling/cli/src/commands/migration-plan.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/migration-plan.ts
@@ -13,7 +13,6 @@ import {
   snapshotsImportPathFrom,
   writeContractSnapshot,
 } from '@internal/migration-tools/contract-snapshot-store';
-import { MigrationToolsError } from '@internal/migration-tools/errors';
 import { computeMigrationHash } from '@internal/migration-tools/hash';
 import { deriveProvidedInvariants } from '@internal/migration-tools/invariants';
 import { formatMigrationDirName, writeMigrationPackage } from '@internal/migration-tools/io';
@@ -31,7 +30,6 @@ import {
   errorMigrationPlanningFailed,
   errorTargetMigrationNotSupported,
   errorUnexpected,
-  mapMigrationToolsError,
 } from '../utils/cli-errors';
 import {
   addGlobalOptions,
@@ -710,9 +708,6 @@ async function executeMigrationPlanCommand(
   } catch (error) {
     if (CliStructuredError.is(error)) {
       return notOk(error);
-    }
-    if (MigrationToolsError.is(error)) {
-      return notOk(mapMigrationToolsError(error));
     }
     const message = error instanceof Error ? error.message : String(error);
     return notOk(

--- a/packages/1-framework/3-tooling/cli/src/commands/migration-show.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/migration-show.ts
@@ -175,7 +175,7 @@ async function executeMigrationShowCommand(
     const matched = findPackageByDirPath(packages, resolved.value);
     if (!matched) {
       return notOk(
-        errorRuntime('Migration package not found', {
+        errorRuntime('MIGRATION.PACKAGE_NOT_FOUND', 'Migration package not found', {
           why: `No loaded migration package at ${relative(process.cwd(), resolved.value)}`,
           fix: 'Pass a directory name, hash prefix, or path to an on-disk app-space migration package.',
         }),
@@ -185,7 +185,7 @@ async function executeMigrationShowCommand(
   } else {
     if (packages.length === 0) {
       return notOk(
-        errorRuntime('No migrations found', {
+        errorRuntime('MIGRATION.NO_MIGRATIONS', 'No migrations found', {
           why: `No migration packages found in ${appMigrationsRelative}`,
           fix: 'Run `prisma-next migration plan` to create a migration first.',
         }),
@@ -200,7 +200,7 @@ async function executeMigrationShowCommand(
     );
     if (!matchedPkg) {
       return notOk(
-        errorRuntime('Migration package not found', {
+        errorRuntime('MIGRATION.PACKAGE_NOT_FOUND', 'Migration package not found', {
           why: `Resolved migration "${migResult.value.dirName}" but the package was not loaded`,
           fix: 'The migrations directory may be corrupted. Inspect the migration.json files.',
         }),

--- a/packages/1-framework/3-tooling/cli/src/commands/migration-status.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/migration-status.ts
@@ -22,7 +22,6 @@ import { createControlClient } from '../control-api/client';
 import {
   CliStructuredError,
   errorUnexpected,
-  mapMigrationToolsError,
   mapRefResolutionError,
   requireLiveDatabase,
 } from '../utils/cli-errors';
@@ -302,7 +301,7 @@ export async function executeMigrationStatusCommand(
     allRefs = await readRefs(refsDir);
   } catch (error) {
     if (MigrationToolsError.is(error)) {
-      return notOk(mapMigrationToolsError(error));
+      return notOk(error);
     }
     throw error;
   }
@@ -453,13 +452,11 @@ export async function executeMigrationStatusCommand(
     const unknown = activeRefEntry.invariants.filter((id) => !known.has(id));
     if (unknown.length > 0) {
       return notOk(
-        mapMigrationToolsError(
-          errorUnknownInvariant({
-            ...ifDefined('refName', activeRefName),
-            unknown,
-            declared: [...declared].sort(),
-          }),
-        ),
+        errorUnknownInvariant({
+          ...ifDefined('refName', activeRefName),
+          unknown,
+          declared: [...declared].sort(),
+        }),
       );
     }
   }
@@ -597,14 +594,12 @@ export async function executeMigrationStatusCommand(
         });
         if (outcome.kind === 'unsatisfiable') {
           return notOk(
-            mapMigrationToolsError(
-              errorNoInvariantPath({
-                ...ifDefined('refName', activeRefName),
-                required: [...missing].sort(),
-                missing: outcome.missing,
-                structuralPath: outcome.structuralPath.map(toStructuralEdge),
-              }),
-            ),
+            errorNoInvariantPath({
+              ...ifDefined('refName', activeRefName),
+              required: [...missing].sort(),
+              missing: outcome.missing,
+              structuralPath: outcome.structuralPath.map(toStructuralEdge),
+            }),
           );
         }
       }

--- a/packages/1-framework/3-tooling/cli/src/commands/ref.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/ref.ts
@@ -66,7 +66,7 @@ function mapError(error: unknown): CliStructuredError {
 }
 
 function cliErrorInvalidRefName(name: string): CliStructuredError {
-  return errorRuntime(`Invalid ref name "${name}"`, {
+  return errorRuntime('MIGRATION.INVALID_REF_NAME', `Invalid ref name "${name}"`, {
     why: `Ref name "${name}" does not match the required format`,
     fix: 'Ref names must be lowercase alphanumeric with hyphens or forward slashes, no `.` or `..` segments',
   });

--- a/packages/1-framework/3-tooling/cli/src/commands/ref.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/ref.ts
@@ -26,7 +26,6 @@ import {
   errorRefSetHashNotInGraph,
   errorRuntime,
   errorUnexpected,
-  mapMigrationToolsError,
   mapRefResolutionError,
 } from '../utils/cli-errors';
 import {
@@ -60,7 +59,7 @@ interface RefListResult {
 
 function mapError(error: unknown): CliStructuredError {
   if (MigrationToolsError.is(error)) {
-    return mapMigrationToolsError(error);
+    return error;
   }
   return errorUnexpected(error instanceof Error ? error.message : String(error));
 }

--- a/packages/1-framework/3-tooling/cli/src/control-api/operations/contract-emit.ts
+++ b/packages/1-framework/3-tooling/cli/src/control-api/operations/contract-emit.ts
@@ -39,11 +39,17 @@ function endSpan(
   onProgress?.({ action: EMIT_ACTION, kind: 'spanEnd', spanId, outcome });
 }
 
-function failedToResolveContractSource(why: string, fix: string, meta?: Record<string, unknown>) {
-  return errorRuntime('Failed to resolve contract source', {
+function failedToResolveContractSource(
+  why: string,
+  fix: string,
+  meta?: Record<string, unknown>,
+  cause?: unknown,
+) {
+  return errorRuntime('CONTRACT.SOURCE_LOAD_FAILED', 'Failed to resolve contract source', {
     why,
     fix,
     ...ifDefined('meta', meta),
+    ...ifDefined('cause', cause),
   });
 }
 
@@ -217,6 +223,8 @@ export async function executeContractEmit(
       throw failedToResolveContractSource(
         error instanceof Error ? error.message : String(error),
         'Ensure contract.source.load resolves to ok(Contract) or returns structured diagnostics.',
+        undefined,
+        error,
       );
     }
 

--- a/packages/1-framework/3-tooling/cli/src/control-api/operations/db-run.ts
+++ b/packages/1-framework/3-tooling/cli/src/control-api/operations/db-run.ts
@@ -251,6 +251,7 @@ export async function executeRun<TFamilyId extends string, TTargetId extends str
       ...ifDefined('why', applied.failure.why),
       meta: applied.failure.meta,
       ...ifDefined('warnings', plannerWarnings),
+      ...ifDefined('cause', applied.failure.cause),
     });
   }
 
@@ -427,6 +428,7 @@ function buildRunnerFailure(args: {
   readonly why?: string;
   readonly meta: Record<string, unknown>;
   readonly warnings?: readonly MigrationPlannerConflict[];
+  readonly cause?: unknown;
 }): DbInitResult | DbUpdateResult {
   const failure: DbInitFailure | DbUpdateFailure = {
     code: 'RUNNER_FAILED',
@@ -435,6 +437,7 @@ function buildRunnerFailure(args: {
     meta: args.meta,
     conflicts: undefined,
     ...ifDefined('warnings', args.warnings),
+    ...ifDefined('cause', args.cause),
   };
   return blindCast<
     DbInitResult | DbUpdateResult,

--- a/packages/1-framework/3-tooling/cli/src/control-api/operations/format.ts
+++ b/packages/1-framework/3-tooling/cli/src/control-api/operations/format.ts
@@ -56,9 +56,10 @@ export async function executeFormat(
     contents = await readFile(inputPath, 'utf-8');
   } catch (error) {
     return notOk(
-      errorRuntime('Failed to read contract source file', {
+      errorRuntime('CONTRACT.SOURCE_LOAD_FAILED', 'Failed to read contract source file', {
         why: error instanceof Error ? error.message : String(error),
         fix: `Check that ${inputPath} exists and is readable.`,
+        cause: error,
       }),
     );
   }
@@ -74,10 +75,11 @@ export async function executeFormat(
   } catch (error) {
     if (isStructuredError(error) && error.code === 'PSL.PARSE_FAILED') {
       return notOk(
-        errorRuntime('Cannot format PSL with parse errors', {
+        errorRuntime('PSL.PARSE_FAILED', 'Cannot format PSL with parse errors', {
           why: error.message,
           fix: 'Fix the parse errors in your schema and try again.',
           meta: { diagnostics: error.meta?.['diagnostics'] },
+          cause: error,
         }),
       );
     }
@@ -88,9 +90,10 @@ export async function executeFormat(
     await writeFile(inputPath, formatted, 'utf-8');
   } catch (error) {
     return notOk(
-      errorRuntime('Failed to write formatted contract source file', {
+      errorRuntime('CLI.FILE_WRITE_FAILED', 'Failed to write formatted contract source file', {
         why: error instanceof Error ? error.message : String(error),
         fix: `Check that ${inputPath} is writable.`,
+        cause: error,
       }),
     );
   }

--- a/packages/1-framework/3-tooling/cli/src/control-api/operations/migrate.ts
+++ b/packages/1-framework/3-tooling/cli/src/control-api/operations/migrate.ts
@@ -291,6 +291,7 @@ export async function executeMigrate<TFamilyId extends string, TTargetId extends
       summary: applied.failure.summary,
       why: applied.failure.why,
       meta: applied.failure.meta,
+      ...ifDefined('cause', applied.failure.cause),
     };
     return notOk(failure);
   }

--- a/packages/1-framework/3-tooling/cli/src/control-api/operations/run-migration.ts
+++ b/packages/1-framework/3-tooling/cli/src/control-api/operations/run-migration.ts
@@ -40,6 +40,11 @@ export interface RunnerFailure {
   readonly summary: string;
   readonly why?: string;
   readonly meta: Record<string, unknown>;
+  /**
+   * The runner's original failure object, preserved verbatim so callers
+   * can attach it as `cause` on the CLI error they build from this shape.
+   */
+  readonly cause?: unknown;
 }
 
 export interface RunMigrationInputs<TFamilyId extends string, TTargetId extends string> {
@@ -168,6 +173,7 @@ export async function runMigration<TFamilyId extends string, TTargetId extends s
         failingSpace: runnerResult.failure.failingSpace,
         runnerErrorCode: runnerResult.failure.code,
       },
+      cause: runnerResult.failure,
     });
   }
   onProgress?.({ action, kind: 'spanEnd', spanId: RUN_SPAN_ID, outcome: 'ok' });

--- a/packages/1-framework/3-tooling/cli/src/control-api/types.ts
+++ b/packages/1-framework/3-tooling/cli/src/control-api/types.ts
@@ -413,6 +413,8 @@ export interface DbInitFailure {
   readonly conflicts: ReadonlyArray<MigrationPlannerConflict> | undefined;
   readonly warnings?: ReadonlyArray<MigrationPlannerConflict>;
   readonly meta: Record<string, unknown> | undefined;
+  /** Underlying failure or error for diagnostics; never serialized into envelopes. */
+  readonly cause?: unknown;
   readonly marker?: {
     readonly storageHash?: string;
     readonly profileHash?: string;
@@ -485,6 +487,8 @@ export interface DbUpdateFailure {
   readonly conflicts: ReadonlyArray<MigrationPlannerConflict> | undefined;
   readonly warnings?: ReadonlyArray<MigrationPlannerConflict>;
   readonly meta: Record<string, unknown> | undefined;
+  /** Underlying failure or error for diagnostics; never serialized into envelopes. */
+  readonly cause?: unknown;
 }
 
 /**
@@ -693,6 +697,8 @@ export interface MigrateFailure {
   readonly summary: string;
   readonly why: string | undefined;
   readonly meta: Record<string, unknown> | undefined;
+  /** Underlying failure or error for diagnostics; never serialized into envelopes. */
+  readonly cause?: unknown;
 }
 
 /**

--- a/packages/1-framework/3-tooling/cli/src/migration-cli.ts
+++ b/packages/1-framework/3-tooling/cli/src/migration-cli.ts
@@ -53,7 +53,7 @@ import {
 } from '@internal/errors/control';
 import { errorMigrationTargetMismatch } from '@internal/errors/migration';
 import { createControlStack } from '@internal/framework-components/control';
-import { errorInvalidJson, MigrationToolsError } from '@internal/migration-tools/errors';
+import { errorInvalidJson } from '@internal/migration-tools/errors';
 import type { MigrationMetadata } from '@internal/migration-tools/metadata';
 import { buildMigrationArtifacts, type Migration } from '@internal/migration-tools/migration';
 import { Cli, Command, Option, UsageError } from 'clipanion';
@@ -310,15 +310,10 @@ async function orchestrate(
     return 0;
   } catch (err) {
     if (CliStructuredError.is(err)) {
-      writeStructuredError(ctx.stderr, err);
-    } else if (MigrationToolsError.is(err)) {
       // Migration-tools errors (e.g. `errorInvalidJson` thrown by
-      // `readExistingMetadata` when migration.json is malformed) carry
-      // their own `code`/`why`/`fix` shape. Render them with the same
-      // visual structure as `CliStructuredError` so consumers grepping
-      // for `MIGRATION.<CODE>` see consistent output across surfaces.
-      const fix = err.fix ? `\n${err.fix}` : '';
-      ctx.stderr.write(`${err.code}: ${err.message}\n${err.why}${fix}\n`);
+      // `readExistingMetadata` when migration.json is malformed) are
+      // `CliStructuredError`s and render through the same surface.
+      writeStructuredError(ctx.stderr, err);
     } else {
       ctx.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
     }

--- a/packages/1-framework/3-tooling/cli/src/utils/cli-errors.ts
+++ b/packages/1-framework/3-tooling/cli/src/utils/cli-errors.ts
@@ -83,30 +83,36 @@ export function errorRefSetHashNotInGraph(
         ? `Set the ref to a graph-node hash such as ${graphTipHash}, or run \`prisma-next migration plan\` to extend the graph.`
         : 'Set the ref to a hash that appears in the migration graph.'
       : 'Run `prisma-next migration plan` first.';
-  return errorRuntime(`Resolved contract hash is not in the migration graph: ${resolvedHash}`, {
-    why:
-      reachableHashes.length > 0
-        ? `The migration graph reaches ${reachableList}; resolved ${resolvedHash} isn't a graph node.`
-        : 'The migration graph is empty — no hashes reachable.',
-    fix,
-    meta: {
-      code: 'MIGRATION.HASH_NOT_IN_GRAPH',
-      resolvedHash,
-      reachableHashes: [...reachableHashes],
-      ...(graphTipHash !== null ? { graphTipHash } : {}),
+  return errorRuntime(
+    'MIGRATION.HASH_NOT_IN_GRAPH',
+    `Resolved contract hash is not in the migration graph: ${resolvedHash}`,
+    {
+      why:
+        reachableHashes.length > 0
+          ? `The migration graph reaches ${reachableList}; resolved ${resolvedHash} isn't a graph node.`
+          : 'The migration graph is empty — no hashes reachable.',
+      fix,
+      meta: {
+        resolvedHash,
+        reachableHashes: [...reachableHashes],
+        ...(graphTipHash !== null ? { graphTipHash } : {}),
+      },
     },
-  });
+  );
 }
 
 export function errorRefSetEmptySentinel(hash: string): CliStructuredError {
-  return errorRuntime(`Cannot set ref to the empty-database sentinel: ${hash}`, {
-    why: 'The empty-database sentinel is a planner internal; it is not a valid ref target.',
-    fix: 'Set the ref to a contract hash from the migration graph, or use another ref name.',
-    meta: {
-      code: 'MIGRATION.REF_SET_EMPTY_SENTINEL',
-      hash,
+  return errorRuntime(
+    'MIGRATION.REF_SET_EMPTY_SENTINEL',
+    `Cannot set ref to the empty-database sentinel: ${hash}`,
+    {
+      why: 'The empty-database sentinel is a planner internal; it is not a valid ref target.',
+      fix: 'Set the ref to a contract hash from the migration graph, or use another ref name.',
+      meta: {
+        hash,
+      },
     },
-  });
+  );
 }
 
 /**
@@ -116,14 +122,17 @@ export function errorRefSetEmptySentinel(hash: string): CliStructuredError {
 export function errorLegendHumanOnly(
   conflictingFlag: '--json' | '--dot' | '--quiet',
 ): CliStructuredError {
-  return errorRuntime('`--legend` is only available for human-readable output', {
-    why: `\`--legend\` prints a glyph key to stderr and cannot be combined with ${conflictingFlag}.`,
-    fix: `Omit ${conflictingFlag} to print the legend alongside the tree, or omit --legend when using ${conflictingFlag}.`,
-    meta: {
-      code: 'MIGRATION.LEGEND_HUMAN_ONLY',
-      conflictingFlag,
+  return errorRuntime(
+    'MIGRATION.LEGEND_HUMAN_ONLY',
+    '`--legend` is only available for human-readable output',
+    {
+      why: `\`--legend\` prints a glyph key to stderr and cannot be combined with ${conflictingFlag}.`,
+      fix: `Omit ${conflictingFlag} to print the legend alongside the tree, or omit --legend when using ${conflictingFlag}.`,
+      meta: {
+        conflictingFlag,
+      },
     },
-  });
+  );
 }
 
 /**
@@ -133,11 +142,10 @@ export function errorLegendHumanOnly(
  * directory with that name would be skipped by the enumerator.
  */
 export function errorInvalidSpaceId(spaceId: string): CliStructuredError {
-  return errorRuntime(`Invalid contract space id: ${spaceId}`, {
+  return errorRuntime('MIGRATION.INVALID_SPACE_ID', `Invalid contract space id: ${spaceId}`, {
     why: 'Contract space ids must match [a-z][a-z0-9_-]{0,63} (lowercase, starts with a letter, max 64 characters — the rule applied to every on-disk space directory).',
     fix: 'Pass a space id that matches the directory naming rule, or omit --space to list every space.',
     meta: {
-      code: 'MIGRATION.INVALID_SPACE_ID',
       spaceId,
     },
   });
@@ -166,11 +174,10 @@ export function errorSpaceNotFound(
     availableSpaces.length > 0
       ? `Pick one of: ${availableList}. Run \`prisma-next migration list\` (no --space) to see every space's migrations.`
       : 'Author a migration with `prisma-next migration new` to create the first contract-space directory.';
-  return errorRuntime(`Unknown contract space: ${spaceId}`, {
+  return errorRuntime('MIGRATION.SPACE_NOT_FOUND', `Unknown contract space: ${spaceId}`, {
     why: `No directory named "${spaceId}" exists under the migrations root.`,
     fix,
     meta: {
-      code: 'MIGRATION.SPACE_NOT_FOUND',
       spaceId,
       availableSpaces: [...availableSpaces],
     },
@@ -178,14 +185,17 @@ export function errorSpaceNotFound(
 }
 
 export function errorRefSetBundleNotFound(hash: string): CliStructuredError {
-  return errorRuntime(`No migration bundle matches graph-node hash ${hash}`, {
-    why: `The hash is a graph node but no on-disk bundle has metadata.to = ${hash}.`,
-    fix: 'Run `pnpm fixtures:check`, or re-emit the migration that produces this hash so its bundle is restored.',
-    meta: {
-      code: 'MIGRATION.REF_SET_BUNDLE_NOT_FOUND',
-      hash,
+  return errorRuntime(
+    'MIGRATION.REF_SET_BUNDLE_NOT_FOUND',
+    `No migration bundle matches graph-node hash ${hash}`,
+    {
+      why: `The hash is a graph node but no on-disk bundle has metadata.to = ${hash}.`,
+      fix: 'Run `pnpm fixtures:check`, or re-emit the migration that produces this hash so its bundle is restored.',
+      meta: {
+        hash,
+      },
     },
-  });
+  );
 }
 
 export function errorPlanForgotTheFlag(
@@ -203,16 +213,19 @@ export function errorPlanForgotTheFlag(
       : graphTipHash !== null
         ? `Run migration plan --from ${graphTipHash}.`
         : 'Commit pending migrations first, then run migration plan.';
-  return errorRuntime(`Resolved from-hash is not in the migration graph: ${resolvedHash}`, {
-    why: `The migration graph reaches ${reachableList}; resolved ${resolvedHash} isn't a graph node.`,
-    fix: refFix,
-    meta: {
-      code: 'MIGRATION.HASH_NOT_IN_GRAPH',
-      resolvedHash,
-      reachableRefs: reachableRefs.map((r) => r.name),
-      ...(graphTipHash !== null ? { graphTipHash } : {}),
+  return errorRuntime(
+    'MIGRATION.HASH_NOT_IN_GRAPH',
+    `Resolved from-hash is not in the migration graph: ${resolvedHash}`,
+    {
+      why: `The migration graph reaches ${reachableList}; resolved ${resolvedHash} isn't a graph node.`,
+      fix: refFix,
+      meta: {
+        resolvedHash,
+        reachableRefs: reachableRefs.map((r) => r.name),
+        ...(graphTipHash !== null ? { graphTipHash } : {}),
+      },
     },
-  });
+  );
 }
 
 /**
@@ -232,6 +245,7 @@ export function errorSnapshotMissing(
     ? `Create the ref with "prisma-next ref set ${identifier} <hash>" (or advance it via "prisma-next db update --advance-ref ${identifier}"), or pass a hash that is a node in the migration graph.`
     : `No contract source exists for hash "${identifier}" on an empty migration graph. Use --from with a ref name (its contract resolves through the snapshot store), or run db update first.`;
   return errorRuntime(
+    'MIGRATION.SNAPSHOT_MISSING',
     viaRef
       ? `Ref "${identifier}" is not resolvable`
       : `No contract source for from-hash "${identifier}"`,
@@ -241,7 +255,6 @@ export function errorSnapshotMissing(
         : `Hash "${identifier}" is not a node in the migration graph (the graph is empty), and it does not name a ref either.`,
       fix,
       meta: {
-        code: 'MIGRATION.SNAPSHOT_MISSING',
         identifier,
         viaRef,
       },
@@ -260,20 +273,23 @@ export function errorMarkerMismatch(
     graphTip !== null
       ? `Run \`prisma-next migration plan --from ${graphTip}\` if the live marker is canonical and the on-disk graph needs catching up.`
       : 'Run `prisma-next migration plan` if the live marker is canonical and the on-disk graph needs catching up.';
-  return errorRuntime('Database marker is not reachable in the on-disk migration graph', {
-    why: `DB marker is ${markerHash}, but the on-disk migration graph reaches: ${reachableList}.`,
-    fix: [
-      planFromFix,
-      `Run \`prisma-next ref set db ${markerHash}\` if the on-disk graph is canonical and the local \`db\` ref drifted.`,
-      'Investigate whether the database was migrated by an out-of-band process.',
-    ].join('\n'),
-    meta: {
-      code: 'MIGRATION.MARKER_MISMATCH',
-      markerHash,
-      reachableHashes: [...reachableHashes],
-      ...(graphTip !== null ? { graphTip } : {}),
+  return errorRuntime(
+    'MIGRATION.MARKER_MISMATCH',
+    'Database marker is not reachable in the on-disk migration graph',
+    {
+      why: `DB marker is ${markerHash}, but the on-disk migration graph reaches: ${reachableList}.`,
+      fix: [
+        planFromFix,
+        `Run \`prisma-next ref set db ${markerHash}\` if the on-disk graph is canonical and the local \`db\` ref drifted.`,
+        'Investigate whether the database was migrated by an out-of-band process.',
+      ].join('\n'),
+      meta: {
+        markerHash,
+        reachableHashes: [...reachableHashes],
+        ...(graphTip !== null ? { graphTip } : {}),
+      },
     },
-  });
+  );
 }
 
 export function errorPathUnreachable(failure: MigrateFailure): CliStructuredError {
@@ -322,7 +338,7 @@ export function errorPathUnreachable(failure: MigrateFailure): CliStructuredErro
     targetHash !== null && !neverPlanned
       ? `prisma-next migrate --to ${targetHash}`
       : 'prisma-next migrate';
-  return errorRuntime(failure.summary, {
+  return errorRuntime('MIGRATION.PATH_UNREACHABLE', failure.summary, {
     why:
       failure.why ??
       `Cannot reach target "${targetHash ?? '<unknown>'}" from current marker "${fromHashMeta ?? '<unknown>'}".${deadEndsSuffix}`,
@@ -336,7 +352,6 @@ export function errorPathUnreachable(failure: MigrateFailure): CliStructuredErro
     ].join('\n'),
     meta: {
       ...meta,
-      code: 'MIGRATION.PATH_UNREACHABLE',
     },
   });
 }
@@ -357,10 +372,11 @@ export function errorPathUnreachable(failure: MigrateFailure): CliStructuredErro
  * `errorUnexpected`, etc.).
  */
 export function mapMigrationToolsError(error: MigrationToolsError): CliStructuredError {
-  return errorRuntime(error.message, {
+  return errorRuntime(error.code, error.message, {
     why: error.why,
     fix: error.fix,
-    meta: { code: error.code, ...(error.details ?? {}) },
+    ...ifDefined('meta', error.details),
+    cause: error,
   });
 }
 
@@ -405,12 +421,12 @@ export function errorAmbiguousMigrationRef(
 ): CliStructuredError {
   const spaceList = spaceIds.join(', ');
   return errorRuntime(
+    'MIGRATION.AMBIGUOUS_MIGRATION_REF',
     `Ambiguous migration reference: "${ref}" resolves in multiple spaces — qualify with --space <id>`,
     {
       why: `"${ref}" matches migrations in spaces: ${spaceList}.`,
       fix: `Qualify with --space <id> to select one space. Available matching spaces: ${spaceList}.`,
       meta: {
-        code: 'MIGRATION.AMBIGUOUS_MIGRATION_REF',
         ref,
         spaceIds: [...spaceIds],
       },
@@ -421,31 +437,43 @@ export function errorAmbiguousMigrationRef(
 export function mapRefResolutionError(error: RefResolutionError): CliStructuredError {
   switch (error.kind) {
     case 'not-found':
-      return errorRuntime(`Not a known ${error.grammar} reference: "${error.input}"`, {
-        why: `No ${error.grammar} matching "${error.input}" exists in the migration graph or refs index.`,
-        fix:
-          error.grammar === 'contract'
-            ? 'Provide a valid contract hash, ref name, or migration directory name.'
-            : 'Provide a valid migration directory name or migration hash.',
-        meta: { input: error.input, grammar: error.grammar },
-      });
+      return errorRuntime(
+        'MIGRATION.REF_NOT_FOUND',
+        `Not a known ${error.grammar} reference: "${error.input}"`,
+        {
+          why: `No ${error.grammar} matching "${error.input}" exists in the migration graph or refs index.`,
+          fix:
+            error.grammar === 'contract'
+              ? 'Provide a valid contract hash, ref name, or migration directory name.'
+              : 'Provide a valid migration directory name or migration hash.',
+          meta: { input: error.input, grammar: error.grammar },
+        },
+      );
     case 'ambiguous':
-      return errorRuntime(`Ambiguous ${error.grammar} reference: "${error.input}"`, {
-        why: `"${error.input}" matches multiple ${error.grammar}s: ${error.candidates.join(', ')}`,
-        fix: 'Provide a longer prefix or use the full hash to disambiguate.',
-        meta: { input: error.input, candidates: error.candidates, grammar: error.grammar },
-      });
+      return errorRuntime(
+        'MIGRATION.REF_AMBIGUOUS',
+        `Ambiguous ${error.grammar} reference: "${error.input}"`,
+        {
+          why: `"${error.input}" matches multiple ${error.grammar}s: ${error.candidates.join(', ')}`,
+          fix: 'Provide a longer prefix or use the full hash to disambiguate.',
+          meta: { input: error.input, candidates: error.candidates, grammar: error.grammar },
+        },
+      );
     case 'wrong-grammar':
-      return errorRuntime(error.message, {
+      return errorRuntime('MIGRATION.REF_WRONG_GRAMMAR', error.message, {
         why: error.message,
         fix: error.fix,
         meta: { input: error.input, expectedGrammar: error.expectedGrammar },
       });
     case 'invalid-format':
-      return errorRuntime(`Invalid reference format: "${error.input}"`, {
-        why: error.reason,
-        fix: 'Provide a valid contract hash, ref name, or migration directory name.',
-        meta: { input: error.input },
-      });
+      return errorRuntime(
+        'MIGRATION.REF_INVALID_FORMAT',
+        `Invalid reference format: "${error.input}"`,
+        {
+          why: error.reason,
+          fix: 'Provide a valid contract hash, ref name, or migration directory name.',
+          meta: { input: error.input },
+        },
+      );
   }
 }

--- a/packages/1-framework/3-tooling/cli/src/utils/cli-errors.ts
+++ b/packages/1-framework/3-tooling/cli/src/utils/cli-errors.ts
@@ -375,7 +375,7 @@ export function mapMigrationToolsError(error: MigrationToolsError): CliStructure
   return errorRuntime(error.code, error.message, {
     why: error.why,
     fix: error.fix,
-    ...ifDefined('meta', error.details),
+    ...ifDefined('meta', error.details && { ...error.details }),
     cause: error,
   });
 }

--- a/packages/1-framework/3-tooling/cli/src/utils/cli-errors.ts
+++ b/packages/1-framework/3-tooling/cli/src/utils/cli-errors.ts
@@ -26,7 +26,6 @@ import {
   errorUnexpected,
 } from '@internal/errors/control';
 import { errorRuntime } from '@internal/errors/execution';
-import type { MigrationToolsError } from '@internal/migration-tools/errors';
 import type { RefResolutionError } from '@internal/migration-tools/ref-resolution';
 import { ifDefined } from '@internal/utils/defined';
 import type { MigrateFailure } from '../control-api/types';
@@ -202,6 +201,7 @@ export function errorPlanForgotTheFlag(
   resolvedHash: string,
   reachableRefs: ReadonlyArray<{ readonly name: string; readonly hash: string }>,
   graphTipHash: string | null,
+  options?: { readonly cause?: unknown },
 ): CliStructuredError {
   const reachableList =
     reachableRefs.length > 0
@@ -224,6 +224,7 @@ export function errorPlanForgotTheFlag(
         reachableRefs: reachableRefs.map((r) => r.name),
         ...(graphTipHash !== null ? { graphTipHash } : {}),
       },
+      ...ifDefined('cause', options?.cause),
     },
   );
 }
@@ -238,7 +239,7 @@ export function errorPlanForgotTheFlag(
  */
 export function errorSnapshotMissing(
   identifier: string,
-  options?: { readonly viaRef?: boolean },
+  options?: { readonly viaRef?: boolean; readonly cause?: unknown },
 ): CliStructuredError {
   const viaRef = options?.viaRef !== false;
   const fix = viaRef
@@ -258,6 +259,7 @@ export function errorSnapshotMissing(
         identifier,
         viaRef,
       },
+      ...ifDefined('cause', options?.cause),
     },
   );
 }
@@ -353,30 +355,6 @@ export function errorPathUnreachable(failure: MigrateFailure): CliStructuredErro
     meta: {
       ...meta,
     },
-  });
-}
-
-/**
- * Maps a `MigrationToolsError` raised by the migration-tools loader/graph
- * surface (`readMigrationPackage`, `readMigrationsDir`, `readRefs`,
- * `resolveRef`, `reconstructGraph`, ...) into a CLI `errorRuntime` envelope.
- *
- * The full `error.details` payload is forwarded into `meta` so machine
- * consumers (`--json`) see structural fields like `dir`, `storedHash`,
- * `computedHash` (for `MIGRATION.HASH_MISMATCH`) alongside the stable
- * `code`. The user-visible `summary`/`why`/`fix` text is unchanged.
- *
- * Callers are expected to gate on `MigrationToolsError.is(error)` first
- * (mirroring the original inline pattern); non-`MigrationToolsError`
- * values are caller-classified (rethrow, wrap with command-specific
- * `errorUnexpected`, etc.).
- */
-export function mapMigrationToolsError(error: MigrationToolsError): CliStructuredError {
-  return errorRuntime(error.code, error.message, {
-    why: error.why,
-    fix: error.fix,
-    ...ifDefined('meta', error.details && { ...error.details }),
-    cause: error,
   });
 }
 

--- a/packages/1-framework/3-tooling/cli/src/utils/command-helpers.ts
+++ b/packages/1-framework/3-tooling/cli/src/utils/command-helpers.ts
@@ -95,10 +95,14 @@ export interface MigrationCommandOptions extends CommonCommandOptions {
  */
 export function resolveContractPath(config: { contract?: { output?: string } }): string {
   if (config.contract?.output === undefined) {
-    throw errorRuntime('config.contract.output is required to resolve the contract path', {
-      why: 'CLI commands read the emitted contract from config.contract.output; the config has no value to read.',
-      fix: 'Ensure your prisma-next.config.ts goes through `defineConfig()`, which normalises a default output when the provider supplies an input path, or set `contract.output` explicitly.',
-    });
+    throw errorRuntime(
+      'CONFIG.VALIDATION_FAILED',
+      'config.contract.output is required to resolve the contract path',
+      {
+        why: 'CLI commands read the emitted contract from config.contract.output; the config has no value to read.',
+        fix: 'Ensure your prisma-next.config.ts goes through `defineConfig()`, which normalises a default output when the provider supplies an input path, or set `contract.output` explicitly.',
+      },
+    );
   }
   return resolve(config.contract.output);
 }

--- a/packages/1-framework/3-tooling/cli/src/utils/contract-at-errors.ts
+++ b/packages/1-framework/3-tooling/cli/src/utils/contract-at-errors.ts
@@ -6,7 +6,6 @@ import {
   errorFileNotFound,
   errorSnapshotMissing,
   errorUnexpected,
-  mapMigrationToolsError,
 } from './cli-errors';
 
 export function mapContractAtError(
@@ -17,39 +16,37 @@ export function mapContractAtError(
     switch (error.code) {
       case 'MIGRATION.REF_NOT_RESOLVABLE': {
         const refName =
-          typeof error.details?.['refName'] === 'string'
-            ? error.details['refName']
-            : typeof error.details?.['identifier'] === 'string'
-              ? error.details['identifier']
+          typeof error.meta?.['refName'] === 'string'
+            ? error.meta['refName']
+            : typeof error.meta?.['identifier'] === 'string'
+              ? error.meta['identifier']
               : 'unknown';
-        return notOk(errorSnapshotMissing(refName));
+        return notOk(errorSnapshotMissing(refName, { cause: error }));
       }
       case 'MIGRATION.CONTRACT_DESERIALIZATION_FAILED': {
         const filePath =
-          typeof error.details?.['filePath'] === 'string' ? error.details['filePath'] : 'unknown';
+          typeof error.meta?.['filePath'] === 'string' ? error.meta['filePath'] : 'unknown';
         const message =
-          typeof error.details?.['message'] === 'string' ? error.details['message'] : error.message;
+          typeof error.meta?.['message'] === 'string' ? error.meta['message'] : error.message;
         return notOk(
           errorContractValidationFailed(
             `Predecessor contract at ${filePath} failed to deserialize: ${message}`,
-            { where: { path: filePath } },
+            { where: { path: filePath }, cause: error },
           ),
         );
       }
       case 'MIGRATION.INVALID_JSON': {
         const filePath =
-          typeof error.details?.['filePath'] === 'string' ? error.details['filePath'] : 'unknown';
+          typeof error.meta?.['filePath'] === 'string' ? error.meta['filePath'] : 'unknown';
         const message =
-          typeof error.details?.['parseError'] === 'string'
-            ? error.details['parseError']
-            : error.message;
+          typeof error.meta?.['parseError'] === 'string' ? error.meta['parseError'] : error.message;
         const role = options?.artifactRole ?? 'from';
         return notOk(
           errorContractValidationFailed(
             role === 'to'
               ? `Target contract at ${filePath} failed to deserialize: ${message}`
               : `Predecessor contract at ${filePath} failed to deserialize: ${message}`,
-            { where: { path: filePath } },
+            { where: { path: filePath }, cause: error },
           ),
         );
       }
@@ -58,12 +55,13 @@ export function mapContractAtError(
           errorUnexpected(error.message, {
             why: error.why,
             fix: error.fix,
+            cause: error,
           }),
         );
       case 'MIGRATION.CONTRACT_SNAPSHOT_MISSING': {
         const expectedPath =
-          typeof error.details?.['expectedPath'] === 'string'
-            ? error.details['expectedPath']
+          typeof error.meta?.['expectedPath'] === 'string'
+            ? error.meta['expectedPath']
             : 'migrations/snapshots/';
         const role = options?.artifactRole ?? 'from';
         return notOk(
@@ -73,11 +71,12 @@ export function mapContractAtError(
                 ? `Target migration is missing its contract snapshot at ${expectedPath}`
                 : `Predecessor migration is missing its contract snapshot at ${expectedPath}`,
             fix: 'Restore migrations/snapshots/ from version control, or re-run the command that produced this migration to regenerate its snapshot.',
+            cause: error,
           }),
         );
       }
       default:
-        return notOk(mapMigrationToolsError(error));
+        return notOk(error);
     }
   }
   if (CliStructuredError.is(error)) {

--- a/packages/1-framework/3-tooling/cli/src/utils/contract-space-aggregate-loader.ts
+++ b/packages/1-framework/3-tooling/cli/src/utils/contract-space-aggregate-loader.ts
@@ -14,7 +14,7 @@ import { EMPTY_CONTRACT_HASH } from '@internal/migration-tools/constants';
 import { MigrationToolsError } from '@internal/migration-tools/errors';
 import { blindCast } from '@internal/utils/casts';
 import { notOk, ok, type Result } from '@internal/utils/result';
-import { CliStructuredError, errorUnexpected, mapMigrationToolsError } from './cli-errors';
+import { CliStructuredError, errorUnexpected } from './cli-errors';
 import { readContractEnvelope, resolveContractPath } from './command-helpers';
 import { toDeclaredExtensionsFromRaw } from './extension-pack-inputs';
 
@@ -384,7 +384,7 @@ export async function buildReadAggregate(
     return ok({ aggregate: loaded.value, contractHash });
   } catch (error) {
     if (MigrationToolsError.is(error)) {
-      return notOk(mapMigrationToolsError(error));
+      return notOk(error);
     }
     return notOk(
       errorUnexpected(error instanceof Error ? error.message : String(error), {

--- a/packages/1-framework/3-tooling/cli/src/utils/migration-path-target.ts
+++ b/packages/1-framework/3-tooling/cli/src/utils/migration-path-target.ts
@@ -21,10 +21,14 @@ export function resolveAppTargetPath(
     isAbsolute(relativeToApp);
   if (isOutsideAppDir) {
     return notOk(
-      errorRuntime('Target must point to an app-space migration', {
-        why: `Expected a path under ${appMigrationsRelative}, got ${target}`,
-        fix: 'Pass an app-space migration directory or use a hash prefix.',
-      }),
+      errorRuntime(
+        'MIGRATION.TARGET_NOT_APP_SPACE',
+        'Target must point to an app-space migration',
+        {
+          why: `Expected a path under ${appMigrationsRelative}, got ${target}`,
+          fix: 'Pass an app-space migration directory or use a hash prefix.',
+        },
+      ),
     );
   }
   return ok(targetPath);

--- a/packages/1-framework/3-tooling/cli/src/utils/plan-resolution.ts
+++ b/packages/1-framework/3-tooling/cli/src/utils/plan-resolution.ts
@@ -73,7 +73,9 @@ export function assertFromIsGraphNode(
     assertHashIsGraphNode(fromHash, graph);
   } catch (error) {
     if (MigrationToolsError.is(error) && error.code === 'MIGRATION.HASH_NOT_IN_GRAPH') {
-      throw errorPlanForgotTheFlag(fromHash, getReachableRefs(refs, graph), graphTipHash);
+      throw errorPlanForgotTheFlag(fromHash, getReachableRefs(refs, graph), graphTipHash, {
+        cause: error,
+      });
     }
     throw error;
   }

--- a/packages/1-framework/3-tooling/cli/src/utils/project-import-root.ts
+++ b/packages/1-framework/3-tooling/cli/src/utils/project-import-root.ts
@@ -54,10 +54,11 @@ function nearestManifest(from: string): Record<string, unknown> | undefined {
       raw = readFileSync(path, 'utf8');
     } catch (cause) {
       if (!MANIFEST_ABSENT_CODES.has(errorCode(cause) ?? '')) {
-        throw errorRuntime(`Failed to read ${path}`, {
+        throw errorRuntime('CLI.PROJECT_MANIFEST_UNREADABLE', `Failed to read ${path}`, {
           why: `\`${path}\` exists but could not be read: ${cause instanceof Error ? cause.message : String(cause)}`,
           fix: `Make \`${path}\` readable, then re-run the command. Emission reads it to decide which package names generated files should import.`,
           meta: { path },
+          cause,
         });
       }
       const parent = dirname(dir);
@@ -69,14 +70,15 @@ function nearestManifest(from: string): Record<string, unknown> | undefined {
     try {
       parsed = JSON.parse(raw);
     } catch (cause) {
-      throw errorRuntime(`Failed to parse ${path}`, {
+      throw errorRuntime('CLI.PROJECT_MANIFEST_INVALID', `Failed to parse ${path}`, {
         why: `\`${path}\` is not valid JSON: ${cause instanceof Error ? cause.message : String(cause)}`,
         fix: `Fix the JSON syntax in \`${path}\` (a missing comma or unbalanced brace is the most common cause), then re-run the command. Emission reads it to decide which package names generated files should import.`,
         meta: { path },
+        cause,
       });
     }
     if (!isRecord(parsed)) {
-      throw errorRuntime(`Failed to read ${path}`, {
+      throw errorRuntime('CLI.PROJECT_MANIFEST_INVALID', `Failed to read ${path}`, {
         why: `\`${path}\` is valid JSON but not a JSON object, so it states no dependencies.`,
         fix: `Make \`${path}\` a JSON object with the usual manifest fields, then re-run the command. Emission reads it to decide which package names generated files should import.`,
         meta: { path },

--- a/packages/1-framework/3-tooling/cli/test/cli-errors.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/cli-errors.test.ts
@@ -51,7 +51,7 @@ describe('errorPathUnreachable', () => {
       meta: { spaceId: 'app', kind: 'pathUnreachable', fromHash, targetHash },
     };
     const envelope = errorPathUnreachable(failure).toEnvelope();
-    expect(envelope.meta?.['code']).toBe('MIGRATION.PATH_UNREACHABLE');
+    expect(envelope.code).toBe('MIGRATION.PATH_UNREACHABLE');
     expect(envelope.fix).toContain(
       `prisma-next migration plan --from ${fromHash} --to ${targetHash} --name <slug>`,
     );
@@ -158,7 +158,7 @@ describe('errorRefSetHashNotInGraph', () => {
       reachableHashes,
       graphTip,
     ).toEnvelope();
-    expect(envelope.meta?.['code']).toBe('MIGRATION.HASH_NOT_IN_GRAPH');
+    expect(envelope.code).toBe('MIGRATION.HASH_NOT_IN_GRAPH');
     expect(envelope.meta?.['resolvedHash']).toBe(resolvedHash);
     expect(envelope.meta?.['reachableHashes']).toEqual(reachableHashes);
     expect(envelope.meta?.['graphTipHash']).toBe(graphTip);
@@ -175,7 +175,7 @@ describe('errorRefSetHashNotInGraph', () => {
 describe('errorRefSetEmptySentinel', () => {
   it('emits MIGRATION.REF_SET_EMPTY_SENTINEL', () => {
     const envelope = errorRefSetEmptySentinel('empty').toEnvelope();
-    expect(envelope.meta?.['code']).toBe('MIGRATION.REF_SET_EMPTY_SENTINEL');
+    expect(envelope.code).toBe('MIGRATION.REF_SET_EMPTY_SENTINEL');
     expect(envelope.summary).toContain('empty-database sentinel');
   });
 });

--- a/packages/1-framework/3-tooling/cli/test/commands/db-update-read-aggregate-json-golden.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/commands/db-update-read-aggregate-json-golden.test.ts
@@ -160,8 +160,9 @@ describe('db update read aggregate --json golden', () => {
         throw error;
       }
       exitCode = getExitCode() ?? 0;
+    } finally {
+      cleanup();
     }
-    cleanup();
 
     expect(exitCode).toBe(2);
     const json = consoleOutput.join('\n');

--- a/packages/1-framework/3-tooling/cli/test/commands/db-update-read-aggregate-json-golden.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/commands/db-update-read-aggregate-json-golden.test.ts
@@ -8,7 +8,7 @@ import type { MigrationMetadata } from '@internal/migration-tools/metadata';
 import { join } from 'pathe';
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createDbUpdateCommand } from '../../src/commands/db-update';
-import { executeCommand, setupCommandMocks } from '../utils/test-helpers';
+import { executeCommand, getExitCode, setupCommandMocks } from '../utils/test-helpers';
 
 const mocks = vi.hoisted(() => ({
   loadConfig: vi.fn(),
@@ -104,6 +104,82 @@ describe('db update read aggregate --json golden', () => {
   afterEach(async () => {
     await Promise.all(createdDirs.map((dir) => rm(dir, { recursive: true, force: true })));
     createdDirs.length = 0;
+  });
+
+  it('pins the --json envelope when ref advancement throws a MigrationToolsError', async () => {
+    // Command-level envelope pin for the db-sign/-update/-init group: a
+    // MigrationToolsError raised inside the command (here MIGRATION.INVALID_REF_NAME
+    // from --advance-ref validation) must surface byte-identical through --json.
+    const { contractPath, dirNext } = await setupFixture();
+    mocks.loadConfig.mockResolvedValue({
+      family: {
+        familyId: 'sql',
+        create: vi.fn().mockReturnValue({
+          deserializeContract: (json: unknown) => json,
+        }),
+      },
+      target: {
+        id: 'postgres',
+        familyId: 'sql',
+        targetId: 'postgres',
+        kind: 'target',
+        migrations: {},
+      },
+      adapter: { kind: 'adapter', familyId: 'sql', targetId: 'postgres' },
+      driver: { kind: 'driver' },
+      db: { connection: 'postgres://localhost/db-update-golden' },
+      contract: { output: contractPath },
+    });
+    mocks.dbUpdate.mockResolvedValue({
+      ok: true,
+      value: {
+        ok: true as const,
+        mode: 'apply' as const,
+        destination: { storageHash: HASH_B },
+        summary: 'Applied',
+      },
+    });
+
+    const { consoleOutput, cleanup } = setupCommandMocks({ isTTY: false });
+    const updateCmd = createDbUpdateCommand();
+    let exitCode: number;
+    try {
+      exitCode = await executeCommand(updateCmd, [
+        '--to',
+        dirNext,
+        '--advance-ref',
+        'BAD NAME',
+        '--json',
+        '--db',
+        'postgres://localhost/db-update-golden',
+        '--config',
+        contractPath,
+      ]);
+    } catch (error) {
+      if (!(error instanceof Error) || error.message !== 'process.exit called') {
+        throw error;
+      }
+      exitCode = getExitCode() ?? 0;
+    }
+    cleanup();
+
+    expect(exitCode).toBe(2);
+    const json = consoleOutput.join('\n');
+    expect(json).toBe(
+      [
+        '{',
+        '  "ok": false,',
+        '  "code": "MIGRATION.INVALID_REF_NAME",',
+        '  "severity": "error",',
+        '  "summary": "Invalid ref name",',
+        `  "why": "Ref name \\"BAD NAME\\" is invalid. Names must be lowercase alphanumeric with hyphens or forward slashes (no \\".\\" or \\"..\\" segments).",`,
+        `  "fix": "Use a valid ref name (e.g., \\"staging\\", \\"envs/production\\").",`,
+        '  "meta": {',
+        '    "refName": "BAD NAME"',
+        '  }',
+        '}',
+      ].join('\n'),
+    );
   });
 
   it('pins --json dry-run output when --to resolves via aggregate packages', async () => {

--- a/packages/1-framework/3-tooling/cli/test/commands/migration-check-multi-space-command.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/commands/migration-check-multi-space-command.test.ts
@@ -215,7 +215,7 @@ describe('migration check multi-space (command)', () => {
 
     expect(exitCode).toBe(2);
     expect(envelope.ok).toBe(false);
-    expect(envelope.meta?.['code']).toBe('MIGRATION.INVALID_SPACE_ID');
+    expect(envelope.code).toBe('MIGRATION.INVALID_SPACE_ID');
   });
 });
 

--- a/packages/1-framework/3-tooling/cli/test/commands/migration-check-multi-space.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/commands/migration-check-multi-space.test.ts
@@ -274,7 +274,7 @@ describe('migration check — --space narrowing', () => {
     expect(outcome.ok).toBe(false);
     if (outcome.ok) throw new Error('unreachable');
     const envelope = outcome.failure.toEnvelope();
-    expect(envelope.meta?.['code']).toBe('MIGRATION.INVALID_SPACE_ID');
+    expect(envelope.code).toBe('MIGRATION.INVALID_SPACE_ID');
     expect(envelope.meta?.['spaceId']).toBe('../escape');
   });
 
@@ -296,7 +296,7 @@ describe('migration check — --space narrowing', () => {
     expect(outcome.ok).toBe(false);
     if (outcome.ok) throw new Error('unreachable');
     const envelope = outcome.failure.toEnvelope();
-    expect(envelope.meta?.['code']).toBe('MIGRATION.SPACE_NOT_FOUND');
+    expect(envelope.code).toBe('MIGRATION.SPACE_NOT_FOUND');
     expect(envelope.meta?.['spaceId']).toBe('nope');
     expect(envelope.meta?.['availableSpaces']).toEqual(['app']);
   });

--- a/packages/1-framework/3-tooling/cli/test/commands/migration-check-ref-error.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/commands/migration-check-ref-error.test.ts
@@ -133,7 +133,7 @@ describe('migration check ref-resolution error', () => {
 
     expect(exitCode).toBe(2);
     expect(envelope.ok).toBe(false);
-    expect(envelope.code).toBe('CONTRACT.VERIFY_FAILED');
+    expect(envelope.code).toBe('MIGRATION.REF_NOT_FOUND');
     expect(envelope.meta?.['input']).toBe('does-not-exist');
     expect(envelope.meta?.['grammar']).toBe('migration');
   });

--- a/packages/1-framework/3-tooling/cli/test/commands/migration-check-single-target-multi-space.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/commands/migration-check-single-target-multi-space.test.ts
@@ -225,7 +225,7 @@ describe('migration check <ref> — single-target multi-space resolution', () =>
 
     expect(exitCode).toBe(2);
     expect(envelope.ok).toBe(false);
-    expect(envelope.meta?.['code']).toBe('MIGRATION.INVALID_SPACE_ID');
+    expect(envelope.code).toBe('MIGRATION.INVALID_SPACE_ID');
   });
 
   it('(b) --space <unknown-id> → PRECONDITION SPACE_NOT_FOUND', async () => {
@@ -245,7 +245,7 @@ describe('migration check <ref> — single-target multi-space resolution', () =>
 
     expect(exitCode).toBe(2);
     expect(envelope.ok).toBe(false);
-    expect(envelope.meta?.['code']).toBe('MIGRATION.SPACE_NOT_FOUND');
+    expect(envelope.code).toBe('MIGRATION.SPACE_NOT_FOUND');
     expect(envelope.meta?.['spaceId']).toBe('nope');
   });
 
@@ -261,7 +261,7 @@ describe('migration check <ref> — single-target multi-space resolution', () =>
 
     expect(exitCode).toBe(2);
     expect(envelope.ok).toBe(false);
-    expect(envelope.meta?.['code']).toBe('MIGRATION.AMBIGUOUS_MIGRATION_REF');
+    expect(envelope.code).toBe('MIGRATION.AMBIGUOUS_MIGRATION_REF');
     expect(envelope.summary).toContain('--space');
   });
 

--- a/packages/1-framework/3-tooling/cli/test/commands/migration-invariants.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/commands/migration-invariants.test.ts
@@ -260,9 +260,10 @@ describe('migrate / migration status — invariant-routing pre-checks', {
     const jsonLine = consoleOutput.find((line) => line.trimStart().startsWith('{'));
     expect(jsonLine).toBeDefined();
     const envelope = JSON.parse(jsonLine!) as {
-      meta?: { code?: string; unknown?: string[]; declared?: string[] };
+      code?: string;
+      meta?: { unknown?: string[]; declared?: string[] };
     };
-    expect(envelope.meta?.code).toBe('MIGRATION.UNKNOWN_INVARIANT');
+    expect(envelope.code).toBe('MIGRATION.UNKNOWN_INVARIANT');
     expect(envelope.meta?.unknown).toEqual(['typo-id']);
     expect(envelope.meta?.declared).toEqual(['real-id']);
   });
@@ -284,8 +285,8 @@ describe('migrate / migration status — invariant-routing pre-checks', {
     expect(exitCode).not.toBe(0);
     const jsonLine = consoleOutput.find((line) => line.trimStart().startsWith('{'));
     expect(jsonLine).toBeDefined();
-    const envelope = JSON.parse(jsonLine!) as { meta?: { code?: string } };
-    expect(envelope.meta?.code).toBe('MIGRATION.UNKNOWN_INVARIANT');
+    const envelope = JSON.parse(jsonLine!) as { code?: string };
+    expect(envelope.code).toBe('MIGRATION.UNKNOWN_INVARIANT');
   });
 
   it('migrate --to does not fire UNKNOWN_INVARIANT when a retired invariant is already on the marker', async () => {
@@ -345,8 +346,8 @@ describe('migrate / migration status — invariant-routing pre-checks', {
 
     const jsonLine = consoleOutput.find((line) => line.trimStart().startsWith('{'));
     if (jsonLine !== undefined && exitCode !== 0) {
-      const envelope = JSON.parse(jsonLine) as { meta?: { code?: string } };
-      expect(envelope.meta?.code).not.toBe('MIGRATION.UNKNOWN_INVARIANT');
+      const envelope = JSON.parse(jsonLine) as { code?: string };
+      expect(envelope.code).not.toBe('MIGRATION.UNKNOWN_INVARIANT');
     }
     expect(consoleErrors.join('\n')).not.toContain('MIGRATION.UNKNOWN_INVARIANT');
   });
@@ -399,8 +400,8 @@ describe('migrate / migration status — invariant-routing pre-checks', {
     // Either the command succeeded (exit 0, no JSON envelope), or it failed
     // for a *later* reason (driver/runner) — but never with UNKNOWN_INVARIANT.
     if (jsonLine !== undefined && exitCode !== 0) {
-      const envelope = JSON.parse(jsonLine) as { meta?: { code?: string } };
-      expect(envelope.meta?.code).not.toBe('MIGRATION.UNKNOWN_INVARIANT');
+      const envelope = JSON.parse(jsonLine) as { code?: string };
+      expect(envelope.code).not.toBe('MIGRATION.UNKNOWN_INVARIANT');
     }
     expect(consoleErrors.join('\n')).not.toContain('MIGRATION.UNKNOWN_INVARIANT');
   });

--- a/packages/1-framework/3-tooling/cli/test/commands/migration-legend-commands.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/commands/migration-legend-commands.test.ts
@@ -100,8 +100,8 @@ function envelopeCode(consoleOutput: readonly string[]): string | undefined {
   if (jsonLine === undefined) {
     return undefined;
   }
-  const envelope = JSON.parse(jsonLine) as { meta?: { code?: string } };
-  return envelope.meta?.code;
+  const envelope = JSON.parse(jsonLine) as { code?: string };
+  return envelope.code;
 }
 
 const createdDirs: string[] = [];

--- a/packages/1-framework/3-tooling/cli/test/commands/migration-list.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/commands/migration-list.test.ts
@@ -634,7 +634,7 @@ describe('runMigrationList — --space flag', () => {
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('unreachable');
     const envelope = result.failure.toEnvelope();
-    expect(envelope.meta?.['code']).toBe('MIGRATION.SPACE_NOT_FOUND');
+    expect(envelope.code).toBe('MIGRATION.SPACE_NOT_FOUND');
     expect(envelope.meta?.['spaceId']).toBe('postgis');
     expect(envelope.meta?.['availableSpaces']).toEqual(['app']);
     expect(envelope.summary).toBe('Unknown contract space: postgis');
@@ -649,7 +649,7 @@ describe('runMigrationList — --space flag', () => {
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('unreachable');
     const envelope = result.failure.toEnvelope();
-    expect(envelope.meta?.['code']).toBe('MIGRATION.SPACE_NOT_FOUND');
+    expect(envelope.code).toBe('MIGRATION.SPACE_NOT_FOUND');
     expect(envelope.meta?.['availableSpaces']).toEqual([]);
   });
 
@@ -662,7 +662,7 @@ describe('runMigrationList — --space flag', () => {
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('unreachable');
     const envelope = result.failure.toEnvelope();
-    expect(envelope.meta?.['code']).toBe('MIGRATION.INVALID_SPACE_ID');
+    expect(envelope.code).toBe('MIGRATION.INVALID_SPACE_ID');
     expect(envelope.meta?.['spaceId']).toBe('../escape');
   });
 
@@ -691,7 +691,7 @@ describe('runMigrationList — --space flag', () => {
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('unreachable');
     const envelope = result.failure.toEnvelope();
-    expect(envelope.meta?.['code']).toBe('MIGRATION.SPACE_NOT_FOUND');
+    expect(envelope.code).toBe('MIGRATION.SPACE_NOT_FOUND');
     expect(envelope.meta?.['spaceId']).toBe('refs');
     expect(envelope.meta?.['availableSpaces']).toEqual(['app']);
   });

--- a/packages/1-framework/3-tooling/cli/test/commands/migration-plan-command.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/commands/migration-plan-command.test.ts
@@ -161,7 +161,7 @@ function buildResolutionSpace(
           {
             why: `The hash ${hash} is a graph node but no on-disk migration package has a destination (\`to\`) hash matching it.`,
             fix: 'Provide a ref or hash that corresponds to an existing migration package, or run `migration list` to see available migrations.',
-            details: { hash },
+            meta: { hash },
           },
         );
       }

--- a/packages/1-framework/3-tooling/cli/test/commands/migration-plan.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/commands/migration-plan.test.ts
@@ -1,7 +1,9 @@
 import { mkdir, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { CliStructuredError } from '@internal/errors/control';
 import type { MigrationPlanOperation } from '@internal/framework-components/control';
+import { MigrationToolsError } from '@internal/migration-tools/errors';
 import { computeMigrationHash } from '@internal/migration-tools/hash';
 import {
   formatMigrationDirName,
@@ -313,24 +315,29 @@ describe('--from hash lookup', () => {
   );
 });
 
-describe('MigrationToolsError mapping', () => {
-  it('MigrationToolsError has expected shape for CLI mapping', () => {
-    // Simulate a MigrationToolsError-like object as the CLI would encounter it
-    const error = new Error('Directory already exists: /tmp/test');
-    error.name = 'MigrationToolsError';
-    Object.assign(error, {
-      code: 'MIGRATION.DIR_EXISTS',
-      category: 'MIGRATION',
-      why: 'A migration directory with this name already exists on disk.',
-      fix: 'Choose a different name or remove the existing directory.',
-      details: { dir: '/tmp/test' },
-    });
+describe('MigrationToolsError passthrough shape', () => {
+  it('MigrationToolsError is a CliStructuredError the CLI can pass straight through', () => {
+    const error = new MigrationToolsError(
+      'MIGRATION.DIR_EXISTS',
+      'Migration directory already exists',
+      {
+        why: 'A migration directory with this name already exists on disk.',
+        fix: 'Choose a different name or remove the existing directory.',
+        meta: { dir: '/tmp/test' },
+      },
+    );
 
-    expect(error.name).toBe('MigrationToolsError');
-    expect((error as unknown as { code: string }).code).toBe('MIGRATION.DIR_EXISTS');
-    expect((error as unknown as { category: string }).category).toBe('MIGRATION');
-    expect(typeof (error as unknown as { why: string }).why).toBe('string');
-    expect(typeof (error as unknown as { fix: string }).fix).toBe('string');
-    expect(error instanceof Error).toBe(true);
+    expect(CliStructuredError.is(error)).toBe(true);
+    expect(MigrationToolsError.is(error)).toBe(true);
+    expect(error.name).toBe('CliStructuredError');
+    expect(error.code).toBe('MIGRATION.DIR_EXISTS');
+    expect(error.category).toBe('MIGRATION');
+    expect(typeof error.why).toBe('string');
+    expect(typeof error.fix).toBe('string');
+    expect(error.toEnvelope()).toMatchObject({
+      ok: false,
+      code: 'MIGRATION.DIR_EXISTS',
+      meta: { dir: '/tmp/test' },
+    });
   });
 });

--- a/packages/1-framework/3-tooling/cli/test/commands/migration-read-commands-parity.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/commands/migration-read-commands-parity.test.ts
@@ -858,7 +858,7 @@ describe('migration check multi-space parity (D6 lock)', () => {
     const envelope = result.failure.toEnvelope();
     expect(envelope.ok).toBe(false);
     expect(typeof envelope.code).toBe('string');
-    expect(envelope.meta?.['code']).toBe('MIGRATION.SPACE_NOT_FOUND');
+    expect(envelope.code).toBe('MIGRATION.SPACE_NOT_FOUND');
   });
 });
 

--- a/packages/1-framework/3-tooling/cli/test/commands/migration-ref-error-mapping.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/commands/migration-ref-error-mapping.test.ts
@@ -14,7 +14,7 @@ vi.mock('@internal/config-loader', () => ({
 
 const HASH_A = `${'a'.repeat(64)}`;
 
-describe('migration-ref MigrationToolsError envelope mapping', () => {
+describe('migration-ref MigrationToolsError envelope passthrough', () => {
   let tempDir: string;
   let configPath: string;
 
@@ -43,7 +43,7 @@ describe('migration-ref MigrationToolsError envelope mapping', () => {
   });
 
   it(
-    'forwards MigrationToolsError details into the CliStructuredError meta payload',
+    'surfaces the MigrationToolsError meta payload unchanged in the envelope',
     async () => {
       const { executeRefDeleteCommand } = await import('../../src/commands/ref');
 

--- a/packages/1-framework/3-tooling/cli/test/commands/migration-ref-error-mapping.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/commands/migration-ref-error-mapping.test.ts
@@ -53,8 +53,8 @@ describe('migration-ref MigrationToolsError envelope mapping', () => {
       if (result.ok) return;
 
       const envelope = result.failure.toEnvelope();
+      expect(envelope.code).toBe('MIGRATION.UNKNOWN_REF');
       expect(envelope.meta).toMatchObject({
-        code: 'MIGRATION.UNKNOWN_REF',
         refName: 'does-not-exist',
       });
       expect(envelope.meta).toHaveProperty('filePath');

--- a/packages/1-framework/3-tooling/cli/test/commands/migration-tamper.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/commands/migration-tamper.test.ts
@@ -190,7 +190,7 @@ async function setupTamperFixture(): Promise<TamperFixture> {
  * the rendered text is already identical across tests (each test chdirs
  * into its own tempdir before invoking the command, and uses the same
  * package dir name). This normalization is a defensive belt: it scrubs
- * the absolute `details.dir` in the JSON envelope and any future leakage
+ * the absolute `meta.dir` in the JSON envelope and any future leakage
  * of an absolute path into the rendered surface.
  */
 function normalizePaths(text: string, tempDir: string): string {

--- a/packages/1-framework/3-tooling/cli/test/commands/ref.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/commands/ref.test.ts
@@ -230,7 +230,7 @@ describe('ref commands', { timeout: timeouts.databaseOperation }, () => {
       expect(result.ok).toBe(false);
       if (result.ok) return;
       const envelope = result.failure.toEnvelope();
-      expect(envelope.meta?.['code']).toBe('MIGRATION.HASH_NOT_IN_GRAPH');
+      expect(envelope.code).toBe('MIGRATION.HASH_NOT_IN_GRAPH');
       expect(envelope.meta?.['resolvedHash']).toBe(HASH_FLOAT);
       expect(envelope.meta?.['reachableHashes']).toEqual(
         expect.arrayContaining([HASH_A, HASH_B, HASH_C]),
@@ -249,7 +249,7 @@ describe('ref commands', { timeout: timeouts.databaseOperation }, () => {
       expect(result.ok).toBe(false);
       if (result.ok) return;
       const envelope = result.failure.toEnvelope();
-      expect(envelope.meta?.['code']).toBe('MIGRATION.HASH_NOT_IN_GRAPH');
+      expect(envelope.code).toBe('MIGRATION.HASH_NOT_IN_GRAPH');
       expect(envelope.why).toContain('empty');
       expect(envelope.fix).toContain('migration plan');
     } finally {
@@ -269,7 +269,7 @@ describe('ref commands', { timeout: timeouts.databaseOperation }, () => {
       expect(result.ok).toBe(false);
       if (result.ok) return;
       const envelope = result.failure.toEnvelope();
-      expect(envelope.meta?.['code']).toBe('MIGRATION.REF_SET_EMPTY_SENTINEL');
+      expect(envelope.code).toBe('MIGRATION.REF_SET_EMPTY_SENTINEL');
     } finally {
       process.chdir(prev);
     }
@@ -434,7 +434,7 @@ describe('ref commands', { timeout: timeouts.databaseOperation }, () => {
       const result = await executeRefDeleteCommand('missing', { config: configPath });
       expect(result.ok).toBe(false);
       if (result.ok) return;
-      expect(result.failure.toEnvelope().meta?.['code']).toBe('MIGRATION.UNKNOWN_REF');
+      expect(result.failure.toEnvelope().code).toBe('MIGRATION.UNKNOWN_REF');
     } finally {
       process.chdir(prev);
     }

--- a/packages/1-framework/3-tooling/cli/test/control-api/apply.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/control-api/apply.test.ts
@@ -14,7 +14,7 @@ import {
   buildFabricatedMigrationEdge,
   createContractSpaceAggregate,
 } from '@internal/migration-tools/aggregate';
-import { ok } from '@internal/utils/result';
+import { notOk, ok } from '@internal/utils/result';
 import { describe, expect, it, vi } from 'vitest';
 import { type RunAction, runMigration } from '../../src/control-api/operations/run-migration';
 import type { ControlProgressEvent } from '../../src/control-api/types';
@@ -139,6 +139,49 @@ describe('runMigration apply span label', () => {
     expect(start).toMatchObject({
       action: 'migrate',
       label: 'Running migration plan across spaces',
+    });
+  });
+});
+
+describe('runMigration runner-failure cause forwarding', () => {
+  it('preserves the runner failure object as `cause` on the RunnerFailure', async () => {
+    const runnerFailure = {
+      code: 'MIGRATION.APPLY_FAILED',
+      summary: 'relation "users" already exists',
+      why: 'CREATE TABLE users conflicted with an existing relation',
+      meta: { sqlState: '42P07' },
+      failingSpace: 'app',
+    };
+    const failingResult: MigrationRunnerResult = notOk(runnerFailure);
+    const migrations = {
+      createRunner: () => ({
+        execute: async () => failingResult,
+      }),
+    } as unknown as TargetMigrationsCapability<
+      'sql',
+      'postgres',
+      ControlFamilyInstance<'sql', unknown>
+    >;
+
+    const result = await runMigration<'sql', 'postgres'>({
+      aggregate: makeAggregate(),
+      perSpacePlans: new Map([['app', makePerSpacePlan()]]),
+      applyOrder: ['app'],
+      driver: {} as ControlDriverInstance<'sql', 'postgres'>,
+      familyInstance: { familyId: 'sql' } as unknown as ControlFamilyInstance<'sql', unknown>,
+      migrations,
+      frameworkComponents: [],
+      policy: { allowedOperationClasses: ['additive', 'widening', 'destructive', 'data'] },
+      action: 'migrate',
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.cause).toBe(runnerFailure);
+    expect(result.failure.meta).toMatchObject({
+      failingSpace: 'app',
+      runnerErrorCode: 'MIGRATION.APPLY_FAILED',
+      sqlState: '42P07',
     });
   });
 });

--- a/packages/1-framework/3-tooling/cli/test/control-api/contract-emit.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/control-api/contract-emit.test.ts
@@ -195,19 +195,19 @@ describe('executeContractEmit', () => {
           meta: { sourceId: 'schema.prisma' },
         },
       })),
-      expectedCode: 'CONTRACT.VERIFY_FAILED',
+      expectedCode: 'CONTRACT.SOURCE_LOAD_FAILED',
       expectedSubstring: 'Provider parse failed',
     },
     {
       label: 'rejects malformed failure result',
       source: createSourceProvider(async () => ({ ok: false }) as unknown),
-      expectedCode: 'CONTRACT.VERIFY_FAILED',
+      expectedCode: 'CONTRACT.SOURCE_LOAD_FAILED',
       expectedSubstring: 'malformed failure result',
     },
     {
       label: 'rejects malformed success result',
       source: createSourceProvider(async () => ({ ok: true }) as unknown),
-      expectedCode: 'CONTRACT.VERIFY_FAILED',
+      expectedCode: 'CONTRACT.SOURCE_LOAD_FAILED',
       expectedSubstring: 'malformed success result',
     },
   ])('source provider validation', ({ label, source, expectedCode, expectedSubstring }) => {

--- a/packages/1-framework/3-tooling/cli/test/output.errors.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/output.errors.test.ts
@@ -90,7 +90,7 @@ describe('formatErrorOutput - issues list label and body fallback', () => {
     // PSL interpretation diagnostics stamp `kind` (their diagnostic code) and `message` (their prose).
     const error: CliErrorEnvelope = {
       ...baseError,
-      code: 'CONTRACT.VERIFY_FAILED',
+      code: 'CONTRACT.SOURCE_LOAD_FAILED',
       summary: 'Failed to resolve contract source',
       meta: {
         issues: [{ kind: 'PSL_ORPHANED_BACKRELATION', message: 'orphaned backrelation list' }],
@@ -108,7 +108,7 @@ describe('formatErrorOutput - issues list label and body fallback', () => {
     // `path` plus the `expected`/`actual` presence the label derives from.
     const error: CliErrorEnvelope = {
       ...baseError,
-      code: 'CONTRACT.VERIFY_FAILED',
+      code: 'CONTRACT.SOURCE_LOAD_FAILED',
       summary: 'Failed to resolve contract source',
       meta: {
         // expected-only → a missing object.

--- a/packages/1-framework/3-tooling/cli/test/utils/aggregate-loader-preflight.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/utils/aggregate-loader-preflight.test.ts
@@ -5,7 +5,7 @@
  * `buildReadAggregate`'s terminal catch guards the whole pre-flight assembly
  * (family construction + the on-disk refs / migration-package reads). The
  * property pinned here is its classification contract: a `MigrationToolsError`
- * maps via `mapMigrationToolsError`; any other throw becomes `errorUnexpected`.
+ * passes through unchanged; any other throw becomes `errorUnexpected`.
  * Either way the call resolves to a `Result` — it never propagates.
  *
  * The failure is injected through a dependency the function consumes —
@@ -61,7 +61,7 @@ describe('buildReadAggregate — pre-flight loading failures return a structured
     expect(result.failure.why).toContain('EACCES');
   });
 
-  it('maps a MigrationToolsError thrown during pre-flight assembly via mapMigrationToolsError', async () => {
+  it('passes a MigrationToolsError thrown during pre-flight assembly straight through', async () => {
     const toolsError = errorInvalidJson(
       '/nonexistent/migrations/app/refs/head.json',
       'Unexpected end of JSON input',
@@ -75,9 +75,8 @@ describe('buildReadAggregate — pre-flight loading failures return a structured
 
     expect(result.ok).toBe(false);
     if (result.ok) return;
-    // Mapped via mapMigrationToolsError (errorRuntime envelope), not errorUnexpected.
+    // Passed through unchanged (the error is itself a CliStructuredError), not errorUnexpected.
+    expect(result.failure).toBe(toolsError);
     expect(result.failure.code).toBe('MIGRATION.INVALID_JSON');
-    expect(result.failure.message).toBe(toolsError.message);
-    expect(result.failure.why).toBe(toolsError.why);
   });
 });

--- a/packages/1-framework/3-tooling/cli/test/utils/aggregate-loader-preflight.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/utils/aggregate-loader-preflight.test.ts
@@ -76,9 +76,8 @@ describe('buildReadAggregate — pre-flight loading failures return a structured
     expect(result.ok).toBe(false);
     if (result.ok) return;
     // Mapped via mapMigrationToolsError (errorRuntime envelope), not errorUnexpected.
-    expect(result.failure.code).toBe('CONTRACT.VERIFY_FAILED');
+    expect(result.failure.code).toBe('MIGRATION.INVALID_JSON');
     expect(result.failure.message).toBe(toolsError.message);
     expect(result.failure.why).toBe(toolsError.why);
-    expect(result.failure.meta?.['code']).toBe(toolsError.code);
   });
 });

--- a/packages/1-framework/3-tooling/cli/test/utils/legend.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/utils/legend.test.ts
@@ -27,7 +27,7 @@ describe('validateLegendOptions', () => {
       expect(result.failure.message).toContain('--legend');
       expect(result.failure.message).not.toContain('graph');
       expect(result.failure.why).toContain('--json');
-      expect(result.failure.meta?.['code']).toBe('MIGRATION.LEGEND_HUMAN_ONLY');
+      expect(result.failure.code).toBe('MIGRATION.LEGEND_HUMAN_ONLY');
     }
   });
 
@@ -35,7 +35,7 @@ describe('validateLegendOptions', () => {
     const result = validateLegendOptions({ legend: true }, { ...PRETTY, quiet: true });
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.failure.meta?.['code']).toBe('MIGRATION.LEGEND_HUMAN_ONLY');
+      expect(result.failure.code).toBe('MIGRATION.LEGEND_HUMAN_ONLY');
       expect(result.failure.why).toContain('--quiet');
     }
   });
@@ -46,7 +46,7 @@ describe('validateLegendOptions', () => {
     if (!result.ok) {
       expect(result.failure.message).toContain('--legend');
       expect(result.failure.why).toContain('--dot');
-      expect(result.failure.meta?.['code']).toBe('MIGRATION.LEGEND_HUMAN_ONLY');
+      expect(result.failure.code).toBe('MIGRATION.LEGEND_HUMAN_ONLY');
     }
   });
 

--- a/packages/1-framework/3-tooling/cli/test/utils/plan-resolution.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/utils/plan-resolution.test.ts
@@ -116,7 +116,7 @@ function baseInput(
 }
 
 function expectRefuse(error: CliStructuredError, migrationCode: string, fixFragment: string): void {
-  expect(error.meta?.['code']).toBe(migrationCode);
+  expect(error.code).toBe(migrationCode);
   expect(error.fix).toContain(fixFragment);
 }
 
@@ -392,7 +392,7 @@ describe('resolveFromForPlan', () => {
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.failure.meta?.['code']).toBe('MIGRATION.INVALID_REF_FILE');
+      expect(result.failure.code).toBe('MIGRATION.INVALID_REF_FILE');
     }
   });
 

--- a/packages/1-framework/3-tooling/cli/test/utils/plan-resolution.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/utils/plan-resolution.test.ts
@@ -280,7 +280,7 @@ describe('resolveFromForPlan', () => {
         new MigrationToolsError('MIGRATION.REF_NOT_RESOLVABLE', `Ref "db" is not resolvable`, {
           why: 'Ref "db" has no pointer file, and the hash being resolved is not a node in the migration graph either.',
           fix: 'Create the ref with "prisma-next ref set db <hash>" (or advance it via "prisma-next db update --advance-ref db"), or pass a hash that is a node in the migration graph.',
-          details: { refName: 'db' },
+          meta: { refName: 'db' },
         }),
       ),
     );
@@ -338,7 +338,7 @@ describe('resolveFromForPlan', () => {
         new MigrationToolsError('MIGRATION.REF_NOT_RESOLVABLE', `Ref "staging" is not resolvable`, {
           why: 'Ref "staging" has no pointer file, and the hash being resolved is not a node in the migration graph either.',
           fix: 'Create the ref with "prisma-next ref set staging <hash>" (or advance it via "prisma-next db update --advance-ref staging"), or pass a hash that is a node in the migration graph.',
-          details: { refName: 'staging' },
+          meta: { refName: 'staging' },
         }),
       ),
     );
@@ -361,7 +361,7 @@ describe('resolveFromForPlan', () => {
           {
             why: `Contract at "/project/migrations/snapshots/${'a'.repeat(64)}/contract.json" failed to deserialize: unsupported legacy shape`,
             fix: 'Re-emit.',
-            details: {
+            meta: {
               filePath: `/project/migrations/snapshots/${'a'.repeat(64)}/contract.json`,
               message: 'unsupported legacy shape',
             },

--- a/packages/1-framework/3-tooling/migration/package.json
+++ b/packages/1-framework/3-tooling/migration/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@internal/contract": "workspace:8.0.0-rc.1",
+    "@internal/errors": "workspace:8.0.0-rc.1",
     "@internal/framework-components": "workspace:8.0.0-rc.1",
     "@internal/utils": "workspace:8.0.0-rc.1",
     "arktype": "catalog:",

--- a/packages/1-framework/3-tooling/migration/src/assert-descriptor-self-consistency.ts
+++ b/packages/1-framework/3-tooling/migration/src/assert-descriptor-self-consistency.ts
@@ -42,7 +42,7 @@ export interface DescriptorSelfConsistencyInputs {
  *
  * Synchronous, pure, no I/O. Throws
  * `MIGRATION.DESCRIPTOR_HEAD_HASH_MISMATCH` on failure with both the
- * recomputed and published hashes in `details` so callers can surface a
+ * recomputed and published hashes in `meta` so callers can surface a
  * clear remediation hint without re-deriving them.
  */
 export function assertDescriptorSelfConsistency(inputs: DescriptorSelfConsistencyInputs): void {

--- a/packages/1-framework/3-tooling/migration/src/errors.ts
+++ b/packages/1-framework/3-tooling/migration/src/errors.ts
@@ -35,14 +35,14 @@ function reemitHint(dir: string, fallback?: string): string {
  * - details:  Machine-readable structured data for agents
  */
 export class MigrationToolsError extends Error {
-  readonly code: string;
+  readonly code: `MIGRATION.${string}`;
   readonly category = 'MIGRATION' as const;
   readonly why: string;
   readonly fix: string;
   readonly details: Record<string, unknown> | undefined;
 
   constructor(
-    code: string,
+    code: `MIGRATION.${string}`,
     summary: string,
     options: {
       readonly why: string;

--- a/packages/1-framework/3-tooling/migration/src/errors.ts
+++ b/packages/1-framework/3-tooling/migration/src/errors.ts
@@ -1,3 +1,4 @@
+import { CliStructuredError } from '@internal/errors/control';
 import { ifDefined } from '@internal/utils/defined';
 import { basename, dirname, relative } from 'pathe';
 import type { MigrationGraph } from './graph';
@@ -32,36 +33,33 @@ function reemitHint(dir: string, fallback?: string): string {
  * - category: Always 'MIGRATION'
  * - why:      Explains the cause in plain language
  * - fix:      Actionable remediation step
- * - details:  Machine-readable structured data for agents
+ * - meta:     Machine-readable structured data for agents
  */
-export class MigrationToolsError extends Error {
-  readonly code: `MIGRATION.${string}`;
+export class MigrationToolsError extends CliStructuredError {
   readonly category = 'MIGRATION' as const;
-  readonly why: string;
-  readonly fix: string;
-  readonly details: Record<string, unknown> | undefined;
+  declare readonly code: `MIGRATION.${string}`;
+  declare readonly why: string;
+  declare readonly fix: string;
 
+  // biome-ignore lint/complexity/noUselessConstructor: narrows the parent's optional why/fix/options to the required shape every factory relies on
   constructor(
     code: `MIGRATION.${string}`,
     summary: string,
     options: {
       readonly why: string;
       readonly fix: string;
-      readonly details?: Record<string, unknown>;
+      readonly meta?: Record<string, unknown>;
     },
   ) {
-    super(summary);
-    this.name = 'MigrationToolsError';
-    this.code = code;
-    this.why = options.why;
-    this.fix = options.fix;
-    this.details = options.details;
+    super(code, summary, options);
   }
 
-  static is(error: unknown): error is MigrationToolsError {
-    if (!(error instanceof Error)) return false;
-    const candidate = error as MigrationToolsError;
-    return candidate.name === 'MigrationToolsError' && typeof candidate.code === 'string';
+  static override is(error: unknown): error is MigrationToolsError {
+    return (
+      CliStructuredError.is(error) &&
+      (error as MigrationToolsError).category === 'MIGRATION' &&
+      error.code.startsWith('MIGRATION.')
+    );
   }
 }
 
@@ -69,7 +67,7 @@ export function errorDirectoryExists(dir: string): MigrationToolsError {
   return new MigrationToolsError('MIGRATION.DIR_EXISTS', 'Migration directory already exists', {
     why: `The directory "${dir}" already exists. Each migration must have a unique directory.`,
     fix: 'Use --name to pick a different name, or delete the existing directory and re-run.',
-    details: { dir },
+    meta: { dir },
   });
 }
 
@@ -80,7 +78,7 @@ export function errorMissingFile(file: string, dir: string): MigrationToolsError
       dir,
       'or delete the directory if the migration is unwanted and the source TypeScript is gone.',
     ),
-    details: { file, dir },
+    meta: { file, dir },
   });
 }
 
@@ -88,7 +86,7 @@ export function errorInvalidJson(filePath: string, parseError: string): Migratio
   return new MigrationToolsError('MIGRATION.INVALID_JSON', 'Invalid JSON in migration file', {
     why: `Failed to parse "${filePath}": ${parseError}`,
     fix: reemitHint(dirname(filePath), 'or restore the directory from version control.'),
-    details: { filePath, parseError },
+    meta: { filePath, parseError },
   });
 }
 
@@ -96,7 +94,7 @@ export function errorInvalidManifest(filePath: string, reason: string): Migratio
   return new MigrationToolsError('MIGRATION.INVALID_MANIFEST', 'Invalid migration manifest', {
     why: `Migration manifest at "${filePath}" is invalid: ${reason}`,
     fix: reemitHint(dirname(filePath), 'or restore the directory from version control.'),
-    details: { filePath, reason },
+    meta: { filePath, reason },
   });
 }
 
@@ -107,7 +105,7 @@ export function errorDescribeMissingEndContract(): MigrationToolsError {
     {
       why: 'Migration.describe() was called on a migration that carries no endContractJson and does not override describe(), so no destination contract hash can be derived.',
       fix: 'Set endContractJson on the migration, or override describe() to return the { from, to } metadata explicitly.',
-      details: { reason: 'missing-end-contract' },
+      meta: { reason: 'missing-end-contract' },
     },
   );
 }
@@ -119,7 +117,7 @@ export function errorDescribeInvalidMetadata(summary: string): MigrationToolsErr
     {
       why: `The migration's describe() returned metadata that failed schema validation: ${summary}.`,
       fix: 'Ensure describe() returns { from: string | null, to: string } with valid contract hashes.',
-      details: { reason: 'invalid-metadata', summary },
+      meta: { reason: 'invalid-metadata', summary },
     },
   );
 }
@@ -128,7 +126,7 @@ export function errorOperationsNotArray(): MigrationToolsError {
   return new MigrationToolsError('MIGRATION.PLAN_NOT_ARRAY', 'operations must be an array', {
     why: "The migration instance's `operations` getter returned a non-array value.",
     fix: 'Ensure the `operations` getter returns an array of migration operations.',
-    details: {},
+    meta: {},
   });
 }
 
@@ -139,7 +137,7 @@ export function errorSpaceHeadRefMissing(spaceId: string): MigrationToolsError {
     {
       why: `Contract space "${spaceId}" declares no refs/head.json, so there is no hash to resolve its contract against the snapshot store.`,
       fix: "Re-emit the contract-space migrations and head-ref artifacts (the extension's contract-space build), or restore refs/head.json from version control.",
-      details: { spaceId },
+      meta: { spaceId },
     },
   );
 }
@@ -151,7 +149,7 @@ export function errorInvalidOperationEntry(index: number, reason: string): Migra
     {
       why: `Operation at index ${index} returned by the migration class failed schema validation: ${reason}.`,
       fix: "Update the migration class so each entry of `operations` carries `id` (string), `label` (string), and `operationClass` (one of 'additive' | 'widening' | 'destructive' | 'data').",
-      details: { index, reason },
+      meta: { index, reason },
     },
   );
 }
@@ -160,7 +158,7 @@ export function errorInvalidSlug(slug: string): MigrationToolsError {
   return new MigrationToolsError('MIGRATION.INVALID_NAME', 'Invalid migration name', {
     why: `The slug "${slug}" contains no valid characters after sanitization (only a-z, 0-9 are kept).`,
     fix: 'Provide a name with at least one alphanumeric character, e.g. --name add_users.',
-    details: { slug },
+    meta: { slug },
   });
 }
 
@@ -168,7 +166,7 @@ export function errorInvalidDestName(destName: string): MigrationToolsError {
   return new MigrationToolsError('MIGRATION.INVALID_DEST_NAME', 'Invalid copy destination name', {
     why: `The destination name "${destName}" must be a single path segment (no ".." or directory separators).`,
     fix: 'Use a simple file name such as "contract.json" for each destination in the copy list.',
-    details: { destName },
+    meta: { destName },
   });
 }
 
@@ -179,7 +177,7 @@ export function errorInvalidSpaceId(spaceId: string): MigrationToolsError {
     {
       why: `The space id "${spaceId}" does not match the required pattern /^[a-z][a-z0-9_-]{0,63}$/. Space ids are used as filesystem directory names under \`migrations/\`, so the pattern is conservative on purpose.`,
       fix: 'Pick a lowercase identifier that begins with a letter and contains only lowercase letters, digits, hyphens, or underscores; max 64 characters total.',
-      details: { spaceId },
+      meta: { spaceId },
     },
   );
 }
@@ -196,7 +194,7 @@ export function errorDescriptorHeadHashMismatch(args: {
     {
       why: `Extension "${extensionId}" publishes a \`contractSpace\` whose \`headRef.hash\` (${headRefHash}) does not match the canonical hash recomputed from \`contractSpace.contractJson\` (${recomputedHash}). This means the extension descriptor was published with stale \`headRef.hash\` — typically because the contract was bumped without rerunning the extension's emit pipeline.`,
       fix: 'Re-run the extension authoring pipeline so `contractJson.storage.storageHash` and `headRef.hash` agree, then republish the extension. If you are the extension author and you intentionally bumped `contractJson`, recompute and update `headRef.hash` (and refresh any on-disk migration metadata that derives from it).',
-      details: { extensionId, recomputedHash, headRefHash },
+      meta: { extensionId, recomputedHash, headRefHash },
     },
   );
 }
@@ -208,7 +206,7 @@ export function errorDuplicateSpaceId(spaceId: string): MigrationToolsError {
     {
       why: `The space id "${spaceId}" appears more than once in the per-space planner input. Each space id must be unique across the inputs (the per-space planner emits one output entry per id).`,
       fix: 'Deduplicate the inputs before passing them to `planAllSpaces` — typically by checking your `extensions` declaration for repeated entries.',
-      details: { spaceId },
+      meta: { spaceId },
     },
   );
 }
@@ -224,7 +222,7 @@ export function errorSameSourceAndTarget(dir: string, hash: string): MigrationTo
         dir,
         'and either change the contract so from ≠ to, add a dataTransform op, or delete the directory if the migration is unwanted.',
       ),
-      details: { dirName, hash },
+      meta: { dirName, hash },
     },
   );
 }
@@ -245,7 +243,7 @@ export function errorAmbiguousTarget(
   return new MigrationToolsError('MIGRATION.AMBIGUOUS_TARGET', 'Ambiguous migration target', {
     why: `The migration history has diverged into multiple branches: ${branchTips.join(', ')}. This typically happens when two developers plan migrations from the same starting point.${divergenceInfo}`,
     fix: 'Use `ref set <name> <hash>` to target a specific branch, delete one of the conflicting migration directories and re-run `migration plan`, or use --from <hash> to explicitly select a starting point.',
-    details: {
+    meta: {
       branchTips,
       ...(context ? { divergencePoint: context.divergencePoint, branches: context.branches } : {}),
     },
@@ -256,7 +254,7 @@ export function errorNoInitialMigration(nodes: readonly string[]): MigrationTool
   return new MigrationToolsError('MIGRATION.NO_INITIAL_MIGRATION', 'No initial migration found', {
     why: `No migration starts from the empty contract state (known hashes: ${nodes.join(', ')}). At least one migration must originate from the empty state.`,
     fix: 'Inspect the migrations directory for corrupted migration.json files. At least one migration must start from the empty contract hash.',
-    details: { nodes },
+    meta: { nodes },
   });
 }
 
@@ -264,7 +262,7 @@ export function errorInvalidRefs(refsPath: string, reason: string): MigrationToo
   return new MigrationToolsError('MIGRATION.INVALID_REFS', 'Invalid refs.json', {
     why: `refs.json at "${refsPath}" is invalid: ${reason}`,
     fix: 'Ensure refs.json is a flat object mapping valid ref names to contract hash strings.',
-    details: { path: refsPath, reason },
+    meta: { path: refsPath, reason },
   });
 }
 
@@ -272,7 +270,7 @@ export function errorInvalidRefFile(filePath: string, reason: string): Migration
   return new MigrationToolsError('MIGRATION.INVALID_REF_FILE', 'Invalid ref file', {
     why: `Ref file at "${filePath}" is invalid: ${reason}`,
     fix: 'Ensure the ref file contains valid JSON with { "hash": "<64 hex chars>", "invariants": ["..."] }.',
-    details: { path: filePath, reason },
+    meta: { path: filePath, reason },
   });
 }
 
@@ -280,7 +278,7 @@ export function errorInvalidRefName(refName: string): MigrationToolsError {
   return new MigrationToolsError('MIGRATION.INVALID_REF_NAME', 'Invalid ref name', {
     why: `Ref name "${refName}" is invalid. Names must be lowercase alphanumeric with hyphens or forward slashes (no "." or ".." segments).`,
     fix: `Use a valid ref name (e.g., "staging", "envs/production").`,
-    details: { refName },
+    meta: { refName },
   });
 }
 
@@ -288,7 +286,7 @@ export function errorNoTarget(reachableHashes: readonly string[]): MigrationTool
   return new MigrationToolsError('MIGRATION.NO_TARGET', 'No migration target could be resolved', {
     why: `The migration history contains cycles and no target can be resolved automatically (reachable hashes: ${reachableHashes.join(', ')}). This typically happens after rollback migrations (e.g., C1→C2→C1).`,
     fix: 'Use --from <hash> to specify the planning origin explicitly.',
-    details: { reachableHashes },
+    meta: { reachableHashes },
   });
 }
 
@@ -296,7 +294,7 @@ export function errorInvalidRefValue(value: string): MigrationToolsError {
   return new MigrationToolsError('MIGRATION.INVALID_REF_VALUE', 'Invalid ref value', {
     why: `Ref value "${value}" is not a valid contract hash. Values must be a 64-character hex digest or "empty".`,
     fix: 'Use a valid storage hash from `prisma-next contract emit` output or an existing migration.',
-    details: { value },
+    meta: { value },
   });
 }
 
@@ -307,7 +305,7 @@ export function errorDuplicateMigrationHash(migrationHash: string): MigrationToo
     {
       why: `Multiple migrations share migrationHash "${migrationHash}". Each migration must have a unique content-addressed identity.`,
       fix: 'Regenerate one of the conflicting migrations so each migrationHash is unique, then re-run migration commands.',
-      details: { migrationHash },
+      meta: { migrationHash },
     },
   );
 }
@@ -316,7 +314,7 @@ export function errorInvalidInvariantId(invariantId: string): MigrationToolsErro
   return new MigrationToolsError('MIGRATION.INVALID_INVARIANT_ID', 'Invalid invariantId', {
     why: `invariantId ${JSON.stringify(invariantId)} is invalid. Ids must be non-empty and contain no whitespace or control characters (including Unicode whitespace like NBSP); other content (kebab-case, camelCase, namespaced, Unicode letters) is allowed.`,
     fix: 'Pick an invariantId without spaces, tabs, newlines, or control characters — e.g. "backfill-user-phone", "users/backfill-phone", or "BackfillUserPhone".',
-    details: { invariantId },
+    meta: { invariantId },
   });
 }
 
@@ -327,7 +325,7 @@ export function errorDuplicateInvariantInEdge(invariantId: string): MigrationToo
     {
       why: `invariantId "${invariantId}" is declared by more than one dataTransform on the same migration. The marker stores invariants as a set and the routing layer treats them as edge-level, so two ops cannot share a routing identity.`,
       fix: 'Rename one of the conflicting dataTransform invariantIds, or drop invariantId on the op that does not need to be routing-visible.',
-      details: { invariantId },
+      meta: { invariantId },
     },
   );
 }
@@ -356,7 +354,7 @@ export function errorProvidedInvariantsMismatch(
     {
       why,
       fix: reemitHint(dirname(filePath), 'or restore the directory from version control.'),
-      details: { filePath, stored, derived, difference: { missing, extra } },
+      meta: { filePath, stored, derived, difference: { missing, extra } },
     },
   );
 }
@@ -396,7 +394,7 @@ export function errorNoInvariantPath(args: {
     {
       why: `${refClause} requires invariants the reachable path doesn't cover. required=[${requiredList}], missing=[${missingList}].`,
       fix: 'Add a migration on the path that runs `dataTransform({ invariantId: "<id>", … })` for each missing invariant, or retarget the ref to a hash whose path already provides them.',
-      details: {
+      meta: {
         required,
         missing,
         structuralPath,
@@ -420,7 +418,7 @@ export function errorUnknownInvariant(args: {
     {
       why: `${refClause} invariants no migration in the graph provides. unknown=[${unknownList}].`,
       fix: 'Either the ref has a typo, or the declaring migration has not been authored/attested yet. Re-check the ref file and the migrations directory.',
-      details: {
+      meta: {
         unknown,
         declared,
         ...ifDefined('refName', refName),
@@ -436,12 +434,12 @@ export function errorMigrationHashMismatch(
 ): MigrationToolsError {
   // Render a cwd-relative path in the human-readable diagnostic so users
   // running CLI commands from the project root see a familiar short path.
-  // Keep the absolute path in `details.dir` for machine consumers.
+  // Keep the absolute path in `meta.dir` for machine consumers.
   const relativeDir = relative(process.cwd(), dir);
   return new MigrationToolsError('MIGRATION.HASH_MISMATCH', 'Migration package is corrupt', {
     why: `Stored migrationHash "${storedHash}" does not match the recomputed hash "${computedHash}" for "${relativeDir}". The migration.json or ops.json has been edited or partially written since emit.`,
     fix: reemitHint(dir, 'or restore the directory from version control.'),
-    details: { dir, storedHash, computedHash },
+    meta: { dir, storedHash, computedHash },
   });
 }
 
@@ -458,7 +456,7 @@ export function errorRefNotResolvable(refName: string): MigrationToolsError {
     {
       why: `Ref "${refName}" has no pointer file, and the hash being resolved is not a node in the migration graph either — there is nothing to materialize a contract from.`,
       fix: `Create the ref with "prisma-next ref set ${refName} <hash>" (or advance it via "prisma-next db update --advance-ref ${refName}"), or pass a hash that is a node in the migration graph.`,
-      details: { refName, identifier: refName },
+      meta: { refName, identifier: refName },
     },
   );
 }
@@ -473,7 +471,7 @@ export function errorBundleNotFoundForGraphNode(
   return new MigrationToolsError('MIGRATION.BUNDLE_NOT_FOUND_FOR_GRAPH_NODE', summary, {
     why: `The hash ${hash} is a graph node but no on-disk migration package has a destination (\`to\`) hash matching it.`,
     fix: 'Provide a ref or hash that corresponds to an existing migration package, or run `migration list` to see available migrations.',
-    details: { hash, ...(explicitLabel ? { explicitLabel } : {}) },
+    meta: { hash, ...(explicitLabel ? { explicitLabel } : {}) },
   });
 }
 
@@ -487,7 +485,7 @@ export function errorContractDeserializationFailed(
     {
       why: `Contract at "${filePath}" failed to deserialize: ${message}`,
       fix: reemitHint(dirname(filePath), 'or restore the directory from version control.'),
-      details: { filePath, message },
+      meta: { filePath, message },
     },
   );
 }
@@ -501,7 +499,7 @@ export function errorHashNotInGraph(hash: string, graph: MigrationGraph): Migrat
     {
       why: `The migration graph contains nodes ${reachableList}; "${hash}" isn't one of them.`,
       fix: `Pass a hash that's the from-or-to of an on-disk migration bundle, use --from with a graph-node hash, or run "prisma-next migration plan" to introduce it.`,
-      details: { hash, reachableHashes },
+      meta: { hash, reachableHashes },
     },
   );
 }
@@ -516,7 +514,7 @@ export function errorContractSnapshotMissing(
     {
       why: `Expected a contract snapshot for ${storageHash} at "${expectedPath}" but the file does not exist.`,
       fix: "Re-emit the contract snapshot by re-running the command that authored the migration referencing this hash (`prisma-next migration plan` for app-space migrations; the extension's contract-space build for extension spaces), or restore migrations/snapshots/ from version control.",
-      details: { storageHash, expectedPath },
+      meta: { storageHash, expectedPath },
     },
   );
 }
@@ -532,7 +530,7 @@ export function errorContractSnapshotHashMismatch(
     {
       why: `The contract JSON's inner storage.storageHash ("${actualHash}") does not match the requested storage hash ("${storageHash}") for snapshot directory "${dir}".`,
       fix: 'Pass a contractJson whose storage.storageHash equals the storageHash argument passed to writeContractSnapshot — the two must agree by construction.',
-      details: { storageHash, actualHash, dir },
+      meta: { storageHash, actualHash, dir },
     },
   );
 }
@@ -548,7 +546,7 @@ export function errorMigrationContractViewMissing(
     {
       why: `${className}.${accessor} was read, but this instance has no ${jsonField} to build the view from.`,
       fix: `Set ${jsonField} to the migration's committed contract JSON, or avoid reading ${accessor} on a migration that overrides describe() and carries no contract.`,
-      details: { className, accessor, jsonField },
+      meta: { className, accessor, jsonField },
     },
   );
 }

--- a/packages/1-framework/3-tooling/migration/src/errors.ts
+++ b/packages/1-framework/3-tooling/migration/src/errors.ts
@@ -36,12 +36,11 @@ function reemitHint(dir: string, fallback?: string): string {
  * - meta:     Machine-readable structured data for agents
  */
 export class MigrationToolsError extends CliStructuredError {
-  readonly category = 'MIGRATION' as const;
+  readonly category: 'MIGRATION';
   declare readonly code: `MIGRATION.${string}`;
   declare readonly why: string;
   declare readonly fix: string;
 
-  // biome-ignore lint/complexity/noUselessConstructor: narrows the parent's optional why/fix/options to the required shape every factory relies on
   constructor(
     code: `MIGRATION.${string}`,
     summary: string,
@@ -52,12 +51,14 @@ export class MigrationToolsError extends CliStructuredError {
     },
   ) {
     super(code, summary, options);
+    this.category = 'MIGRATION';
   }
 
   static override is(error: unknown): error is MigrationToolsError {
     return (
       CliStructuredError.is(error) &&
-      (error as MigrationToolsError).category === 'MIGRATION' &&
+      'category' in error &&
+      error.category === 'MIGRATION' &&
       error.code.startsWith('MIGRATION.')
     );
   }

--- a/packages/1-framework/3-tooling/migration/src/io.ts
+++ b/packages/1-framework/3-tooling/migration/src/io.ts
@@ -420,14 +420,14 @@ export async function readMigrationsDir(
       const dirName = entry;
       if (MigrationToolsError.is(error)) {
         if (error.code === 'MIGRATION.HASH_MISMATCH') {
-          const details = error.details;
+          const meta = error.meta;
           const rawPkg = await readMigrationPackageRaw(entryPath);
           if (rawPkg !== null) packages.push(rawPkg);
           problems.push({
             kind: 'hashMismatch',
             dirName,
-            stored: typeof details?.['storedHash'] === 'string' ? details['storedHash'] : '',
-            computed: typeof details?.['computedHash'] === 'string' ? details['computedHash'] : '',
+            stored: typeof meta?.['storedHash'] === 'string' ? meta['storedHash'] : '',
+            computed: typeof meta?.['computedHash'] === 'string' ? meta['computedHash'] : '',
           });
           continue;
         }

--- a/packages/1-framework/3-tooling/migration/src/refs.ts
+++ b/packages/1-framework/3-tooling/migration/src/refs.ts
@@ -85,7 +85,7 @@ export async function readRef(refsDir: string, name: string): Promise<RefEntry> 
       throw new MigrationToolsError('MIGRATION.UNKNOWN_REF', `Unknown ref "${name}"`, {
         why: `No ref file found at "${filePath}".`,
         fix: `Create the ref with: prisma-next ref set ${name} <hash>`,
-        details: { refName: name, filePath },
+        meta: { refName: name, filePath },
       });
     }
     throw error;
@@ -263,7 +263,7 @@ export async function deleteRef(refsDir: string, name: string): Promise<void> {
       throw new MigrationToolsError('MIGRATION.UNKNOWN_REF', `Unknown ref "${name}"`, {
         why: `No ref file found at "${filePath}".`,
         fix: 'Run `prisma-next ref list` to see available refs.',
-        details: { refName: name, filePath },
+        meta: { refName: name, filePath },
       });
     }
     throw error;
@@ -327,7 +327,7 @@ export function resolveRef(refs: Refs, name: string): RefEntry {
     throw new MigrationToolsError('MIGRATION.UNKNOWN_REF', `Unknown ref "${name}"`, {
       why: `No ref named "${name}" exists.`,
       fix: `Available refs: ${Object.keys(refs).join(', ') || '(none)'}. Create a ref with: prisma-next ref set ${name} <hash>`,
-      details: { refName: name, availableRefs: Object.keys(refs) },
+      meta: { refName: name, availableRefs: Object.keys(refs) },
     });
   }
 

--- a/packages/1-framework/3-tooling/migration/test/aggregate/contract-at.test.ts
+++ b/packages/1-framework/3-tooling/migration/test/aggregate/contract-at.test.ts
@@ -170,7 +170,7 @@ describe('AggregateContractSpace.contractAt', () => {
 
     await expect(space.contractAt(HASH_B)).rejects.toMatchObject({
       code: 'MIGRATION.CONTRACT_SNAPSHOT_MISSING',
-      details: { storageHash: HASH_B },
+      meta: { storageHash: HASH_B },
     });
   });
 
@@ -183,7 +183,7 @@ describe('AggregateContractSpace.contractAt', () => {
 
     await expect(space.contractAt(HASH_A, { refName: 'staging' })).rejects.toMatchObject({
       code: 'MIGRATION.CONTRACT_SNAPSHOT_MISSING',
-      details: { storageHash: HASH_A },
+      meta: { storageHash: HASH_A },
     });
   });
 
@@ -219,7 +219,7 @@ describe('AggregateContractSpace.contractAt', () => {
 
     await expect(space.contractAt(HASH_A, { refName: 'staging' })).rejects.toMatchObject({
       code: 'MIGRATION.REF_NOT_RESOLVABLE',
-      details: { refName: 'staging' },
+      meta: { refName: 'staging' },
     });
   });
 
@@ -230,7 +230,7 @@ describe('AggregateContractSpace.contractAt', () => {
 
     await expect(space.contractAt(HASH_A)).rejects.toMatchObject({
       code: 'MIGRATION.HASH_NOT_IN_GRAPH',
-      details: { hash: HASH_A },
+      meta: { hash: HASH_A },
     });
   });
 

--- a/packages/1-framework/3-tooling/migration/test/assert-descriptor-self-consistency.test.ts
+++ b/packages/1-framework/3-tooling/migration/test/assert-descriptor-self-consistency.test.ts
@@ -69,7 +69,7 @@ describe('assertDescriptorSelfConsistency', () => {
     ).toThrowError(MigrationToolsError);
   });
 
-  it('error names the extension and includes both hashes in details', () => {
+  it('error names the extension and includes both hashes in meta', () => {
     let captured: MigrationToolsError | undefined;
     try {
       assertDescriptorSelfConsistency({
@@ -87,7 +87,7 @@ describe('assertDescriptorSelfConsistency', () => {
     expect(captured?.why).toContain('"cipherstash"');
     expect(captured?.why).toContain('stale-hash');
     expect(captured?.why).toContain(REAL_HASH);
-    expect(captured?.details).toEqual({
+    expect(captured?.meta).toEqual({
       extensionId: 'cipherstash',
       recomputedHash: REAL_HASH,
       headRefHash: 'stale-hash',

--- a/packages/1-framework/3-tooling/migration/test/errors.test.ts
+++ b/packages/1-framework/3-tooling/migration/test/errors.test.ts
@@ -1,5 +1,45 @@
+import { CliStructuredError } from '@internal/errors/control';
 import { describe, expect, it } from 'vitest';
-import { errorNoInvariantPath, errorUnknownInvariant, MigrationToolsError } from '../src/errors';
+import {
+  errorAmbiguousTarget,
+  errorBundleNotFoundForGraphNode,
+  errorContractDeserializationFailed,
+  errorContractSnapshotHashMismatch,
+  errorContractSnapshotMissing,
+  errorDescribeInvalidMetadata,
+  errorDescribeMissingEndContract,
+  errorDescriptorHeadHashMismatch,
+  errorDirectoryExists,
+  errorDuplicateInvariantInEdge,
+  errorDuplicateMigrationHash,
+  errorDuplicateSpaceId,
+  errorHashNotInGraph,
+  errorInvalidDestName,
+  errorInvalidInvariantId,
+  errorInvalidJson,
+  errorInvalidManifest,
+  errorInvalidOperationEntry,
+  errorInvalidRefFile,
+  errorInvalidRefName,
+  errorInvalidRefs,
+  errorInvalidRefValue,
+  errorInvalidSlug,
+  errorInvalidSpaceId,
+  errorMigrationContractViewMissing,
+  errorMigrationHashMismatch,
+  errorMissingFile,
+  errorNoInitialMigration,
+  errorNoInvariantPath,
+  errorNoTarget,
+  errorOperationsNotArray,
+  errorProvidedInvariantsMismatch,
+  errorRefNotResolvable,
+  errorSameSourceAndTarget,
+  errorSpaceHeadRefMissing,
+  errorUnknownInvariant,
+  MigrationToolsError,
+} from '../src/errors';
+import type { MigrationGraph } from '../src/graph';
 
 describe('errorNoInvariantPath', () => {
   const baseStructural = [
@@ -23,36 +63,36 @@ describe('errorNoInvariantPath', () => {
     expect(err.category).toBe('MIGRATION');
   });
 
-  it('puts required, missing, and structuralPath on details', () => {
+  it('puts required, missing, and structuralPath on meta', () => {
     const err = errorNoInvariantPath({
       required: ['X', 'Y'],
       missing: ['Y'],
       structuralPath: baseStructural,
     });
-    expect(err.details).toMatchObject({
+    expect(err.meta).toMatchObject({
       required: ['X', 'Y'],
       missing: ['Y'],
       structuralPath: baseStructural,
     });
   });
 
-  it('includes refName on details when provided', () => {
+  it('includes refName on meta when provided', () => {
     const err = errorNoInvariantPath({
       refName: 'prod',
       required: ['X'],
       missing: ['X'],
       structuralPath: baseStructural,
     });
-    expect(err.details?.['refName']).toBe('prod');
+    expect(err.meta?.['refName']).toBe('prod');
   });
 
-  it('omits refName from details when not provided', () => {
+  it('omits refName from meta when not provided', () => {
     const err = errorNoInvariantPath({
       required: ['X'],
       missing: ['X'],
       structuralPath: baseStructural,
     });
-    expect(err.details).not.toHaveProperty('refName');
+    expect(err.meta).not.toHaveProperty('refName');
   });
 
   it('quotes the missing ids in the why message so a typo is readable', () => {
@@ -96,7 +136,7 @@ describe('errorNoInvariantPath', () => {
       missing: ['X'],
       structuralPath: baseStructural,
     });
-    const path = err.details?.['structuralPath'] as readonly Record<string, unknown>[];
+    const path = err.meta?.['structuralPath'] as readonly Record<string, unknown>[];
     expect(path).toHaveLength(1);
     expect(Object.keys(path[0]!).sort()).toEqual([
       'dirName',
@@ -119,24 +159,24 @@ describe('errorUnknownInvariant', () => {
     expect(err.category).toBe('MIGRATION');
   });
 
-  it('puts unknown and declared on details', () => {
+  it('puts unknown and declared on meta', () => {
     const err = errorUnknownInvariant({
       unknown: ['typo-id'],
       declared: ['real-id-1', 'real-id-2'],
     });
-    expect(err.details).toMatchObject({
+    expect(err.meta).toMatchObject({
       unknown: ['typo-id'],
       declared: ['real-id-1', 'real-id-2'],
     });
   });
 
-  it('includes refName on details when provided', () => {
+  it('includes refName on meta when provided', () => {
     const err = errorUnknownInvariant({
       refName: 'prod',
       unknown: ['x'],
       declared: [],
     });
-    expect(err.details?.['refName']).toBe('prod');
+    expect(err.meta?.['refName']).toBe('prod');
   });
 
   it('quotes unknown ids in the why message so a typo is readable', () => {
@@ -153,5 +193,96 @@ describe('errorUnknownInvariant', () => {
       declared: [],
     });
     expect(err.fix).toMatch(/typo|attest/i);
+  });
+});
+
+describe('MigrationToolsError base type', () => {
+  const graph = { nodes: new Set(['aaa']) } as unknown as MigrationGraph;
+
+  const structuralEdge = {
+    dirName: '20260424T0900_add_posts_table',
+    migrationHash: 'mh:abc',
+    from: 'empty',
+    to: 'a94b',
+    invariants: [],
+  };
+
+  const factoryInstances: ReadonlyArray<MigrationToolsError> = [
+    errorDirectoryExists('/tmp/m/20260101_init'),
+    errorMissingFile('ops.json', '/tmp/m/20260101_init'),
+    errorInvalidJson('/tmp/m/20260101_init/migration.json', 'Unexpected token'),
+    errorInvalidManifest('/tmp/m/20260101_init/migration.json', 'missing to'),
+    errorDescribeMissingEndContract(),
+    errorDescribeInvalidMetadata('bad shape'),
+    errorOperationsNotArray(),
+    errorSpaceHeadRefMissing('app'),
+    errorInvalidOperationEntry(0, 'missing id'),
+    errorInvalidSlug('!!!'),
+    errorInvalidDestName('../outside.json'),
+    errorInvalidSpaceId('Bad Space'),
+    errorDescriptorHeadHashMismatch({
+      extensionId: 'ext',
+      recomputedHash: 'a'.repeat(64),
+      headRefHash: 'b'.repeat(64),
+    }),
+    errorDuplicateSpaceId('app'),
+    errorSameSourceAndTarget('/tmp/m/20260101_init', 'a'.repeat(64)),
+    errorAmbiguousTarget(['aaa', 'bbb']),
+    errorNoInitialMigration(['aaa']),
+    errorInvalidRefs('/tmp/m/refs.json', 'not an object'),
+    errorInvalidRefFile('/tmp/m/refs/prod.json', 'not an object'),
+    errorInvalidRefName('BAD NAME'),
+    errorNoTarget(['aaa']),
+    errorInvalidRefValue('not-a-hash'),
+    errorDuplicateMigrationHash('mh:abc'),
+    errorInvalidInvariantId('has a space'),
+    errorDuplicateInvariantInEdge('shared'),
+    errorProvidedInvariantsMismatch('/tmp/m/20260101_init/migration.json', ['a'], ['b']),
+    errorNoInvariantPath({ required: ['x'], missing: ['x'], structuralPath: [structuralEdge] }),
+    errorUnknownInvariant({ unknown: ['x'], declared: [] }),
+    errorMigrationHashMismatch('/tmp/m/20260101_init', 'a'.repeat(64), 'b'.repeat(64)),
+    errorRefNotResolvable('prod'),
+    errorBundleNotFoundForGraphNode('a'.repeat(64)),
+    errorContractDeserializationFailed('/tmp/m/snapshots/x/contract.json', 'bad shape'),
+    errorHashNotInGraph('bbb', graph),
+    errorContractSnapshotMissing('a'.repeat(64), '/tmp/m/snapshots/x/contract.json'),
+    errorContractSnapshotHashMismatch('a'.repeat(64), 'b'.repeat(64), '/tmp/m/snapshots/x'),
+    errorMigrationContractViewMissing('MyMigration', 'endContract', 'endContractJson'),
+  ];
+
+  it('is a CliStructuredError and keeps the parent name for boundary duck-typing', () => {
+    const err = errorDirectoryExists('/tmp/m/20260101_init');
+    expect(err).toBeInstanceOf(CliStructuredError);
+    expect(err.name).toBe('CliStructuredError');
+    expect(CliStructuredError.is(err)).toBe(true);
+    expect(MigrationToolsError.is(err)).toBe(true);
+  });
+
+  it('exposes toEnvelope() with code, summary, why, fix, and meta', () => {
+    const err = errorDirectoryExists('/tmp/m/20260101_init');
+    expect(err.toEnvelope()).toEqual({
+      ok: false,
+      code: 'MIGRATION.DIR_EXISTS',
+      severity: 'error',
+      summary: 'Migration directory already exists',
+      why: err.why,
+      fix: err.fix,
+      meta: { dir: '/tmp/m/20260101_init' },
+    });
+  });
+
+  it('is() rejects a plain CliStructuredError outside the MIGRATION namespace', () => {
+    const err = new CliStructuredError('CONFIG.FILE_NOT_FOUND', 'Config file not found');
+    expect(MigrationToolsError.is(err)).toBe(false);
+  });
+
+  it('no factory passes identical why and fix, so the parent never drops fix', () => {
+    // `CliStructuredError` normalizes `fix` to undefined when it equals
+    // `why`; the `declare` narrows on this class assume that never fires.
+    for (const err of factoryInstances) {
+      expect(err.why).toBeTypeOf('string');
+      expect(err.fix).toBeTypeOf('string');
+      expect(err.fix).not.toBe(err.why);
+    }
   });
 });

--- a/packages/1-framework/3-tooling/migration/test/graph-membership.test.ts
+++ b/packages/1-framework/3-tooling/migration/test/graph-membership.test.ts
@@ -80,8 +80,8 @@ describe('assertHashIsGraphNode', () => {
       expect(err.why).toContain('missing');
       expect(err.fix).toMatch(/migration plan/i);
       expect(err.fix).toMatch(/--from/i);
-      expect(err.details?.['hash']).toBe('missing');
-      expect(err.details?.['reachableHashes']).toEqual(['aaa', 'bbb', 'zzz']);
+      expect(err.meta?.['hash']).toBe('missing');
+      expect(err.meta?.['reachableHashes']).toEqual(['aaa', 'bbb', 'zzz']);
     }
   });
 
@@ -96,8 +96,8 @@ describe('assertHashIsGraphNode', () => {
       expect(MigrationToolsError.is(error)).toBe(true);
       const err = error as MigrationToolsError;
       expect(err.code).toBe('MIGRATION.HASH_NOT_IN_GRAPH');
-      expect(err.details?.['hash']).toBe('not-a-valid-hash');
-      expect(err.details?.['reachableHashes']).toEqual([]);
+      expect(err.meta?.['hash']).toBe('not-a-valid-hash');
+      expect(err.meta?.['reachableHashes']).toEqual([]);
     }
   });
 });

--- a/packages/1-framework/3-tooling/migration/test/invariants.test.ts
+++ b/packages/1-framework/3-tooling/migration/test/invariants.test.ts
@@ -83,7 +83,7 @@ describe('deriveProvidedInvariants', () => {
     expect(() => deriveProvidedInvariants([dataOp('with space', 'has a space')])).toThrowError(
       expect.objectContaining({
         code: 'MIGRATION.INVALID_INVARIANT_ID',
-        details: { invariantId: 'has a space' },
+        meta: { invariantId: 'has a space' },
       }) as unknown as Error,
     );
   });
@@ -101,7 +101,7 @@ describe('deriveProvidedInvariants', () => {
     expect(MigrationToolsError.is(caught)).toBe(true);
     if (MigrationToolsError.is(caught)) {
       expect(caught.code).toBe('MIGRATION.DUPLICATE_INVARIANT_IN_EDGE');
-      expect(caught.details).toEqual({ invariantId: 'shared' });
+      expect(caught.meta).toEqual({ invariantId: 'shared' });
     }
   });
 });

--- a/packages/1-framework/3-tooling/migration/test/io.test.ts
+++ b/packages/1-framework/3-tooling/migration/test/io.test.ts
@@ -168,7 +168,7 @@ describe('writeMigrationPackage + readMigrationPackage', () => {
 
     await expect(readMigrationPackage(dir, { migrationsDir: tmpDir })).rejects.toSatisfy((e) => {
       expectMigrationError(e, 'MIGRATION.FILE_MISSING');
-      expect((e as MigrationToolsError).details).toHaveProperty('file', 'ops.json');
+      expect((e as MigrationToolsError).meta).toHaveProperty('file', 'ops.json');
       return true;
     });
   });
@@ -180,7 +180,7 @@ describe('writeMigrationPackage + readMigrationPackage', () => {
 
     await expect(readMigrationPackage(dir, { migrationsDir: tmpDir })).rejects.toSatisfy((e) => {
       expectMigrationError(e, 'MIGRATION.FILE_MISSING');
-      expect((e as MigrationToolsError).details).toHaveProperty('file', 'migration.json');
+      expect((e as MigrationToolsError).meta).toHaveProperty('file', 'migration.json');
       return true;
     });
   });
@@ -385,7 +385,7 @@ describe('writeMigrationPackage + readMigrationPackage', () => {
       writeMigrationPackage(dir, createTestMetadata(), createTestOps()),
     ).rejects.toSatisfy((e) => {
       expectMigrationError(e, 'MIGRATION.DIR_EXISTS');
-      expect((e as MigrationToolsError).details).toHaveProperty('dir');
+      expect((e as MigrationToolsError).meta).toHaveProperty('dir');
       return true;
     });
   });
@@ -422,14 +422,12 @@ describe('writeMigrationPackage + readMigrationPackage', () => {
     await expect(readMigrationPackage(dir, { migrationsDir: tmpDir })).rejects.toSatisfy((e) => {
       expectMigrationError(e, 'MIGRATION.HASH_MISMATCH');
       const mte = e as MigrationToolsError;
-      expect(mte.details).toMatchObject({
+      expect(mte.meta).toMatchObject({
         dir,
         storedHash: metadata.migrationHash,
       });
-      expect(mte.details).toHaveProperty('computedHash');
-      expect((mte.details as { computedHash: string }).computedHash).not.toBe(
-        metadata.migrationHash,
-      );
+      expect(mte.meta).toHaveProperty('computedHash');
+      expect((mte.meta as { computedHash: string }).computedHash).not.toBe(metadata.migrationHash);
       const relativeDir = relative(process.cwd(), dir);
       expect(mte.why).toContain(relativeDir);
       expect(mte.fix).toContain(relativeDir);
@@ -449,14 +447,12 @@ describe('writeMigrationPackage + readMigrationPackage', () => {
     await expect(readMigrationPackage(dir, { migrationsDir: tmpDir })).rejects.toSatisfy((e) => {
       expectMigrationError(e, 'MIGRATION.HASH_MISMATCH');
       const mte = e as MigrationToolsError;
-      expect(mte.details).toMatchObject({
+      expect(mte.meta).toMatchObject({
         dir,
         storedHash: metadata.migrationHash,
       });
-      expect(mte.details).toHaveProperty('computedHash');
-      expect((mte.details as { computedHash: string }).computedHash).not.toBe(
-        metadata.migrationHash,
-      );
+      expect(mte.meta).toHaveProperty('computedHash');
+      expect((mte.meta as { computedHash: string }).computedHash).not.toBe(metadata.migrationHash);
       const relativeDir = relative(process.cwd(), dir);
       expect(mte.why).toContain(relativeDir);
       expect(mte.fix).toContain(relativeDir);
@@ -500,7 +496,7 @@ describe('writeMigrationPackage + readMigrationPackage', () => {
     await expect(readMigrationPackage(dir, { migrationsDir: tmpDir })).rejects.toSatisfy((e) => {
       expectMigrationError(e, 'MIGRATION.PROVIDED_INVARIANTS_MISMATCH');
       const mte = e as MigrationToolsError;
-      expect(mte.details).toMatchObject({
+      expect(mte.meta).toMatchObject({
         stored: ['alpha', 'phantom'],
         derived: ['alpha'],
         difference: { extra: ['phantom'], missing: [] },
@@ -547,7 +543,7 @@ describe('writeMigrationPackage + readMigrationPackage', () => {
       expectMigrationError(e, 'MIGRATION.PROVIDED_INVARIANTS_MISMATCH');
       const mte = e as MigrationToolsError;
       expect(mte.why).toContain('different order');
-      expect(mte.details).toMatchObject({
+      expect(mte.meta).toMatchObject({
         difference: { missing: [], extra: [] },
       });
       return true;
@@ -587,7 +583,7 @@ describe('writeMigrationPackage + readMigrationPackage', () => {
     await expect(readMigrationPackage(dir, { migrationsDir: tmpDir })).rejects.toSatisfy((e) => {
       expectMigrationError(e, 'MIGRATION.INVALID_INVARIANT_ID');
       const mte = e as MigrationToolsError;
-      expect(mte.details).toEqual({ invariantId: badId });
+      expect(mte.meta).toEqual({ invariantId: badId });
       return true;
     });
   });
@@ -632,7 +628,7 @@ describe('writeMigrationPackage + readMigrationPackage', () => {
     await expect(readMigrationPackage(dir, { migrationsDir: tmpDir })).rejects.toSatisfy((e) => {
       expectMigrationError(e, 'MIGRATION.DUPLICATE_INVARIANT_IN_EDGE');
       const mte = e as MigrationToolsError;
-      expect(mte.details).toEqual({ invariantId: 'shared' });
+      expect(mte.meta).toEqual({ invariantId: 'shared' });
       return true;
     });
   });
@@ -945,7 +941,7 @@ describe('copyFilesWithRename', () => {
       copyFilesWithRename(destDir, [{ sourcePath: src, destName: '../outside.json' }]),
     ).rejects.toSatisfy((e) => {
       expectMigrationError(e, 'MIGRATION.INVALID_DEST_NAME');
-      expect((e as MigrationToolsError).details).toHaveProperty('destName', '../outside.json');
+      expect((e as MigrationToolsError).meta).toHaveProperty('destName', '../outside.json');
       return true;
     });
   });
@@ -991,7 +987,7 @@ describe('formatMigrationDirName', () => {
       expect.fail('expected error');
     } catch (e) {
       expectMigrationError(e, 'MIGRATION.INVALID_NAME');
-      expect((e as MigrationToolsError).details).toHaveProperty('slug', '!!!');
+      expect((e as MigrationToolsError).meta).toHaveProperty('slug', '!!!');
     }
   });
 });

--- a/packages/1-framework/3-tooling/migration/test/migration-base.test.ts
+++ b/packages/1-framework/3-tooling/migration/test/migration-base.test.ts
@@ -296,7 +296,7 @@ describe('buildMigrationArtifacts', () => {
     await expect(buildMigrationArtifacts(makeMigration(ops), null)).rejects.toThrowError(
       expect.objectContaining({
         code: 'MIGRATION.INVALID_OPERATION_ENTRY',
-        details: expect.objectContaining({ index: 0 }),
+        meta: expect.objectContaining({ index: 0 }),
       }) as unknown as Error,
     );
   });
@@ -306,7 +306,7 @@ describe('buildMigrationArtifacts', () => {
     await expect(buildMigrationArtifacts(makeMigration(ops), null)).rejects.toThrowError(
       expect.objectContaining({
         code: 'MIGRATION.INVALID_OPERATION_ENTRY',
-        details: expect.objectContaining({ index: 0 }),
+        meta: expect.objectContaining({ index: 0 }),
       }) as unknown as Error,
     );
   });
@@ -316,7 +316,7 @@ describe('buildMigrationArtifacts', () => {
     await expect(buildMigrationArtifacts(makeMigration(ops), null)).rejects.toThrowError(
       expect.objectContaining({
         code: 'MIGRATION.INVALID_OPERATION_ENTRY',
-        details: expect.objectContaining({ index: 0 }),
+        meta: expect.objectContaining({ index: 0 }),
       }) as unknown as Error,
     );
   });
@@ -326,7 +326,7 @@ describe('buildMigrationArtifacts', () => {
     await expect(buildMigrationArtifacts(makeMigration(ops), null)).rejects.toThrowError(
       expect.objectContaining({
         code: 'MIGRATION.INVALID_OPERATION_ENTRY',
-        details: expect.objectContaining({ index: 0 }),
+        meta: expect.objectContaining({ index: 0 }),
       }) as unknown as Error,
     );
   });
@@ -340,7 +340,7 @@ describe('buildMigrationArtifacts', () => {
     await expect(buildMigrationArtifacts(makeMigration(ops), null)).rejects.toThrowError(
       expect.objectContaining({
         code: 'MIGRATION.INVALID_OPERATION_ENTRY',
-        details: expect.objectContaining({ index: 2 }),
+        meta: expect.objectContaining({ index: 2 }),
       }) as unknown as Error,
     );
   });

--- a/packages/1-framework/3-tooling/migration/test/migration-graph.test.ts
+++ b/packages/1-framework/3-tooling/migration/test/migration-graph.test.ts
@@ -230,7 +230,7 @@ describe('findLeaf', () => {
       const mte = e as MigrationToolsError;
       expect(mte.code).toBe('MIGRATION.NO_TARGET');
       expect(mte.fix).toContain('--from');
-      expect(mte.details).toHaveProperty('reachableHashes');
+      expect(mte.meta).toHaveProperty('reachableHashes');
     }
   });
 
@@ -256,7 +256,7 @@ describe('findLeaf', () => {
       const mte = e as MigrationToolsError;
       expect(mte.code).toBe('MIGRATION.AMBIGUOUS_TARGET');
       expect(mte.category).toBe('MIGRATION');
-      expect(mte.details).toHaveProperty('branchTips');
+      expect(mte.meta).toHaveProperty('branchTips');
       expect(mte.fix).toContain('--from');
     }
   });

--- a/packages/2-sql/4-lanes/relational-core/src/ast/types.ts
+++ b/packages/2-sql/4-lanes/relational-core/src/ast/types.ts
@@ -429,9 +429,13 @@ export class FunctionSource extends FromSource {
   ) {
     super();
     if (alias?.columnAliases?.length === 0) {
-      throw structuredError('SQL.AST_INVALID', 'FunctionSource column aliases must not be empty', {
-        meta: { kind: 'function-source', field: 'columnAliases' },
-      });
+      throw structuredError(
+        'RUNTIME.AST_INVALID',
+        'FunctionSource column aliases must not be empty',
+        {
+          meta: { kind: 'function-source', field: 'columnAliases' },
+        },
+      );
     }
     this.fn = fn;
     this.args = frozenArrayCopy(args);
@@ -969,7 +973,7 @@ export class CaseExpr extends Expression {
   constructor(branches: ReadonlyArray<CaseBranch>, elseExpr?: AnyExpression) {
     super();
     if (branches.length === 0) {
-      throw structuredError('SQL.AST_INVALID', 'CaseExpr requires at least one branch', {
+      throw structuredError('RUNTIME.AST_INVALID', 'CaseExpr requires at least one branch', {
         meta: { kind: 'case', field: 'branches' },
       });
     }

--- a/packages/2-sql/4-lanes/relational-core/test/ast/scalar-projection-expressions.test.ts
+++ b/packages/2-sql/4-lanes/relational-core/test/ast/scalar-projection-expressions.test.ts
@@ -88,7 +88,7 @@ describe('scalar projection expressions', () => {
     expect(() => CaseExpr.of([])).toThrow(
       expect.objectContaining({
         name: 'StructuredError',
-        code: 'SQL.AST_INVALID',
+        code: 'RUNTIME.AST_INVALID',
         message: 'CaseExpr requires at least one branch',
         meta: { kind: 'case', field: 'branches' },
       }),

--- a/packages/2-sql/4-lanes/relational-core/test/ast/select.test.ts
+++ b/packages/2-sql/4-lanes/relational-core/test/ast/select.test.ts
@@ -166,7 +166,7 @@ describe('ast/select', () => {
     ).toThrow(
       expect.objectContaining({
         name: 'StructuredError',
-        code: 'SQL.AST_INVALID',
+        code: 'RUNTIME.AST_INVALID',
         message: 'FunctionSource column aliases must not be empty',
         meta: { kind: 'function-source', field: 'columnAliases' },
       }),

--- a/packages/3-mongo-target/3-mongo-driver/src/exports/control.ts
+++ b/packages/3-mongo-target/3-mongo-driver/src/exports/control.ts
@@ -43,10 +43,11 @@ const mongoControlDriverDescriptor: ControlDriverDescriptor<'mongo', 'mongo', Mo
         }
         const message = error instanceof Error ? error.message : String(error);
         const redacted = redactDatabaseUrl(url);
-        throw errorRuntime('Database connection failed', {
+        throw errorRuntime('DRIVER.CONNECTION_FAILED', 'Database connection failed', {
           why: message,
           fix: 'Verify the MongoDB URL, ensure the database is reachable, and confirm credentials/permissions',
           meta: { ...redacted },
+          cause: error,
         });
       }
     },

--- a/packages/3-targets/3-targets/postgres/src/core/codec-descriptor.ts
+++ b/packages/3-targets/3-targets/postgres/src/core/codec-descriptor.ts
@@ -266,7 +266,7 @@ export function buildPostgresCodecDescriptorRegistry(
     if (!isPostgresCodecDescriptor(descriptor)) {
       const codecId = candidateCodecId(descriptor);
       throw structuredError(
-        'POSTGRES.CODEC_DESCRIPTOR_INVALID',
+        'RUNTIME.CODEC_DESCRIPTOR_INVALID',
         `Codec descriptor '${codecId}' is not a valid PostgreSQL codec descriptor.`,
         {
           why: 'PostgreSQL codec registries require the postgres-codec discriminant and complete target descriptor methods.',
@@ -278,12 +278,12 @@ export function buildPostgresCodecDescriptorRegistry(
 
     if (byId.has(descriptor.codecId)) {
       throw structuredError(
-        'POSTGRES.CODEC_DESCRIPTOR_DUPLICATE',
+        'RUNTIME.DUPLICATE_CODEC',
         `Duplicate PostgreSQL codec descriptor id '${descriptor.codecId}'.`,
         {
           why: 'Each codecId must resolve to exactly one PostgreSQL descriptor during registry composition.',
           fix: 'Remove the duplicate target, adapter, or extension contribution.',
-          meta: { codecId: descriptor.codecId },
+          meta: { codecId: descriptor.codecId, target: 'postgres' },
         },
       );
     }

--- a/packages/3-targets/3-targets/postgres/test/postgres-codec-descriptor.test.ts
+++ b/packages/3-targets/3-targets/postgres/test/postgres-codec-descriptor.test.ts
@@ -399,5 +399,15 @@ describe('Postgres codec descriptor registry', () => {
     expect(() => buildPostgresCodecDescriptorRegistry([validShape, validShape])).toThrow(
       /Duplicate PostgreSQL codec descriptor id.*demo\/direct-vector@1/,
     );
+
+    expect(() =>
+      buildPostgresCodecDescriptorRegistry([{ ...validShape, descriptorKind: 'sqlite-codec' }]),
+    ).toThrow(expect.objectContaining({ code: 'RUNTIME.CODEC_DESCRIPTOR_INVALID' }));
+    expect(() => buildPostgresCodecDescriptorRegistry([validShape, validShape])).toThrow(
+      expect.objectContaining({
+        code: 'RUNTIME.DUPLICATE_CODEC',
+        meta: expect.objectContaining({ target: 'postgres' }),
+      }),
+    );
   });
 });

--- a/packages/3-targets/3-targets/sqlite/src/core/codec-descriptor.ts
+++ b/packages/3-targets/3-targets/sqlite/src/core/codec-descriptor.ts
@@ -31,7 +31,7 @@ export abstract class SqliteCodecDescriptor<P = void>
   projectJson(expression: ProjectionExpr, ref: CodecRef): ProjectionExpr {
     if (ref.many === true) {
       throw structuredError(
-        'SQLITE.CODEC_DESCRIPTOR_ARRAY_UNSUPPORTED',
+        'RUNTIME.CODEC_DESCRIPTOR_ARRAY_UNSUPPORTED',
         `Codec '${ref.codecId}' uses CodecRef.many, but SQLite codec descriptors do not support stored scalar arrays.`,
         {
           why: 'SQLite has no stored scalar-array codec protocol, so applying a scalar projection to the whole stored array would be ambiguous.',
@@ -201,7 +201,7 @@ export function buildSqliteCodecDescriptorRegistry(
     if (!isSqliteCodecDescriptor(descriptor)) {
       const codecId = candidateCodecId(descriptor);
       throw structuredError(
-        'SQLITE.CODEC_DESCRIPTOR_INVALID',
+        'RUNTIME.CODEC_DESCRIPTOR_INVALID',
         `Codec descriptor '${codecId}' is not a valid SQLite codec descriptor.`,
         {
           why: 'SQLite codec registries require the sqlite-codec discriminant and complete target descriptor methods.',
@@ -213,12 +213,12 @@ export function buildSqliteCodecDescriptorRegistry(
 
     if (byId.has(descriptor.codecId)) {
       throw structuredError(
-        'SQLITE.CODEC_DESCRIPTOR_DUPLICATE',
+        'RUNTIME.DUPLICATE_CODEC',
         `Duplicate SQLite codec descriptor id '${descriptor.codecId}'.`,
         {
           why: 'Each codecId must resolve to exactly one SQLite descriptor during registry composition.',
           fix: 'Remove the duplicate target, adapter, or extension contribution.',
-          meta: { codecId: descriptor.codecId },
+          meta: { codecId: descriptor.codecId, target: 'sqlite' },
         },
       );
     }

--- a/packages/3-targets/3-targets/sqlite/test/sqlite-codec-descriptor.test.ts
+++ b/packages/3-targets/3-targets/sqlite/test/sqlite-codec-descriptor.test.ts
@@ -164,6 +164,17 @@ describe('SqliteCodecDescriptor', () => {
     ).toThrow(/SQLite codec descriptors do not support stored scalar arrays/);
     expect(descriptor.jsonProjectionParams).toEqual([]);
   });
+
+  it('rejects stored scalar arrays with RUNTIME.CODEC_DESCRIPTOR_ARRAY_UNSUPPORTED', () => {
+    const descriptor = new DirectVectorDescriptor();
+
+    expect(() =>
+      descriptor.projectJson(ColumnRef.of('items', 'embeddings'), {
+        ...scalarRef(descriptor.codecId, 5),
+        many: true,
+      }),
+    ).toThrow(expect.objectContaining({ code: 'RUNTIME.CODEC_DESCRIPTOR_ARRAY_UNSUPPORTED' }));
+  });
 });
 
 describe('sqliteCodec', () => {
@@ -258,6 +269,16 @@ describe('SQLite codec descriptor registry', () => {
 
     expect(() => buildSqliteCodecDescriptorRegistry([validShape, validShape])).toThrow(
       /Duplicate SQLite codec descriptor id.*demo\/direct-vector@1/,
+    );
+
+    expect(() =>
+      buildSqliteCodecDescriptorRegistry([{ ...validShape, descriptorKind: 'postgres-codec' }]),
+    ).toThrow(expect.objectContaining({ code: 'RUNTIME.CODEC_DESCRIPTOR_INVALID' }));
+    expect(() => buildSqliteCodecDescriptorRegistry([validShape, validShape])).toThrow(
+      expect.objectContaining({
+        code: 'RUNTIME.DUPLICATE_CODEC',
+        meta: expect.objectContaining({ target: 'sqlite' }),
+      }),
     );
   });
 });

--- a/packages/3-targets/6-adapters/sqlite/src/core/adapter.ts
+++ b/packages/3-targets/6-adapters/sqlite/src/core/adapter.ts
@@ -332,14 +332,14 @@ function renderSource(source: AnyFromSource, ctx: SqliteRenderContext): string {
     case 'function-source': {
       if (node.ordinality) {
         throw structuredError(
-          'ADAPTER.CAPABILITY_MISSING',
+          'RUNTIME.AST_UNSUPPORTED',
           'SQLite does not support WITH ORDINALITY on function sources',
           { meta: { target: 'sqlite', feature: 'function-source-with-ordinality' } },
         );
       }
       if (node.columnAliases !== undefined) {
         throw structuredError(
-          'ADAPTER.CAPABILITY_MISSING',
+          'RUNTIME.AST_UNSUPPORTED',
           'SQLite does not support returned-column aliases on function sources',
           { meta: { target: 'sqlite', feature: 'function-source-column-aliases' } },
         );

--- a/packages/3-targets/6-adapters/sqlite/test/adapter.test.ts
+++ b/packages/3-targets/6-adapters/sqlite/test/adapter.test.ts
@@ -260,7 +260,7 @@ describe('SQLite adapter', () => {
       expect(() => adapter.lower(ast, { contract })).toThrow(
         expect.objectContaining({
           name: 'StructuredError',
-          code: 'ADAPTER.CAPABILITY_MISSING',
+          code: 'RUNTIME.AST_UNSUPPORTED',
           message,
           meta: { target: 'sqlite', feature },
         }),

--- a/packages/3-targets/7-drivers/postgres/src/exports/control.ts
+++ b/packages/3-targets/7-drivers/postgres/src/exports/control.ts
@@ -62,15 +62,16 @@ const postgresDriverDescriptor: ControlDriverDescriptor<'sql', 'postgres', Postg
           'cause' in normalized && normalized.cause
             ? (normalized.cause as { code?: unknown }).code
             : undefined;
-        const code = codeFromSqlState ?? causeCode;
+        const sqlState = codeFromSqlState ?? causeCode;
 
-        throw errorRuntime('Database connection failed', {
+        throw errorRuntime('DRIVER.CONNECTION_FAILED', 'Database connection failed', {
           why: normalized.message,
           fix: 'Verify the database URL, ensure the database is reachable, and confirm credentials/permissions',
           meta: {
-            ...ifDefined('code', code),
+            ...ifDefined('sqlState', sqlState),
             ...redacted,
           },
+          cause: error,
         });
       }
     },

--- a/packages/3-targets/7-drivers/sqlite/src/core/control-driver.ts
+++ b/packages/3-targets/7-drivers/sqlite/src/core/control-driver.ts
@@ -38,12 +38,13 @@ const sqliteDriverDescriptor: ControlDriverDescriptor<'sql', 'sqlite', SqliteCon
       db.exec('PRAGMA foreign_keys = ON');
       return new SqliteControlDriver(db);
     } catch (error) {
-      throw errorRuntime('Database connection failed', {
+      throw errorRuntime('DRIVER.CONNECTION_FAILED', 'Database connection failed', {
         why: error instanceof Error ? error.message : String(error),
         fix: 'Verify the database file path exists and is accessible',
         meta: {
           path: pathOrMemory,
         },
+        cause: error,
       });
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1520,6 +1520,9 @@ importers:
       '@internal/contract':
         specifier: workspace:8.0.0-rc.1
         version: link:../../0-foundation/contract
+      '@internal/errors':
+        specifier: workspace:8.0.0-rc.1
+        version: link:../../1-core/errors
       '@internal/framework-components':
         specifier: workspace:8.0.0-rc.1
         version: link:../../1-core/framework-components

--- a/test/integration/test/cli-journeys/invariant-routing.e2e.test.ts
+++ b/test/integration/test/cli-journeys/invariant-routing.e2e.test.ts
@@ -284,11 +284,10 @@ withTempDir(({ createTempDir }) => {
         const applyFail = await runMigrate(ctx, ['--to', 'prod', '--json']);
         expect(applyFail.exitCode, 'P.04: apply exits 2').toBe(2);
         const applyEnvelope = parseJsonOutput<{
-          meta?: { code?: string; unknown?: readonly string[]; declared?: readonly string[] };
+          code?: string;
+          meta?: { unknown?: readonly string[]; declared?: readonly string[] };
         }>(applyFail);
-        expect(applyEnvelope.meta?.code, 'P.04: apply error code').toBe(
-          'MIGRATION.UNKNOWN_INVARIANT',
-        );
+        expect(applyEnvelope.code, 'P.04: apply error code').toBe('MIGRATION.UNKNOWN_INVARIANT');
         expect(applyEnvelope.meta?.unknown, 'P.04: apply error names the typo').toEqual([
           'typo-no-migration-declares-this',
         ]);
@@ -307,10 +306,8 @@ withTempDir(({ createTempDir }) => {
         // P.06: status --ref prod is fatal too (parity with apply).
         const statusFail = await runMigrationStatus(ctx, ['--to', 'prod', '--json']);
         expect(statusFail.exitCode, 'P.06: status exits 2').toBe(2);
-        const statusEnvelope = parseJsonOutput<{ meta?: { code?: string } }>(statusFail);
-        expect(statusEnvelope.meta?.code, 'P.06: status error code').toBe(
-          'MIGRATION.UNKNOWN_INVARIANT',
-        );
+        const statusEnvelope = parseJsonOutput<{ code?: string }>(statusFail);
+        expect(statusEnvelope.code, 'P.06: status error code').toBe('MIGRATION.UNKNOWN_INVARIANT');
       },
       timeouts.spinUpPpgDev,
     );
@@ -384,14 +381,14 @@ withTempDir(({ createTempDir }) => {
         const applyFail = await runMigrate(ctx, ['--to', 'prod', '--json']);
         expect(applyFail.exitCode, 'Q.05: apply exits 2').toBe(2);
         const envelope = parseJsonOutput<{
+          code?: string;
           meta?: {
-            code?: string;
             required?: readonly string[];
             missing?: readonly string[];
             structuralPath?: readonly { dirName: string; invariants: readonly string[] }[];
           };
         }>(applyFail);
-        expect(envelope.meta?.code, 'Q.05: error code').toBe('MIGRATION.NO_INVARIANT_PATH');
+        expect(envelope.code, 'Q.05: error code').toBe('MIGRATION.NO_INVARIANT_PATH');
         expect(envelope.meta?.required, 'Q.05: required reflects ref').toEqual([INVARIANT_ID]);
         expect(
           envelope.meta?.missing,

--- a/test/integration/test/cli-journeys/invariant-routing.mongo.e2e.test.ts
+++ b/test/integration/test/cli-journeys/invariant-routing.mongo.e2e.test.ts
@@ -555,9 +555,10 @@ describe('Journey: Mongo invariant-aware ref routing (live database)', {
     const applyFail = await migrationApply(ctx, ['--to', 'prod', '--json']);
     expect(applyFail.exitCode, 'Mongo-P.04: apply exits 2').toBe(2);
     const applyEnvelope = parseJsonOutput<{
-      meta?: { code?: string; unknown?: readonly string[]; declared?: readonly string[] };
+      code?: string;
+      meta?: { unknown?: readonly string[]; declared?: readonly string[] };
     }>(applyFail);
-    expect(applyEnvelope.meta?.code, 'Mongo-P.04: error code').toBe('MIGRATION.UNKNOWN_INVARIANT');
+    expect(applyEnvelope.code, 'Mongo-P.04: error code').toBe('MIGRATION.UNKNOWN_INVARIANT');
     expect(applyEnvelope.meta?.unknown, 'Mongo-P.04: unknown listed').toEqual([
       'typo-no-migration-declares-this',
     ]);
@@ -575,8 +576,8 @@ describe('Journey: Mongo invariant-aware ref routing (live database)', {
     // Mongo-P.06: status --ref also fatal (parity with apply).
     const statusFail = await migrationStatus(ctx, ['--to', 'prod', '--json']);
     expect(statusFail.exitCode, 'Mongo-P.06: status exits 2').toBe(2);
-    const statusEnvelope = parseJsonOutput<{ meta?: { code?: string } }>(statusFail);
-    expect(statusEnvelope.meta?.code, 'Mongo-P.06: status error code').toBe(
+    const statusEnvelope = parseJsonOutput<{ code?: string }>(statusFail);
+    expect(statusEnvelope.code, 'Mongo-P.06: status error code').toBe(
       'MIGRATION.UNKNOWN_INVARIANT',
     );
   });
@@ -654,14 +655,14 @@ describe('Journey: Mongo invariant-aware ref routing (live database)', {
     const applyFail = await migrationApply(ctx, ['--to', 'prod', '--json']);
     expect(applyFail.exitCode, 'Mongo-Q.05: apply exits 2').toBe(2);
     const envelope = parseJsonOutput<{
+      code?: string;
       meta?: {
-        code?: string;
         required?: readonly string[];
         missing?: readonly string[];
         structuralPath?: readonly { dirName: string; invariants: readonly string[] }[];
       };
     }>(applyFail);
-    expect(envelope.meta?.code, 'Mongo-Q.05: error code').toBe('MIGRATION.NO_INVARIANT_PATH');
+    expect(envelope.code, 'Mongo-Q.05: error code').toBe('MIGRATION.NO_INVARIANT_PATH');
     expect(envelope.meta?.required, 'Mongo-Q.05: required').toEqual([INVARIANT_ID]);
     expect(envelope.meta?.missing, 'Mongo-Q.05: missing').toEqual([INVARIANT_ID]);
     expect(envelope.meta?.structuralPath, 'Mongo-Q.05: structuralPath populated').toBeDefined();

--- a/test/integration/test/cli.db-init.e2e.errors.test.ts
+++ b/test/integration/test/cli.db-init.e2e.errors.test.ts
@@ -115,7 +115,7 @@ withTempDir(({ createTempDir }) => {
             >;
 
             expect(errorJson).toMatchObject({
-              code: 'CONTRACT.VERIFY_FAILED',
+              code: 'DRIVER.CONNECTION_FAILED',
               summary: 'Database connection failed',
               meta: {
                 port: '1',

--- a/test/integration/test/cli.db-ref-advancement.e2e.test.ts
+++ b/test/integration/test/cli.db-ref-advancement.e2e.test.ts
@@ -272,9 +272,7 @@ withTempDir(({ createTempDir }) => {
             string,
             unknown
           >;
-          expect(parsed['meta']).toEqual(
-            expect.objectContaining({ code: 'MIGRATION.INVALID_REF_NAME' }),
-          );
+          expect(parsed['code']).toBe('MIGRATION.INVALID_REF_NAME');
         });
       },
       timeouts.spinUpPpgDev,

--- a/test/integration/test/cli.migrate-drift-check.e2e.test.ts
+++ b/test/integration/test/cli.migrate-drift-check.e2e.test.ts
@@ -16,8 +16,8 @@ import {
 
 interface MigrateErrorJson {
   readonly ok?: boolean;
+  readonly code?: string;
   readonly meta?: {
-    readonly code?: string;
     readonly markerHash?: string;
     readonly reachableHashes?: readonly string[];
     readonly graphTip?: string;
@@ -74,7 +74,7 @@ withTempDir(({ createTempDir }) => {
             const drift = await runMigrate(ctx, ['--json']);
             expect(drift.exitCode).not.toBe(0);
             const err = parseJsonOutput<MigrateErrorJson>(drift);
-            expect(err.meta?.code).toBe('MIGRATION.MARKER_MISMATCH');
+            expect(err.code).toBe('MIGRATION.MARKER_MISMATCH');
             expect(err.meta?.markerHash).toBe(staleMarker);
             expect(err.meta?.reachableHashes?.length).toBeGreaterThan(0);
             expect(err.meta?.reachableHashes).not.toContain(staleMarker);
@@ -130,7 +130,7 @@ withTempDir(({ createTempDir }) => {
             const drift = await runMigrate(ctx, ['--json']);
             expect(drift.exitCode).not.toBe(0);
             const err = parseJsonOutput<MigrateErrorJson>(drift);
-            expect(err.meta?.code).toBe('MIGRATION.MARKER_MISMATCH');
+            expect(err.code).toBe('MIGRATION.MARKER_MISMATCH');
             expect(err.meta?.markerHash).toMatch(/^[a-f0-9]{64}$/);
             expect(err.meta?.reachableHashes).toEqual([]);
           });
@@ -161,7 +161,7 @@ withTempDir(({ createTempDir }) => {
             const drift = await runMigrate(ctx, ['--to', bundleDir, '--json']);
             expect(drift.exitCode).not.toBe(0);
             const err = parseJsonOutput<MigrateErrorJson>(drift);
-            expect(err.meta?.code).toBe('MIGRATION.MARKER_MISMATCH');
+            expect(err.code).toBe('MIGRATION.MARKER_MISMATCH');
           });
         });
       },
@@ -187,7 +187,7 @@ withTempDir(({ createTempDir }) => {
             const unreachable = await runMigrate(ctx, ['--json']);
             expect(unreachable.exitCode).not.toBe(0);
             const err = parseJsonOutput<MigrateErrorJson>(unreachable);
-            expect(err.meta?.code).toBe('MIGRATION.PATH_UNREACHABLE');
+            expect(err.code).toBe('MIGRATION.PATH_UNREACHABLE');
             expect(err.meta?.kind).toBe('pathUnreachable');
             expect(err.fix).toMatch(/migration list/);
             expect(err.fix).toMatch(/migration plan/);

--- a/test/integration/test/cli.migrate-ref-advancement.e2e.test.ts
+++ b/test/integration/test/cli.migrate-ref-advancement.e2e.test.ts
@@ -445,9 +445,7 @@ withTempDir(({ createTempDir }) => {
             string,
             unknown
           >;
-          expect(parsed['meta']).toEqual(
-            expect.objectContaining({ code: 'MIGRATION.INVALID_REF_NAME' }),
-          );
+          expect(parsed['code']).toBe('MIGRATION.INVALID_REF_NAME');
         });
       },
       timeouts.spinUpPpgDev,

--- a/test/integration/test/cli.migration-plan-ref-aware.e2e.test.ts
+++ b/test/integration/test/cli.migration-plan-ref-aware.e2e.test.ts
@@ -371,7 +371,7 @@ withTempDir(({ createTempDir }) => {
             const plan = await runMigrationPlan(ctx, ['--json']);
             expect(plan.exitCode).toBe(2);
             const err = parseJsonOutput<PlanJsonResult>(plan);
-            expect(err.meta?.code).toBe('MIGRATION.HASH_NOT_IN_GRAPH');
+            expect(err.code).toBe('MIGRATION.HASH_NOT_IN_GRAPH');
             expect(err.fix).toMatch(/--from/);
           });
         });

--- a/test/integration/test/cli.migration-plan-ref-aware.e2e.test.ts
+++ b/test/integration/test/cli.migration-plan-ref-aware.e2e.test.ts
@@ -68,7 +68,6 @@ interface PlanJsonResult {
   readonly baselineDir?: string;
   readonly noOp?: boolean;
   readonly code?: string;
-  readonly meta?: { readonly code?: string };
   readonly why?: string;
   readonly fix?: string;
 }


### PR DESCRIPTION
Before this PR, a dozen CLI failures reported the wrong error code. `errorRuntime` hardcoded `CONTRACT.VERIFY_FAILED`, so call sites that needed a different code smuggled the real one into metadata:

```ts
// before — the envelope says CONTRACT.VERIFY_FAILED; the truth hides in meta
return errorRuntime(`Cannot set ref to the empty-database sentinel: ${hash}`, {
  meta: { code: 'MIGRATION.REF_SET_EMPTY_SENTINEL', hash },
});

// after — the envelope carries the code consumers branch on
return errorRuntime('MIGRATION.REF_SET_EMPTY_SENTINEL', `Cannot set ref to the empty-database sentinel: ${hash}`, {
  meta: { hash },
});
```

`envelope.code` is the stable machine-branching surface (ADR 239) — for those failures it was lying, and anything branching on it had to know a secret `meta.code` fallback. This PR makes the code explicit at every construction site, and adds two related repairs the same foundation needs.

## The three repairs

**1. The generic path takes a code.** `errorRuntime(code, summary, options)`. All 43 production call sites audited and assigned their true code: the 12 that smuggled now declare what they always meant (`MIGRATION.HASH_NOT_IN_GRAPH`, `SNAPSHOT_MISSING`, `MARKER_MISMATCH`, …), the codeless ones get 14 new codes (`DRIVER.CONNECTION_FAILED`, `CLI.PROJECT_MANIFEST_INVALID`, the `MIGRATION.REF_*` resolution family, …), and the one site that legitimately meant `CONTRACT.VERIFY_FAILED` restates its defaults explicitly. `meta.code` no longer appears in production source; the Postgres driver's SQLSTATE moved to `meta.sqlState` so the key reads as a defect wherever it survives.

**2. `cause` support on `CliStructuredError`.** The class accepted no `cause`, so every `catch` that built a structured error dropped the underlying failure. It now forwards `cause` to `Error`; `toEnvelope()` deliberately does not serialize it (a cause is for in-process consumers and logs, not the wire). Five factories that wrapped caught errors forward it; input validators with nothing to forward were left alone.

**3. Namespace drift.** `SQL.*`, `SQLITE.*`, `POSTGRES.*`, and `ADAPTER.*` were in live use outside ADR 239's closed list — targets and adapters do not get namespaces of their own. They remap onto the concern namespaces already covering those conditions (`RUNTIME.AST_INVALID`, `RUNTIME.AST_UNSUPPORTED`, `RUNTIME.DUPLICATE_CODEC` + `meta.target`, plus two new codec-descriptor subcodes). None were published, so the remaps are non-breaking. ADR 239 gains a paragraph closing the gap that produced the drift.

## Why now

These are pre-freeze repairs: ADR 239 freezes the taxonomy at RC, and published codes cannot be renamed cheaply afterwards. They are also the precondition for sharing this error foundation across the other Prisma CLIs (the consolidate-clis project) — a foundation whose codes lie is not one to copy.

## Verification

`@internal/errors` (99), `@internal/cli` (1,389), `@internal/migration-tools` (587), plus driver/target/adapter/relational-core suites — all green. Full integration suite: 1,811 passed; every remaining failure was re-run against a detached `origin/main` checkout and reproduces identically there. `lint:casts` and `lint:throws` deltas 0 (`MigrationToolsError.code` narrowed to a dotted template type, so the one tempting cast was unnecessary). Independently reviewed against the slice design.

Test churn is concentrated in assertions that read `meta.code` and now read `envelope.code` — the behavior change is the point. Structural meta assertions were preserved.

## Known

CI is red on `main` today (an unrelated driver-SPI drift in the supabase extension, plus `DRIVER.PREPARE_FAILED` missing from the error reference); a separate fix is in flight. Six review nits are outstanding, tracked for a follow-up commit: producing-site updates for nine existing error-reference entries, a `fix` line on one new site, a defensive copy in `mapMigrationToolsError`, an ADR 207 example code, and a dead test-type field.

Refs: TML-3180

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized structured error codes across CLI, migration, runtime, database, and connection operations.
  * Error responses now expose codes consistently at the top level while retaining diagnostic metadata.
  * Improved diagnostics by preserving underlying causes where available.
  * Added clearer categorization for manifest, migration, contract, connection, codec, and unsupported-feature failures.

* **Documentation**
  * Expanded the error reference with new codes and examples.
  * Clarified error namespace conventions and CLI capability messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->