### PR TITLE
fix(target-postgres): treat naive Postgres timestamps as UTC on the wire

### DIFF
--- a/packages/3-targets/3-targets/postgres/src/core/codec-descriptor.ts
+++ b/packages/3-targets/3-targets/postgres/src/core/codec-descriptor.ts
@@ -108,6 +108,15 @@ export interface PostgresCodecOptions<P> {
   readonly nativeType: (params: P) => string;
   readonly jsonProjection: (expression: ProjectionExpr, params: P) => ProjectionExpr;
   readonly jsonArrayProjection?: (expression: ProjectionExpr, params: P) => ProjectionExpr;
+  /**
+   * Replaces the wrapped descriptor's codec factory when the Postgres wire
+   * format needs target-specific encode/decode (e.g. the pg driver's
+   * local-time `timestamp` parsing). Must produce codecs with the wrapped
+   * descriptor's codecId and traits.
+   */
+  readonly factory?: (
+    params: P,
+  ) => (ctx: CodecInstanceContext) => Codec<string, readonly CodecTrait[], unknown, unknown>;
 }
 
 export type AdaptedPostgresCodecDescriptor<D extends AnyCodecDescriptor> = Pick<
@@ -142,7 +151,7 @@ class PostgresCodecDescriptorAdapter<D extends AnyCodecDescriptor> extends Postg
     this.traits = descriptor.traits;
     this.targetTypes = descriptor.targetTypes;
     this.paramsSchema = descriptor.paramsSchema;
-    this.factory = (params) => descriptor.factory(params);
+    this.factory = options.factory ?? ((params) => descriptor.factory(params));
 
     const renderOutputType = descriptor.renderOutputType;
     if (renderOutputType !== undefined) {

--- a/packages/3-targets/3-targets/postgres/src/core/codec-helpers.ts
+++ b/packages/3-targets/3-targets/postgres/src/core/codec-helpers.ts
@@ -106,7 +106,39 @@ const ISO_8601_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?$/
 const ISO_8601_TIMESTAMPTZ =
   /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2})$/;
 
