### PR TITLE
feat(sql-orm-client): add upsertAll bulk write terminal

### DIFF
--- a/docs/reference/error-reference.md
+++ b/docs/reference/error-reference.md
@@ -463,7 +463,7 @@ The Mongo ORM client was asked to operate on a model name that is not in the con
 
 ### ORM.MUTATION_DATA_MISSING
 
-`create()` or `createAndCount()` was called with zero rows; at least one row of data is required. Meta: `method`, `namespaceId`, `tableName`.
+`create()`, `createAndCount()`, or `upsertAll()` was called with zero rows; at least one row of data is required. Meta: `method`, `namespaceId`, `tableName`.
 
 ### ORM.MUTATION_ROW_MISSING
 

--- a/docs/reference/error-reference.md
+++ b/docs/reference/error-reference.md
@@ -463,7 +463,7 @@ The Mongo ORM client was asked to operate on a model name that is not in the con
 
 ### ORM.MUTATION_DATA_MISSING
 
-`create()`, `createAndCount()`, or `upsertAll()` was called with zero rows; at least one row of data is required. Meta: `method`, `namespaceId`, `tableName`.
+`create()` or `createAndCount()` was called with zero rows; at least one row of data is required. Meta: `method`, `namespaceId`, `tableName`.
 
 ### ORM.MUTATION_ROW_MISSING
 

--- a/packages/3-extensions/sql-orm-client/src/collection-internal-types.ts
+++ b/packages/3-extensions/sql-orm-client/src/collection-internal-types.ts
@@ -65,7 +65,8 @@ export type IncludeRefinementTerminals =
   | 'delete'
   | 'deleteAll'
   | 'deleteAndCount'
-  | 'upsert';
+  | 'upsert'
+  | 'upsertAll';
 
 /**
  * The members a to-one refinement collection strips: the scalar reducers the

--- a/packages/3-extensions/sql-orm-client/src/collection.ts
+++ b/packages/3-extensions/sql-orm-client/src/collection.ts
@@ -1832,7 +1832,9 @@ class CollectionImpl<
    * Each conflicting row is updated with its own proposed values — the
    * update is not a single literal payload shared by the batch. `update`
    * selects which fields that overwrite covers; it defaults to every field
-   * the input rows carry except the conflict target and the primary key.
+   * the caller supplied except the conflict target and the primary key.
+   * Fields that only an `onCreate` default fills (a generated id, a
+   * `createdAt`) stay out of it, so a conflicting row keeps its own.
    *
    * ```typescript
    * // Insert-or-refresh a batch keyed on the primary key:
@@ -1878,9 +1880,14 @@ class CollectionImpl<
         'resolved upsert inputs are model-field records for storage mapping'
       >(data),
     );
+    // Read before `applyCreateDefaults` mutates the rows: only what the caller
+    // actually supplied may drive the implicit update set. An onCreate default
+    // (`created_at`, a generated id) belongs to the insert branch alone — taking
+    // it from `excluded` would stamp an existing row with the new row's value.
+    const providedColumns = [...new Set(mappedRows.flatMap((row) => Object.keys(row)))];
     applyCreateDefaults(this.ctx, this.namespaceId, this.tableName, mappedRows);
 
-    const conflict = this.#resolveBatchedConflict(mappedRows, options);
+    const conflict = this.#resolveBatchedConflict(providedColumns, options);
     const { selectedForQuery: selectedForUpsert, hiddenColumns } = this.#augmentMutationSelection();
 
     const dispatch = {
@@ -1926,7 +1933,7 @@ class CollectionImpl<
   }
 
   #resolveBatchedConflict(
-    mappedRows: readonly Record<string, unknown>[],
+    providedColumns: readonly string[],
     options: UpsertAllOptions<TContract, ModelName> | undefined,
   ): UpsertConflictResolution {
     const primaryKeyColumns = resolveUpsertConflictColumns(
@@ -1969,15 +1976,11 @@ class CollectionImpl<
       };
     }
 
-    // The union across rows, not any single row: `normalizeInsertRows` widens
-    // every row to that union, so a column only some rows carry is still a
-    // real column of the proposed row. The primary key is held back along
-    // with the conflict target — when the two differ, overwriting it would
-    // reassign the identity of a row the caller only meant to refresh.
+    // The primary key is held back along with the conflict target — when the
+    // two differ, overwriting it would reassign the identity of a row the
+    // caller only meant to refresh.
     const withheld = new Set([...columns, ...primaryKeyColumns]);
-    const updateColumns = [...new Set(mappedRows.flatMap((row) => Object.keys(row)))].filter(
-      (column) => !withheld.has(column),
-    );
+    const updateColumns = providedColumns.filter((column) => !withheld.has(column));
 
     return {
       columns,

--- a/packages/3-extensions/sql-orm-client/src/collection.ts
+++ b/packages/3-extensions/sql-orm-client/src/collection.ts
@@ -95,7 +95,10 @@ import {
   compileUpdateCount,
   compileUpdateReturning,
   compileUpsertReturning,
+  compileUpsertReturningMany,
+  compileUpsertReturningManySplit,
   mergeAnnotations,
+  type UpsertConflictResolution,
 } from './query-plan';
 import {
   type AggregateBuilder,
@@ -124,6 +127,7 @@ import {
   type RuntimeQueryable,
   type ShorthandWhereFilter,
   type UniqueConstraintCriterion,
+  type UpsertAllOptions,
   type VariantAwareIncludeRelationNames,
   type VariantAwareModelAccessor,
   type VariantModelRow,
@@ -171,6 +175,34 @@ function applyUpdateDefaults(
   for (const def of applied) {
     values[def.column] = def.value;
   }
+}
+
+/**
+ * The onUpdate defaults a batched upsert must bind as literals: those for
+ * columns the conflict update does not already assign. Columns already in
+ * `assignedColumns` are left alone — they are written from the proposed row,
+ * which carries its own create-branch default for the same column.
+ *
+ * An empty `assignedColumns` means nothing is being updated, and an empty
+ * update payload skips onUpdate defaults by design (ADR 158) — so the probe
+ * stays empty and no default is generated.
+ */
+function collectUpdateDefaults(
+  ctx: CollectionContext<Contract<SqlStorage>>,
+  namespaceId: string,
+  tableName: string,
+  assignedColumns: readonly string[],
+): Record<string, unknown> {
+  const probe: Record<string, unknown> = Object.fromEntries(
+    assignedColumns.map((column) => [column, null]),
+  );
+  const applied = ctx.context.applyMutationDefaults({
+    op: 'update',
+    table: tableName,
+    namespace: namespaceId,
+    values: probe,
+  });
+  return Object.fromEntries(applied.map((def) => [def.column, def.value]));
 }
 
 type WhereDirectInput = WhereArg;
@@ -1790,6 +1822,173 @@ class CollectionImpl<
       `upsert() for model "${this.modelName}" did not return a row`,
       { meta: { operation: 'upsert', model: this.modelName } },
     );
