### PR TITLE
fix(adapter-better-sqlite3): recover from failed transactions

### DIFF
--- a/packages/adapter-better-sqlite3/src/better-sqlite3.test.ts
+++ b/packages/adapter-better-sqlite3/src/better-sqlite3.test.ts
@@ -1,0 +1,202 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { SqlQuery } from '@prisma/driver-adapter-utils'
+import Database from 'better-sqlite3'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { PrismaBetterSqlite3Adapter } from './better-sqlite3'
+
+const COMMIT_QUERY: SqlQuery = { sql: 'COMMIT', args: [], argTypes: [] }
+const ROLLBACK_QUERY: SqlQuery = { sql: 'ROLLBACK', args: [], argTypes: [] }
+
+const insertQuery = (value: string): SqlQuery => ({
+  sql: 'INSERT INTO t (v) VALUES (?)',
+  args: [value],
+  argTypes: [{ scalarType: 'string', arity: 'scalar' }],
+})
+
+/**
+ * The transaction manager dispatches COMMIT and ROLLBACK as regular queries and then calls the
+ * transaction's `commit()`/`rollback()` lifecycle callbacks, so the tests drive the adapter the
+ * same way `TransactionManager.#closeTransaction` does.
+ */
+function createAdapter(file?: string) {
+  const db = new Database(file ?? ':memory:', { timeout: 0 })
+  db.defaultSafeIntegers(true)
+  db.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)')
+  db.prepare("INSERT INTO t (v) VALUES ('x')").run()
+  return { db, adapter: new PrismaBetterSqlite3Adapter(db) }
+}
+
+describe('better-sqlite3 driver adapter transactions', () => {
+  const tmpDirs: string[] = []
+
+  afterEach(() => {
+    for (const dir of tmpDirs) {
+      // Best-effort: on Windows an open handle can keep the temp dir locked.
+      try {
+        rmSync(dir, { recursive: true, force: true })
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+    tmpDirs.length = 0
+  })
+
+  it('commits a successful transaction', async () => {
+    const { db, adapter } = createAdapter()
+
+    const tx = await adapter.startTransaction()
+    await tx.executeRaw(insertQuery('a'))
+    await tx.executeRaw(COMMIT_QUERY)
+    await tx.commit()
+
+    expect(db.inTransaction).toBe(false)
+    expect(
+      db
+        .prepare('SELECT v FROM t ORDER BY v')
+        .all()
+        .map((row) => (row as { v: string }).v),
+    ).toEqual(['a', 'x'])
+
+    await adapter.dispose()
+  })
+
+  it('rolls back a successful transaction', async () => {
+    const { db, adapter } = createAdapter()
+
+    const tx = await adapter.startTransaction()
+    await tx.executeRaw(insertQuery('a'))
+    await tx.executeRaw(ROLLBACK_QUERY)
+    await tx.rollback()
+
+    expect(db.inTransaction).toBe(false)
+    expect(
+      db
+        .prepare('SELECT v FROM t ORDER BY v')
+        .all()
+        .map((row) => (row as { v: string }).v),
+    ).toEqual(['x'])
+
+    await adapter.dispose()
+  })
+
+  it('recovers the connection after a COMMIT hits SQLITE_BUSY', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'better-sqlite3-adapter-'))
+    tmpDirs.push(dir)
+    const file = join(dir, 'test.db')
+    const { db, adapter } = createAdapter(file)
+
+    let reader: Database.Database | undefined
+    try {
+      // A second connection holding a read transaction keeps a SHARED lock on the database,
+      // so the adapter's COMMIT cannot upgrade to EXCLUSIVE and fails with SQLITE_BUSY.
+      reader = new Database(file, { timeout: 0 })
+      reader.prepare('BEGIN').run()
+      reader.prepare('SELECT COUNT(*) FROM t').get()
+
+      const tx = await adapter.startTransaction()
+      await tx.executeRaw(insertQuery('y'))
+      await expect(tx.executeRaw(COMMIT_QUERY)).rejects.toThrow()
+
+      // The transaction manager calls rollback() without sending a ROLLBACK query on the
+      // failed-COMMIT path; the connection must still be left outside a transaction.
+      await tx.rollback()
+      expect(db.inTransaction).toBe(false)
+
+      reader.prepare('COMMIT').run()
+
+      // A later transaction on the same adapter must be able to commit again, and the writes
+      // of the failed transaction must not survive.
+      const tx2 = await adapter.startTransaction()
+      await tx2.executeRaw(insertQuery('z'))
+      await tx2.executeRaw(COMMIT_QUERY)
+      await tx2.commit()
+
+      expect(
+        db
+          .prepare('SELECT v FROM t ORDER BY v')
+          .all()
+          .map((row) => (row as { v: string }).v),
+      ).toEqual(['x', 'z'])
+    } finally {
+      reader?.close()
+      await adapter.dispose().catch(() => {})
+    }
+  })
+
+  it('preserves the original error and releases the mutex when rollback cleanup fails', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'better-sqlite3-adapter-'))
+    tmpDirs.push(dir)
+    const file = join(dir, 'test.db')
+    const { db, adapter } = createAdapter(file)
+
+    let reader: Database.Database | undefined
+    try {
+      reader = new Database(file, { timeout: 0 })
+      reader.prepare('BEGIN').run()
+      reader.prepare('SELECT COUNT(*) FROM t').get()
+
+      const tx = await adapter.startTransaction()
+      await tx.executeRaw(insertQuery('y'))
+
+      // Make the cleanup ROLLBACK issued by rollback() fail as well, so the
+      // cleanup path itself cannot release the connection.
+      const originalExec = db.exec.bind(db)
+      db.exec = ((sql: string) => {
+        if (sql === 'ROLLBACK') throw new Error('cleanup boom')
+        return originalExec(sql)
+      }) as typeof db.exec
+
+      const commitError = (await tx.executeRaw(COMMIT_QUERY).then(
+        () => null,
+        (e) => e as Error & { cause?: { originalCode?: string } },
+      ))!
+
+      // The original COMMIT error stays the externally observed error and is not
+      // replaced or masked by the cleanup failure.
+      expect(commitError.cause?.originalCode).toBe('SQLITE_BUSY')
+      expect(commitError.message).not.toContain('cleanup boom')
+
+      // rollback() must not throw when the cleanup ROLLBACK fails.
+      await tx.rollback()
+
+      // The mutex must still be released: the next startTransaction must reject
+      // (BEGIN fails on the still-open transaction) instead of hanging forever.
+      const result = await Promise.race([
+        adapter.startTransaction().then(
+          () => 'resolved',
+          () => 'rejected',
+        ),
+        new Promise((resolve) => setTimeout(() => resolve('timeout'), 500)),
+      ])
+
+      expect(result).toBe('rejected')
+    } finally {
+      reader?.close()
+      await adapter.dispose().catch(() => {})
+    }
+  })
+
+  it('releases the mutex when BEGIN fails', async () => {
+    const db = new Database(':memory:', { timeout: 0 })
+    db.defaultSafeIntegers(true)
+    const adapter = new PrismaBetterSqlite3Adapter(db)
+    db.close()
+
+    await expect(adapter.startTransaction()).rejects.toThrow()
+
+    // With the mutex leaked, the second start would never acquire it and hang forever.
+    const result = await Promise.race([
+      adapter.startTransaction().then(
+        () => 'resolved',
+        () => 'rejected',
+      ),
+      new Promise((resolve) => setTimeout(() => resolve('timeout'), 500)),
+    ])
+
+    expect(result).toBe('rejected')
+  })
+})

