### PR TITLE
fix(adapter-pg): release the pool client at most once per transaction

### DIFF
--- a/packages/adapter-pg/src/__tests__/pg.test.ts
+++ b/packages/adapter-pg/src/__tests__/pg.test.ts
@@ -1,7 +1,7 @@
 import { getLogs } from '@prisma/debug'
 import type { SqlQuery } from '@prisma/driver-adapter-utils'
 import pg, { DatabaseError } from 'pg'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { PrismaPgAdapterFactory } from '../pg'
 
@@ -151,5 +151,118 @@ describe('PrismaPgAdapterFactory', () => {
     expect(mockQuery).toHaveBeenCalledWith(expect.objectContaining({ name: undefined }))
 
     await adapter.dispose()
+  })
+})
+
+describe('PgTransaction', () => {
+  // Regression tests for https://github.com/prisma/prisma/issues/29952: when an
+  // interactive transaction timeout expires while COMMIT is in flight, the query
+  // engine settles the transaction twice (the abandoned commit chain and the
+  // compensating rollback), which must not release the pooled client twice or
+  // dispatch SQL on a client the pool may have re-lent.
+  //
+  // No database is needed: pg.Client's connect/query/end are stubbed and the
+  // engine's settlement sequences are scripted directly against the adapter.
+
+  const statements: string[] = []
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  async function setup(queryImpl?: (text: string) => Promise<unknown> | undefined) {
+    statements.length = 0
+
+    vi.spyOn(pg.Client.prototype, 'connect').mockImplementation(function (cb?: (err?: Error) => void) {
+      process.nextTick(() => cb?.())
+    } as never)
+    vi.spyOn(pg.Client.prototype, 'end').mockImplementation((() => Promise.resolve()) as never)
+    vi.spyOn(pg.Client.prototype, 'query').mockImplementation(((query: string | { text: string }) => {
+      const text = typeof query === 'string' ? query : query.text
+      statements.push(text)
+      return queryImpl?.(text) ?? Promise.resolve({ rowCount: 0, rows: [], fields: [] })
+    }) as never)
+
+    const pool = new pg.Pool({
+      connectionString: 'postgresql://user:pass@localhost:5432/db',
+      max: 1,
+    })
+    const releases: unknown[] = []
+    pool.on('release', (err) => releases.push(err))
+    const adapter = await new PrismaPgAdapterFactory(pool).connect()
+
+    return { pool, adapter, releases }
+  }
+
+  it('should release the client exactly once when COMMIT is sent before commit()', async () => {
+    const { pool, adapter, releases } = await setup()
+    const tx = await adapter.startTransaction()
+
+    await tx.executeRaw({ sql: 'COMMIT', args: [], argTypes: [] })
+    await tx.commit()
+
+    expect(statements).toEqual(['BEGIN', 'COMMIT'])
+    expect(releases).toEqual([undefined])
+    expect(pool.idleCount).toBe(1)
+    expect(pool.totalCount).toBe(1)
+  })
+
+  it('should treat the second settlement as a no-op instead of releasing twice', async () => {
+    const { pool, adapter, releases } = await setup()
+    const tx = await adapter.startTransaction()
+
+    await tx.commit()
+    await expect(tx.rollback()).resolves.toBeUndefined()
+
+    expect(releases).toEqual([undefined])
+    expect(pool.idleCount).toBe(1)
+    expect(pool.totalCount).toBe(1)
+  })
+
+  it('should not release a client the pool has re-lent to a new owner', async () => {
+    const { pool, adapter } = await setup()
+    const tx = await adapter.startTransaction()
+
+    // The engine's compensation sequence when the transaction deadline drops an
+    // in-flight commit: rollback wins first, the pool re-lends the client, then
+    // the orphaned commit chain lands late.
+    await tx.rollback()
+    const nextOwner = await pool.connect()
+    await tx.commit()
+
+    expect(() => nextOwner.release()).not.toThrow()
+    expect(pool.idleCount).toBe(1)
+    expect(pool.totalCount).toBe(1)
+  })
+
+  it('should reject queries after settlement without dispatching SQL', async () => {
+    const { adapter } = await setup()
+    const tx = await adapter.startTransaction()
+
+    await tx.rollback()
+    statements.length = 0
+
+    await expect(tx.executeRaw({ sql: 'ROLLBACK', args: [], argTypes: [] })).rejects.toMatchObject({
+      name: 'DriverAdapterError',
+      cause: { kind: 'TransactionAlreadyClosed' },
+    })
+    await expect(tx.queryRaw({ sql: 'SELECT 1', args: [], argTypes: [] })).rejects.toMatchObject({
+      name: 'DriverAdapterError',
+      cause: { kind: 'TransactionAlreadyClosed' },
+    })
+    expect(statements).toEqual([])
+  })
+
+  it('should destroy the connection when settling with a query still in flight', async () => {
+    const { pool, adapter, releases } = await setup((text) =>
+      text === 'SELECT pending' ? new Promise(() => {}) : undefined,
+    )
+    const tx = await adapter.startTransaction()
+
+    void tx.executeRaw({ sql: 'SELECT pending', args: [], argTypes: [] })
+    await tx.rollback()
+
+    expect(releases).toEqual([expect.any(Error)])
+    expect(pool.totalCount).toBe(0)
   })
 })

