### PR TITLE
fix(cli): honor the schema option in ControlClient.introspect

### DIFF
--- a/packages/1-framework/1-core/framework-components/src/control/control-instances.ts
+++ b/packages/1-framework/1-core/framework-components/src/control/control-instances.ts
@@ -100,9 +100,16 @@ export interface ControlFamilyInstance<TFamilyId extends string, TSchemaIR>
     readonly space?: string;
   }): Promise<readonly LedgerEntryRecord[]>;
 
+  /**
+   * Reads the live database schema. `schema` selects the single schema to
+   * read and only applies when no `contract` is given — a contract carries
+   * its own declared namespaces, which the target walks instead. Targets
+   * without a schema namespace (SQLite, Mongo) ignore it.
+   */
   introspect(options: {
     readonly driver: ControlDriverInstance<TFamilyId, string>;
     readonly contract?: unknown;
+    readonly schema?: string;
   }): Promise<TSchemaIR>;
 }
 

--- a/packages/1-framework/3-tooling/cli/src/control-api/client.ts
+++ b/packages/1-framework/3-tooling/cli/src/control-api/client.ts
@@ -537,10 +537,6 @@ class ControlClientImpl implements ControlClient {
     await this.connectWithProgress(options?.connection, 'introspect', onProgress);
     const { driver, familyInstance } = await this.ensureConnected();
 
-    // TODO: Pass schema option to familyInstance.introspect when schema filtering is implemented
-    const _schema = options?.schema;
-    void _schema;
-
     // Emit introspect span
     onProgress?.({
       action: 'introspect',
@@ -550,7 +546,10 @@ class ControlClientImpl implements ControlClient {
     });
 
     try {
-      const result = await familyInstance.introspect({ driver });
+      const result = await familyInstance.introspect({
+        driver,
+        ...ifDefined('schema', options?.schema),
+      });
 
       onProgress?.({
         action: 'introspect',

--- a/packages/1-framework/3-tooling/cli/src/control-api/types.ts
+++ b/packages/1-framework/3-tooling/cli/src/control-api/types.ts
@@ -271,7 +271,8 @@ export interface DbVerifyOptions {
  */
 export interface IntrospectOptions {
   /**
-   * Optional schema name to introspect.
+   * Schema to introspect. Postgres reads this schema instead of its `public`
+   * default; targets without a schema namespace (SQLite, Mongo) ignore it.
    */
   readonly schema?: string;
   /**

--- a/packages/1-framework/3-tooling/cli/test/control-api/client.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/control-api/client.test.ts
@@ -64,8 +64,12 @@ function createMockComponents() {
     close: async () => {},
   } as unknown as ControlDriverInstance<string, string>;
 
+  const mockIntrospect = vi.fn(
+    async (_options: { driver: unknown; contract?: unknown; schema?: string }) => ({ tables: [] }),
+  );
+
   const mockFamilyInstance = {
-    introspect: async () => ({ tables: [] }),
+    introspect: mockIntrospect,
     deserializeContract: (ir: unknown) => ir as Contract,
     readMarker: async () => null,
     readLedger: async () => [],
@@ -146,6 +150,7 @@ function createMockComponents() {
   return {
     mockDriver,
     mockFamilyInstance,
+    mockIntrospect,
     mockFamily,
     mockTarget,
     mockAdapter,
@@ -420,6 +425,52 @@ describe('ControlClient progress emission', () => {
         (e) => e.kind === 'spanStart' && e.spanId === 'introspect',
       );
       expect(introspectStart).toBeDefined();
+    });
+
+    it('forwards the schema option to the family instance', async () => {
+      const {
+        mockFamily,
+        mockTarget,
+        mockAdapter,
+        mockDriverDescriptor,
+        mockIntrospect,
+        mockDriver,
+      } = createMockComponents();
+
+      const client = createControlClient({
+        family: mockFamily,
+        target: mockTarget,
+        adapter: mockAdapter,
+        driver: mockDriverDescriptor,
+      });
+
+      await client.introspect({ connection: 'postgres://test', schema: 'sales' });
+      await client.close();
+
+      expect(mockIntrospect).toHaveBeenCalledWith({ driver: mockDriver, schema: 'sales' });
+    });
+
+    it('omits schema when the caller did not request one', async () => {
+      const {
+        mockFamily,
+        mockTarget,
+        mockAdapter,
+        mockDriverDescriptor,
+        mockIntrospect,
+        mockDriver,
+      } = createMockComponents();
+
+      const client = createControlClient({
+        family: mockFamily,
+        target: mockTarget,
+        adapter: mockAdapter,
+        driver: mockDriverDescriptor,
+      });
+
+      await client.introspect({ connection: 'postgres://test' });
+      await client.close();
+
+      expect(mockIntrospect).toHaveBeenCalledWith({ driver: mockDriver });
     });
   });
 

--- a/packages/2-sql/9-family/src/core/control-instance.ts
+++ b/packages/2-sql/9-family/src/core/control-instance.ts
@@ -274,9 +274,14 @@ export interface SqlControlFamilyInstance
     readonly configPath?: string;
   }): Promise<SignDatabaseResult>;
 
+  /**
+   * Reads the live database schema. `schema` names the single schema to read
+   * and only applies when no `contract` is given; see `SqlControlAdapter.introspect`.
+   */
   introspect(options: {
     readonly driver: SqlControlDriverInstance<string>;
     readonly contract?: unknown;
+    readonly schema?: string;
   }): Promise<SqlSchemaIRNode>;
 
   inferPslContract(schemaIR: SqlSchemaIRNode): PslDocumentAst;
@@ -994,8 +999,9 @@ export function createSqlFamilyInstance<TTargetId extends string>(
     async introspect(options: {
       readonly driver: SqlControlDriverInstance<string>;
       readonly contract?: unknown;
+      readonly schema?: string;
     }): Promise<SqlSchemaIRNode> {
-      return getControlAdapter().introspect(options.driver, options.contract);
+      return getControlAdapter().introspect(options.driver, options.contract, options.schema);
     },
 
     inferPslContract(schemaIR: SqlSchemaIRNode): PslDocumentAst {

--- a/packages/2-sql/9-family/test/control-instance.introspect.test.ts
+++ b/packages/2-sql/9-family/test/control-instance.introspect.test.ts
@@ -1,0 +1,102 @@
+import type {
+  ControlFamilyDescriptor,
+  ControlTargetDescriptor,
+} from '@internal/framework-components/control';
+import { createControlStack } from '@internal/framework-components/control';
+import type { SqlControlDriverInstance } from '@internal/sql-contract/types';
+import { SqlSchemaIR } from '@internal/sql-schema-ir/types';
+import { describe, expect, it } from 'vitest';
+import type { SqlControlAdapter } from '../src/core/control-adapter';
+import { createSqlFamilyInstance } from '../src/core/control-instance';
+
+type IntrospectCall = {
+  readonly contract: unknown;
+  readonly schema: string | undefined;
+};
+
+function makeStack(calls: IntrospectCall[]) {
+  const adapterStub = {
+    familyId: 'sql',
+    targetId: 'postgres',
+    introspect: async (
+      _driver: SqlControlDriverInstance<'postgres'>,
+      contract?: unknown,
+      schema?: string,
+    ) => {
+      calls.push({ contract, schema });
+      return new SqlSchemaIR({ tables: {} });
+    },
+  } as unknown as SqlControlAdapter<string>;
+
+  return createControlStack({
+    family: {
+      kind: 'family',
+      id: 'sql',
+      familyId: 'sql',
+      version: '0.0.1',
+      create: (() => ({})) as unknown as ControlFamilyDescriptor<'sql'>['create'],
+      emission: {
+        id: 'sql',
+        generateStorageType: () => '{ readonly storageHash: StorageHash }',
+        generateModelStorageType: () => 'Record<string, never>',
+        getFamilyImports: () => [],
+        getFamilyTypeAliases: () => '',
+        getTypeMapsExpression: () => 'unknown',
+        getContractWrapper: (base: string) => `export type Contract = ${base};`,
+      },
+    },
+    target: {
+      kind: 'target',
+      id: 'postgres',
+      version: '0.0.1',
+      familyId: 'sql',
+      targetId: 'postgres',
+      contractSerializer: {
+        deserializeContract: (json) => json as never,
+        serializeContract: (contract) => contract as never,
+      },
+      create: () => ({ familyId: 'sql', targetId: 'postgres' }),
+    } as ControlTargetDescriptor<'sql', 'postgres'>,
+    adapter: {
+      kind: 'adapter',
+      id: 'postgres',
+      version: '0.0.1',
+      familyId: 'sql',
+      targetId: 'postgres',
+      create: (() => adapterStub) as unknown as (stack: unknown) => never,
+    },
+    extensions: [],
+  });
+}
+
+describe('SqlFamilyInstance.introspect', () => {
+  const driver = {} as SqlControlDriverInstance<string>;
+
+  it('forwards the requested schema to the control adapter', async () => {
+    const calls: IntrospectCall[] = [];
+    const instance = createSqlFamilyInstance(makeStack(calls));
+
+    await instance.introspect({ driver, schema: 'sales' });
+
+    expect(calls).toEqual([{ contract: undefined, schema: 'sales' }]);
+  });
+
+  it('leaves the schema undefined so the adapter applies its own default', async () => {
+    const calls: IntrospectCall[] = [];
+    const instance = createSqlFamilyInstance(makeStack(calls));
+
+    await instance.introspect({ driver });
+
+    expect(calls).toEqual([{ contract: undefined, schema: undefined }]);
+  });
+
+  it('passes the contract alongside the schema for contract-guided walks', async () => {
+    const calls: IntrospectCall[] = [];
+    const instance = createSqlFamilyInstance(makeStack(calls));
+    const contract = { marker: 'contract' };
+
+    await instance.introspect({ driver, contract, schema: 'sales' });
+
+    expect(calls).toEqual([{ contract, schema: 'sales' }]);
+  });
+});


### PR DESCRIPTION
## Linked issue

Fixes #29923

## Summary

`ControlClient.introspect()` took a `schema` option and dropped it on the floor. The TODO in `client.ts` parked it behind "when schema filtering is implemented", but the Postgres control adapter has taken a `schema` argument all along, so the only thing missing was passing it down. Now it travels client → family instance → adapter, and asking for `sales` actually reads `sales` instead of quietly giving you `public`.

## Testing performed

- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @internal/family-sql test`
- `pnpm --filter @internal/cli test test/control-api/client.test.ts`

Tests came first: two of the three new family-level cases fail without the fix.

## Skill update

n/a — no new CLI flag or config field. `schema` was already part of the published `IntrospectOptions` type, it just did nothing.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the DCO.
- [x] I read CONTRIBUTING.md and the change is scoped to one logical concern.
- [x] Tests are updated.
- [x] The PR title is a conventional commit (per CONTRIBUTING.md for external contributors).
- [x] The **Skill update** section above is filled in.

## Notes for the reviewer

I left the Postgres adapter alone. `introspect(driver, contract, schema = 'public')` already did the right thing and its third argument is covered by `control-adapter.test.ts:1310`. SQLite and Mongo just ignore it.

One thing worth a second opinion: when a contract is passed, the adapter walks the namespaces the contract declares and `schema` has no effect. I documented that on the interface instead of rejecting the combination, since the CLI client never passes a contract on this path. Happy to make it stricter if you'd rather.

No `--schema` flag for `contract infer` / `db schema` here on purpose. The issue is about the client API, and a user-facing flag feels like its own conversation — easy follow-up if you want one.

Small detail: I used `ifDefined` so the key stays absent rather than passing `schema: undefined`, which keeps the adapter's own default in charge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional schema selection during control introspection.
  - PostgreSQL introspection can now target a specified schema instead of defaulting to `public`.
  - Schema-less targets continue to ignore the schema option.
  - Contract-based introspection continues to use contract-defined namespaces.

- **Bug Fixes**
  - Ensured requested schema settings are correctly forwarded during introspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->