### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/create-git-tag/action.yml
+++ b/.github/actions/create-git-tag/action.yml
@@ -20,7 +20,7 @@ runs:
   using: composite
   steps:
     - name: Create tag
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       env:
         INPUT_REPOSITORY: ${{ inputs.repository }}
         TAG_NAME: ${{ inputs.tag-name }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -24,11 +24,11 @@ runs:
     # set up below. This lets the test matrix keep exercising Node.js 20 (which
     # pnpm 11 itself does not support) while pnpm-driven scripts still run under
     # the matrix Node.js resolved from PATH.
-    - uses: pnpm/action-setup@v4.2.0
+    - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
       with:
         standalone: true
     - name: Use Node.js ${{ inputs.node-version }}
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
       with:
         node-version: ${{ inputs.node-version }}
         cache: 'pnpm'
@@ -45,7 +45,7 @@ runs:
 
     - name: Download custom engines
       id: custom-engine
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       with:
         key: ${{ runner.os }}-engine-${{ inputs.engine-hash }}-${{ github.event.number }}
         path: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -53,7 +53,7 @@ jobs:
     # access to the `gh-pages` benchmark history is available to a fork.
     if: github.repository == 'prisma/prisma'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install & build
         uses: ./.github/actions/setup
@@ -66,7 +66,7 @@ jobs:
 
       - name: Store benchmark result
         if: ${{ github.ref == 'refs/heads/v7' }}
-        uses: rhysd/github-action-benchmark@v1
+        uses: rhysd/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           name: Benchmark.js Benchmark
           tool: 'benchmarkjs'
@@ -87,7 +87,7 @@ jobs:
           fail-on-alert: false
 
       - name: Run benchmarks for Codspeed
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@f22792bfac16f3e14eb9fbea76f4a48e9cc22b93 # v4.19.1
         with:
           mode: simulation
           run: pnpm run bench-stdout-only

--- a/.github/workflows/build-engine-branch.yml
+++ b/.github/workflows/build-engine-branch.yml
@@ -50,7 +50,7 @@ jobs:
     outputs:
       engineHash: ${{ steps.engine-hash.outputs.engineHash }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           repository: prisma/prisma-engines
           ref: ${{ needs.parseCommand.outputs.branchName }}
@@ -60,7 +60,7 @@ jobs:
         shell: bash
         run: echo "engineHash=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         name: Artifacts cache
         id: artifacts-cache
         with:
@@ -72,10 +72,10 @@ jobs:
             schema-engine/schema-engine-wasm/pkg
           key: ${{ runner.os }}-engine-${{ steps.engine-hash.outputs.engineHash }}-${{ github.event.number }}
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         if: steps.artifacts-cache.outputs.cache-hit != 'true'
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         name: Dependencies cache
         if: steps.artifacts-cache.outputs.cache-hit != 'true'
         with:
@@ -93,7 +93,7 @@ jobs:
         run: |
           cargo build --release -p schema-engine-cli
 
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: cargo-bins/cargo-binstall@b5723a5790b379eeac6713950acef86189492996 # main
 
       - name: Extract wasm-bindgen version and install matching CLI
         if: steps.artifacts-cache.outputs.cache-hit != 'true'
@@ -120,7 +120,7 @@ jobs:
           fi
 
       - name: Install Binaryen (includes wasm-opt)
-        uses: jaxxstorm/action-install-gh-release@v2.1.0
+        uses: jaxxstorm/action-install-gh-release@6096f2a2bbfee498ced520b6922ac2c06e990ed2 # v2.1.0
         with:
           repo: WebAssembly/binaryen
           tag: version_122

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install & build
         uses: ./.github/actions/setup
@@ -36,7 +36,7 @@ jobs:
           skip-tsc: true
           skip-build: true
 
-      - uses: andresz1/size-limit-action@v1
+      - uses: andresz1/size-limit-action@e7493a72a44b113341c0cf6186ab49c17c4b65c1 # v1.6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           build_script: bundle-size

--- a/.github/workflows/lint-workflow-files.yml
+++ b/.github/workflows/lint-workflow-files.yml
@@ -8,7 +8,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       # see https://github.com/rhysd/actionlint/blob/main/docs/usage.md
       - name: Check workflow files

--- a/.github/workflows/pr-code-security.yml
+++ b/.github/workflows/pr-code-security.yml
@@ -7,8 +7,8 @@ on:
 jobs:
   secret-detection:
     name: Secret Detection
-    uses: prisma/.github/.github/workflows/secret_detection.yml@main
+    uses: prisma/.github/.github/workflows/secret_detection.yml@7e808313ce87dfbd166654e9819606097a68d8c8 # main
     secrets: inherit
   code-scanning:
     name: Code Scanning
-    uses: prisma/.github/.github/workflows/code_scanning.yml@main
+    uses: prisma/.github/.github/workflows/code_scanning.yml@7e808313ce87dfbd166654e9819606097a68d8c8 # main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           echo "$THE_INPUT"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install & build
         uses: ./.github/actions/setup
@@ -161,7 +161,7 @@ jobs:
         run: echo "SLACK_FOOTER=<$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Click here to go to the job logs>" >> "$GITHUB_ENV"
 
       - name: Slack Notification on Success
-        uses: rtCamp/action-slack-notify@v2.3.2
+        uses: rtCamp/action-slack-notify@c33737706dea87cd7784c687dadc9adf1be59990 # v2.3.2
         env:
           SLACK_TITLE: 'prisma/prisma Release ${{ needs.release.outputs.prismaVersion }} succeeded :white_check_mark:'
           SLACK_COLOR: '#55ff55'
@@ -179,7 +179,7 @@ jobs:
         run: echo "SLACK_FOOTER=<$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Click here to go to the job logs>" >> "$GITHUB_ENV"
 
       - name: Slack Notification on Failure
-        uses: rtCamp/action-slack-notify@v2.3.2
+        uses: rtCamp/action-slack-notify@c33737706dea87cd7784c687dadc9adf1be59990 # v2.3.2
         env:
           SLACK_TITLE: ${{ env.FAILURE_TITLE_TEMPLATE }}
           SLACK_COLOR: '#FF0000'

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install & build
         uses: ./.github/actions/setup
@@ -117,10 +117,10 @@ jobs:
       JEST_JUNIT_SUITE_NAME: 'client/functional'
       JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Start Docker Compose Services
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
           timeout_minutes: 10
           max_attempts: 5
@@ -146,7 +146,7 @@ jobs:
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.
         if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse' && github.repository == 'prisma/prisma'
-        uses: buildpulse/buildpulse-action@v0.11.0
+        uses: buildpulse/buildpulse-action@d0d30f53585cf16b2e01811a5a753fd47968654a # v0.11.0
         with:
           account: 17219288
           repository: 192925833
@@ -169,10 +169,10 @@ jobs:
         node: ['20.19.0', '22.12.0', '24']
         flavor: ['js_pg']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Start Docker Compose Services
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
           timeout_minutes: 10
           max_attempts: 5
@@ -198,7 +198,7 @@ jobs:
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.
         if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse' && github.repository == 'prisma/prisma'
-        uses: buildpulse/buildpulse-action@v0.11.0
+        uses: buildpulse/buildpulse-action@d0d30f53585cf16b2e01811a5a753fd47968654a # v0.11.0
         with:
           account: 17219288
           repository: 192925833
@@ -237,10 +237,10 @@ jobs:
         node: ['20.19.0']
         previewFeatures: ['', 'relationJoins']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Start Docker Compose Services
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
           timeout_minutes: 10
           max_attempts: 5
@@ -266,7 +266,7 @@ jobs:
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.
         if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse' && github.repository == 'prisma/prisma'
-        uses: buildpulse/buildpulse-action@v0.11.0
+        uses: buildpulse/buildpulse-action@d0d30f53585cf16b2e01811a5a753fd47968654a # v0.11.0
         with:
           account: 17219288
           repository: 192925833
@@ -304,10 +304,10 @@ jobs:
         node: ['20.19.0']
         previewFeatures: ['', 'relationJoins']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Start Docker Compose Services
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
           timeout_minutes: 10
           max_attempts: 5
@@ -333,7 +333,7 @@ jobs:
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.
         if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse' && github.repository == 'prisma/prisma'
-        uses: buildpulse/buildpulse-action@v0.11.0
+        uses: buildpulse/buildpulse-action@d0d30f53585cf16b2e01811a5a753fd47968654a # v0.11.0
         with:
           account: 17219288
           repository: 192925833
@@ -359,10 +359,10 @@ jobs:
         shard: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
         node: ['20.19.0']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Start Docker Compose Services
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
           timeout_minutes: 10
           max_attempts: 5
@@ -388,7 +388,7 @@ jobs:
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.
         if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse' && github.repository == 'prisma/prisma'
-        uses: buildpulse/buildpulse-action@v0.11.0
+        uses: buildpulse/buildpulse-action@d0d30f53585cf16b2e01811a5a753fd47968654a # v0.11.0
         with:
           account: 17219288
           repository: 192925833
@@ -419,11 +419,11 @@ jobs:
         # several machines. See `--shard` in tests/e2e/_utils/run.ts.
         shard: ['1/3', '2/3', '3/3']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       # Not currently needed, but we might need it in the future
       - name: Start Docker Compose Services
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
           timeout_minutes: 10
           max_attempts: 5
@@ -464,7 +464,7 @@ jobs:
       JEST_JUNIT_SUITE_NAME: 'client/functional'
       JEST_JUNIT_UNIQUE_OUTPUT_NAME: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Set RELATION_MODE custom test env var
         run: |
@@ -474,7 +474,7 @@ jobs:
           fi
 
       - name: Start Docker Compose Services
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
           timeout_minutes: 10
           max_attempts: 5
@@ -511,7 +511,7 @@ jobs:
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.
         if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse' && github.repository == 'prisma/prisma'
-        uses: buildpulse/buildpulse-action@v0.11.0
+        uses: buildpulse/buildpulse-action@d0d30f53585cf16b2e01811a5a753fd47968654a # v0.11.0
         with:
           account: 17219288
           repository: 192925833
@@ -534,7 +534,7 @@ jobs:
       matrix:
         node: ['20.19.0']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install & build
         uses: ./.github/actions/setup
@@ -562,7 +562,7 @@ jobs:
       matrix:
         node: ['20.19.0', '22.12.0', '24']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install & build
         uses: ./.github/actions/setup
@@ -607,7 +607,7 @@ jobs:
       matrix:
         node: ['20.19.0']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install & build
         uses: ./.github/actions/setup
@@ -633,10 +633,10 @@ jobs:
       matrix:
         node: ['20.19.0']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Start Docker Compose Services
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
           timeout_minutes: 10
           max_attempts: 5
@@ -669,10 +669,10 @@ jobs:
         os: [ubuntu-latest]
         node: ['20.19.0', '22.12.0', '24']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Start Docker Compose Services
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
           timeout_minutes: 10
           max_attempts: 5
@@ -707,10 +707,10 @@ jobs:
         # driverAdapter: ['', 'libsql'] # TODO: once we have all tests pass with driver adapters actually enable them on CI and add further adapters
         driverAdapter: ['']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Start Docker Compose Services
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
           timeout_minutes: 10
           max_attempts: 5
@@ -745,10 +745,10 @@ jobs:
         os: [ubuntu-latest]
         node: ['20.19.0', '22.12.0', '24']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Start Docker Compose Services
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
           timeout_minutes: 10
           max_attempts: 5
@@ -786,7 +786,7 @@ jobs:
           - os: macos-latest
             version: 18
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install & build
         uses: ./.github/actions/setup
@@ -812,7 +812,7 @@ jobs:
         os: [ubuntu-latest]
         node: ['20.19.0', '22.12.0', '24']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install & build
         uses: ./.github/actions/setup
@@ -895,7 +895,7 @@ jobs:
         os: [ubuntu-latest]
         node: ['20.19.0', '24']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install & build
         uses: ./.github/actions/setup
@@ -950,7 +950,7 @@ jobs:
         os: [ubuntu-latest]
         node: ['24']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install & build
         uses: ./.github/actions/setup
@@ -974,7 +974,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install & build
         uses: ./.github/actions/setup
@@ -1013,7 +1013,7 @@ jobs:
       contains(inputs.jobsToRun, '-all-') ||
       contains(inputs.jobsToRun, '-client-')
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Prerequisites
         shell: bash
@@ -1052,7 +1052,7 @@ jobs:
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.
         if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason =='buildpulse' && github.repository == 'prisma/prisma'
-        uses: buildpulse/buildpulse-action@v0.11.0
+        uses: buildpulse/buildpulse-action@d0d30f53585cf16b2e01811a5a753fd47968654a # v0.11.0
         with:
           account: 17219288
           repository: 192925833
@@ -1076,7 +1076,7 @@ jobs:
         os: [macos-14, windows-latest]
         node: ['20.19.0']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Prerequisites
         shell: bash
@@ -1273,7 +1273,7 @@ jobs:
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.
         if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse' && github.repository == 'prisma/prisma'
-        uses: buildpulse/buildpulse-action@v0.11.0
+        uses: buildpulse/buildpulse-action@d0d30f53585cf16b2e01811a5a753fd47968654a # v0.11.0
         with:
           account: 17219288
           repository: 192925833

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,10 +45,11 @@ jobs:
     outputs:
       jobs: ${{ steps.detect.outputs.jobs }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - id: files
-        uses: Ana06/get-changed-files@v2.3.0 # it's a fork of jitterbit/get-changed-files@v1 which works better with pull requests
+        # This fork of jitterbit/get-changed-files@v1 works better with pull requests.
+        uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c # v2.3.0
         with:
           format: 'json'
       - id: detect
@@ -65,7 +66,7 @@ jobs:
           echo "Pull Request Body contains /integration: ${{ contains(env.PR_BODY, '/integration') }}"
 
       - name: Find "ci test all" comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: findTestAllComment
         if: ${{ github.event_name == 'pull_request' }}
         with:
@@ -89,7 +90,7 @@ jobs:
             github.event.pull_request.author_association == 'COLLABORATOR' ||
             github.event.pull_request.author_association == 'CONTRIBUTOR'
           )
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2
         with:
           workflow: publish.yml
           token: ${{ secrets.BOT_TOKEN }}
@@ -107,14 +108,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Find past custom engine comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: findEngineComment
         if: ${{ github.event_name == 'pull_request' }}
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: '<!-- custom-engine -->'
       - name: Create or update comment (block)
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         if: ${{ needs.build_custom_engine.outputs.engineHash != '' }}
         with:
           comment-id: ${{ steps.findEngineComment.outputs.comment-id }}
@@ -131,7 +132,7 @@ jobs:
           edit-mode: replace
 
       - name: Create or update comment (clear)
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         if: ${{ steps.findEngineComment.outputs.comment-id != '' && needs.build_custom_engine.outputs.engineHash == '' }}
         with:
           comment-id: ${{ steps.findEngineComment.outputs.comment-id }}

--- a/.github/workflows/v7-manage-dist-tag.yml
+++ b/.github/workflows/v7-manage-dist-tag.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           echo "$THE_INPUT"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Check if version is valid
         if: ${{ github.event.inputs.tagAction == 'add' }}

--- a/.github/workflows/v7-update-engines-version.yml
+++ b/.github/workflows/v7-update-engines-version.yml
@@ -27,13 +27,13 @@ jobs:
         run: |
           echo "$THE_INPUT"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
-      - uses: pnpm/action-setup@v4.0.0
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
         with:
           standalone: true
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           cache: 'pnpm'
           node-version: '20.19.0'
@@ -64,7 +64,7 @@ jobs:
           pnpm --package=@prisma/ensure-npm-release dlx enr update -p @prisma/schema-engine-wasm -u ${{ github.event.inputs.version }}
 
       - name: Update the dependencies (@prisma/engines-version)
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
           timeout_minutes: 7
           max_attempts: 3
@@ -73,7 +73,7 @@ jobs:
             pnpm update -r @prisma/engines-version@${{ github.event.inputs.version }}
 
       - name: Update the dependencies (@prisma/prisma-schema-wasm)
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
           timeout_minutes: 7
           max_attempts: 3
@@ -82,7 +82,7 @@ jobs:
             pnpm update -r @prisma/prisma-schema-wasm@${{ github.event.inputs.version }}
 
       - name: Update the dependencies (@prisma/query-compiler-wasm)
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
           timeout_minutes: 7
           max_attempts: 3
@@ -91,7 +91,7 @@ jobs:
             pnpm update -r @prisma/query-compiler-wasm@${{ github.event.inputs.version }}
 
       - name: Update the dependencies (@prisma/schema-engine-wasm)
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
           timeout_minutes: 7
           max_attempts: 3
@@ -101,7 +101,7 @@ jobs:
 
       - name: Extract Engine Commit hash from version
         id: extract-engine-commit-hash
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const hash = context.payload.inputs.version.split('.').pop()
@@ -114,7 +114,7 @@ jobs:
       - name: Create Pull Request
         id: cpr
         if: github.event.inputs.npmDistTag == 'latest'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.BOT_TOKEN }}
           commit-message: 'chore(deps): update engines to ${{ github.event.inputs.version }}'