--- a/packages/adapter-pg/src/__tests__/pg.test.ts
+++ b/packages/adapter-pg/src/__tests__/pg.test.ts
@@ -165,8 +165,11 @@ describe('PgTransaction', () => {
   // engine's settlement sequences are scripted directly against the adapter.
 
   const statements: string[] = []
+  const pools: pg.Pool[] = []
 
-  afterEach(() => {
+  afterEach(async () => {
+    await Promise.all(pools.map((pool) => pool.end()))
+    pools.length = 0
     vi.restoreAllMocks()
   })
 
@@ -187,6 +190,7 @@ describe('PgTransaction', () => {
       connectionString: 'postgresql://user:pass@localhost:5432/db',
       max: 1,
     })
+    pools.push(pool)
     const releases: unknown[] = []
     pool.on('release', (err) => releases.push(err))
     const adapter = await new PrismaPgAdapterFactory(pool).connect()

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -98,7 +98,7 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements SqlQ
    * Should the query fail due to a connection error, the connection is
    * marked as unhealthy.
    */
-  private async performIO(query: SqlQuery): Promise<pg.QueryArrayResult<any>> {
+  protected async performIO(query: SqlQuery): Promise<pg.QueryArrayResult<any>> {
     const { sql, args } = query
     const values = args.map((arg, i) => mapArg(arg, query.argTypes[i]))
 
@@ -132,6 +132,9 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements SqlQ
 }
 
 class PgTransaction extends PgQueryable<TransactionClient> implements Transaction {
+  private settled = false
+  private inFlightQueries = 0
+
   constructor(
     client: pg.PoolClient,
     readonly options: TransactionOptions,
@@ -141,18 +144,56 @@ class PgTransaction extends PgQueryable<TransactionClient> implements Transactio
     super(client, pgOptions)
   }
 
+  protected override async performIO(query: SqlQuery): Promise<pg.QueryArrayResult<any>> {
+    if (this.settled) {
+      throw new DriverAdapterError({
+        kind: 'TransactionAlreadyClosed',
+        cause: 'The transaction has already been committed or rolled back',
+      })
+    }
+
+    this.inFlightQueries++
+    try {
+      return await super.performIO(query)
+    } finally {
+      this.inFlightQueries--
+    }
+  }
+
+  /**
+   * Settles the transaction at most once. The query engine can settle twice when
+   * an interactive transaction timeout expires while COMMIT is in flight: the
+   * abandoned commit chain and the compensating rollback both reach the adapter
+   * (https://github.com/prisma/prisma/issues/29952). A second `release()` would
+   * corrupt pg-pool's accounting once the pool has re-lent the client, so it is
+   * skipped, and a client with statements still in flight is released with an
+   * error so the pool destroys the connection instead of re-lending a busy one.
+   */
+  private settle(): void {
+    if (this.settled) {
+      return
+    }
+    this.settled = true
+
+    this.cleanup?.()
+
+    if (this.inFlightQueries > 0) {
+      this.client.release(new Error('Transaction settled with statements still in flight'))
+    } else {
+      this.client.release()
+    }
+  }
+
   async commit(): Promise<void> {
     debug(`[js::commit]`)
 
-    this.cleanup?.()
-    this.client.release()
+    this.settle()
   }
 
   async rollback(): Promise<void> {
     debug(`[js::rollback]`)
 
-    this.cleanup?.()
-    this.client.release()
+    this.settle()
   }
 
   async createSavepoint(name: string): Promise<void> {

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -175,12 +175,14 @@ class PgTransaction extends PgQueryable<TransactionClient> implements Transactio
     }
     this.settled = true
 
-    this.cleanup?.()
-
-    if (this.inFlightQueries > 0) {
-      this.client.release(new Error('Transaction settled with statements still in flight'))
-    } else {
-      this.client.release()
+    try {
+      this.cleanup?.()
+    } finally {
+      if (this.inFlightQueries > 0) {
+        this.client.release(new Error('Transaction settled with statements still in flight'))
+      } else {
+        this.client.release()
+      }
     }
   }
 


### PR DESCRIPTION
Fixes the adapter side of #29952: `@prisma/adapter-pg` double-releases the pg pool client when the query engine settles an interactive transaction twice, which eventually kills the Node process with an uncatchable error.

## Mechanism

When an interactive transaction timeout expires while `COMMIT` is awaiting the driver adapter, the engine's `tx_timeout!` select drops the commit future, but the napi-backed JS chain cannot be cancelled and eventually calls `PgTransaction.commit()` → `client.release()`. The timeout arm then compensates with a rollback, producing a second chain: `executeRaw("ROLLBACK")` on the still-busy client, then `PgTransaction.rollback()` → `client.release()` again. pg-pool's double-release guard is per-checkout, so when the pool has re-lent the client between the two releases, the second release lands silently on the new owner's fresh closure and pushes a busy client back into the idle set. The new owner's own release then throws `Release called on client which has already been released to the pool` inside pg's socket-data handler, rethrown on `process.nextTick` — uncatchable, killing the process.

The root cause (the engine dropping an uncancellable JS commit future and compensating while the first chain is still running) is in prisma-engines and is out of scope here; this PR hardens the adapter so a double settlement can no longer crash the process. App-visible behavior is unchanged: the racing transaction still fails with the engine's expired-transaction error.

## Fix

`PgTransaction` settles at most once:

- A second `commit()`/`rollback()` is a no-op — never a second `client.release()`.
- `queryRaw`/`executeRaw` after settlement reject with `TransactionAlreadyClosed` without dispatching SQL, so the compensation's `ROLLBACK` cannot land on a client the pool already re-lent. The normal `usePhantomQuery: false` flow (the engine sends `COMMIT`/`ROLLBACK` as `executeRaw` on the open transaction before settling) is unaffected and pinned by a test.
- If settlement finds statements still in flight (the engine abandoned the transaction mid-operation), the client is released with an error so pg-pool destroys the connection instead of re-lending a busy one. In-flight detection is adapter-owned (a counter around `performIO`) rather than reaching into `pg` client internals.

## Tests

The new `PgTransaction` tests stub `pg.Client`'s `connect`/`query`/`end` (no database needed) and script the engine's settlement sequences directly, including the exact re-lend interleaving from the issue. All four regression tests fail on the unpatched adapter — the re-lend test reproduces the exact `Release called on client which has already been released to the pool` error — and pass with the fix. The pre-existing suite stays green.

## Sibling adapter audit

Kept out of this PR to keep the fix reviewable:

- `adapter-neon` has the verbatim same `commit()`/`rollback()` → `client.release()` shape and the same hole; this fix applies to it directly.
- `adapter-mariadb` has the same class of hole: unguarded double settlement double-`end()`s the pooled connection and can dispatch late SQL on a re-lent connection.
- `adapter-planetscale` settles idempotently via a deferred, but still dispatches SQL after settlement.
- `adapter-libsql` and `adapter-better-sqlite3` double-invoke `client.commit()`/`unlockParent()` on double settlement — different, milder failure modes.
- `adapter-mssql` (mutex plus the tedious transaction state machine), `adapter-d1` (no-op settlement), and `adapter-ppg` (already guarded with a `#finished` flag) are not exposed to the pool-corruption scenario.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PostgreSQL transaction cleanup when queries are still in progress.
  - Prevented clients from being released more than once or reused after transaction completion.
  - Queries issued after commit or rollback are now rejected without being sent to the database.
  - Ensured busy connections are safely destroyed when a transaction settles during an active query.

- **Tests**
  - Added coverage for transaction settlement, client release, post-settlement queries, and in-flight operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->