### PR TITLE
fix(driver-postgres): direct-driver transaction integrity + supabase prepared-statement coverage (TML-3167 follow-up)

### DIFF
--- a/packages/3-extensions/supabase/test/supabase-runtime.test.ts
+++ b/packages/3-extensions/supabase/test/supabase-runtime.test.ts
@@ -8,8 +8,16 @@ import {
 } from '@internal/framework-components/execution';
 import { SqlStorage } from '@internal/sql-contract/types';
 import type { Codec, SqlDriver, SqlExecuteRequest } from '@internal/sql-relational-core/ast';
-import { SelectAst as SelectAstCtor, TableSource } from '@internal/sql-relational-core/ast';
-import type { SqlExecutionPlan } from '@internal/sql-relational-core/plan';
+import {
+  BinaryExpr,
+  ColumnRef,
+  collectOrderedParamRefs,
+  ProjectionItem,
+  SelectAst as SelectAstCtor,
+  TableSource,
+} from '@internal/sql-relational-core/ast';
+import type { Expression, ScopeField } from '@internal/sql-relational-core/expression';
+import type { SqlExecutionPlan, SqlQueryPlan } from '@internal/sql-relational-core/plan';
 import type {
   SqlMiddleware,
   SqlRuntimeAdapterDescriptor,
@@ -24,6 +32,7 @@ import {
 import { applicationDomainOf } from '@repo/test-utils';
 import { describe, expect, it, vi } from 'vitest';
 import { createTestSqlNamespace } from '../../../2-sql/1-core/contract/test/test-support';
+import { descriptorsFromCodecs } from '../../../2-sql/5-runtime/test/utils';
 import type { SupabaseRoleBinding } from '../src/runtime/supabase-runtime';
 import { SupabaseRuntimeImpl } from '../src/runtime/supabase-runtime';
 
@@ -173,6 +182,7 @@ function createStubAdapter() {
 function createTestAdapterDescriptor(
   adapter: ReturnType<typeof createStubAdapter>,
 ): SqlRuntimeAdapterDescriptor<'postgres'> {
+  const descriptors = descriptorsFromCodecs(adapter.__codecs);
   return {
     kind: 'adapter',
     rawCodecInferer: { inferCodec: () => 'pg/text' },
@@ -180,7 +190,7 @@ function createTestAdapterDescriptor(
     version: '0.0.1',
     familyId: 'sql' as const,
     targetId: 'postgres' as const,
-    codecs: () => [],
+    codecs: () => descriptors,
     create() {
       return Object.assign(
         { familyId: 'sql' as const, targetId: 'postgres' as const },
@@ -254,6 +264,24 @@ function stubPlan(): SqlExecutionPlan<Record<string, unknown>> {
       lane: 'raw',
     },
   };
+}
+
+function buildEqUserIdPlan(userId: Expression<ScopeField>): SqlQueryPlan<{ id: number }> {
+  const users = TableSource.named('users');
+  const ast = SelectAstCtor.from(users)
+    .withProjection([
+      ProjectionItem.of('id', ColumnRef.of('id', 'users'), { codecId: 'pg/int4@1' }),
+    ])
+    .withWhere(BinaryExpr.eq(ColumnRef.of('id', 'users'), userId.buildAst()));
+  return Object.freeze({
+    ast,
+    params: collectOrderedParamRefs(ast).map((r) => (r.kind === 'param-ref' ? r.value : undefined)),
+    meta: {
+      target: testContract.target,
+      storageHash: testContract.storage.storageHash,
+      lane: 'dsl' as const,
+    },
+  });
 }
 
 describe('SupabaseRuntimeImpl', () => {
@@ -474,6 +502,41 @@ describe('SupabaseRuntimeImpl', () => {
 
       expect(driver.connection.destroy).toHaveBeenCalledOnce();
       expect(driver.connection.release).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('openRoleSession — prepared statements', () => {
+    it('executePrepared on the session runs on the session connection', async () => {
+      const { runtime, driver } = createTestSetup();
+      const ps = await runtime.prepare({ userId: 'pg/int4@1' as const }, (params) =>
+        buildEqUserIdPlan(params.userId),
+      );
+      const session = await runtime.openRoleSession({ role: 'authenticated' });
+
+      const rows = await session.executePrepared(ps, { userId: 1 }).toArray();
+      await session.release();
+
+      expect(rows).toEqual([{ id: 1 }]);
+      expect(driver.connection.queryCalls).toHaveLength(1);
+      expect(driver.query).not.toHaveBeenCalled();
+    });
+
+    it('executePrepared on a session transaction runs on that transaction', async () => {
+      const { runtime, driver } = createTestSetup();
+      const ps = await runtime.prepare({ userId: 'pg/int4@1' as const }, (params) =>
+        buildEqUserIdPlan(params.userId),
+      );
+      const session = await runtime.openRoleSession({ role: 'authenticated' });
+
+      const tx = await session.transaction();
+      const rows = await tx.executePrepared(ps, { userId: 1 }).toArray();
+      await tx.commit();
+      await session.release();
+
+      expect(rows).toEqual([{ id: 1 }]);
+      expect(driver.connection.transaction.queryCalls).toHaveLength(1);
+      expect(driver.connection.queryCalls).toHaveLength(0);
+      expect(driver.query).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/3-extensions/supabase/test/supabase-runtime.test.ts
+++ b/packages/3-extensions/supabase/test/supabase-runtime.test.ts
@@ -29,10 +29,10 @@ import {
   createSqlExecutionStack,
   withTransaction,
 } from '@internal/sql-runtime';
+import { descriptorsFromCodecs } from '@internal/sql-runtime/test/utils';
 import { applicationDomainOf } from '@repo/test-utils';
 import { describe, expect, it, vi } from 'vitest';
 import { createTestSqlNamespace } from '../../../2-sql/1-core/contract/test/test-support';
-import { descriptorsFromCodecs } from '../../../2-sql/5-runtime/test/utils';
 import type { SupabaseRoleBinding } from '../src/runtime/supabase-runtime';
 import { SupabaseRuntimeImpl } from '../src/runtime/supabase-runtime';
 
@@ -55,7 +55,11 @@ const testContract: Contract<SqlStorage> = {
 
 interface RecordingTransaction {
   readonly id: symbol;
-  readonly queryCalls: Array<{ sql: string; params: readonly unknown[] | undefined }>;
+  readonly queryCalls: Array<{
+    sql: string;
+    params: readonly unknown[] | undefined;
+    handle: unknown;
+  }>;
   execute: ReturnType<typeof vi.fn>;
   query: ReturnType<typeof vi.fn>;
   commit: ReturnType<typeof vi.fn>;
@@ -65,7 +69,11 @@ interface RecordingTransaction {
 interface RecordingConnection {
   readonly id: symbol;
   readonly executeCalls: Array<{ sql: string; params: readonly unknown[] | undefined }>;
-  readonly queryCalls: Array<{ sql: string; params: readonly unknown[] | undefined }>;
+  readonly queryCalls: Array<{
+    sql: string;
+    params: readonly unknown[] | undefined;
+    handle: unknown;
+  }>;
   readonly beginTransactionSpy: ReturnType<typeof vi.fn>;
   execute: ReturnType<typeof vi.fn>;
   query: ReturnType<typeof vi.fn>;
@@ -90,9 +98,17 @@ function createRecordingDriver(
 ): RecordingDriver {
   const txId = Symbol('transaction');
   const connId = Symbol('connection');
-  const txQueryCalls: Array<{ sql: string; params: readonly unknown[] | undefined }> = [];
+  const txQueryCalls: Array<{
+    sql: string;
+    params: readonly unknown[] | undefined;
+    handle: unknown;
+  }> = [];
   const connExecuteCalls: Array<{ sql: string; params: readonly unknown[] | undefined }> = [];
-  const connQueryCalls: Array<{ sql: string; params: readonly unknown[] | undefined }> = [];
+  const connQueryCalls: Array<{
+    sql: string;
+    params: readonly unknown[] | undefined;
+    handle: unknown;
+  }> = [];
 
   const transaction: RecordingTransaction = {
     id: txId,
@@ -101,7 +117,11 @@ function createRecordingDriver(
     },
     execute: vi.fn().mockResolvedValue({ affectedRows: 0 }),
     query: vi.fn().mockImplementation(async function* (request: SqlExecuteRequest) {
-      txQueryCalls.push({ sql: request.sql, params: request.params });
+      txQueryCalls.push({
+        sql: request.sql,
+        params: request.params,
+        handle: request.preparedStatementHandle,
+      });
       for (const row of executeRows) yield row;
     }),
     commit: vi.fn().mockResolvedValue(undefined),
@@ -126,7 +146,11 @@ function createRecordingDriver(
       return { affectedRows: 0 };
     }),
     query: vi.fn().mockImplementation(async function* (request: SqlExecuteRequest) {
-      connQueryCalls.push({ sql: request.sql, params: request.params });
+      connQueryCalls.push({
+        sql: request.sql,
+        params: request.params,
+        handle: request.preparedStatementHandle,
+      });
       for (const row of executeRows) yield row;
     }),
     release: vi.fn().mockResolvedValue(undefined),
@@ -320,7 +344,11 @@ describe('SupabaseRuntimeImpl', () => {
         request: SqlExecuteRequest,
       ) {
         queriedOnConn.push(driver.connection.id);
-        driver.connection.queryCalls.push({ sql: request.sql, params: request.params });
+        driver.connection.queryCalls.push({
+          sql: request.sql,
+          params: request.params,
+          handle: request.preparedStatementHandle,
+        });
         yield { id: 1 };
       });
 
@@ -518,6 +546,7 @@ describe('SupabaseRuntimeImpl', () => {
 
       expect(rows).toEqual([{ id: 1 }]);
       expect(driver.connection.queryCalls).toHaveLength(1);
+      expect(driver.connection.queryCalls[0]?.handle).toBeDefined();
       expect(driver.query).not.toHaveBeenCalled();
     });
 
@@ -535,6 +564,7 @@ describe('SupabaseRuntimeImpl', () => {
 
       expect(rows).toEqual([{ id: 1 }]);
       expect(driver.connection.transaction.queryCalls).toHaveLength(1);
+      expect(driver.connection.transaction.queryCalls[0]?.handle).toBeDefined();
       expect(driver.connection.queryCalls).toHaveLength(0);
       expect(driver.query).not.toHaveBeenCalled();
     });

--- a/packages/3-targets/7-drivers/postgres/src/postgres-driver.ts
+++ b/packages/3-targets/7-drivers/postgres/src/postgres-driver.ts
@@ -473,22 +473,36 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
   }
 }
 
+/**
+ * Transaction-open flag shared between a connection and the driver whose
+ * socket it borrows. A direct driver runs every query — connection-scoped or
+ * driver-level — on one client, so a driver-level query issued while the
+ * connection holds an open transaction must see that state: the cursor
+ * portal-protection wrap would otherwise issue its own BEGIN…COMMIT and
+ * terminate the caller's transaction mid-flight.
+ */
+interface SharedTransactionState {
+  open: boolean;
+}
+
 class PostgresConnectionImpl extends PostgresQueryable implements SqlConnection {
   #connection: PoolClient | Client;
   #onRelease: (() => void) | undefined;
   #onDestroy: ((reason: unknown) => Promise<void> | void) | undefined;
-  #transactionOpen = false;
+  #txState: SharedTransactionState;
 
   constructor(
     connection: PoolClient | Client,
     options: ConnectionOptions,
     onRelease?: () => void,
     onDestroy?: (reason: unknown) => Promise<void> | void,
+    txState?: SharedTransactionState,
   ) {
     super(options);
     this.#connection = connection;
     this.#onRelease = onRelease;
     this.#onDestroy = onDestroy;
+    this.#txState = txState ?? { open: false };
   }
 
   override acquireClient(): Promise<PoolClient | Client> {
@@ -500,7 +514,7 @@ class PostgresConnectionImpl extends PostgresQueryable implements SqlConnection 
   }
 
   protected override inExplicitTransaction(): boolean {
-    return this.#transactionOpen;
+    return this.#txState.open;
   }
 
   async beginTransaction(): Promise<SqlTransaction> {
@@ -510,9 +524,9 @@ class PostgresConnectionImpl extends PostgresQueryable implements SqlConnection 
     } finally {
       releaseLock();
     }
-    this.#transactionOpen = true;
+    this.#txState.open = true;
     return new PostgresTransactionImpl(this.#connection, this.options, () => {
-      this.#transactionOpen = false;
+      this.#txState.open = false;
     });
   }
 
@@ -659,10 +673,18 @@ class PostgresDirectDriverImpl
   #closed = false;
   #connected = false;
   #connectPromise: Promise<void> | undefined;
+  // Shared with every connection this driver hands out: one socket means a
+  // driver-level query must know when a connection's transaction is open, or
+  // the cursor portal-protection wrap would COMMIT the caller's transaction.
+  readonly #txState: SharedTransactionState = { open: false };
 
   constructor(options: PostgresDriverOptions & { connect: { client: Client } }) {
     super(buildConnectionOptions(options));
     this.directClient = options.connect.client;
+  }
+
+  protected override inExplicitTransaction(): boolean {
+    return this.#txState.open;
   }
 
   get state(): SqlDriverState {
@@ -696,6 +718,7 @@ class PostgresDirectDriverImpl
             releaseLease();
           }
         },
+        this.#txState,
       );
     } catch (error) {
       releaseLease();

--- a/packages/3-targets/7-drivers/postgres/test/driver.stream-portal-protection.integration.test.ts
+++ b/packages/3-targets/7-drivers/postgres/test/driver.stream-portal-protection.integration.test.ts
@@ -328,4 +328,33 @@ describe('streamed execute on a shared single-session backend', () => {
     },
     timeouts.spinUpDbServer,
   );
+
+  it(
+    'a driver-level streamed query during an open connection transaction does not end it',
+    async () => {
+      const h = await createSharedSessionHarness({ cursorBatchSize: 10 });
+      await seedRows(h, 5);
+
+      const connection = await h.driver.acquireConnection();
+      const tx = await connection.beginTransaction();
+      try {
+        await executeSql(tx, 'insert into items (id, n) values (100, 200)');
+
+        // A driver-level read on the shared socket (the runtime's lazy
+        // verify-marker read does exactly this mid-mutation). The portal
+        // protection wrap must be skipped: its COMMIT would end the open
+        // transaction and the rollback below would undo nothing.
+        const rows = await queryRows(h.driver, 'select id from items where id = 100');
+        expect(rows).toHaveLength(1);
+        expect(h.recordedQueryTexts).not.toContain('COMMIT');
+      } finally {
+        await tx.rollback();
+        await connection.release();
+      }
+
+      const after = await queryRows(h.driver, 'select id from items where id = 100');
+      expect(after).toEqual([]);
+    },
+    timeouts.spinUpDbServer,
+  );
 });

--- a/skills/prisma-8-extension-upgrade/upgrades/0.17-to-8.0.0-rc.1/instructions.md
+++ b/skills/prisma-8-extension-upgrade/upgrades/0.17-to-8.0.0-rc.1/instructions.md
@@ -66,6 +66,26 @@ changes:
         - 'renderValueLiteral'
         - 'generateContractDts'
       anyMatch: true
+  - id: driver-spi-splits-query-and-execute
+    summary: |
+      The relational driver contract (`SqlQueryable` in `@internal/sql-relational-core`) splits
+      into one streaming path and one statistics path: `query<Row>(request)` returns
+      `AsyncIterable<Row>`, and `execute(request)` runs a statement without row output and
+      resolves to `SqlStatementStats` (`{ affectedRows }`). The prepared-specific
+      `executePrepared` driver method and the buffered `query(sql, params)` convenience (with its
+      `SqlQueryResult` type) are gone — preparedness travels as the optional
+      `preparedStatementHandle` on `SqlExecuteRequest`, and `query()` serves ad-hoc and prepared
+      requests alike. A pack that implements a driver, wraps one, or ships a driver fake for
+      tests implements the two-method surface, reports its engine's native affected-row count
+      unnormalized, and surfaces a failed prepared-statement retry as the structural
+      `DRIVER.PREPARE_FAILED` error envelope.
+    detection:
+      glob: "**/*.{ts,tsx}"
+      contains:
+        - "SqlQueryable"
+        - "PreparedExecuteRequest"
+        - "SqlQueryResult"
+      anyMatch: true
 ---
 
 # 0.17 → 8.0.0-rc.1 — Extension-author upgrade instructions
@@ -139,6 +159,35 @@ Two things worth knowing when you update these:
   needed, and the artefacts your pack ships (`contract.json`, `contract.d.ts`, migrations) are
   unchanged. If your pack's committed contract artefacts do show a diff after upgrading, that is
   a different change in this transition, not this one.
+
+## `driver-spi-splits-query-and-execute`
+
+The driver contract used one streaming method for every statement, a prepared-specific variant beside it, and a buffered convenience query. It is now two methods with distinct jobs:
+
+```ts
+// Before (0.17)
+export interface SqlQueryable {
+  execute<Row>(request: SqlExecuteRequest): AsyncIterable<Row>;
+  executePrepared<Row>(request: PreparedExecuteRequest): AsyncIterable<Row>;
+  explain?(request: SqlExecuteRequest): Promise<SqlExplainResult>;
+  query<Row>(sql: string, params?: readonly unknown[]): Promise<SqlQueryResult<Row>>;
+}
+
+// After (0.18)
+export interface SqlQueryable {
+  query<Row>(request: SqlExecuteRequest): AsyncIterable<Row>;
+  execute(request: SqlExecuteRequest): Promise<SqlStatementStats>; // { affectedRows }
+  explain?(request: SqlExecuteRequest): Promise<SqlExplainResult>;
+}
+```
+
+For a pack that implements a driver, wraps one, or ships a driver fake:
+
+- Move the streaming implementation from `execute(request)` to `query(request)`. The buffered `query(sql, params)` overload and its `SqlQueryResult` type are gone; callers stream and collect instead.
+- Implement `execute(request): Promise<SqlStatementStats>` for statements executed without row output. Report your engine's native affected-row count — the in-tree PostgreSQL driver reports `rowCount`, SQLite reports `stmt.run().changes` — and do not normalize semantics across engines.
+- Delete `executePrepared`. Preparedness is a property of the request: a prepared plan arrives at `query()` carrying `preparedStatementHandle` on the `SqlExecuteRequest`.
+- If your engine cannot return rows from `execute()`, reject `RETURNING`-style statements up front rather than silently dropping their rows (the in-tree SQLite driver does this).
+- If your driver retries stale prepared statements, surface a failed retry as the structural `DRIVER.PREPARE_FAILED` error envelope (ADR 239) with the normalized driver error as its `cause`.
 
 <!--
 TML-3171 (nested SQL ORM self-relation predicate scopes): `changes: []`. The `packages/3-extensions/sql-orm-client` diff fixes internal query planning and adds regression coverage; it changes no public API, contract shape, emitted artefact, extension-authoring surface, adapter API, or downstream source translation. Incidental substrate diff only.

--- a/skills/prisma-8-extension-upgrade/upgrades/8.0.0-rc.1-to-8.0.0-rc.2/instructions.md
+++ b/skills/prisma-8-extension-upgrade/upgrades/8.0.0-rc.1-to-8.0.0-rc.2/instructions.md
@@ -8,4 +8,6 @@ changes: []
 
 <!--
 PR #29910: `changes: []`. Binding internal mutation-reload filters and repairing Supabase runtime coverage after the driver SPI split require no downstream extension source translation.
+
+PR #29920: `changes: []`. Adds prepared-statement test coverage to the Supabase runtime suite (test-fixture codec registration only) and fixes a postgres direct-driver transaction defect; neither requires downstream extension source translation. The SPI split itself is recorded as `driver-spi-splits-query-and-execute` in the 0.17-to-8.0.0-rc.1 transition.
 -->


### PR DESCRIPTION
Rebased onto main after #29910 landed the bulk of the TML-3167 fallout repairs (supabase runtime port, error-reference entry, cache-test spies, fixture re-emits). Two commits remain — the pieces #29910 did not cover:

1. **A real transaction defect in the postgres direct driver.** A direct driver shares one socket with the connection it hands out, but driver-level `query()` calls reported `inExplicitTransaction() === false`. A driver-level read issued while that connection held an open transaction (the runtime's lazy verify-marker read does exactly this mid-mutation) took the cursor portal-protection path and wrapped itself in `BEGIN…COMMIT` — and that COMMIT ended the caller's transaction, so subsequent statements ran autocommit and `ROLLBACK` undid nothing. This is what originally broke `integration/mn-nested-write`; #29910 sidestepped it by disabling the cursor path in the PGlite test harness, which fixes the suite but leaves the defect reachable for any direct-driver consumer. The driver and its connection now share the transaction-open flag. Regression test in `driver.stream-portal-protection.integration.test.ts` — it fails on the unfixed driver and passes now.
2. **Prepared-statement test coverage for the Supabase runtime**, whose fixture needed to register the stub adapter's codecs via `descriptorsFromCodecs` (the sibling `2-sql/5-runtime` pattern) so `prepare()` can resolve `pg/int4@1`.

## Upgrade instructions

The SPI split shipped in 8.0.0-rc.1 without an extension-author upgrade entry. This PR records `driver-spi-splits-query-and-execute` in `skills/prisma-8-extension-upgrade/upgrades/0.17-to-8.0.0-rc.1/instructions.md` and notes itself (`changes: []`) in the in-flight `8.0.0-rc.1-to-8.0.0-rc.2` declaration.

Verified locally against main: postgres driver 132/132, supabase runtime 18/18, `mn-nested-write` + `middleware-cache` 26/26, supabase typecheck clean, `check:upgrade-coverage` clean.

Refs: TML-3167

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PostgreSQL transaction handling so streamed queries no longer accidentally commit or end an active transaction.
  - Preserved access to uncommitted data during transactions and ensured rollback behavior remains correct.
  - Added support and validation for prepared statements executed through session and transaction connections.

- **Documentation**
  - Added upgrade guidance for the updated relational driver interface, including streaming queries, statement execution, prepared statements, and error handling.
  - Documented the upgrade path to the latest release candidate, with no required downstream changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->