### PR TITLE
refactor: spell control characters as escapes, and lint for raw ones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,8 @@ jobs:
         run: pnpm lint:consumer-internal-imports
       - name: Lint the legacy product name
         run: pnpm lint:legacy-name
+      - name: Lint raw control bytes in source
+        run: pnpm lint:control-bytes
 
       - name: Lint publishability matches the directory layout
         run: pnpm lint:publishability

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "lint:docs": "node scripts/validate-package-readmes.mjs",
     "lint:manifests": "node scripts/validate-package-manifests.mjs && node scripts/validate-typescript-peer.mjs",
     "lint:workflows": "node scripts/lint-workflow-triggers.mjs",
-    "test:scripts": "node --test scripts/lint-workflow-triggers.test.mjs scripts/validate-skills.test.mjs scripts/determine-version-utils.test.ts scripts/check-upgrade-coverage.test.mjs scripts/check-release-notes.test.mjs scripts/set-version-utils.test.ts scripts/check-publish-deps.test.mjs scripts/check-publish-deps-pn-pins.test.mjs scripts/check-publish-deps-declarations.test.mjs scripts/validate-package-manifests.test.mjs scripts/publish-packages-utils.test.mjs scripts/check-clean-tree.test.mjs scripts/lint-casts.test.mjs scripts/lint-throws.test.mjs scripts/list-error-codes.test.mjs scripts/lint-framework-vocabulary.test.mjs scripts/lint-single-import-root.test.mjs scripts/lint-legacy-name.test.mjs scripts/lint-consumer-internal-imports.test.mjs scripts/sync-agent-rules.test.mjs scripts/validate-typescript-peer.test.mjs scripts/run-logged.test.mjs scripts/migrate-migrations-layout.test.mjs packages/9-public/prisma-next/scripts/lint-sync.test.mjs skills-contrib/review-fetch-phase/scripts/render-review-state.test.mjs skills-contrib/review-triage-phase/scripts/render-review-actions.test.mjs",
+    "test:scripts": "node --test scripts/lint-workflow-triggers.test.mjs scripts/validate-skills.test.mjs scripts/determine-version-utils.test.ts scripts/check-upgrade-coverage.test.mjs scripts/check-release-notes.test.mjs scripts/set-version-utils.test.ts scripts/check-publish-deps.test.mjs scripts/check-publish-deps-pn-pins.test.mjs scripts/check-publish-deps-declarations.test.mjs scripts/validate-package-manifests.test.mjs scripts/publish-packages-utils.test.mjs scripts/check-clean-tree.test.mjs scripts/lint-casts.test.mjs scripts/lint-throws.test.mjs scripts/list-error-codes.test.mjs scripts/lint-framework-vocabulary.test.mjs scripts/lint-single-import-root.test.mjs scripts/lint-legacy-name.test.mjs scripts/lint-control-bytes.test.mjs scripts/lint-consumer-internal-imports.test.mjs scripts/sync-agent-rules.test.mjs scripts/validate-typescript-peer.test.mjs scripts/run-logged.test.mjs scripts/migrate-migrations-layout.test.mjs packages/9-public/prisma-next/scripts/lint-sync.test.mjs skills-contrib/review-fetch-phase/scripts/render-review-state.test.mjs skills-contrib/review-triage-phase/scripts/render-review-actions.test.mjs",
     "bump-version": "node scripts/bump-version.ts",
     "check:publish-deps": "node scripts/check-publish-deps.mjs",
     "check:release-notes": "node scripts/check-release-notes.mjs",
@@ -68,6 +68,7 @@
     "errors:list": "node scripts/list-error-codes.mjs",
     "check:error-reference": "node scripts/list-error-codes.mjs --verify docs/reference/error-reference.md",
     "lint:consumer-internal-imports": "node scripts/lint-consumer-internal-imports.mjs",
+    "lint:control-bytes": "node scripts/lint-control-bytes.mjs",
     "lint:legacy-name": "node scripts/lint-legacy-name.mjs",
     "lint:publishability": "node scripts/lint-publishability.mjs"
   },