-export const pgTimestampEncodeJson = (value: Date): JsonValue => value.toISOString().slice(0, -1);
+/**
+ * A Postgres `timestamp without time zone` stores a naive wall clock that
+ * `pg/timestamp@1` canonicalizes as meaning UTC.
+ *
+ * `pgTimestampEncode` formats the instant as naive UTC ISO text
+ * (`2026-07-01T10:00:00.000`), bypassing the pg driver's own `Date`
+ * serialization (`dateToString`), which renders *local* time with an offset
+ * that Postgres would drop — storing local wall clock instead of UTC.
+ */
+export const pgTimestampEncode = (value: Date): string => value.toISOString().slice(0, -1);
+
+/**
+ * Normalizes the pg driver's already-parsed `Date` for a `timestamp` column
+ * into the canonical naive-means-UTC form. The driver (via `postgres-date`)
+ * builds that `Date` at *local* wall-clock time from the wire text; reading it
+ * back with the same (local) getters recovers the exact wall clock the driver
+ * parsed, and reconstructing via `Date.UTC` yields the instant that wall clock
+ * denotes in UTC, independent of the process's timezone.
+ */
+export const pgTimestampDecode = (wire: Date): Date =>
+  new Date(
+    Date.UTC(
+      wire.getFullYear(),
+      wire.getMonth(),
+      wire.getDate(),
+      wire.getHours(),
+      wire.getMinutes(),
+      wire.getSeconds(),
+      wire.getMilliseconds(),
+    ),
+  );
+
+export const pgTimestampEncodeJson = (value: Date): JsonValue => pgTimestampEncode(value);
 export const pgTimestampDecodeJson = (json: JsonValue): Date => {
   if (typeof json !== 'string') {
     throw postgresError(
@@ -132,6 +164,15 @@ export const pgTimestampDecodeJson = (json: JsonValue): Date => {
   }
   return date;
 };
+
+/**
+ * Serializes a `timestamptz` instant as UTC ISO text, bypassing the pg
+ * driver's own `Date` serialization (`dateToString`), which renders local time
+ * with an offset from `getTimezoneOffset()` — whole minutes only, so
+ * historical local-mean-time offsets (e.g. Berlin +00:53:28 before 1893) lose
+ * their seconds and shift the stored instant.
+ */
+export const pgTimestamptzEncode = (value: Date): string => value.toISOString();
 
 export const pgTimestamptzEncodeJson = (value: Date): JsonValue =>
   value.toISOString().replace(/Z$/, '+00:00');

--- a/packages/3-targets/3-targets/postgres/src/core/codecs.ts
+++ b/packages/3-targets/3-targets/postgres/src/core/codecs.ts
@@ -32,6 +32,7 @@ import {
   NullCheckExpr,
   OrExpr,
   type ProjectionExpr,
+  type SQL_TIMESTAMP_CODEC_ID,
   SqlCharCodec,
   SqlFloatCodec,
   SqlIntCodec,
@@ -40,7 +41,9 @@ import {
   sqlFloatDescriptor,
   sqlIntDescriptor,
   sqlTextDescriptor,
+  sqlTimestampDecodeJson,
   sqlTimestampDescriptor,
+  sqlTimestampEncodeJson,
   sqlVarcharDescriptor,
 } from '@internal/sql-relational-core/ast';
 import { blindCast } from '@internal/utils/casts';
@@ -67,9 +70,12 @@ import {
   pgJsonEncode,
   pgNumericDecode,
   pgNumericRenderOutputType,
+  pgTimestampDecode,
   pgTimestampDecodeJson,
+  pgTimestampEncode,
   pgTimestampEncodeJson,
   pgTimestamptzDecodeJson,
+  pgTimestamptzEncode,
   pgTimestamptzEncodeJson,
   renderLength,
   renderPrecision,
@@ -319,9 +325,36 @@ export const postgresSqlTextDescriptor = postgresCodec(sqlTextDescriptor, {
   jsonProjection: identityJsonProjection,
 });
 
+/**
+ * Postgres-specific codec for `sql/timestamp@1`: same JSON form as the family
+ * {@link SqlTimestampCodec}, but the wire path applies the naive-means-UTC
+ * conversions the pg driver requires (see {@link pgTimestampEncode} /
+ * {@link pgTimestampDecode}).
+ */
+class PostgresSqlTimestampCodec extends CodecImpl<
+  typeof SQL_TIMESTAMP_CODEC_ID,
+  readonly ['equality', 'order'],
+  Date | string,
+  Date
+> {
+  async encode(value: Date, _ctx: CodecCallContext): Promise<string> {
+    return pgTimestampEncode(value);
+  }
+  async decode(wire: Date, _ctx: CodecCallContext): Promise<Date> {
+    return pgTimestampDecode(wire);
+  }
+  encodeJson(value: Date): JsonValue {
+    return sqlTimestampEncodeJson(value);
+  }
+  decodeJson(json: JsonValue): Date {
+    return sqlTimestampDecodeJson(json);
+  }
+}
+
 export const postgresSqlTimestampDescriptor = postgresCodec(sqlTimestampDescriptor, {
   nativeType: () => 'timestamp',
   jsonProjection: identityJsonProjection,
+  factory: () => () => new PostgresSqlTimestampCodec(sqlTimestampDescriptor),
 });
 
 export class PgTextCodec extends CodecImpl<
@@ -971,14 +1004,14 @@ pgDateColumn satisfies ColumnHelperForStrict<PgDateDescriptor>;
 export class PgTimestampCodec extends CodecImpl<
   typeof PG_TIMESTAMP_CODEC_ID,
   readonly ['equality', 'order'],
-  Date,
+  Date | string,
   Date
 > {
-  async encode(value: Date, _ctx: CodecCallContext): Promise<Date> {
-    return value;
+  async encode(value: Date, _ctx: CodecCallContext): Promise<string> {
+    return pgTimestampEncode(value);
   }
   async decode(wire: Date, _ctx: CodecCallContext): Promise<Date> {
-    return wire;
+    return pgTimestampDecode(wire);
   }
   encodeJson(value: Date): JsonValue {
     return pgTimestampEncodeJson(value);
@@ -1019,11 +1052,11 @@ pgTimestampColumn satisfies ColumnHelperForStrict<PgTimestampDescriptor>;
 export class PgTimestamptzCodec extends CodecImpl<
   typeof PG_TIMESTAMPTZ_CODEC_ID,
   readonly ['equality', 'order'],
-  Date,
+  Date | string,
   Date
 > {
-  async encode(value: Date, _ctx: CodecCallContext): Promise<Date> {
-    return value;
+  async encode(value: Date, _ctx: CodecCallContext): Promise<string> {
+    return pgTimestamptzEncode(value);
   }
   async decode(wire: Date, _ctx: CodecCallContext): Promise<Date> {
     return wire;

--- a/packages/3-targets/3-targets/postgres/test/codecs-class.test.ts
+++ b/packages/3-targets/3-targets/postgres/test/codecs-class.test.ts
@@ -250,10 +250,28 @@ describe('codecs-class', () => {
       expect(codec.id).toBe(PG_TIMESTAMP_CODEC_ID);
     });
 
-    it('round-trips Date values', async () => {
-      const instant = new Date('2024-01-15T10:30:00Z');
-      expect(await codec.encode(instant, callCtx)).toBe(instant);
-      expect(await codec.decode(instant, callCtx)).toBe(instant);
+    it('decode reinterprets the driver local-wall-clock Date as UTC', async () => {
+      // The pg driver parses `timestamp without time zone` text like
+      // `2026-07-01 10:00:00` into a Date at *local* 10:00. The naive wall
+      // clock means UTC, so decode must recover 10:00:00Z in every timezone.
+      const localWallClock = new Date(2026, 6, 1, 10, 0, 0, 123);
+      const decoded = await codec.decode(localWallClock, callCtx);
+      expect(decoded.getTime()).toBe(Date.UTC(2026, 6, 1, 10, 0, 0, 123));
+    });
+
+    it('encode emits naive UTC text, bypassing the driver Date serialization', async () => {
+      const instant = new Date('2026-07-01T10:00:00.123Z');
+      expect(await codec.encode(instant, callCtx)).toBe('2026-07-01T10:00:00.123');
+    });
+
+    it('round-trips an instant through encode -> decode unchanged', async () => {
+      const original = new Date('2024-01-15T10:30:00.500Z');
+      const wireText = await codec.encode(original, callCtx);
+      // The driver would parse `wireText` back into a local-wall-clock Date;
+      // decode canonicalizes it back to the same UTC instant.
+      const roundTripped = await codec.decode(new Date(2024, 0, 15, 10, 30, 0, 500), callCtx);
+      expect(wireText).toBe('2024-01-15T10:30:00.500');
+      expect(roundTripped.getTime()).toBe(original.getTime());
     });
 
     it('uses the Postgres JSON timestamp representation', () => {
@@ -283,9 +301,16 @@ describe('codecs-class', () => {
       expect(codec.id).toBe(PG_TIMESTAMPTZ_CODEC_ID);
     });
 
-    it('round-trips Date values', async () => {
+    it('encode emits UTC ISO text, bypassing the driver Date serialization', async () => {
+      // The driver serializes Dates via `getTimezoneOffset()`, which is whole
+      // minutes — historical local-mean-time offsets (e.g. Berlin +00:53:28
+      // before 1893) lose their seconds. UTC text has no such dependence.
       const instant = new Date('2024-01-15T10:30:00Z');
-      expect(await codec.encode(instant, callCtx)).toBe(instant);
+      expect(await codec.encode(instant, callCtx)).toBe('2024-01-15T10:30:00.000Z');
+    });
+
+    it('decode passes the driver-parsed Date through', async () => {
+      const instant = new Date('2024-01-15T10:30:00Z');
       expect(await codec.decode(instant, callCtx)).toBe(instant);
     });
 

--- a/packages/3-targets/3-targets/postgres/test/codecs.test.ts
+++ b/packages/3-targets/3-targets/postgres/test/codecs.test.ts
@@ -8,7 +8,6 @@ import {
   sqlFloatDescriptor,
   sqlIntDescriptor,
   sqlTextDescriptor,
-  sqlTimestampDescriptor,
   sqlVarcharDescriptor,
 } from '@internal/sql-relational-core/ast';
 import { describe, expect, it } from 'vitest';
@@ -38,6 +37,7 @@ import {
   pgUuidDescriptor,
   pgVarbitDescriptor,
   pgVarcharDescriptor,
+  postgresSqlTimestampDescriptor,
 } from '../src/core/codecs';
 import { postgresCodecDescriptorRegistry, postgresCodecRegistry } from '../src/core/registry';
 
@@ -49,7 +49,7 @@ const descriptorByScalar = {
   int: sqlIntDescriptor,
   float: sqlFloatDescriptor,
   'sql-text': sqlTextDescriptor,
-  'sql-timestamp': sqlTimestampDescriptor,
+  'sql-timestamp': postgresSqlTimestampDescriptor,
   text: pgTextDescriptor,
   character: pgCharDescriptor,
   'character varying': pgVarcharDescriptor,
@@ -124,31 +124,37 @@ describe('adapter-postgres codecs', () => {
 
   describe('timestamp codec', () => {
     const timestampCodec = codecForScalar('timestamp') as {
-      encode: (value: Date, ctx: SqlCodecCallContext) => Promise<Date>;
+      encode: (value: Date, ctx: SqlCodecCallContext) => Promise<string>;
       decode: (wire: Date, ctx: SqlCodecCallContext) => Promise<Date>;
     };
 
-    it('encodes Date values as-is', async () => {
+    it('encodes Date values as naive UTC text', async () => {
       const date = new Date('2024-01-15T10:30:00Z');
-      expect(await timestampCodec.encode(date, {})).toBe(date);
+      expect(await timestampCodec.encode(date, {})).toBe('2024-01-15T10:30:00.000');
     });
 
-    it('decodes Date values as-is', async () => {
-      const date = new Date('2024-01-15T10:30:00Z');
-      expect(await timestampCodec.decode(date, {})).toBe(date);
+    it('decodes the driver local-wall-clock Date as UTC', async () => {
+      const localWallClock = new Date(2024, 0, 15, 10, 30, 0);
+      const decoded = await timestampCodec.decode(localWallClock, {});
+      expect(decoded.getTime()).toBe(Date.UTC(2024, 0, 15, 10, 30, 0));
     });
   });
 
   describe('sql-timestamp codec', () => {
     const timestampCodec = codecForScalar('sql-timestamp') as {
-      encode: (value: Date, ctx: SqlCodecCallContext) => Promise<Date>;
+      encode: (value: Date, ctx: SqlCodecCallContext) => Promise<string>;
       decode: (wire: Date, ctx: SqlCodecCallContext) => Promise<Date>;
     };
 
-    it('round-trips Date values', async () => {
+    it('encodes Date values as naive UTC text', async () => {
       const date = new Date('2024-01-15T10:30:00Z');
-      expect(await timestampCodec.encode(date, {})).toBe(date);
-      expect(await timestampCodec.decode(date, {})).toBe(date);
+      expect(await timestampCodec.encode(date, {})).toBe('2024-01-15T10:30:00.000');
+    });
+
+    it('decodes the driver local-wall-clock Date as UTC', async () => {
+      const localWallClock = new Date(2024, 0, 15, 10, 30, 0);
+      const decoded = await timestampCodec.decode(localWallClock, {});
+      expect(decoded.getTime()).toBe(Date.UTC(2024, 0, 15, 10, 30, 0));
     });
 
     it('uses the zone-less ISO form a timestamp column holds', () => {
@@ -161,13 +167,17 @@ describe('adapter-postgres codecs', () => {
 
   describe('timestamptz codec', () => {
     const timestamptzCodec = codecForScalar('timestamptz') as {
-      encode: (value: Date, ctx: SqlCodecCallContext) => Promise<Date>;
+      encode: (value: Date, ctx: SqlCodecCallContext) => Promise<string>;
       decode: (wire: Date, ctx: SqlCodecCallContext) => Promise<Date>;
     };
 
-    it('round-trips Date values', async () => {
+    it('encodes Date values as UTC ISO text', async () => {
       const date = new Date('2024-01-15T10:30:00Z');
-      expect(await timestamptzCodec.encode(date, {})).toBe(date);
+      expect(await timestamptzCodec.encode(date, {})).toBe('2024-01-15T10:30:00.000Z');
+    });
+
+    it('decodes driver-parsed Date values as-is', async () => {
+      const date = new Date('2024-01-15T10:30:00Z');
       expect(await timestamptzCodec.decode(date, {})).toBe(date);
     });
   });


### PR DESCRIPTION
## Linked issue

n/a — bug report from pdp-control-plane: PN reads of `timestamp without time zone` columns shift by the process's UTC offset on non-UTC machines.

## At a glance

```ts
// pg/timestamp@1 — packages/3-targets/3-targets/postgres/src/core/codecs.ts
async encode(value: Date, _ctx: CodecCallContext): Promise<string> {
  return pgTimestampEncode(value);   // '2026-07-01T10:00:00.000' (naive UTC text)
}
async decode(wire: Date, _ctx: CodecCallContext): Promise<Date> {
  return pgTimestampDecode(wire);    // driver's local wall clock, reinterpreted as UTC
}
```

Before, both methods were identity passthroughs. The pg driver parses `timestamp without time zone` text as *local* time, so a row stored by Prisma ORM as `2026-07-01T10:00:00Z` came back as `08:00:00Z` on a UTC+2 machine; with `TZ=UTC` everything looked fine, which is why CI never caught it.

## Decision

Naive Postgres timestamps mean UTC, and no wire conversion may depend on the process timezone. Three codecs violated that:

1. **`pg/timestamp@1`** — decode now reinterprets the driver's local-wall-clock `Date` via `Date.UTC` (the pattern `pg/date@1` already uses); encode sends naive UTC ISO text instead of a `Date`, because the driver would otherwise serialize local time with an offset that Postgres drops (storing local wall clock).
2. **`sql/timestamp@1` on Postgres** — same defect, fixed with a Postgres-specific codec. Enabling change: `PostgresCodecOptions` gains an optional `factory` override so `postgresCodec(...)` wrappers can substitute target-specific wire behavior.
3. **`pg/timestamptz@1`** — encode now sends UTC ISO text. The driver serializes `Date`s using `getTimezoneOffset()`, which is whole minutes, so historical local-mean-time offsets (Berlin +00:53:28 before 1893) lost their seconds and shifted the stored instant by 28s.

## How it fits together

1. `codec-helpers.ts` adds `pgTimestampEncode`/`pgTimestampDecode`/`pgTimestamptzEncode` as the single source of truth for the conversions, with doc comments explaining the driver behavior each one bypasses. `pgTimestampEncodeJson` now delegates to `pgTimestampEncode` (same text form).
2. `codecs.ts` wires them into `PgTimestampCodec` and `PgTimestamptzCodec` (wire type widens to `Date | string`, mirroring `PgDateCodec`), and adds `PostgresSqlTimestampCodec` for the `sql/timestamp@1` descriptor.
3. `codec-descriptor.ts` adds the optional `factory` override to `PostgresCodecOptions`; `postgresSqlTimestampDescriptor` is its only user.

## Behavior changes & evidence

- Reads of `timestamp` columns return the stored UTC instant regardless of process timezone — [codec-helpers.ts](packages/3-targets/3-targets/postgres/src/core/codec-helpers.ts), [codecs.ts](packages/3-targets/3-targets/postgres/src/core/codecs.ts). Evidence: [codecs-class.test.ts](packages/3-targets/3-targets/postgres/test/codecs-class.test.ts) (`decode reinterprets the driver local-wall-clock Date as UTC`), and the `ports/prisma/functional/issues-28192-pg-historical-dates` suite now passes under `TZ=Europe/Berlin` (its `timestamp` expectations failed before this change).
- Writes of `timestamp`/`timestamptz` params reach the driver as ISO text, never as `Date` — [codecs.test.ts](packages/3-targets/3-targets/postgres/test/codecs.test.ts). The timestamptz change also fixes the 28-second historical-offset loss the same port suite reproduced in non-UTC zones.

## Reviewer notes

- The DDL literal-default path (`pgRenderDdlColumnDefault` → `codec.encode(def.value)`) assumes the literal is a `Date`. That assumption predates this PR — `pg/date@1`'s shipped `encode` makes it too — and all migration/DDL suites pass; flagging in case a reviewer spots the `ColumnDefaultLiteralInputValue` union includes JSON strings.
- `PgTimestamptzCodec.decode` stays a passthrough: the driver parses offset-carrying text correctly, including seconds-precision offsets.
- pdp-control-plane still needs a `TZ=UTC` pin in its vitest integration configs as a stopgap until it consumes a release with this fix.

## Testing performed

- `pnpm test` in `packages/3-targets/3-targets/postgres` under `TZ=Europe/Berlin` and `TZ=America/New_York` (1,333 tests).
- `pnpm test:packages` (14,515 tests; only pre-existing environment failures in `@internal/cli-telemetry`, which need a `prisma-next` binary missing from this checkout).
- `pnpm test:integration` under `TZ=Europe/Berlin`, including the previously failing `issues-28192-pg-historical-dates` port suite; two unrelated hook-timeout flakes passed on rerun.
- `pnpm typecheck` and `pnpm lint` in the touched package.

## Skill update

n/a — internal wire-codec behavior; no user-facing surface change.

## Alternatives considered

- **Custom type parsers on the pg `Pool`** (`types.setTypeParser(1114, ...)`): would fix reads in one place, but PN accepts caller-supplied `pgPool`/`pgClient` bindings that would silently keep the bug, and it does nothing for the write path. Fixing the codecs covers every binding.
- **Fixing the family `SqlTimestampCodec` itself**: its identity wire behavior is target-agnostic by design; the local-time parse is a pg-driver artifact, so the correction belongs in the Postgres target (via the new `factory` override), not in `relational-core`.
- **Pinning `TZ=UTC` in consumers only**: hides the defect instead of fixing it; any non-UTC deployment of the runtime would still read shifted instants.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the DCO.
- [x] I read CONTRIBUTING.md and the change is scoped to one logical concern.
- [x] Tests are updated.
- [ ] The PR title is in `TML-NNNN: <sentence-case title>` form — no ticket for this change; titled in the repo's conventional-commit form instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL timestamp handling for consistent timezone-independent encoding and decoding.
  * Timestamp values now serialize to PostgreSQL-compatible UTC text, including correct handling for timezone-aware and timezone-less timestamps.
  * SQL timestamp JSON conversion now uses the same consistent formatting.
* **Enhancements**
  * Added support for customizing adapted PostgreSQL codecs through an optional factory configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->