--- a/packages/adapter-better-sqlite3/src/better-sqlite3.ts
+++ b/packages/adapter-better-sqlite3/src/better-sqlite3.ts
@@ -157,8 +157,25 @@ class BetterSQLite3Transaction extends BetterSQLite3Queryable<StdClient> impleme
 
   rollback(): Promise<void> {
     debug(`[js::rollback]`)
+    this.#cleanupConnection()
     this.#unlockParent()
     return Promise.resolve()
+  }
+
+  /**
+   * Best-effort cleanup of the SQLite connection. The transaction manager dispatches
+   * ROLLBACK as a regular query on the ordinary rollback path, but on a failed COMMIT
+   * it calls rollback() without a ROLLBACK query, leaving the connection stuck inside
+   * the transaction unless we clean it up here.
+   */
+  #cleanupConnection(): void {
+    if (this.client.inTransaction) {
+      try {
+        this.client.exec('ROLLBACK')
+      } catch (e) {
+        debug('Error while cleaning up transaction: %O', e)
+      }
+    }
   }
 
   async createSavepoint(name: string): Promise<void> {
@@ -205,13 +222,16 @@ export class PrismaBetterSqlite3Adapter extends BetterSQLite3Queryable<StdClient
     const tag = '[js::startTransaction]'
     debug('%s options: %O', tag, options)
 
+    let release: (() => void) | undefined
+
     try {
-      const release = await this.#mutex.acquire()
+      release = await this.#mutex.acquire()
 
       this.client.prepare('BEGIN').run()
 
       return new BetterSQLite3Transaction(this.client, options, this.adapterOptions, release)
     } catch (e) {
+      release?.()
       this.onError(e)
     }
   }


