### PR TITLE
fix(repo): check out text files as LF on every platform

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,9 @@
+# The whole tree is stored with LF and Biome formats to LF (`lineEnding: "lf"`),
+# so a checkout has to produce LF whatever a contributor's `core.autocrlf` says.
+# Without this, Windows checkouts land CRLF on disk and `pnpm lint` fails on
+# files nobody edited. Content detection still leaves binaries alone.
+* text=auto eol=lf
+
 # Mark ASCII recordings as generated so they don't inflate PR diff stats
 packages/1-framework/3-tooling/cli/recordings/ascii/** linguist-generated
 **/contract.d.ts linguist-generated


### PR DESCRIPTION
## Linked issue

n/a — small change. Happy to file one if you'd rather have it tracked.

## Summary

The tree is stored entirely with LF and Biome formats to LF (`lineEnding: "lf"` in `biome.jsonc`), but `.gitattributes` never said so — it only carries `linguist-generated` markers. That leaves the line endings of a checkout up to each contributor's `core.autocrlf`. With the Windows default (`true`), git writes CRLF to disk, and `pnpm lint` then fails on files nobody touched; `pnpm lint:fix` offers to rewrite the whole tree. `* text=auto eol=lf` settles it in the repo instead of in everyone's global git config, because attributes take precedence over `core.autocrlf`.

## Testing performed

Before changing anything I checked the change cannot renormalise the tree:

- `git ls-files --eol` — zero files stored with CRLF or mixed endings, so nothing gets rewritten
- no `.bat` / `.cmd` in the repo, so no `eol=crlf` exception is needed
- after the change, `git add --renormalize .` stages `.gitattributes` and nothing else

Then the fix itself, on Windows 11 with `core.autocrlf=true`:

- `control-instances.ts` went from `i/lf w/crlf` to `i/lf w/lf` on a forced re-checkout
- `pnpm --filter @internal/framework-components lint`, which failed on that file's line endings, exits 0

## Skill update

n/a — repository configuration, no user-facing surface.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the DCO.
- [x] I read CONTRIBUTING.md and the change is scoped to one logical concern.
- [x] Tests are updated — n/a, this is a git config file; the verification above is the check.
- [x] The PR title is a conventional commit (per CONTRIBUTING.md for external contributors).
- [x] The **Skill update** section above is filled in.

## Notes for the reviewer

`text=auto` rather than a blanket `text`: content detection keeps binaries out of the conversion, which the repo's jpg / png / gz files rely on.

No CI guard comes with this. Since git normalises on commit, CRLF can't really enter the tree once the attribute is in place, so a `lint:eol` script would mostly be belt and braces — say the word if you want one anyway.

Worth noting that all 27 CI jobs run on `ubuntu-latest`, so this class of problem is invisible upstream and only ever bites contributors on Windows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository-wide text file normalization to ensure consistent line endings across environments.
  * Preserved automatic handling of binary files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->