@@ -148,7 +148,7 @@ jobs:
         shell: bash
       - name: Auto approve Pull Request (to trigger automerge if tests passing)
         if: github.event.inputs.npmDistTag == 'latest' && steps.cpr.outputs.pull-request-operation == 'created'
-        uses: juliangruber/approve-pull-request-action@v2
+        uses: juliangruber/approve-pull-request-action@68fcc9a5a73b5641cadf757cf99d73720dcb05d0 # v2.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           number: ${{ steps.cpr.outputs.pull-request-number }}
@@ -162,7 +162,7 @@ jobs:
       - name: Create Pull Request for Integration Engine
         id: cpr-integration
         if: github.event.inputs.npmDistTag == 'integration'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.BOT_TOKEN }}
           commit-message: 'chore(deps): update engines to ${{ github.event.inputs.version }}'
@@ -196,7 +196,7 @@ jobs:
       #
       - name: Extract patch branch name from version
         id: extract-patch-branch-name
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const parts = context.payload.inputs.version.split('.')
@@ -206,7 +206,7 @@ jobs:
       - name: Create Pull Request for Patch Engine
         id: cpr-patch
         if: github.event.inputs.npmDistTag == 'patch'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.BOT_TOKEN }}
           commit-message: 'chore(deps): update engines to ${{ github.event.inputs.version }}'

