### PR TITLE
fix(sql-builder): db.sql orderBy({ nulls }) now emits NULLS FIRST/LAST

### DIFF
--- a/packages/2-sql/4-lanes/relational-core/src/ast/types.ts
+++ b/packages/2-sql/4-lanes/relational-core/src/ast/types.ts
@@ -8,6 +8,7 @@ import { type CodecRef, frozenCodecRef } from './codec-types';
 import type { AnyJsonValueProjection } from './json-value-projection';
 
 export type Direction = 'asc' | 'desc';
+export type OrderByNulls = 'first' | 'last';
 
 export type BinaryOp = 'eq' | 'neq' | 'gt' | 'lt' | 'gte' | 'lte' | 'like' | 'in' | 'notIn';
 
@@ -1065,24 +1066,26 @@ export class OrderByItem extends AstNode {
   readonly kind = 'order-by-item' as const;
   readonly expr: AnyExpression;
   readonly dir: Direction;
+  readonly nulls: OrderByNulls | undefined;
 
-  constructor(expr: AnyExpression, dir: Direction) {
+  constructor(expr: AnyExpression, dir: Direction, nulls?: OrderByNulls) {
     super();
     this.expr = expr;
     this.dir = dir;
+    this.nulls = nulls;
     this.freeze();
   }
 
-  static asc(expr: AnyExpression): OrderByItem {
-    return new OrderByItem(expr, 'asc');
+  static asc(expr: AnyExpression, nulls?: OrderByNulls): OrderByItem {
+    return new OrderByItem(expr, 'asc', nulls);
   }
 
-  static desc(expr: AnyExpression): OrderByItem {
-    return new OrderByItem(expr, 'desc');
+  static desc(expr: AnyExpression, nulls?: OrderByNulls): OrderByItem {
+    return new OrderByItem(expr, 'desc', nulls);
   }
 
   rewrite(rewriter: ExpressionRewriter): OrderByItem {
-    return new OrderByItem(this.expr.rewrite(rewriter), this.dir);
+    return new OrderByItem(this.expr.rewrite(rewriter), this.dir, this.nulls);
   }
 
   /**
@@ -1091,7 +1094,7 @@ export class OrderByItem extends AstNode {
    * this to reverse a user's sort order without reaching into the AST.
    */
   reverse(): OrderByItem {
-    return new OrderByItem(this.expr, this.dir === 'asc' ? 'desc' : 'asc');
+    return new OrderByItem(this.expr, this.dir === 'asc' ? 'desc' : 'asc', this.nulls);
   }
 }
 

--- a/packages/2-sql/4-lanes/sql-builder/src/runtime/builder-base.ts
+++ b/packages/2-sql/4-lanes/sql-builder/src/runtime/builder-base.ts
@@ -365,6 +365,7 @@ export function resolveOrderBy(
   useAggregateFns: boolean,
 ): OrderByItem {
   const dir = options?.direction ?? 'asc';
+  const nulls = options?.nulls;
 
   if (typeof arg === 'string') {
     const combined = orderByScopeOf(scope, rowFields);
@@ -377,7 +378,7 @@ export function resolveOrderBy(
         },
       );
     const expr = IdentifierRef.of(arg);
-    return dir === 'asc' ? OrderByItem.asc(expr) : OrderByItem.desc(expr);
+    return dir === 'asc' ? OrderByItem.asc(expr, nulls) : OrderByItem.desc(expr, nulls);
   }
 
   if (typeof arg === 'function') {
@@ -386,7 +387,9 @@ export function resolveOrderBy(
       ? createAggregateFunctions(ctx.queryOperationTypes, ctx.rawCodecInferer, ctx.aggregates)
       : createFunctions(ctx.queryOperationTypes, ctx.rawCodecInferer);
     const result = (arg as ExprCallback)(createFieldProxy(combined), fns);
-    return dir === 'asc' ? OrderByItem.asc(result.buildAst()) : OrderByItem.desc(result.buildAst());
+    return dir === 'asc'
+      ? OrderByItem.asc(result.buildAst(), nulls)
+      : OrderByItem.desc(result.buildAst(), nulls);
   }
 
   throw structuredError('ORM.ARGUMENT_INVALID', 'Invalid orderBy argument');

--- a/packages/2-sql/4-lanes/sql-builder/test/runtime/builders.test.ts
+++ b/packages/2-sql/4-lanes/sql-builder/test/runtime/builders.test.ts
@@ -267,6 +267,31 @@ describe('orderBy', () => {
     expect(ast.orderBy![0]!.dir).toBe('asc');
   });
 
+  it('orderBy string with nulls placement', () => {
+    const ast = getAst(
+      db().public.users.select('id', 'name').orderBy('name', { direction: 'desc', nulls: 'last' }),
+    );
+    expect(ast.orderBy).toHaveLength(1);
+    expect(ast.orderBy![0]!.dir).toBe('desc');
+    expect(ast.orderBy![0]!.nulls).toBe('last');
+  });
+
+  it('orderBy direction-only leaves nulls undefined', () => {
+    const ast = getAst(db().public.users.select('id').orderBy('id', { direction: 'asc' }));
+    expect(ast.orderBy![0]!.nulls).toBeUndefined();
+  });
+
+  it('orderBy with expression callback and nulls placement', () => {
+    const ast = getAst(
+      db()
+        .public.users.select('id')
+        .orderBy((f) => f.id, { nulls: 'first' }),
+    );
+    expect(ast.orderBy).toHaveLength(1);
+    expect(ast.orderBy![0]!.expr).toBeInstanceOf(IdentifierRef);
+    expect(ast.orderBy![0]!.nulls).toBe('first');
+  });
+
   it('orderBy with expression callback', () => {
     const ast = getAst(
       db()
@@ -312,6 +337,18 @@ describe('groupBy and having', () => {
         .groupBy((f) => f.user_id),
     );
     expect(ast.groupBy).toHaveLength(1);
+  });
+
+  it('grouped orderBy string with nulls placement', () => {
+    const ast = getAst(
+      db()
+        .public.users.select('id')
+        .groupBy('id')
+        .orderBy('id', { direction: 'desc', nulls: 'last' }),
+    );
+    expect(ast.orderBy).toHaveLength(1);
+    expect(ast.orderBy![0]!.dir).toBe('desc');
+    expect(ast.orderBy![0]!.nulls).toBe('last');
   });
 });
 

--- a/packages/3-targets/6-adapters/postgres/src/core/sql-renderer.ts
+++ b/packages/3-targets/6-adapters/postgres/src/core/sql-renderer.ts
@@ -222,7 +222,7 @@ function renderSelect(ast: SelectAst, contract: PostgresContract, pim: ParamInde
     ? `ORDER BY ${ast.orderBy
         .map((order) => {
           const expr = renderOrderByExpr(order.expr, sourcesByRef, contract, pim);
-          return `${expr} ${order.dir.toUpperCase()}`;
+          return renderOrderByItem(order, expr);
         })
         .join(', ')}`
     : '';
@@ -750,13 +750,18 @@ function renderJsonObjectExpr(
   return `json_build_object(${args})`;
 }
 
+function renderOrderByItem(item: OrderByItem, expr: string): string {
+  const nulls = item.nulls ? ` NULLS ${item.nulls.toUpperCase()}` : '';
+  return `${expr} ${item.dir.toUpperCase()}${nulls}`;
+}
+
 function renderOrderByItems(
   items: ReadonlyArray<OrderByItem>,
   contract: PostgresContract,
   pim: ParamIndexMap,
 ): string {
   return items
-    .map((item) => `${renderExpr(item.expr, contract, pim)} ${item.dir.toUpperCase()}`)
+    .map((item) => renderOrderByItem(item, renderExpr(item.expr, contract, pim)))
     .join(', ');
 }
 

--- a/packages/3-targets/6-adapters/postgres/test/adapter.test.ts
+++ b/packages/3-targets/6-adapters/postgres/test/adapter.test.ts
@@ -393,6 +393,35 @@ describe('Postgres adapter', () => {
     );
   });
 
+  it('renders ORDER BY without nulls placement unchanged', () => {
+    const ast = SelectAst.from(TableSource.named('user'))
+      .withProjection([ProjectionItem.of('id', ColumnRef.of('user', 'id'))])
+      .withOrderBy([new OrderByItem(ColumnRef.of('user', 'id'), 'desc')]);
+
+    const sql = adapter.lower(ast, { contract, params: [] }).sql;
+    expect(sql).toBe('SELECT "user"."id" AS "id" FROM "user" ORDER BY "user"."id" DESC');
+  });
+
+  it('renders ORDER BY with NULLS LAST placement', () => {
+    const ast = SelectAst.from(TableSource.named('user'))
+      .withProjection([ProjectionItem.of('id', ColumnRef.of('user', 'id'))])
+      .withOrderBy([new OrderByItem(ColumnRef.of('user', 'id'), 'asc', 'last')]);
+
+    const sql = adapter.lower(ast, { contract, params: [] }).sql;
+    expect(sql).toBe('SELECT "user"."id" AS "id" FROM "user" ORDER BY "user"."id" ASC NULLS LAST');
+  });
+
+  it('renders ORDER BY with DESC NULLS FIRST placement', () => {
+    const ast = SelectAst.from(TableSource.named('user'))
+      .withProjection([ProjectionItem.of('id', ColumnRef.of('user', 'id'))])
+      .withOrderBy([new OrderByItem(ColumnRef.of('user', 'id'), 'desc', 'first')]);
+
+    const sql = adapter.lower(ast, { contract, params: [] }).sql;
+    expect(sql).toBe(
+      'SELECT "user"."id" AS "id" FROM "user" ORDER BY "user"."id" DESC NULLS FIRST',
+    );
+  });
+
   it('renders DISTINCT, GROUP BY, HAVING, and OR clauses', () => {
     const ast = SelectAst.from(TableSource.named('user'))
       .withProjection([

--- a/packages/3-targets/6-adapters/sqlite/src/core/adapter.ts
+++ b/packages/3-targets/6-adapters/sqlite/src/core/adapter.ts
@@ -244,7 +244,7 @@ function renderSelect(ast: SelectAst, ctx: SqliteRenderContext): string {
   const havingClause = ast.having ? `HAVING ${renderExpr(ast.having, ctx)}` : '';
   const orderClause = ast.orderBy?.length
     ? `ORDER BY ${ast.orderBy
-        .map((order) => `${renderExpr(order.expr, ctx)} ${order.dir.toUpperCase()}`)
+        .map((order) => renderOrderByItem(order, renderExpr(order.expr, ctx)))
         .join(', ')}`
     : '';
   const limitClause = renderLimitOffset('LIMIT', ast.limit, ctx);
@@ -671,8 +671,13 @@ function renderJsonObjectExpr(expr: JsonObjectExpr, ctx: SqliteRenderContext): s
   return `json_object(${args})`;
 }
 
+function renderOrderByItem(item: OrderByItem, expr: string): string {
+  const nulls = item.nulls ? ` NULLS ${item.nulls.toUpperCase()}` : '';
+  return `${expr} ${item.dir.toUpperCase()}${nulls}`;
+}
+
 function renderOrderByItems(items: ReadonlyArray<OrderByItem>, ctx: SqliteRenderContext): string {
-  return items.map((item) => `${renderExpr(item.expr, ctx)} ${item.dir.toUpperCase()}`).join(', ');
+  return items.map((item) => renderOrderByItem(item, renderExpr(item.expr, ctx))).join(', ');
 }
 
 function renderJsonArrayAggExpr(expr: JsonArrayAggExpr, ctx: SqliteRenderContext): string {

--- a/packages/3-targets/6-adapters/sqlite/test/adapter.test.ts
+++ b/packages/3-targets/6-adapters/sqlite/test/adapter.test.ts
@@ -125,6 +125,28 @@ describe('SQLite adapter', () => {
       );
     });
 
+    it('renders ORDER BY with NULLS LAST placement', () => {
+      const ast = SelectAst.from(TableSource.named('user'))
+        .withProjection([ProjectionItem.of('id', ColumnRef.of('user', 'id'))])
+        .withOrderBy([new OrderByItem(ColumnRef.of('user', 'id'), 'asc', 'last')]);
+
+      const { sql } = adapter.lower(ast, { contract });
+      expect(sql).toBe(
+        'SELECT "user"."id" AS "id" FROM "user" ORDER BY "user"."id" ASC NULLS LAST',
+      );
+    });
+
+    it('renders ORDER BY with DESC NULLS FIRST placement', () => {
+      const ast = SelectAst.from(TableSource.named('user'))
+        .withProjection([ProjectionItem.of('id', ColumnRef.of('user', 'id'))])
+        .withOrderBy([new OrderByItem(ColumnRef.of('user', 'id'), 'desc', 'first')]);
+
+      const { sql } = adapter.lower(ast, { contract });
+      expect(sql).toBe(
+        'SELECT "user"."id" AS "id" FROM "user" ORDER BY "user"."id" DESC NULLS FIRST',
+      );
+    });
+
     it('renders DISTINCT', () => {
       const ast = SelectAst.from(TableSource.named('user'))
         .withProjection([ProjectionItem.of('email', ColumnRef.of('user', 'email'))])

--- a/test/integration/test/sql-builder/order-by.test.ts
+++ b/test/integration/test/sql-builder/order-by.test.ts
@@ -58,11 +58,15 @@ describe('integration: ORDER BY', { timeout: timeouts.databaseOperation }, () =>
       db()
         .public.users.select('id', 'invited_by_id')
         .orderBy('invited_by_id', { nulls: 'first' })
+        .orderBy('id')
         .build(),
     );
-    expect(rows).toHaveLength(4);
-    expect(rows[0]!.invited_by_id).toBeNull();
-    expect(rows.slice(1).every((r) => r.invited_by_id !== null)).toBe(true);
+    expect(rows).toEqual([
+      { id: 1, invited_by_id: null },
+      { id: 2, invited_by_id: 1 },
+      { id: 3, invited_by_id: 1 },
+      { id: 4, invited_by_id: 2 },
+    ]);
   });
 
   it('NULLS LAST places nulls after non-null values', async () => {
@@ -70,10 +74,14 @@ describe('integration: ORDER BY', { timeout: timeouts.databaseOperation }, () =>
       db()
         .public.users.select('id', 'invited_by_id')
         .orderBy('invited_by_id', { nulls: 'last' })
+        .orderBy('id')
         .build(),
     );
-    expect(rows).toHaveLength(4);
-    expect(rows[rows.length - 1]!.invited_by_id).toBeNull();
-    expect(rows.slice(0, -1).every((r) => r.invited_by_id !== null)).toBe(true);
+    expect(rows).toEqual([
+      { id: 2, invited_by_id: 1 },
+      { id: 3, invited_by_id: 1 },
+      { id: 4, invited_by_id: 2 },
+      { id: 1, invited_by_id: null },
+    ]);
   });
 });

--- a/test/integration/test/sql-builder/order-by.test.ts
+++ b/test/integration/test/sql-builder/order-by.test.ts
@@ -52,4 +52,28 @@ describe('integration: ORDER BY', { timeout: timeouts.databaseOperation }, () =>
     const alicePosts = rows.filter((r) => r.user_id === 1);
     expect(alicePosts[0]!.views).toBeGreaterThan(alicePosts[1]!.views);
   });
+
+  it('NULLS FIRST places nulls before non-null values', async () => {
+    const rows = await runtime().execute(
+      db()
+        .public.users.select('id', 'invited_by_id')
+        .orderBy('invited_by_id', { nulls: 'first' })
+        .build(),
+    );
+    expect(rows).toHaveLength(4);
+    expect(rows[0]!.invited_by_id).toBeNull();
+    expect(rows.slice(1).every((r) => r.invited_by_id !== null)).toBe(true);
+  });
+
+  it('NULLS LAST places nulls after non-null values', async () => {
+    const rows = await runtime().execute(
+      db()
+        .public.users.select('id', 'invited_by_id')
+        .orderBy('invited_by_id', { nulls: 'last' })
+        .build(),
+    );
+    expect(rows).toHaveLength(4);
+    expect(rows[rows.length - 1]!.invited_by_id).toBeNull();
+    expect(rows.slice(0, -1).every((r) => r.invited_by_id !== null)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Linked issue

Fixes #29932

## Summary

`SelectQuery.orderBy(column, { nulls })` (and the expression-callback overload) accepted `nulls: 'first' | 'last'` but silently dropped it: the built `order-by-item` AST carried no null-placement, so no `NULLS FIRST` / `NULLS LAST` clause was ever emitted and results fell back to the database's default NULL ordering.

This adds a `nulls` slot to `OrderByItem`, threads it through `resolveOrderBy`, and renders it in both the SQLite and PostgreSQL SQL renderers (inline `ORDER BY` and window / JSON-aggregate `ORDER BY`). `orderBy('col', { direction: 'desc', nulls: 'last' })` now emits `ORDER BY "col" DESC NULLS LAST`.

## Testing performed

- `pnpm typecheck`: passes for all touched packages (relational-core, sql-builder, sqlite + postgres adapters).
- `pnpm lint`: no diagnostics on the touched packages (only the repo-wide CRLF/LF formatter noise on this Windows checkout, pre-existing).
- sql-builder runtime unit tests: 55/55 pass.
- sqlite adapter suite: 50/50 pass; postgres adapter suite: 40/40 pass (renderer assertions pin the exact `NULLS FIRST`/`NULLS LAST` SQL).
- Real-dialect execution: verified PostgreSQL (PGlite) and SQLite (node:sqlite) accept the rendered `ORDER BY ... NULLS LAST` / `NULLS FIRST` SQL and order rows correctly.
- `test/integration` sql-builder suite: 26 files / 170 tests pass, including new NULLS placement cases in `order-by.test.ts` against a real PostgreSQL (PGlite) database.

Not every suite was runnable on this Windows box, for pre-existing environment reasons unrelated to this change: `pnpm fixtures:check` cannot run here (`fixtures:emit` uses POSIX-only `DATABASE_URL=…` env-prefix syntax), and `pnpm test:e2e` requires `@prisma/orm-sqlite`/`@prisma/orm-postgres` dists whose workspace build does not complete locally. Default-parallel `test/integration` runs also show pre-existing PGlite contention (suite-level spin-up failures that pass in isolation). I did not run those suites, so I am not claiming they pass.

## Skill update

n/a — bug fix for existing db.sql behavior; no skill changes required.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco). The DCO status check will block merge if any commit is missing a `Signed-off-by:` trailer.
- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and the change is scoped to one logical concern.
- [x] Tests are updated (unit + integration).
- [ ] The PR title is in `TML-NNNN: <sentence-case title>` form — no Linear ticket exists for this external GitHub issue; title follows the conventional `fix(scope):` style.
- [x] The **Skill update** section above is filled in (or stated `n/a — internal only`).

## Notes for the reviewer

The fix targets the `db.sql` lane only. The ORM lane's `OrderByItem` AST now also carries `nulls` (typed as `OrderByNulls | undefined`) so the AST is future-proof, but no ORM builder surface exposes it yet — see the linked issue's "two ways to close it" note; exposing it on the ORM lane (e.g. `p.nullable.desc({ nulls: 'last' })`) can be a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for placing null values first or last in `ORDER BY` clauses.
  - Works with ascending and descending sorts, columns, expressions, grouped queries, and aggregate ordering.
  - PostgreSQL and SQLite output preserves `NULLS FIRST` and `NULLS LAST` directives.

- **Tests**
  - Added coverage across query builders, database adapters, and integration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->