+  }
+
+  /**
+   * Write terminal: insert many rows, updating the ones that conflict, and
+   * stream the resulting rows. One statement for the whole batch, so the
+   * cost is one round-trip rather than one per row.
+   *
+   * Each conflicting row is updated with its own proposed values — the
+   * update is not a single literal payload shared by the batch. `update`
+   * selects which fields that overwrite covers; it defaults to every field
+   * the input rows carry except the conflict target and the primary key.
+   *
+   * ```typescript
+   * // Insert-or-refresh a batch keyed on the primary key:
+   * const rows = await db.orm.User.upsertAll([
+   *   { id: 1, name: 'Alice', email: 'alice@example.com' },
+   *   { id: 2, name: 'Bob', email: 'bob@example.com' },
+   * ]);
+   *
+   * // Key on a unique constraint, and overwrite only `name`:
+   * await db.orm.User.upsertAll(users, {
+   *   conflictOn: ['email'],
+   *   update: ['name'],
+   * });
+   *
+   * // Insert-if-absent — `update: []` leaves conflicting rows untouched.
+   * // Those rows are skipped by the statement, so they are absent from
+   * // the result; reloading them would cost a second statement.
+   * await db.orm.User.upsertAll(users, { update: [] });
+   * ```
+   *
+   * Accepts an optional `configure` callback that receives a
+   * `MetaBuilder<'write'>` for attaching typed annotations.
+   *
+   * Not supported on MTI variants.
+   */
+  upsertAll(
+    data: readonly ResolvedCreateInput<TContract, ModelName, State['variantName'], State['nsId']>[],
+    options?: UpsertAllOptions<TContract, ModelName>,
+    configure?: (meta: MetaBuilder<'write'>) => void,
+  ): AsyncIterableResult<Row> {
+    if (data.length === 0) {
+      const generator = async function* (): AsyncGenerator<Row, void, unknown> {};
+      return new AsyncIterableResult(generator());
+    }
+
+    assertReturningCapability(this.contract, 'upsertAll()');
+    this.#assertNotMtiVariant('upsertAll()');
+    const annotationsMap = this.#collectAnnotationsFromMeta(configure, 'write', 'upsertAll');
+
+    const mappedRows = this.#mapCreateRows(
+      blindCast<
+        readonly Record<string, unknown>[],
+        'resolved upsert inputs are model-field records for storage mapping'
+      >(data),
+    );
+    applyCreateDefaults(this.ctx, this.namespaceId, this.tableName, mappedRows);
+
+    const conflict = this.#resolveBatchedConflict(mappedRows, options);
+    const { selectedForQuery: selectedForUpsert, hiddenColumns } = this.#augmentMutationSelection();
+
+    const dispatch = {
+      context: this.ctx.context,
+      runtime: this.ctx.runtime,
+      tableName: this.tableName,
+      modelName: this.modelName,
+      namespaceId: this.namespaceId,
+      variantName: this.state.variantName,
+      includes: this.state.includes,
+      selectedFields: this.state.selectedFields,
+      hiddenColumns,
+      mapRow: (mapped: Record<string, unknown>) =>
+        blindCast<Row, 'mapped mutation storage row matches the collection generic row'>(mapped),
+    };
+
+    if (this.contract.capabilities?.['sql']?.['defaultInInsert'] !== true) {
+      const plans = compileUpsertReturningManySplit(
+        this.contract,
+        this.namespaceId,
+        this.tableName,
+        mappedRows,
+        conflict,
+        selectedForUpsert,
+      ).map((plan) => mergeAnnotations(plan, annotationsMap));
+      return dispatchSplitMutationRows<Row>({ ...dispatch, plans });
+    }
+
+    return dispatchMutationRows<Row>({
+      ...dispatch,
+      compiled: mergeAnnotations(
+        compileUpsertReturningMany(
+          this.contract,
+          this.namespaceId,
+          this.tableName,
+          mappedRows,
+          conflict,
+          selectedForUpsert,
+        ),
+        annotationsMap,
+      ),
+    });
+  }
+
+  #resolveBatchedConflict(
+    mappedRows: readonly Record<string, unknown>[],
+    options: UpsertAllOptions<TContract, ModelName> | undefined,
+  ): UpsertConflictResolution {
+    const primaryKeyColumns = resolveUpsertConflictColumns(
+      this.contract,
+      this.namespaceId,
+      this.modelName,
+      undefined,
+    );
+    const columns = options?.conflictOn?.length
+      ? mapFieldsToColumns(this.contract, this.namespaceId, this.modelName, options.conflictOn)
+      : primaryKeyColumns;
+    if (columns.length === 0) {
+      throw ormError(
+        'ORM.ARGUMENT_INVALID',
+        `upsertAll() for model "${this.modelName}" requires conflict columns`,
+        { meta: { method: 'upsertAll', model: this.modelName } },
+      );
+    }
+
+    // An explicit list is honoured verbatim — naming the conflict column is
+    // legal and meaningful (under a case-insensitive collation the stored
+    // value and the proposed one can genuinely differ), so it is the caller's
+    // call, not something to silently drop.
+    if (options?.update) {
+      const updateColumns = mapFieldsToColumns(
+        this.contract,
+        this.namespaceId,
+        this.modelName,
+        options.update,
+      );
+      return {
+        columns,
+        updateColumns,
+        updateDefaults: collectUpdateDefaults(
+          this.ctx,
+          this.namespaceId,
+          this.tableName,
+          updateColumns,
+        ),
+      };
+    }
+
+    // The union across rows, not any single row: `normalizeInsertRows` widens
+    // every row to that union, so a column only some rows carry is still a
+    // real column of the proposed row. The primary key is held back along
+    // with the conflict target — when the two differ, overwriting it would
+    // reassign the identity of a row the caller only meant to refresh.
+    const withheld = new Set([...columns, ...primaryKeyColumns]);
+    const updateColumns = [...new Set(mappedRows.flatMap((row) => Object.keys(row)))].filter(
+      (column) => !withheld.has(column),
+    );
+
+    return {
+      columns,
+      updateColumns,
+      updateDefaults: collectUpdateDefaults(
+        this.ctx,
+        this.namespaceId,
+        this.tableName,
+        updateColumns,
+      ),
+    };
   }
 
   /**

--- a/packages/3-extensions/sql-orm-client/src/exports/index.ts
+++ b/packages/3-extensions/sql-orm-client/src/exports/index.ts
@@ -29,5 +29,7 @@ export type {
   RuntimeQueryable,
   ShorthandWhereFilter,
   UniqueConstraintCriterion,
+  UniqueConstraintFieldName,
+  UpsertAllOptions,
 } from '../types';
 export { emptyState } from '../types';

--- a/packages/3-extensions/sql-orm-client/src/query-plan-mutations.ts
+++ b/packages/3-extensions/sql-orm-client/src/query-plan-mutations.ts
@@ -328,6 +328,99 @@ export function compileUpsertReturning(
   return buildOrmQueryPlan(contract, ast, params);
 }
 
+/**
+ * How a batched upsert resolves a conflict. `updateColumns` are assigned from
+ * the proposed row (`excluded.<column>`) so each conflicting row is updated
+ * with its own values — the whole point of a batched upsert, which a literal
+ * SET clause shared by every row cannot express. `updateDefaults` are the
+ * onUpdate mutation defaults (e.g. `@updatedAt`) for columns the update set
+ * does not already carry; they bind as literal params and win over an
+ * `excluded` assignment for the same column.
+ */
+export interface UpsertConflictResolution {
+  readonly columns: readonly string[];
+  readonly updateColumns: readonly string[];
+  readonly updateDefaults: Record<string, unknown>;
+}
+
+function buildBatchedOnConflict(
+  contract: Contract<SqlStorage>,
+  namespaceId: string,
+  tableName: string,
+  conflict: UpsertConflictResolution,
+): InsertOnConflict {
+  const target = InsertOnConflict.on(
+    conflict.columns.map((column) => ColumnRef.of(tableName, column)),
+  );
+
+  const set: Record<string, AnyExpression> = {};
+  for (const column of conflict.updateColumns) {
+    set[column] = ColumnRef.of('excluded', column);
+  }
+  if (Object.keys(conflict.updateDefaults).length > 0) {
+    const { assignments } = toParamAssignments(
+      contract,
+      namespaceId,
+      tableName,
+      conflict.updateDefaults,
+    );
+    Object.assign(set, assignments);
+  }
+
+  return Object.keys(set).length === 0 ? target.doNothing() : target.doUpdateSet(set);
+}
+
+/**
+ * Compiles a batched `INSERT ... VALUES (…), (…) ON CONFLICT … DO UPDATE SET`
+ * with a RETURNING clause — one statement for N rows (ADR 003).
+ *
+ * With `DO NOTHING` (no update columns and no update defaults) the statement
+ * returns only the rows it actually inserted; conflicting rows are absent.
+ * Reloading them would mean a second statement, which this lane does not do.
+ */
+export function compileUpsertReturningMany(
+  contract: Contract<SqlStorage>,
+  namespaceId: string,
+  tableName: string,
+  rows: readonly Record<string, unknown>[],
+  conflict: UpsertConflictResolution,
+  returningColumns: readonly string[] | undefined,
+): SqlQueryPlan<Record<string, unknown>> {
+  const { rows: normalizedRows } = normalizeInsertRows(contract, namespaceId, tableName, rows);
+  const ast = InsertAst.into(tableSourceForContract(contract, namespaceId, tableName))
+    .withRows(normalizedRows)
+    .withOnConflict(buildBatchedOnConflict(contract, namespaceId, tableName, conflict))
+    .withReturning(buildReturningColumns(contract, namespaceId, tableName, returningColumns));
+
+  const { params } = deriveParamsFromAst(ast);
+  return buildOrmQueryPlan(contract, ast, params);
+}
+
+/**
+ * Sibling of {@link compileInsertReturningSplit} for targets that cannot spell
+ * `DEFAULT` inside `INSERT ... VALUES`: rows are grouped by their column
+ * signature and each group becomes its own statement. The conflict resolution
+ * is shared verbatim across the groups, so a column a group omits is still
+ * assigned from `excluded` — the proposed row carries that column's default.
+ */
+export function compileUpsertReturningManySplit(
+  contract: Contract<SqlStorage>,
+  namespaceId: string,
+  tableName: string,
+  rows: readonly Record<string, unknown>[],
+  conflict: UpsertConflictResolution,
+  returningColumns: readonly string[] | undefined,
+): ReadonlyArray<SqlQueryPlan<Record<string, unknown>>> {
+  if (rows.length === 0) {
+    throw ormError('ORM.MUTATION_DATA_MISSING', 'upsertAll() requires at least one row', {
+      meta: { method: 'upsertAll', namespaceId, tableName },
+    });
+  }
+  return groupRowsByColumnSignature(rows).map((group) =>
+    compileUpsertReturningMany(contract, namespaceId, tableName, group, conflict, returningColumns),
+  );
+}
+
 export function compileUpdateReturning(
   contract: Contract<SqlStorage>,
   namespaceId: string,

--- a/packages/3-extensions/sql-orm-client/src/query-plan.ts
+++ b/packages/3-extensions/sql-orm-client/src/query-plan.ts
@@ -13,5 +13,8 @@ export {
   compileUpdateCount,
   compileUpdateReturning,
   compileUpsertReturning,
+  compileUpsertReturningMany,
+  compileUpsertReturningManySplit,
+  type UpsertConflictResolution,
 } from './query-plan-mutations';
 export { compileSelect, compileSelectWithIncludes } from './query-plan-select';

--- a/packages/3-extensions/sql-orm-client/src/types.ts
+++ b/packages/3-extensions/sql-orm-client/src/types.ts
@@ -1414,6 +1414,46 @@ export type UniqueConstraintCriterion<
       : never
     : never;
 
+type ConstraintFieldNames<TContract extends Contract<SqlStorage>, ModelName extends string> =
+  ConstraintColumnsUnion<TContract, ModelName> extends infer Columns
+    ? Columns extends readonly string[]
+      ? FieldNameForColumn<TContract, ModelName, Columns[number]>
+      : never
+    : never;
+
+/**
+ * The field names a conflict target may name: every field participating in the
+ * primary key or a unique constraint. A batched upsert names the constraint by
+ * its fields rather than by a field-value record — no single row's values can
+ * stand for the whole batch — so this is the flat name union rather than the
+ * per-constraint record {@link UniqueConstraintCriterion} builds. A contract
+ * whose constraint metadata is not statically known widens to every model
+ * field, mirroring how that criterion widens to an open record.
+ */
+export type UniqueConstraintFieldName<
+  TContract extends Contract<SqlStorage>,
+  ModelName extends string,
+> = [ConstraintFieldNames<TContract, ModelName>] extends [never]
+  ? keyof DefaultModelRow<TContract, ModelName> & string
+  : ConstraintFieldNames<TContract, ModelName>;
+
+export interface UpsertAllOptions<
+  TContract extends Contract<SqlStorage>,
+  ModelName extends string,
+> {
+  /**
+   * Fields of the unique constraint that drives conflict resolution. Defaults
+   * to the model's primary key.
+   */
+  readonly conflictOn?: readonly UniqueConstraintFieldName<TContract, ModelName>[];
+  /**
+   * Fields overwritten from the proposed row when a row conflicts. Defaults to
+   * every non-conflict field the input rows carry. An empty list skips
+   * conflicting rows, which are then absent from the result.
+   */
+  readonly update?: readonly (keyof DefaultModelRow<TContract, ModelName> & string)[];
+}
+
 type RelationConnectCriterion<TContract extends Contract<SqlStorage>, ModelName extends string> = [
   UniqueConstraintCriterion<TContract, ModelName>,
 ] extends [never]

--- a/packages/3-extensions/sql-orm-client/test/collection.state.test.ts
+++ b/packages/3-extensions/sql-orm-client/test/collection.state.test.ts
@@ -366,6 +366,37 @@ describe('Collection', () => {
       expect(runtime.executions).toHaveLength(2);
     });
 
+    it('upsertAll() uses split insert when defaultInInsert is absent', async () => {
+      const { collection, runtime } = createReturningCollectionWithoutDefaultInInsert('User');
+      runtime.setNextResults([
+        [{ id: 1, name: 'Alice', email: 'alice@example.com', invited_by_id: null, address: null }],
+        [{ id: 2, name: 'Bob', email: 'bob@example.com', invited_by_id: 1, address: null }],
+      ]);
+
+      const rows = await collection
+        .upsertAll([
+          { id: 1, name: 'Alice', email: 'alice@example.com' },
+          { id: 2, name: 'Bob', email: 'bob@example.com', invitedById: 1 },
+        ])
+        .toArray();
+
+      expect(rows).toHaveLength(2);
+      expect(runtime.executions).toHaveLength(2);
+      // Every group carries the same conflict resolution — a split batch must
+      // not degrade into per-group update semantics.
+      for (const execution of runtime.executions) {
+        const ast = execution.plan.ast as {
+          onConflict?: { action?: { kind: string; set?: Record<string, unknown> } };
+        };
+        expect(ast.onConflict?.action?.kind).toBe('do-update-set');
+        expect(Object.keys(ast.onConflict?.action?.set ?? {})).toEqual([
+          'name',
+          'email',
+          'invited_by_id',
+        ]);
+      }
+    });
+
     it('createAndCount() uses split insert when defaultInInsert is absent', async () => {
       const { collection, runtime } = createReturningCollectionWithoutDefaultInInsert('User');
       runtime.setNextResults([[], []]);

--- a/packages/3-extensions/sql-orm-client/test/query-plan-mutations.test.ts
+++ b/packages/3-extensions/sql-orm-client/test/query-plan-mutations.test.ts
@@ -19,6 +19,8 @@ import {
   compileUpdateCount,
   compileUpdateReturning,
   compileUpsertReturning,
+  compileUpsertReturningMany,
+  compileUpsertReturningManySplit,
 } from '../src/query-plan';
 import { withReturningCapability } from './collection-fixtures';
 import { getTestContract } from './helpers';
@@ -152,6 +154,118 @@ describe('query plan mutations', () => {
       name: usersColParam(contract, 'name', 'Updated Alice'),
     });
     expect(plan.params).toEqual([10, 'Alice', 'alice@example.com', 'Updated Alice']);
+  });
+
+  describe('compileUpsertReturningMany()', () => {
+    it('assigns every update column from the excluded row across a batched insert', () => {
+      const contract = withReturningCapability(getTestContract());
+      const plan = compileUpsertReturningMany(
+        contract,
+        'public',
+        'users',
+        [
+          { id: 10, name: 'Alice', email: 'alice@example.com' },
+          { id: 11, name: 'Bob', email: 'bob@example.com' },
+        ],
+        { columns: ['id'], updateColumns: ['name', 'email'], updateDefaults: {} },
+        undefined,
+      );
+
+      assertInsertAst(plan.ast);
+      expect(plan.ast.rows).toHaveLength(2);
+      expect(plan.ast.onConflict?.columns).toEqual([ColumnRef.of('users', 'id')]);
+      const action = plan.ast.onConflict?.action as DoUpdateSetConflictAction;
+      expect(action.set).toEqual({
+        name: ColumnRef.of('excluded', 'name'),
+        email: ColumnRef.of('excluded', 'email'),
+      });
+      // The excluded assignments bind nothing — only the VALUES rows carry params.
+      expect(plan.params).toEqual([10, 'Alice', 'alice@example.com', 11, 'Bob', 'bob@example.com']);
+    });
+
+    it('binds update defaults as literal params beside the excluded assignments', () => {
+      const contract = withReturningCapability(getTestContract());
+      const plan = compileUpsertReturningMany(
+        contract,
+        'public',
+        'users',
+        [{ id: 10, name: 'Alice', email: 'alice@example.com' }],
+        {
+          columns: ['id'],
+          updateColumns: ['name'],
+          updateDefaults: { address: 'generated address' },
+        },
+        undefined,
+      );
+
+      assertInsertAst(plan.ast);
+      const action = plan.ast.onConflict?.action as DoUpdateSetConflictAction;
+      expect(action.set).toEqual({
+        name: ColumnRef.of('excluded', 'name'),
+        address: usersColParam(contract, 'address', 'generated address'),
+      });
+      expect(plan.params).toEqual([10, 'Alice', 'alice@example.com', 'generated address']);
+    });
+
+    it('uses DO NOTHING when no update columns and no update defaults remain', () => {
+      const contract = withReturningCapability(getTestContract());
+      const plan = compileUpsertReturningMany(
+        contract,
+        'public',
+        'users',
+        [{ id: 10, name: 'Alice', email: 'alice@example.com' }],
+        { columns: ['id'], updateColumns: [], updateDefaults: {} },
+        undefined,
+      );
+
+      assertInsertAst(plan.ast);
+      expect(plan.ast.onConflict?.action?.kind).toBe('do-nothing');
+      expect(plan.ast.returning?.map((item) => item.alias)).toEqual(
+        Object.keys(unboundTables(contract.storage)['users']!.columns),
+      );
+    });
+
+    it('rejects an empty rows array', () => {
+      const contract = withReturningCapability(getTestContract());
+      expect(() =>
+        compileUpsertReturningMany(
+          contract,
+          'public',
+          'users',
+          [],
+          { columns: ['id'], updateColumns: ['name'], updateDefaults: {} },
+          undefined,
+        ),
+      ).toThrow('at least one row');
+    });
+  });
+
+  describe('compileUpsertReturningManySplit()', () => {
+    it('keeps one update set across the per-column-signature groups', () => {
+      const contract = withReturningCapability(getTestContract());
+      const plans = compileUpsertReturningManySplit(
+        contract,
+        'public',
+        'users',
+        [
+          { id: 1, name: 'Alice', email: 'a@a.com' },
+          { id: 2, name: 'Bob', email: 'b@b.com', address: 'Baker St' },
+        ],
+        { columns: ['id'], updateColumns: ['name', 'email', 'address'], updateDefaults: {} },
+        undefined,
+      );
+
+      expect(plans).toHaveLength(2);
+      for (const plan of plans) {
+        assertInsertAst(plan.ast);
+        const action = plan.ast.onConflict?.action as DoUpdateSetConflictAction;
+        expect(action.set).toEqual({
+          name: ColumnRef.of('excluded', 'name'),
+          email: ColumnRef.of('excluded', 'email'),
+          address: ColumnRef.of('excluded', 'address'),
+        });
+      }
+    });
   });
 
   describe('compileInsertReturningSplit()', () => {

--- a/packages/3-extensions/sql-orm-client/test/query-plan-mutations.test.ts
+++ b/packages/3-extensions/sql-orm-client/test/query-plan-mutations.test.ts
@@ -207,6 +207,29 @@ describe('query plan mutations', () => {
       expect(plan.params).toEqual([10, 'Alice', 'alice@example.com', 'generated address']);
     });
 
+    it('lets an update default win over the excluded assignment for the same column', () => {
+      const contract = withReturningCapability(getTestContract());
+      const plan = compileUpsertReturningMany(
+        contract,
+        'public',
+        'users',
+        [{ id: 10, name: 'Alice', email: 'alice@example.com', address: 'Old St' }],
+        {
+          columns: ['id'],
+          updateColumns: ['name', 'address'],
+          updateDefaults: { address: 'generated address' },
+        },
+        undefined,
+      );
+
+      assertInsertAst(plan.ast);
+      const action = plan.ast.onConflict?.action as DoUpdateSetConflictAction;
+      expect(action.set).toEqual({
+        name: ColumnRef.of('excluded', 'name'),
+        address: usersColParam(contract, 'address', 'generated address'),
+      });
+    });
+
     it('uses DO NOTHING when no update columns and no update defaults remain', () => {
       const contract = withReturningCapability(getTestContract());
       const plan = compileUpsertReturningMany(

--- a/skills/prisma-8/references/queries-postgres.md
+++ b/skills/prisma-8/references/queries-postgres.md
@@ -204,6 +204,12 @@ await db.orm.User
     create: { id, email, displayName, kind, createdAt: new Date() },
     update: { email, displayName, kind },
   });
+
+// Upsert a batch — one statement, each conflicting row updated with its
+// own proposed values. `update` defaults to every field the rows carry
+// except the conflict target and the primary key; `update: []` leaves
+// conflicting rows untouched (and out of the result).
+await db.orm.User.upsertAll(rows, { conflictOn: ['email'], update: ['displayName'] });
 ```
 
 The ORM returns inserted / updated rows by default. The `.returning(...)` selector lives on the SQL builder (next section), where you build a plan and execute it explicitly.

--- a/test/integration/test/sql-orm-client/collection-mutation-defaults.test.ts
+++ b/test/integration/test/sql-orm-client/collection-mutation-defaults.test.ts
@@ -1,6 +1,7 @@
 import postgresAdapter from '@internal/adapter-postgres/runtime';
 import pgvectorRuntime from '@internal/extension-pgvector/runtime';
 import { Collection } from '@internal/sql-orm-client';
+import { ColumnRef, type ParamRef } from '@internal/sql-relational-core/ast';
 import { createExecutionContext, createSqlExecutionStack } from '@internal/sql-runtime';
 import postgresTarget from '@internal/target-postgres/runtime';
 import { describe, expect, it } from 'vitest';
@@ -72,6 +73,42 @@ function buildTagWithUpdatedAtContract(): TestContract {
   return deserializeTestContract(contract);
 }
 
+// Same shape as `buildTagWithUpdatedAtContract`, but the generated column is a
+// `createdAt` carrying an onCreate default and no onUpdate one — the case where
+// sourcing the column from `excluded` on conflict would silently restamp an
+// existing row's creation time.
+function buildTagWithCreatedAtContract(): TestContract {
+  const contract = JSON.parse(
+    JSON.stringify(withReturningCapability(getTestContract())),
+  ) as TestContract;
+
+  const tagModel = contract.domain.namespaces['public']!.models['Tag'] as Record<string, unknown>;
+  const tagFields = tagModel['fields'] as Record<string, unknown>;
+  tagFields['createdAt'] = {
+    nullable: false,
+    type: { kind: 'scalar', codecId: 'pg/timestamptz@1' },
+  };
+  const tagStorage = tagModel['storage'] as Record<string, unknown>;
+  (tagStorage['fields'] as Record<string, unknown>)['createdAt'] = { column: 'created_at' };
+
+  const tagsTable = unboundTables(contract.storage)['tags'] as { columns: Record<string, unknown> };
+  tagsTable.columns['created_at'] = {
+    nativeType: 'timestamptz',
+    codecId: 'pg/timestamptz@1',
+    nullable: false,
+  };
+
+  const execution = contract.execution as unknown as {
+    mutations: { defaults: Array<Record<string, unknown>> };
+  };
+  execution.mutations.defaults.push({
+    ref: { namespace: 'public', table: 'tags', column: 'created_at' },
+    onCreate: { kind: 'generator', id: 'timestampNow' },
+  });
+
+  return deserializeTestContract(contract);
+}
+
 function setupTagCollection(): {
   collection: Collection<TestContract, 'Tag'>;
   runtime: MockRuntime;
@@ -91,9 +128,34 @@ function setupTagCollection(): {
   return { collection, runtime, contract };
 }
 
+function setupCreatedAtTagCollection(): {
+  collection: Collection<TestContract, 'Tag'>;
+  runtime: MockRuntime;
+} {
+  const contract = buildTagWithCreatedAtContract();
+  const context = createExecutionContext({
+    contract,
+    stack: createSqlExecutionStack({
+      target: postgresTarget,
+      adapter: postgresAdapter,
+      extensions: [pgvectorRuntime],
+    }),
+  });
+  const runtime = createMockRuntime();
+  const collection = new Collection({ runtime, context }, 'Tag', { namespaceId: 'public' });
+  return { collection, runtime };
+}
+
 function planParams(execution: { plan: unknown } | undefined): readonly unknown[] {
   const plan = execution?.plan as { params?: readonly unknown[] } | undefined;
   return plan?.params ?? [];
+}
+
+function conflictSet(execution: { plan: unknown } | undefined): Record<string, unknown> {
+  const plan = execution?.plan as
+    | { ast?: { onConflict?: { action?: { set?: Record<string, unknown> } } } }
+    | undefined;
+  return plan?.ast?.onConflict?.action?.set ?? {};
 }
 
 const TAG_A_ID = `${TAG_ID_1.slice(0, -1)}A` as string;
@@ -305,7 +367,7 @@ describe('@updatedAt mutation defaults via Collection', () => {
   });
 
   describe('upsertAll (bulk)', () => {
-    it('carries the create-branch timestamp into the conflict update via excluded', async () => {
+    it('advances updatedAt through an onUpdate literal, not through excluded', async () => {
       const { collection, runtime } = setupTagCollection();
       runtime.setNextResults([
         [
@@ -321,11 +383,18 @@ describe('@updatedAt mutation defaults via Collection', () => {
         ])
         .toArray();
 
-      const params = planParams(runtime.executions[0]);
-      const dateParams = params.filter((p) => p instanceof Date) as Date[];
-      // `updated_at` lands in the default update set, so it is assigned from
-      // `excluded.updated_at` — one shared create-branch Date, no extra literal.
-      expect(dateParams).toHaveLength(2);
+      // `updated_at` is not a caller-supplied column, so it stays out of the
+      // implicit update set and is bound as the onUpdate default instead.
+      const set = conflictSet(runtime.executions[0]);
+      expect(Object.keys(set)).toEqual(['name', 'updated_at']);
+      expect(set['name']).toEqual(ColumnRef.of('excluded', 'name'));
+      expect((set['updated_at'] as ParamRef).value).toBeInstanceOf(Date);
+
+      const dateParams = planParams(runtime.executions[0]).filter(
+        (p) => p instanceof Date,
+      ) as Date[];
+      // Two create-branch Dates sharing one generated value, then the onUpdate literal.
+      expect(dateParams).toHaveLength(3);
       expect(dateParams[1]).toBe(dateParams[0]);
     });
 
@@ -337,11 +406,29 @@ describe('@updatedAt mutation defaults via Collection', () => {
         .upsertAll([{ id: tagId(TAG_A_ID), name: 'one' }], { update: ['name'] })
         .toArray();
 
-      const params = planParams(runtime.executions[0]);
-      const dateParams = params.filter((p) => p instanceof Date) as Date[];
-      // One Date bound in the INSERT row, a second bound as the literal
-      // `updated_at` assignment the DO UPDATE SET clause adds.
+      const set = conflictSet(runtime.executions[0]);
+      expect(Object.keys(set)).toEqual(['name', 'updated_at']);
+      expect(set['name']).toEqual(ColumnRef.of('excluded', 'name'));
+
+      const dateParams = planParams(runtime.executions[0]).filter(
+        (p) => p instanceof Date,
+      ) as Date[];
+      // One Date in the INSERT row, a second as the `updated_at` assignment.
       expect(dateParams).toHaveLength(2);
+      expect((set['updated_at'] as ParamRef).value).toBe(dateParams[1]);
+    });
+
+    it('keeps an onCreate-only column out of the conflict update', async () => {
+      const { collection, runtime } = setupCreatedAtTagCollection();
+      runtime.setNextResults([[{ id: TAG_A_ID, name: 'one', created_at: new Date() }]]);
+
+      await collection.upsertAll([{ id: tagId(TAG_A_ID), name: 'one' }]).toArray();
+
+      // `created_at` is generated for the insert branch only. Assigning it from
+      // `excluded` would restamp the creation time of a row that already exists.
+      const set = conflictSet(runtime.executions[0]);
+      expect(Object.keys(set)).toEqual(['name']);
+      expect(set['name']).toEqual(ColumnRef.of('excluded', 'name'));
     });
 
     it('does not advance updatedAt when the update list is empty', async () => {

--- a/test/integration/test/sql-orm-client/collection-mutation-defaults.test.ts
+++ b/test/integration/test/sql-orm-client/collection-mutation-defaults.test.ts
@@ -420,9 +420,14 @@ describe('@updatedAt mutation defaults via Collection', () => {
 
     it('keeps an onCreate-only column out of the conflict update', async () => {
       const { collection, runtime } = setupCreatedAtTagCollection();
-      runtime.setNextResults([[{ id: TAG_A_ID, name: 'one', created_at: new Date() }]]);
+      runtime.setNextResults([[{ id: TAG_A_ID, name: 'one' }]]);
 
-      await collection.upsertAll([{ id: tagId(TAG_A_ID), name: 'one' }]).toArray();
+      const rows = await collection
+        .select('id', 'name')
+        .upsertAll([{ id: tagId(TAG_A_ID), name: 'one' }])
+        .toArray();
+
+      expect(rows).toEqual([{ id: TAG_A_ID, name: 'one' }]);
 
       // `created_at` is generated for the insert branch only. Assigning it from
       // `excluded` would restamp the creation time of a row that already exists.

--- a/test/integration/test/sql-orm-client/collection-mutation-defaults.test.ts
+++ b/test/integration/test/sql-orm-client/collection-mutation-defaults.test.ts
@@ -303,4 +303,56 @@ describe('@updatedAt mutation defaults via Collection', () => {
       expect(dateParams).toHaveLength(1);
     });
   });
+
+  describe('upsertAll (bulk)', () => {
+    it('carries the create-branch timestamp into the conflict update via excluded', async () => {
+      const { collection, runtime } = setupTagCollection();
+      runtime.setNextResults([
+        [
+          { id: TAG_A_ID, name: 'one', updated_at: new Date() },
+          { id: TAG_B_ID, name: 'two', updated_at: new Date() },
+        ],
+      ]);
+
+      await collection
+        .upsertAll([
+          { id: tagId(TAG_A_ID), name: 'one' },
+          { id: tagId(TAG_B_ID), name: 'two' },
+        ])
+        .toArray();
+
+      const params = planParams(runtime.executions[0]);
+      const dateParams = params.filter((p) => p instanceof Date) as Date[];
+      // `updated_at` lands in the default update set, so it is assigned from
+      // `excluded.updated_at` — one shared create-branch Date, no extra literal.
+      expect(dateParams).toHaveLength(2);
+      expect(dateParams[1]).toBe(dateParams[0]);
+    });
+
+    it('applies an onUpdate default the explicit update list omits', async () => {
+      const { collection, runtime } = setupTagCollection();
+      runtime.setNextResults([[{ id: TAG_A_ID, name: 'one', updated_at: new Date() }]]);
+
+      await collection
+        .upsertAll([{ id: tagId(TAG_A_ID), name: 'one' }], { update: ['name'] })
+        .toArray();
+
+      const params = planParams(runtime.executions[0]);
+      const dateParams = params.filter((p) => p instanceof Date) as Date[];
+      // One Date bound in the INSERT row, a second bound as the literal
+      // `updated_at` assignment the DO UPDATE SET clause adds.
+      expect(dateParams).toHaveLength(2);
+    });
+
+    it('does not advance updatedAt when the update list is empty', async () => {
+      const { collection, runtime } = setupTagCollection();
+      runtime.setNextResults([[{ id: TAG_A_ID, name: 'one', updated_at: new Date() }]]);
+
+      await collection.upsertAll([{ id: tagId(TAG_A_ID), name: 'one' }], { update: [] }).toArray();
+
+      const params = planParams(runtime.executions[0]);
+      const dateParams = params.filter((p) => p instanceof Date) as Date[];
+      expect(dateParams).toHaveLength(1);
+    });
+  });
 });

--- a/test/integration/test/sql-orm-client/upsert.test.ts
+++ b/test/integration/test/sql-orm-client/upsert.test.ts
@@ -208,4 +208,202 @@ describe('integration/upsert', () => {
     },
     timeouts.spinUpPpgDev,
   );
+
+  it(
+    'upsertAll() inserts and updates in one statement, overwriting every non-conflict column',
+    async () => {
+      await withCollectionRuntime(async (runtime) => {
+        const users = createReturningUsersCollection(runtime);
+
+        await seedUsers(runtime, [{ id: 1, name: 'Alice', email: 'alice@example.com' }]);
+
+        runtime.resetExecutions();
+        const upserted = await users.upsertAll([
+          { id: 1, name: 'Alice Updated', email: 'alice+new@example.com', invitedById: null },
+          { id: 2, name: 'Bob', email: 'bob@example.com', invitedById: null },
+        ]);
+
+        expect(upserted).toEqual([
+          {
+            id: 1,
+            name: 'Alice Updated',
+            email: 'alice+new@example.com',
+            invitedById: null,
+            address: null,
+          },
+          { id: 2, name: 'Bob', email: 'bob@example.com', invitedById: null, address: null },
+        ]);
+        expect(runtime.executions).toHaveLength(1);
+
+        const ast = runtime.executions[0]?.ast;
+        expect(isInsertAst(ast)).toBe(true);
+        if (!isInsertAst(ast)) {
+          throw new Error('Expected upsertAll to emit an insert AST');
+        }
+        expect(ast.onConflict?.action?.kind).toBe('do-update-set');
+      });
+    },
+    timeouts.spinUpPpgDev,
+  );
+
+  it(
+    'upsertAll() restricts the conflict update to the requested fields',
+    async () => {
+      await withCollectionRuntime(async (runtime) => {
+        const users = createReturningUsersCollection(runtime);
+
+        await seedUsers(runtime, [{ id: 1, name: 'Alice', email: 'alice@example.com' }]);
+
+        const upserted = await users.upsertAll(
+          [{ id: 1, name: 'Alice Renamed', email: 'ignored@example.com', invitedById: null }],
+          { update: ['name'] },
+        );
+
+        expect(upserted).toEqual([
+          {
+            id: 1,
+            name: 'Alice Renamed',
+            email: 'alice@example.com',
+            invitedById: null,
+            address: null,
+          },
+        ]);
+      });
+    },
+    timeouts.spinUpPpgDev,
+  );
+
+  it(
+    'upsertAll() with an empty update list leaves conflicting rows untouched and omits them',
+    async () => {
+      await withCollectionRuntime(async (runtime) => {
+        const users = createReturningUsersCollection(runtime);
+
+        await seedUsers(runtime, [{ id: 1, name: 'Alice', email: 'alice@example.com' }]);
+
+        runtime.resetExecutions();
+        const upserted = await users.upsertAll(
+          [
+            { id: 1, name: 'Ignored', email: 'ignored@example.com', invitedById: null },
+            { id: 2, name: 'Bob', email: 'bob@example.com', invitedById: null },
+          ],
+          { update: [] },
+        );
+
+        expect(upserted).toEqual([
+          { id: 2, name: 'Bob', email: 'bob@example.com', invitedById: null, address: null },
+        ]);
+
+        const ast = runtime.executions[0]?.ast;
+        expect(isInsertAst(ast)).toBe(true);
+        if (!isInsertAst(ast)) {
+          throw new Error('Expected upsertAll to emit an insert AST');
+        }
+        expect(ast.onConflict?.action?.kind).toBe('do-nothing');
+
+        expect(await users.first({ id: 1 })).toEqual({
+          id: 1,
+          name: 'Alice',
+          email: 'alice@example.com',
+          invitedById: null,
+          address: null,
+        });
+      });
+    },
+    timeouts.spinUpPpgDev,
+  );
+
+  it(
+    'upsertAll() resolves an explicit non-primary-key conflict target',
+    async () => {
+      await withCollectionRuntime(async (runtime) => {
+        const users = createReturningUsersCollection(runtime);
+
+        await runtime.query('create unique index users_email_key on users (email)');
+        await seedUsers(runtime, [{ id: 2, name: 'Bob', email: 'bob@example.com' }]);
+
+        const upserted = await users.upsertAll(
+          [
+            { id: 3, name: 'Bob Updated', email: 'bob@example.com', invitedById: null },
+            { id: 4, name: 'Cara', email: 'cara@example.com', invitedById: null },
+          ],
+          { conflictOn: ['email'], update: ['name'] },
+        );
+
+        expect(upserted).toEqual([
+          {
+            id: 2,
+            name: 'Bob Updated',
+            email: 'bob@example.com',
+            invitedById: null,
+            address: null,
+          },
+          { id: 4, name: 'Cara', email: 'cara@example.com', invitedById: null, address: null },
+        ]);
+        expect(await users.first({ id: 3 })).toBeNull();
+      });
+    },
+    timeouts.spinUpPpgDev,
+  );
+
+  it(
+    'upsertAll() holds the primary key back from the default update set',
+    async () => {
+      await withCollectionRuntime(async (runtime) => {
+        const users = createReturningUsersCollection(runtime);
+
+        await runtime.query('create unique index users_email_key on users (email)');
+        await seedUsers(runtime, [{ id: 2, name: 'Bob', email: 'bob@example.com' }]);
+
+        const upserted = await users.upsertAll(
+          [{ id: 99, name: 'Bob Updated', email: 'bob@example.com', invitedById: null }],
+          { conflictOn: ['email'] },
+        );
+
+        // `name` is refreshed, but the row keeps its identity — an `id`
+        // carried only to satisfy the insert branch must not reassign it.
+        expect(upserted).toEqual([
+          {
+            id: 2,
+            name: 'Bob Updated',
+            email: 'bob@example.com',
+            invitedById: null,
+            address: null,
+          },
+        ]);
+        expect(await users.first({ id: 99 })).toBeNull();
+      });
+    },
+    timeouts.spinUpPpgDev,
+  );
+
+  it(
+    'upsertAll() returns an empty result without touching the database for empty input',
+    async () => {
+      await withCollectionRuntime(async (runtime) => {
+        const users = createReturningUsersCollection(runtime);
+
+        runtime.resetExecutions();
+        expect(await users.upsertAll([])).toEqual([]);
+        expect(runtime.executions).toHaveLength(0);
+      });
+    },
+    timeouts.spinUpPpgDev,
+  );
+
+  it(
+    'upsertAll() rejects when returning capability is disabled',
+    async () => {
+      await withCollectionRuntime(async (runtime) => {
+        const users = createUsersCollectionWithoutReturning(runtime);
+
+        expect(() =>
+          users.upsertAll([
+            { id: 5, name: 'NoReturn', email: 'noreturn@example.com', invitedById: null },
+          ]),
+        ).toThrow(/requires contract capability "returning"/);
+      });
+    },
+    timeouts.spinUpPpgDev,
+  );
 });

--- a/test/integration/test/sql-orm-client/upsert.test.ts
+++ b/test/integration/test/sql-orm-client/upsert.test.ts
@@ -218,20 +218,14 @@ describe('integration/upsert', () => {
         await seedUsers(runtime, [{ id: 1, name: 'Alice', email: 'alice@example.com' }]);
 
         runtime.resetExecutions();
-        const upserted = await users.upsertAll([
+        const upserted = await users.select('id', 'name', 'email', 'invitedById').upsertAll([
           { id: 1, name: 'Alice Updated', email: 'alice+new@example.com', invitedById: null },
           { id: 2, name: 'Bob', email: 'bob@example.com', invitedById: null },
         ]);
 
         expect(upserted).toEqual([
-          {
-            id: 1,
-            name: 'Alice Updated',
-            email: 'alice+new@example.com',
-            invitedById: null,
-            address: null,
-          },
-          { id: 2, name: 'Bob', email: 'bob@example.com', invitedById: null, address: null },
+          { id: 1, name: 'Alice Updated', email: 'alice+new@example.com', invitedById: null },
+          { id: 2, name: 'Bob', email: 'bob@example.com', invitedById: null },
         ]);
         expect(runtime.executions).toHaveLength(1);
 
@@ -254,20 +248,14 @@ describe('integration/upsert', () => {
 
         await seedUsers(runtime, [{ id: 1, name: 'Alice', email: 'alice@example.com' }]);
 
-        const upserted = await users.upsertAll(
-          [{ id: 1, name: 'Alice Renamed', email: 'ignored@example.com', invitedById: null }],
-          { update: ['name'] },
-        );
+        const upserted = await users
+          .select('id', 'name', 'email')
+          .upsertAll(
+            [{ id: 1, name: 'Alice Renamed', email: 'ignored@example.com', invitedById: null }],
+            { update: ['name'] },
+          );
 
-        expect(upserted).toEqual([
-          {
-            id: 1,
-            name: 'Alice Renamed',
-            email: 'alice@example.com',
-            invitedById: null,
-            address: null,
-          },
-        ]);
+        expect(upserted).toEqual([{ id: 1, name: 'Alice Renamed', email: 'alice@example.com' }]);
       });
     },
     timeouts.spinUpPpgDev,
@@ -282,7 +270,7 @@ describe('integration/upsert', () => {
         await seedUsers(runtime, [{ id: 1, name: 'Alice', email: 'alice@example.com' }]);
 
         runtime.resetExecutions();
-        const upserted = await users.upsertAll(
+        const upserted = await users.select('id', 'name', 'email').upsertAll(
           [
             { id: 1, name: 'Ignored', email: 'ignored@example.com', invitedById: null },
             { id: 2, name: 'Bob', email: 'bob@example.com', invitedById: null },
@@ -290,9 +278,7 @@ describe('integration/upsert', () => {
           { update: [] },
         );
 
-        expect(upserted).toEqual([
-          { id: 2, name: 'Bob', email: 'bob@example.com', invitedById: null, address: null },
-        ]);
+        expect(upserted).toEqual([{ id: 2, name: 'Bob', email: 'bob@example.com' }]);
 
         const ast = runtime.executions[0]?.ast;
         expect(isInsertAst(ast)).toBe(true);
@@ -301,12 +287,10 @@ describe('integration/upsert', () => {
         }
         expect(ast.onConflict?.action?.kind).toBe('do-nothing');
 
-        expect(await users.first({ id: 1 })).toEqual({
+        expect(await users.select('id', 'name', 'email').first({ id: 1 })).toEqual({
           id: 1,
           name: 'Alice',
           email: 'alice@example.com',
-          invitedById: null,
-          address: null,
         });
       });
     },
@@ -322,7 +306,7 @@ describe('integration/upsert', () => {
         await runtime.query('create unique index users_email_key on users (email)');
         await seedUsers(runtime, [{ id: 2, name: 'Bob', email: 'bob@example.com' }]);
 
-        const upserted = await users.upsertAll(
+        const upserted = await users.select('id', 'name', 'email').upsertAll(
           [
             { id: 3, name: 'Bob Updated', email: 'bob@example.com', invitedById: null },
             { id: 4, name: 'Cara', email: 'cara@example.com', invitedById: null },
@@ -331,14 +315,8 @@ describe('integration/upsert', () => {
         );
 
         expect(upserted).toEqual([
-          {
-            id: 2,
-            name: 'Bob Updated',
-            email: 'bob@example.com',
-            invitedById: null,
-            address: null,
-          },
-          { id: 4, name: 'Cara', email: 'cara@example.com', invitedById: null, address: null },
+          { id: 2, name: 'Bob Updated', email: 'bob@example.com' },
+          { id: 4, name: 'Cara', email: 'cara@example.com' },
         ]);
         expect(await users.first({ id: 3 })).toBeNull();
       });
@@ -355,22 +333,18 @@ describe('integration/upsert', () => {
         await runtime.query('create unique index users_email_key on users (email)');
         await seedUsers(runtime, [{ id: 2, name: 'Bob', email: 'bob@example.com' }]);
 
-        const upserted = await users.upsertAll(
-          [{ id: 99, name: 'Bob Updated', email: 'bob@example.com', invitedById: null }],
-          { conflictOn: ['email'] },
-        );
+        const upserted = await users
+          .select('id', 'name', 'email')
+          .upsertAll(
+            [{ id: 99, name: 'Bob Updated', email: 'bob@example.com', invitedById: null }],
+            {
+              conflictOn: ['email'],
+            },
+          );
 
         // `name` is refreshed, but the row keeps its identity — an `id`
         // carried only to satisfy the insert branch must not reassign it.
-        expect(upserted).toEqual([
-          {
-            id: 2,
-            name: 'Bob Updated',
-            email: 'bob@example.com',
-            invitedById: null,
-            address: null,
-          },
-        ]);
+        expect(upserted).toEqual([{ id: 2, name: 'Bob Updated', email: 'bob@example.com' }]);
         expect(await users.first({ id: 99 })).toBeNull();
       });
     },


### PR DESCRIPTION
## Linked issue

Refs #10362, Refs #4134 — not `Fixes`. Both were filed against classic Prisma, where the people who
upvoted them are. This lands in Prisma Next only, and features aren't backported to 7.x.

#4134 mixes two features; the [2024 vote](https://github.com/prisma/prisma/issues/4134#issuecomment-2100174342)
settled it 63–8 in favour of the bulk one. That's what this implements. `upsertFirst` is out of scope.

## Summary

`upsert()` does one row, so N rows cost N round-trips. Everyone in both threads works around it with the
same hand-written `INSERT ... ON CONFLICT ... DO UPDATE SET col = EXCLUDED.col` through `$executeRaw`,
giving up type safety to get one statement. `upsertAll` makes that a terminal.

```typescript
await db.orm.User.upsertAll(rows, {
  conflictOn: ['email'],  // defaults to the primary key
  update: ['name'],       // defaults to every non-conflict, non-PK field the rows carry
});                       // update: [] → DO NOTHING
```

Returns rows like `createAll` does. Three things worth a look:

- **Updates come from `EXCLUDED`**, so each conflicting row gets its own values. A shared literal payload
  can't express a batch. Both renderers already handle the `excluded` pseudo-table, so no adapter changes.
- **The primary key is held out of the default update set.** With `conflictOn: ['email']`, updating every
  non-conflict column would rewrite `id` on rows the caller only meant to refresh. An explicit `update`
  list is still taken as written.
- **`DO NOTHING` doesn't reload.** Single-row `upsert()` issues a second query to return the existing row;
  doing that per row would be N+1, so conflicting rows are just absent from the result.

`@updatedAt` still advances: a column already in the update set comes from `excluded`, one that isn't gets
bound as a literal.

## Testing performed

`pnpm lint`, `pnpm lint:deps`, `pnpm lint:skills` — green. `@internal/sql-orm-client` 725/725.
`pnpm test:integration` for `test/sql-orm-client` — 324/324 against real Postgres. 13 tests added.

`pnpm typecheck`, `pnpm test:e2e` and parts of `pnpm test:packages` are red in my checkout, but they're red
on a clean `main` too — `@prisma/orm-framework` fails to build ("ambiguous re-export"), which breaks the
shell packages e2e loads. The `test:packages` failures are all in `@internal/cli` / `cli-telemetry`, differ
run to run, and are 500 ms timeouts when run in isolation. Nothing in `sql-orm-client` fails.

## Skill update

Added `upsertAll` to the write-terminal section of `skills/prisma-8/references/queries-postgres.md`.

(The template points at `packages/0-shared/skills/`, which doesn't exist — the user-facing skills are
under `skills/`. Probably worth fixing separately.)

## Checklist

- [x] All commits signed off (3/3, trailer matches the author).
- [x] Read CONTRIBUTING.md; scoped to one concern.
- [x] Tests updated.
- [ ] `TML-NNNN:` title — no Linear ticket as an external contributor, so the title is conventional-commit
      form per CONTRIBUTING.md. Retitle if you'd rather.
- [x] Skill update filled in.

## Notes for the reviewer

I'd rather hear the direction now than rewrite later. Both issues are years old, have no milestone, and
have never had an implementation PR, so nothing here is settled:

- **Name** — `upsertAll` follows `createAll`/`updateAll`/`deleteAll`; the issues say `upsertMany`.
- **Semantics** — #10362 suggests 1 SELECT + 1 INSERT + N UPDATE. This is one statement instead.
- **`update` shape** — array of field names, matching `distinct(...)`/`groupBy(...)`. A commenter suggested
  `{ name: true }` instead.

One gap: SQLite doesn't declare `defaultInInsert`, so it takes the split-statement path. That path has unit
and mock-runtime coverage but has never run against a real SQLite, since e2e can't load here. Worth
re-running e2e once the `orm-framework` build is fixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added batch upsert support for inserting or updating multiple records in one operation.
  - Supports configurable conflict targets and selected update fields.
  - Returns affected records and handles empty update sets without modifying existing data.
  - Added public configuration types for batch upsert operations.

- **Bug Fixes**
  - Improved handling of default values and conflict updates during batch operations.

- **Documentation**
  - Added usage guidance and examples for batch upserts, conflict handling, and update options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->