--- a/packages/1-framework/3-tooling/emitter/test/domain-type-generation.test.ts
+++ b/packages/1-framework/3-tooling/emitter/test/domain-type-generation.test.ts
@@ -123,7 +123,7 @@ describe('serializeValue', () => {
       expect(serializeValue('a\nb')).toBe('"a\\nb"');
       expect(serializeValue('a\rb')).toBe('"a\\rb"');
       expect(serializeValue('a\tb')).toBe('"a\\tb"');
-      expect(serializeValue('ab')).toBe('"a\\u0007b"');
+      expect(serializeValue('a\u0007b')).toBe('"a\\u0007b"');
     });
 
     it('quotes object keys that look like identifier bypass attempts', () => {

--- a/packages/2-sql/1-core/contract/src/validators.ts
+++ b/packages/2-sql/1-core/contract/src/validators.ts
@@ -211,6 +211,12 @@ type NamespacedStorageWalk = {
 };
 
 /**
+ * Separator for the (table, name) key below: no SQL identifier can contain a
+ * NUL, so the pair never collides the way a printable separator would.
+ */
+const TABLE_SCOPED_KEY_SEPARATOR = '\u0000';
+
+/**
  * Any entries entity that declares both a `tableName` and a physical `name`
  * (e.g. a target's RLS policy entities) shares one physical-name space per
  * table: two such entries of one kind on the same table would collide as
@@ -235,7 +241,7 @@ function validateTableScopedEntryNames(storage: SqlStorage, errors: string[]): v
         const name = record['name'];
         const tableName = record['tableName'];
         if (typeof name !== 'string' || typeof tableName !== 'string') continue;
-        const key = `${tableName} ${name}`;
+        const key = `${tableName}${TABLE_SCOPED_KEY_SEPARATOR}${name}`;
         seen.set(key, (seen.get(key) ?? 0) + 1);
         if (seen.get(key) === 2) {
           errors.push(

--- a/scripts/lint-control-bytes.mjs
+++ b/scripts/lint-control-bytes.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Control characters live in source as escapes, never as raw bytes.
+ *
+ * `'\u0000'` and a literal NUL byte are the same string at runtime, so the
+ * difference only ever shows up in the tooling around the code — which is
+ * exactly where it hurts. Git reads a file holding a NUL as binary, so GitHub
+ * renders no diff for it and `git blame -L`, `git log -S` and `grep` all skip
+ * it. The rest of the control range is merely invisible: an editor shows
+ * nothing, a reviewer reads a string that looks like it has no separator at
+ * all, and printing the file to a terminal makes it beep.
+ *
+ * Tab, newline and carriage return are how text files are written and stay
+ * allowed. Everything else in the C0 range, and DEL, is a mistake — usually a
+ * paste that expanded an escape into the character it stands for.
+ *
+ * The fix is always the same: write the escape. If a file ever has to carry a
+ * raw control byte, add the allowance here with the reason rather than
+ * silencing the check.
+ *
+ * Exit codes:
+ *   0 — no raw control byte
+ *   1 — at least one, named by file, line and byte
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const GIT_ROOT = process.cwd();
+
+const SKIP_PATH = /(^|\/)(node_modules|dist|dist-tsc|dist-tsc-prod|coverage|\.turbo)\//;
+
+/**
+ * Formats whose bytes are not text at all. Content sniffing is not an option
+ * here: a NUL byte is precisely what marks a file as binary, so detecting
+ * binaries by content would skip the files this check exists to find.
+ */
+const BINARY = /\.(png|jpe?g|gif|ico|webp|woff2?|ttf|eot|pdf|zip|t?gz|wasm|mp4|node|snap)$/i;
+
+/** Written as text and expected in text: tab, line feed, carriage return. */
+const ALLOWED_BYTES = new Set([0x09, 0x0a, 0x0d]);
+
+const isControl = (byte) => (byte < 0x20 || byte === 0x7f) && !ALLOWED_BYTES.has(byte);
+
+export function trackedFiles(scanDir) {
+  return execFileSync('git', ['ls-files', '-z'], {
+    cwd: scanDir,
+    encoding: 'utf-8',
+    stdio: 'pipe',
+    maxBuffer: 256 * 1024 * 1024,
+  })
+    .split('\0')
+    .filter(Boolean)
+    .filter((relPath) => !SKIP_PATH.test(relPath) && !BINARY.test(relPath));
+}
+
+/** Every raw control byte in `scanDir`, at most one per file. */
+export function findViolations(scanDir, files = trackedFiles(scanDir)) {
+  const violations = [];
+  for (const relPath of files) {
+    let content;
+    try {
+      content = readFileSync(join(scanDir, relPath));
+    } catch {
+      continue;
+    }
+    const at = content.findIndex(isControl);
+    if (at === -1) continue;
+    violations.push({
+      file: relPath,
+      line: content.subarray(0, at).toString('utf-8').split('\n').length,
+      byte: `0x${content[at].toString(16).padStart(2, '0')}`,
+    });
+  }
+  return violations;
+}
+
+export function main(scanDir = GIT_ROOT) {
+  const violations = findViolations(scanDir);
+  if (violations.length === 0) {
+    console.log('No raw control byte in tracked source.');
+    return 0;
+  }
+
+  console.error(`${violations.length} file(s) hold a raw control byte:\n`);
+  for (const violation of violations) {
+    console.error(`  ${violation.file}:${violation.line}: ${violation.byte}`);
+  }
+  console.error(
+    '\nWrite the character as an escape (`\\u0000`, `\\u0007`, …) instead. A raw\n' +
+      'NUL makes git treat the file as binary, so GitHub shows no diff for it and\n' +
+      'blame, log -S and grep skip it; the rest of the range is simply invisible\n' +
+      'to whoever reads the code next.\n',
+  );
+  return 1;
+}
+
+if (process.argv[1] === import.meta.filename) process.exit(main());

--- a/scripts/lint-control-bytes.test.mjs
+++ b/scripts/lint-control-bytes.test.mjs
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import { findViolations, main } from './lint-control-bytes.mjs';
+
+/**
+ * Assembled rather than written out: a fixture holding the literal byte would
+ * be flagged by this very check when it runs over the repository.
+ */
+const NUL = String.fromCharCode(0);
+const BEL = String.fromCharCode(7);
+
+let repo;
+
+function git(...args) {
+  return execFileSync('git', args, {
+    cwd: repo,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function write(relPath, content) {
+  const full = join(repo, relPath);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, content);
+}
+
+beforeEach(() => {
+  repo = mkdtempSync(join(tmpdir(), 'lint-control-bytes-'));
+  git('init', '--quiet', '--initial-branch=main');
+  git('config', 'user.email', 'test@example.com');
+  git('config', 'user.name', 'Test');
+  git('config', 'commit.gpgsign', 'false');
+});
+
+afterEach(() => {
+  rmSync(repo, { recursive: true, force: true });
+});
+
+describe('findViolations', () => {
+  test('names the file, line and byte of a raw NUL', () => {
+    write('src/keys.ts', `const a = 1;\nconst key = \`\${table}${NUL}\${name}\`;\n`);
+    git('add', '-A');
+
+    assert.deepEqual(findViolations(repo), [{ file: 'src/keys.ts', line: 2, byte: '0x00' }]);
+  });
+
+  test('catches the rest of the control range, not just NUL', () => {
+    write('test/serialize.ts', `expect(serialize('a${BEL}b'));\n`);
+    git('add', '-A');
+
+    assert.equal(findViolations(repo)[0]?.byte, '0x07');
+  });
+
+  test('leaves an escaped control character alone', () => {
+    write('src/escaped.ts', 'const key = `${table}\\u0000${name}`;\n');
+    git('add', '-A');
+
+    assert.deepEqual(findViolations(repo), []);
+  });
+
+  test('allows tab, line feed and carriage return', () => {
+    write('src/whitespace.ts', 'const rows = [\n\t1,\r\n\t2,\n];\n');
+    git('add', '-A');
+
+    assert.deepEqual(findViolations(repo), []);
+  });
+
+  test('skips formats whose bytes are not text', () => {
+    write('assets/logo.png', `\x89PNG\r\n${NUL}fixture`);
+    git('add', '-A');
+
+    assert.deepEqual(findViolations(repo), []);
+  });
+});
+
+describe('main(scanDir)', () => {
+  test('fails on a tree holding a raw control byte', () => {
+    write('src/keys.ts', `const key = \`\${table}${NUL}\${name}\`;\n`);
+    git('add', '-A');
+
+    assert.equal(main(repo), 1);
+  });
+
+  test('passes on a tree that writes them as escapes', () => {
+    write('src/escaped.ts', "export const bell = '\\u0007';\n");
+    git('add', '-A');
+
+    assert.equal(main(repo), 0);
+  });
+});


### PR DESCRIPTION
## Linked issue

n/a — nothing filed. Say the word if you'd rather talk the check over first.

## Summary

Two files hold a control character as a raw byte where an escape was meant. Same string at runtime, so nothing misbehaves. The cost is all in the tooling around the code.

`packages/2-sql/1-core/contract/src/validators.ts` separates the halves of a `(tableName, name)` key with a NUL. Git reads a file containing a NUL as binary, so GitHub shows no diff for 1100 lines of validation logic, and blame, `log -S` and grep skip it.

`packages/1-framework/3-tooling/emitter/test/domain-type-generation.test.ts` has a raw BEL in a test input. That test is about escaping control characters, every neighbouring line writes its own character as an escape, and the expectation on the same line asks for the escaped form — so the intent isn't in question.

The separator itself is a good idea and a house pattern. `schema-diff.ts` has `SIBLING_KEY_DELIMITER`, `psl-field-resolution.ts` has `MODEL_COORDINATE_SEPARATOR`, `migration-graph.ts` spells out the reasoning in a comment: no identifier can contain a NUL, so `("a_b", "c")` can never collide with `("a", "b_c")`. Only the spelling was off.

The second commit adds `pnpm lint:control-bytes` so nobody has to catch this by eye next time.

## Testing performed

Finding them meant scanning all 6711 tracked files byte by byte. Git's own binary flag wasn't enough — it only reads the first 8000 bytes, so a NUL further down a long file never shows up.

- `pnpm lint:control-bytes` against the pre-fix files exits 1 and names both, with line and byte; on the fixed tree it exits 0
- `node --test scripts/lint-control-bytes.test.mjs` — 7 cases: NUL, the rest of the C0 range, an already-escaped character, tab/LF/CR, binary formats, and both exit codes
- `pnpm test:scripts` — 395 tests, 371 pass. Without this branch it's 388/364 with the same 24 failures, so nothing here adds one. Those 24 are path-separator assertions in unrelated scripts that only fail on Windows
- `pnpm --filter @internal/emitter test` 208/208 and `pnpm --filter @internal/sql-contract test` 322/322, plus typecheck and lint on both
- `pnpm lint:workflows` after adding the CI step

`git ls-files --eol` now calls `validators.ts` `i/lf`, where it was `i/-text`. It's a text file again.

## Skill update

n/a — internal tooling, plus two literals rewritten to the same value.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the DCO.
- [x] I read CONTRIBUTING.md and the change is scoped to one logical concern.
- [x] Tests are updated.
- [x] The PR title is a conventional commit (per CONTRIBUTING.md for external contributors).
- [x] The **Skill update** section above is filled in.

## Notes for the reviewer

The check skips binaries by file extension rather than by sniffing content, which is the one call worth arguing about. A NUL byte is what makes a file look binary in the first place, so sniffing would skip exactly the files this is meant to find. The cost is that a new binary format has to be added to the list, and until it is the check complains instead of going quiet. I'd rather have it that way round, but it's your call.

It also only looks at tracked files, so a violation in a file you haven't added yet is invisible. I walked into that myself while writing it: the script picked up a raw NUL in its own doc comment and reported the tree clean, because it wasn't tracked. CI runs against a commit, so everything is tracked there.

In `validators.ts` I named a constant instead of inlining the escape, following the two sites that already do that. Both styles exist in the tree, so switch me if you prefer the inline one.

Two commits, literals first and the check second, so you can drop the CI step without losing the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new validation check to catch raw control characters in source files during CI.
  * Added a command to run this check locally from the package scripts.

* **Bug Fixes**
  * Improved handling of escaped control characters in serialization tests, keeping output unchanged.

* **Tests**
  * Added coverage for detecting raw control bytes, reporting file/line details, and ignoring binary or whitespace-safe cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->