--- a/.github/workflows/v7-update-studio-version.yml
+++ b/.github/workflows/v7-update-studio-version.yml
@@ -13,13 +13,13 @@ jobs:
     name: 'Check and update Studio to ${{ github.event.inputs.version }}'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
-      - uses: pnpm/action-setup@v4.0.0
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
         with:
           standalone: true
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           cache: 'pnpm'
           node-version: '20.19.0'
@@ -40,7 +40,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.BOT_TOKEN }}
           commit-message: 'chore(deps): update studio to ${{ github.event.inputs.version }}'
@@ -71,7 +71,7 @@ jobs:
 
       - name: Auto approve Pull Request (to trigger automerge if tests passing)
         if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: juliangruber/approve-pull-request-action@v2
+        uses: juliangruber/approve-pull-request-action@68fcc9a5a73b5641cadf757cf99d73720dcb05d0 # v2.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           number: ${{ steps.cpr.outputs.pull-request-number }}

--- a/packages/client-engine-runtime/package.json
+++ b/packages/client-engine-runtime/package.json
@@ -34,7 +34,7 @@
     "@prisma/param-graph": "workspace:*",
     "@prisma/json-protocol": "workspace:*",
     "klona": "2.0.6",
-    "nanoid": "5.1.5",
+    "nanoid": "5.1.16",
     "ulid": "3.0.0",
     "uuid": "14.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ overrides:
   ajv@^8.0.0: '>=8.18.0'
   '@azure/core-rest-pipeline@^1.0.0': '>=1.14.0'
   '@azure/msal-node>uuid': '>=14.0.0'