### PR DESCRIPTION
## Linked issue

Fixes #29933

## Summary

A failed SQLite `COMMIT` could leave the shared better-sqlite3 connection
inside an open transaction, while a later `BEGIN` failure could leak the
adapter mutex permanently.

This makes `rollback()` perform best-effort connection cleanup when SQLite
still reports an active transaction, and releases the mutex when `BEGIN`
fails. Successful transaction behavior and the existing
`usePhantomQuery: false` contract are unchanged.

## Testing performed

- Added focused transaction regression coverage for successful commit and
  rollback, failed-COMMIT recovery, failed-BEGIN mutex release, and cleanup
  failure behavior.
- Focused transaction suite: 5/5 passed.
- End-to-end #29933 reproduction passed in rollback-journal mode:
  - the blocked COMMIT fails with the original `SQLITE_BUSY`-mapped error
  - the adapter connection is no longer left inside a transaction
  - subsequent transactions succeed
  - no P2028 mutex poison occurs
  - subsequent acknowledged writes remain committed on a fresh connection
- Mutation checks confirmed both regressions return when either the failed-BEGIN
  release or failed-COMMIT cleanup is removed.
- Typecheck passed.
- ESLint passed for the affected files.
- Prettier check passed.
- `git diff --check` passed.

The full adapter package suite has one pre-existing
`errors.test.ts > UniqueConstraintViolation` failure caused by the local
better-sqlite3 12.6.0 error-message shape. The same failure was reproduced on
a pristine v7 checkout; the new transaction tests remain green.

## Skill update

n/a — bug fix for existing adapter transaction behavior; no skill changes required.

## Checklist

- [x] All commits are signed off with DCO.
- [x] The change is scoped to one logical concern.
- [x] Regression tests are included.
- [ ] No Linear ticket exists for this external GitHub issue; the title follows
      the conventional `fix(scope):` form.
- [x] The Skill update section is filled in.

## Notes for the reviewer

With `usePhantomQuery: false`, the transaction manager owns normal
COMMIT/ROLLBACK SQL and the adapter's `commit()` / `rollback()` methods are
lifecycle callbacks.

The cleanup added here therefore runs only when `rollback()` observes that
better-sqlite3 is still inside a transaction, which is the failed-COMMIT case.
Cleanup is best-effort so a secondary ROLLBACK failure cannot replace the
original transaction error.

The misleading `SQLITE_BUSY` → `SocketTimeout` mapping is intentionally out
of scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction rollback handling with best-effort cleanup when SQLite remains in an active transaction.
  - Preserved the original transaction error when cleanup also encounters a failure.
  - Improved recovery after busy database errors during commit.
  - Ensured transaction locks are released when startup or cleanup fails.

- **Tests**
  - Added comprehensive coverage for commit, rollback, failure recovery, and lock-release scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->