### PR TITLE
fix(build): handle Windows paths in the public shell build

### DIFF
--- a/packages/0-config/tsdown/package.json
+++ b/packages/0-config/tsdown/package.json
@@ -11,8 +11,7 @@
     "@repo/tsconfig": "workspace:8.0.0-rc.1",
     "es-module-lexer": "^2.3.1",
     "tsdown": "catalog:",
-    "typescript": "catalog:",
-    "vitest": "catalog:"
+    "typescript": "catalog:"
   },
   "scripts": {
     "lint": "biome check . --error-on-warnings",

--- a/packages/0-config/tsdown/package.json
+++ b/packages/0-config/tsdown/package.json
@@ -11,12 +11,14 @@
     "@repo/tsconfig": "workspace:8.0.0-rc.1",
     "es-module-lexer": "^2.3.1",
     "tsdown": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "scripts": {
     "lint": "biome check . --error-on-warnings",
     "lint:fix": "biome check --write .",
     "lint:fix:unsafe": "biome check --write --unsafe .",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "exports": {

--- a/packages/0-config/tsdown/shell-build.ts
+++ b/packages/0-config/tsdown/shell-build.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, join, resolve, win32 } from 'node:path';
 import { platformEntrypointOf } from '@internal/publish-surface/import-roots';
 import {
   excludedSubpaths,
@@ -191,7 +191,9 @@ export async function defineShellConfig(shellName: ShellName): Promise<UserConfi
     const binPath = resolve(repoRoot, binFile);
     binFiles.add(binPath);
     const entryFile = addEntry(`bin/${binName}`, `bin/${binName}.mjs`);
-    writeFileSync(entryFile, `import '${binPath}';\n`);
+    // `JSON.stringify`, not quotes: a Windows path carries backslashes, and
+    // `import 'C:\repo\1-framework\...'` reads `\1` as an octal escape.
+    writeFileSync(entryFile, `import ${JSON.stringify(binPath)};\n`);
   }
   for (const [binName, specifier] of Object.entries(shell.forwardedBins ?? {})) {
     const entryFile = addEntry(`bin/${binName}`, `bin/${binName}.mjs`);
@@ -203,9 +205,9 @@ export async function defineShellConfig(shellName: ShellName): Promise<UserConfi
 
   return defineConfig({
     entry,
-    copy: (shell.copy ?? []).map((pattern) => ({ from: resolve(repoRoot, pattern) })),
+    copy: (shell.copy ?? []).map((pattern) => ({ from: copyGlobFrom(repoRoot, pattern) })),
     skipNodeModulesBundle: false,
-    external: (id: string) => /^[@a-zA-Z]/.test(id) && !id.startsWith('@internal/'),
+    external: isExternalSpecifier,
     dts: { enabled: true, sourcemap: true },
     exports: {
       enabled: 'local-only',
@@ -329,6 +331,29 @@ function publicSpecifier(source: string, shellName: ShellName): { shell: ShellNa
       { cause },
     );
   }
+}
+
+/**
+ * Every bare specifier stays external except the internal packages this shell
+ * bundles. An absolute id is a resolved module rather than a specifier, so it
+ * is never external: on Windows it opens with a drive letter (`C:\...`), which
+ * a leading-letter test reads as a bare specifier and would leave every
+ * internal module unbundled, emitted as a raw path whose backslashes the
+ * output string then swallows. Windows rules also accept POSIX absolutes, so
+ * one test classifies an id the same way whatever host the build runs on.
+ */
+export function isExternalSpecifier(id: string): boolean {
+  if (win32.isAbsolute(id)) return false;
+  return /^[@a-zA-Z]/.test(id) && !id.startsWith('@internal/');
+}
+
+/**
+ * A shell's copy entries are globs rooted at the repository, and glob syntax
+ * reads `\` as an escape — so a Windows-resolved path stops matching the file
+ * it names. Separators go back to `/`, which globs accept on every platform.
+ */
+export function copyGlobFrom(repoRoot: string, pattern: string): string {
+  return resolve(repoRoot, pattern).replaceAll('\\', '/');
 }
 
 function crossShellRewritePlugin(shellName: ShellName) {

--- a/packages/0-config/tsdown/test/shell-build.test.ts
+++ b/packages/0-config/tsdown/test/shell-build.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { copyGlobFrom, isExternalSpecifier } from '../shell-build.ts';
+import { copyGlobFrom, isExternalSpecifier } from '../shell-build';
 
 describe('isExternalSpecifier', () => {
   it('keeps third-party and sibling-shell specifiers external', () => {

--- a/packages/0-config/tsdown/test/shell-build.test.ts
+++ b/packages/0-config/tsdown/test/shell-build.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { copyGlobFrom, isExternalSpecifier } from '../shell-build.ts';
+
+describe('isExternalSpecifier', () => {
+  it('keeps third-party and sibling-shell specifiers external', () => {
+    expect(isExternalSpecifier('tsdown')).toBe(true);
+    expect(isExternalSpecifier('@prisma/orm-postgres')).toBe(true);
+  });
+
+  it('bundles the internal packages a shell owns', () => {
+    expect(isExternalSpecifier('@internal/contract/types')).toBe(false);
+  });
+
+  it('bundles resolved ids, whichever platform resolved them', () => {
+    expect(isExternalSpecifier('/repo/packages/1-framework/contract/dist/types.mjs')).toBe(false);
+    expect(
+      isExternalSpecifier(String.raw`C:\repo\packages\1-framework\contract\dist\types.mjs`),
+    ).toBe(false);
+    expect(isExternalSpecifier('C:/repo/packages/1-framework/contract/dist/types.mjs')).toBe(false);
+  });
+});
+
+describe('copyGlobFrom', () => {
+  it('roots the glob at the repository without platform separators', () => {
+    const from = copyGlobFrom(process.cwd(), 'packages/1-framework/3-tooling/cli/dist/*.md');
+
+    expect(from).not.toContain('\\');
+    expect(from.endsWith('/packages/1-framework/3-tooling/cli/dist/*.md')).toBe(true);
+  });
+});

--- a/packages/0-config/tsdown/vitest.config.ts
+++ b/packages/0-config/tsdown/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -878,6 +878,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/0-shared/extension-author-tools:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -878,9 +878,6 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
-      vitest:
-        specifier: 'catalog:'
-        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/0-shared/extension-author-tools:
     dependencies:


### PR DESCRIPTION
## Linked issue

n/a — no issue filed yet. Happy to open one if you'd rather track it separately; nothing in the tracker covers this today.

## Summary

`pnpm build` cannot finish on Windows: the `@prisma/orm-*` shell builds fail, first in `@prisma/orm-framework` and then in `@prisma/orm-toolchain`. Three spots in `shell-build.ts` hand a Windows path to something that expects a POSIX path or a bare specifier, and each one fails in its own way. Every CI job runs on `ubuntu-latest`, so none of this is visible upstream.

The three:

1. **The externals predicate reads a drive letter as a package name.** `/^[@a-zA-Z]/.test(id)` was meant to catch bare specifiers, and on POSIX a resolved id starts with `/` and falls through. On Windows it starts with `C:\`, so every internal module stayed external and its absolute path was emitted as the specifier — where the backslashes were then eaten (`\1` → `\x01`, `\t` → tab, `\0` → NUL). The aggregate exported nothing, and `assertAggregatesComplete` reported every name as dropped "to star-export ambiguity", including names bound by exactly one subpath.

2. **The generated bin entry embeds the path unescaped.** `import 'C:\repo\packages\1-framework\...'` makes rolldown fail with "for octal literals use the '0o' prefix instead", because `\1` is an octal escape.

3. **Copy patterns stop matching.** `shell.copy` entries are globs, and glob syntax reads `\` as an escape, so a Windows-resolved pattern no longer matches the file it names. tsdown then falls back to a literal path and dies with `ENOENT: lstat '...\dist\*.md'`.

## Testing performed

On Windows 11 / Node 24.15:

- `pnpm build` — 86/86 tasks, whole repo (it stopped at `@prisma/orm-framework` before)
- `pnpm typecheck` — 165/165
- `pnpm --filter @repo/tsdown test` — new unit tests, 4/4
- Smoke: `node packages/9-public/@prisma/orm-toolchain/dist/bin__prisma-next.mjs --version` prints `8.0.0-rc.1`, and the copy step lands `readme-*.md` / `quick-reference-*.md` in the shell dist

I checked the tests fail without the fix rather than passing by accident.

## Skill update

n/a — internal build tooling, no user-facing surface.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the DCO.
- [x] I read CONTRIBUTING.md and the change is scoped to one logical concern.
- [x] Tests are updated.
- [x] The PR title is a conventional commit (per CONTRIBUTING.md for external contributors).
- [x] The **Skill update** section above is filled in.

## Notes for the reviewer

`win32.isAbsolute` rather than `node:path`'s `isAbsolute` is deliberate: the platform-bound version returns false for `C:\...` on Linux, so the regression test would pass on your CI while the bug was still there. The win32 rules also accept POSIX absolutes, so one call classifies an id the same way on every host and the test is meaningful wherever it runs.

`@repo/tsdown` had no test script, so this adds a small vitest setup (config, `test` script, `vitest` from the catalog) — hence the three-line lockfile change. Two functions are exported purely so they can be tested; say the word if you would rather keep the surface closed and drop the tests.

The three fixes are one commit because they are one bug wearing three hats, and fixing any one alone leaves the build red. Happy to split them if you prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell builds on Windows with more reliable path and file-pattern handling.
  * Preserved accurate external dependency detection across Windows and POSIX path formats.

* **Tests**
  * Added automated coverage for path handling, dependency classification, module bundling, and repository file matching.
  * Added Vitest configuration and a test command for running the suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->