-  fast-uri@<=3.1.3: '>=3.1.4 <4'
+  fast-uri@<3.1.5: '>=3.1.5 <4'
   ws@>=8.0.0 <8.20.1: '>=8.20.1'
 
 importers:
@@ -1000,8 +1000,8 @@ importers:
         specifier: 2.0.6
         version: 2.0.6
       nanoid:
-        specifier: 5.1.5
-        version: 5.1.5
+        specifier: 5.1.16
+        version: 5.1.16
       ulid:
         specifier: 3.0.0
         version: 3.0.0
@@ -6004,8 +6004,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -7251,8 +7251,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.1.5:
-    resolution: {integrity: sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==}
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -10946,7 +10946,7 @@ snapshots:
   '@redocly/ajv@8.17.1':
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -11950,7 +11950,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -13227,7 +13227,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -14771,7 +14771,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  nanoid@5.1.5: {}
+  nanoid@5.1.16: {}
 
   nanospinner@1.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,7 +23,7 @@ overrides:
   ajv@^8.0.0: '>=8.18.0'
   '@azure/core-rest-pipeline@^1.0.0': '>=1.14.0'
   '@azure/msal-node>uuid': '>=14.0.0'
-  fast-uri@<=3.1.3: '>=3.1.4 <4'
+  fast-uri@<3.1.5: '>=3.1.5 <4'
   ws@>=8.0.0 <8.20.1: '>=8.20.1'
 
 peerDependencyRules:


### PR DESCRIPTION
Pins every remote GitHub Action and reusable workflow used by the v7 CI configuration to an immutable full-length commit SHA while retaining human-readable version comments. It also updates the two dependencies flagged by the production audit gate.

## Changes

- **Workflow dependencies**: Pin all 88 remote `uses:` references across workflows and composite actions to full commit SHAs.
- **Branch references**: Resolve the four `main`/`stable` references that pinact intentionally skips to their current commits without changing the code each workflow executes.
- **Audit remediation**: Update `fast-uri` to 3.1.5 and `nanoid` to 5.1.16, clearing the three high-severity production audit findings exposed by CI.
- **Review context**: Preserve the existing explanation for the `Ana06/get-changed-files` fork alongside its generated version comment.

## Actions allow-list

A selected-actions policy should explicitly allow these 17 exact third-party action commits (16 repositories; `pnpm/action-setup` is used at two versions):

```text
Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c,
andresz1/size-limit-action@e7493a72a44b113341c0cf6186ab49c17c4b65c1,
benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26,
buildpulse/buildpulse-action@d0d30f53585cf16b2e01811a5a753fd47968654a,
cargo-bins/cargo-binstall@b5723a5790b379eeac6713950acef86189492996,
CodSpeedHQ/action@f22792bfac16f3e14eb9fbea76f4a48e9cc22b93,
dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c,
jaxxstorm/action-install-gh-release@6096f2a2bbfee498ced520b6922ac2c06e990ed2,
juliangruber/approve-pull-request-action@68fcc9a5a73b5641cadf757cf99d73720dcb05d0,
nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08,
peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9,
peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1,
peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad,
pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061,
pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2,
rhysd/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba,
rtCamp/action-slack-notify@c33737706dea87cd7784c687dadc9adf1be59990
```

`actions/*` dependencies are covered by **Allow actions created by GitHub**. The `prisma/.github` reusable workflows are organization-owned, and local `./.github/actions/*` references do not need external allow-list entries. The existing `docker://rhysd/actionlint:1.7.1` reference is a Docker Hub image rather than a GitHub-hosted action and cannot be expressed as an `OWNER/REPOSITORY@REF` entry.

## Why

Mutable tags and branches can move after review. Full commit SHAs make the executed action source immutable, while version comments keep dependency versions understandable and updateable by automation.

## Verification

- `pinact run --check --verify`
- `actionlint -color=false`
- `pnpm audit --prod`
- `pnpm --filter @prisma/client-engine-runtime... build`
- `pnpm --filter @prisma/client-engine-runtime test` (234 tests)
- Confirmed all 88 remote `uses:` references contain 40-character commit SHAs
- `git diff --check`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Pinned automated workflow actions to immutable commit references instead of mutable tags or branches.
  * Improved the integrity and reproducibility of builds, tests, releases, benchmarks, and security checks.

* **Maintenance**
  * Preserved existing workflow behavior while updating action references with version annotations.
  * Updated `nanoid` and refreshed the supported `fast-uri` version range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
