### PR TITLE
refactor(sql): normalize IR node inputs through static from() factories

### DIFF
--- a/packages/2-sql/1-core/contract/src/ir/foreign-key-reference.ts
+++ b/packages/2-sql/1-core/contract/src/ir/foreign-key-reference.ts
@@ -50,4 +50,8 @@ export class ForeignKeyReference extends SqlNode {
     if (input.spaceId !== undefined) this.spaceId = input.spaceId;
     freezeNode(this);
   }
+
+  static from(value: ForeignKeyReference | ForeignKeyReferenceInput): ForeignKeyReference {
+    return value instanceof ForeignKeyReference ? value : new ForeignKeyReference(value);
+  }
 }

--- a/packages/2-sql/1-core/contract/src/ir/foreign-key.ts
+++ b/packages/2-sql/1-core/contract/src/ir/foreign-key.ts
@@ -41,17 +41,15 @@ export class ForeignKey extends SqlNode {
 
   constructor(input: ForeignKeyInput) {
     super();
-    this.source =
-      input.source instanceof ForeignKeyReference
-        ? input.source
-        : new ForeignKeyReference(input.source);
-    this.target =
-      input.target instanceof ForeignKeyReference
-        ? input.target
-        : new ForeignKeyReference(input.target);
+    this.source = ForeignKeyReference.from(input.source);
+    this.target = ForeignKeyReference.from(input.target);
     if (input.name !== undefined) this.name = input.name;
     if (input.onDelete !== undefined) this.onDelete = input.onDelete;
     if (input.onUpdate !== undefined) this.onUpdate = input.onUpdate;
     freezeNode(this);
+  }
+
+  static from(value: ForeignKey | ForeignKeyInput): ForeignKey {
+    return value instanceof ForeignKey ? value : new ForeignKey(value);
   }
 }

--- a/packages/2-sql/1-core/contract/src/ir/primary-key.ts
+++ b/packages/2-sql/1-core/contract/src/ir/primary-key.ts
@@ -19,4 +19,8 @@ export class PrimaryKey extends SqlNode {
     if (input.name !== undefined) this.name = input.name;
     freezeNode(this);
   }
+
+  static from(value: PrimaryKey | PrimaryKeyInput): PrimaryKey {
+    return value instanceof PrimaryKey ? value : new PrimaryKey(value);
+  }
 }

--- a/packages/2-sql/1-core/contract/src/ir/sql-index.ts
+++ b/packages/2-sql/1-core/contract/src/ir/sql-index.ts
@@ -96,4 +96,8 @@ export class Index extends SqlNode {
     if (input.options !== undefined) this.options = input.options;
     freezeNode(this);
   }
+
+  static from(value: Index | IndexInput): Index {
+    return value instanceof Index ? value : new Index(value);
+  }
 }

--- a/packages/2-sql/1-core/contract/src/ir/storage-column.ts
+++ b/packages/2-sql/1-core/contract/src/ir/storage-column.ts
@@ -61,4 +61,8 @@ export class StorageColumn extends SqlNode {
     if (input.valueSet !== undefined) this.valueSet = input.valueSet;
     freezeNode(this);
   }
+
+  static from(value: StorageColumn | StorageColumnInput): StorageColumn {
+    return value instanceof StorageColumn ? value : new StorageColumn(value);
+  }
 }

--- a/packages/2-sql/1-core/contract/src/ir/storage-table.ts
+++ b/packages/2-sql/1-core/contract/src/ir/storage-table.ts
@@ -44,25 +44,15 @@ export class StorageTable extends SqlNode {
     super();
     this.columns = Object.freeze(
       Object.fromEntries(
-        Object.entries(input.columns).map(([name, col]) => [
-          name,
-          col instanceof StorageColumn ? col : new StorageColumn(col),
-        ]),
+        Object.entries(input.columns).map(([name, col]) => [name, StorageColumn.from(col)]),
       ),
     );
     if (input.primaryKey !== undefined) {
-      this.primaryKey =
-        input.primaryKey instanceof PrimaryKey
-          ? input.primaryKey
-          : new PrimaryKey(input.primaryKey);
+      this.primaryKey = PrimaryKey.from(input.primaryKey);
     }
-    this.uniques = Object.freeze(
-      input.uniques.map((u) => (u instanceof UniqueConstraint ? u : new UniqueConstraint(u))),
-    );
-    this.indexes = Object.freeze(input.indexes.map((i) => (i instanceof Index ? i : new Index(i))));
-    this.foreignKeys = Object.freeze(
-      input.foreignKeys.map((fk) => (fk instanceof ForeignKey ? fk : new ForeignKey(fk))),
-    );
+    this.uniques = Object.freeze(input.uniques.map(UniqueConstraint.from));
+    this.indexes = Object.freeze(input.indexes.map(Index.from));
+    this.foreignKeys = Object.freeze(input.foreignKeys.map(ForeignKey.from));
     if (input.control !== undefined) this.control = input.control;
     if (input.checks !== undefined && input.checks.length > 0) {
       this.checks = Object.freeze(input.checks.map(CheckConstraint.from));

--- a/packages/2-sql/1-core/contract/src/ir/unique-constraint.ts
+++ b/packages/2-sql/1-core/contract/src/ir/unique-constraint.ts
@@ -19,4 +19,8 @@ export class UniqueConstraint extends SqlNode {
     if (input.name !== undefined) this.name = input.name;
     freezeNode(this);
   }
+
+  static from(value: UniqueConstraint | UniqueConstraintInput): UniqueConstraint {
+    return value instanceof UniqueConstraint ? value : new UniqueConstraint(value);
+  }
 }

--- a/packages/2-sql/1-core/contract/test/ir-node-from.test.ts
+++ b/packages/2-sql/1-core/contract/test/ir-node-from.test.ts
@@ -1,0 +1,110 @@
+import { UNBOUND_NAMESPACE_ID } from '@internal/framework-components/ir';
+import { parseNaming } from '@internal/sql-schema-ir/naming';
+import { describe, expect, it } from 'vitest';
+import { ForeignKey } from '../src/ir/foreign-key';
+import { ForeignKeyReference } from '../src/ir/foreign-key-reference';
+import { PrimaryKey } from '../src/ir/primary-key';
+import { Index, type IndexInput } from '../src/ir/sql-index';
+import { StorageColumn } from '../src/ir/storage-column';
+import { StorageTable } from '../src/ir/storage-table';
+import { UniqueConstraint } from '../src/ir/unique-constraint';
+
+const columnInput = { codecId: 'pg/int4@1', nativeType: 'int4', nullable: false } as const;
+const referenceInput = {
+  namespaceId: UNBOUND_NAMESPACE_ID,
+  tableName: 'user',
+  columns: ['id'],
+} as const;
+const foreignKeyInput = {
+  source: { namespaceId: UNBOUND_NAMESPACE_ID, tableName: 'post', columns: ['author_id'] },
+  target: referenceInput,
+} as const;
+const indexInput: IndexInput = {
+  naming: parseNaming('users_email_idx_ab12cd34', 'users_email_idx'),
+  columns: ['email'],
+  where: undefined,
+  unique: false,
+  type: undefined,
+  options: undefined,
+};
+
+// Each factory has two paths. Building from raw input is what the constructors
+// always did; returning an existing instance untouched is the property that
+// would silently disappear if `from` were "simplified" to always construct,
+// so both are pinned per class.
+describe('IR node from() factories', () => {
+  it('StorageColumn builds from input and passes an instance through', () => {
+    const built = StorageColumn.from(columnInput);
+    expect(built).toBeInstanceOf(StorageColumn);
+    expect(Object.isFrozen(built)).toBe(true);
+    expect(StorageColumn.from(built)).toBe(built);
+  });
+
+  it('PrimaryKey builds from input and passes an instance through', () => {
+    const built = PrimaryKey.from({ columns: ['id'] });
+    expect(built).toBeInstanceOf(PrimaryKey);
+    expect(Object.isFrozen(built)).toBe(true);
+    expect(PrimaryKey.from(built)).toBe(built);
+  });
+
+  it('UniqueConstraint builds from input and passes an instance through', () => {
+    const built = UniqueConstraint.from({ columns: ['email'] });
+    expect(built).toBeInstanceOf(UniqueConstraint);
+    expect(Object.isFrozen(built)).toBe(true);
+    expect(UniqueConstraint.from(built)).toBe(built);
+  });
+
+  it('Index builds from input and passes an instance through', () => {
+    const built = Index.from(indexInput);
+    expect(built).toBeInstanceOf(Index);
+    expect(Object.isFrozen(built)).toBe(true);
+    expect(Index.from(built)).toBe(built);
+  });
+
+  it('ForeignKeyReference builds from input and passes an instance through', () => {
+    const built = ForeignKeyReference.from(referenceInput);
+    expect(built).toBeInstanceOf(ForeignKeyReference);
+    expect(Object.isFrozen(built)).toBe(true);
+    expect(ForeignKeyReference.from(built)).toBe(built);
+  });
+
+  it('ForeignKey builds from input, normalizes its references, and passes an instance through', () => {
+    const built = ForeignKey.from(foreignKeyInput);
+    expect(built).toBeInstanceOf(ForeignKey);
+    expect(built.source).toBeInstanceOf(ForeignKeyReference);
+    expect(built.target).toBeInstanceOf(ForeignKeyReference);
+    expect(ForeignKey.from(built)).toBe(built);
+  });
+
+  it('StorageTable hydrates raw inputs and carries instances over untouched', () => {
+    const raw = new StorageTable({
+      columns: { id: columnInput },
+      primaryKey: { columns: ['id'] },
+      uniques: [{ columns: ['email'] }],
+      indexes: [indexInput],
+      foreignKeys: [foreignKeyInput],
+    });
+
+    expect(raw.columns['id']).toBeInstanceOf(StorageColumn);
+    expect(raw.primaryKey).toBeInstanceOf(PrimaryKey);
+    expect(raw.uniques[0]).toBeInstanceOf(UniqueConstraint);
+    expect(raw.indexes[0]).toBeInstanceOf(Index);
+    expect(raw.foreignKeys[0]).toBeInstanceOf(ForeignKey);
+
+    const carriedPrimaryKey = raw.primaryKey;
+    if (carriedPrimaryKey === undefined) throw new Error('expected a primary key');
+    const rehydrated = new StorageTable({
+      columns: raw.columns,
+      primaryKey: carriedPrimaryKey,
+      uniques: raw.uniques,
+      indexes: raw.indexes,
+      foreignKeys: raw.foreignKeys,
+    });
+
+    expect(rehydrated.columns['id']).toBe(raw.columns['id']);
+    expect(rehydrated.primaryKey).toBe(raw.primaryKey);
+    expect(rehydrated.uniques[0]).toBe(raw.uniques[0]);
+    expect(rehydrated.indexes[0]).toBe(raw.indexes[0]);
+    expect(rehydrated.foreignKeys[0]).toBe(raw.foreignKeys[0]);
+  });
+});

--- a/packages/2-sql/1-core/schema-ir/src/ir/primary-key.ts
+++ b/packages/2-sql/1-core/schema-ir/src/ir/primary-key.ts
@@ -52,6 +52,10 @@ export class PrimaryKey extends SqlSchemaIRNode implements DiffableNode {
     return [];
   }
 
+  static from(value: PrimaryKey | PrimaryKeyInput): PrimaryKey {
+    return value instanceof PrimaryKey ? value : new PrimaryKey(value);
+  }
+
   static is(node: SqlSchemaIRNode): node is PrimaryKey {
     return node.nodeKind === RelationalSchemaNodeKind.primaryKey;
   }

--- a/packages/2-sql/1-core/schema-ir/src/ir/sql-check-constraint-ir.ts
+++ b/packages/2-sql/1-core/schema-ir/src/ir/sql-check-constraint-ir.ts
@@ -60,6 +60,10 @@ export class SqlCheckConstraintIR extends SqlSchemaIRNode implements DiffableNod
     return [];
   }
 
+  static from(value: SqlCheckConstraintIR | SqlCheckConstraintIRInput): SqlCheckConstraintIR {
+    return value instanceof SqlCheckConstraintIR ? value : new SqlCheckConstraintIR(value);
+  }
+
   static is(node: SqlSchemaIRNode): node is SqlCheckConstraintIR {
     return node.nodeKind === RelationalSchemaNodeKind.check;
   }

--- a/packages/2-sql/1-core/schema-ir/src/ir/sql-index-ir.ts
+++ b/packages/2-sql/1-core/schema-ir/src/ir/sql-index-ir.ts
@@ -135,6 +135,10 @@ export class SqlIndexIR extends SqlSchemaIRNode implements DiffableNode {
     return [];
   }
 
+  static from(value: SqlIndexIR | SqlIndexIRInput): SqlIndexIR {
+    return value instanceof SqlIndexIR ? value : new SqlIndexIR(value);
+  }
+
   static is(node: SqlSchemaIRNode): node is SqlIndexIR {
     return node.nodeKind === RelationalSchemaNodeKind.index;
   }

--- a/packages/2-sql/1-core/schema-ir/src/ir/sql-table-ir.ts
+++ b/packages/2-sql/1-core/schema-ir/src/ir/sql-table-ir.ts
@@ -71,22 +71,13 @@ export class SqlTableIR extends SqlSchemaIRNode implements DiffableNode {
     this.uniques = Object.freeze(
       input.uniques.map((u) => (u instanceof SqlUniqueIR ? u : new SqlUniqueIR(u))),
     );
-    this.indexes = Object.freeze(
-      input.indexes.map((i) => (i instanceof SqlIndexIR ? i : new SqlIndexIR(i))),
-    );
+    this.indexes = Object.freeze(input.indexes.map(SqlIndexIR.from));
     if (input.primaryKey !== undefined) {
-      this.primaryKey =
-        input.primaryKey instanceof PrimaryKey
-          ? input.primaryKey
-          : new PrimaryKey(input.primaryKey);
+      this.primaryKey = PrimaryKey.from(input.primaryKey);
     }
     if (input.annotations !== undefined) this.annotations = input.annotations;
     if (input.checks !== undefined && input.checks.length > 0) {
-      this.checks = Object.freeze(
-        input.checks.map((c) =>
-          c instanceof SqlCheckConstraintIR ? c : new SqlCheckConstraintIR(c),
-        ),
-      );
+      this.checks = Object.freeze(input.checks.map(SqlCheckConstraintIR.from));
     }
     freezeNode(this);
   }

--- a/packages/2-sql/1-core/schema-ir/test/ir-node-from.test.ts
+++ b/packages/2-sql/1-core/schema-ir/test/ir-node-from.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { PrimaryKey } from '../src/ir/primary-key';
+import { SqlCheckConstraintIR } from '../src/ir/sql-check-constraint-ir';
+import { SqlIndexIR } from '../src/ir/sql-index-ir';
+import { SqlTableIR } from '../src/ir/sql-table-ir';
+import { computeCheckContentHash } from '../src/naming';
+
+const expression = `"email" <> ''`;
+const checkInput = {
+  naming: { kind: 'wire', prefix: 'users_email_check', hash: computeCheckContentHash(expression) },
+  expression,
+  dependsOn: undefined,
+} as const;
+const indexInput = {
+  naming: { kind: 'exact', name: 'users_email_idx' },
+  columns: ['email'],
+  where: undefined,
+  unique: false,
+  partial: false,
+  type: undefined,
+  options: undefined,
+  annotations: undefined,
+  dependsOn: undefined,
+} as const;
+
+describe('schema-IR node from() factories', () => {
+  describe('PrimaryKey', () => {
+    it('constructs from raw input', () => {
+      expect(PrimaryKey.from({ columns: ['id'] })).toBeInstanceOf(PrimaryKey);
+    });
+
+    it('returns an existing instance by identity', () => {
+      const pk = new PrimaryKey({ columns: ['id'] });
+      expect(PrimaryKey.from(pk)).toBe(pk);
+    });
+
+    // `dependsOn` is non-enumerable, so a factory that rebuilt instead of
+    // returning them would not lose it — but identity would go, and with it
+    // the reference equality the differ's node bookkeeping relies on.
+    it('preserves dependsOn through the instance path', () => {
+      const pk = new PrimaryKey({
+        columns: ['id'],
+        dependsOn: [[{ nodeKind: 'sql-column', id: 'column:id' }]],
+      });
+      const carried = PrimaryKey.from(pk);
+      expect(carried).toBe(pk);
+      expect(carried.dependsOn).toEqual(pk.dependsOn);
+    });
+  });
+
+  describe('SqlIndexIR', () => {
+    it('constructs from raw input', () => {
+      expect(SqlIndexIR.from(indexInput)).toBeInstanceOf(SqlIndexIR);
+    });
+
+    it('returns an existing instance by identity', () => {
+      const index = new SqlIndexIR(indexInput);
+      expect(SqlIndexIR.from(index)).toBe(index);
+    });
+  });
+
+  describe('SqlCheckConstraintIR', () => {
+    it('constructs from raw input', () => {
+      expect(SqlCheckConstraintIR.from(checkInput)).toBeInstanceOf(SqlCheckConstraintIR);
+    });
+
+    it('returns an existing instance by identity', () => {
+      const check = new SqlCheckConstraintIR(checkInput);
+      expect(SqlCheckConstraintIR.from(check)).toBe(check);
+    });
+  });
+
+  it('SqlTableIR hydrates raw inputs and instances alike', () => {
+    const raw = new SqlTableIR({
+      name: 'users',
+      columns: { email: { name: 'email', nativeType: 'text', nullable: false } },
+      primaryKey: { columns: ['email'] },
+      foreignKeys: [],
+      uniques: [],
+      indexes: [indexInput],
+      checks: [checkInput],
+    });
+    const carriedPrimaryKey = raw.primaryKey;
+    if (carriedPrimaryKey === undefined) throw new Error('expected a primary key');
+    const rehydrated = new SqlTableIR({
+      name: 'users',
+      columns: { email: { name: 'email', nativeType: 'text', nullable: false } },
+      primaryKey: carriedPrimaryKey,
+      foreignKeys: [],
+      uniques: [],
+      indexes: raw.indexes,
+      checks: raw.checks ?? [],
+    });
+
+    expect(raw.primaryKey).toBeInstanceOf(PrimaryKey);
+    expect(raw.indexes[0]).toBeInstanceOf(SqlIndexIR);
+    expect(raw.checks?.[0]).toBeInstanceOf(SqlCheckConstraintIR);
+
+    expect(rehydrated.primaryKey).toBe(raw.primaryKey);
+    expect(rehydrated.indexes[0]).toBe(raw.indexes[0]);
+    expect(rehydrated.checks?.[0]).toBe(raw.checks?.[0]);
+  });
+});


### PR DESCRIPTION
## Linked issue

No Linear ticket — cleanup follow-up carried out of the [sql-check-constraint-unification](projects/sql-check-constraint-unification/spec.md) project (surfaced in the slice-1 review of #29892).

## At a glance

```ts
// StorageTable's constructor, before
this.uniques = Object.freeze(
  input.uniques.map((u) => (u instanceof UniqueConstraint ? u : new UniqueConstraint(u))),
);
this.indexes = Object.freeze(input.indexes.map((i) => (i instanceof Index ? i : new Index(i))));
this.foreignKeys = Object.freeze(
  input.foreignKeys.map((fk) => (fk instanceof ForeignKey ? fk : new ForeignKey(fk))),
);

// after
this.uniques = Object.freeze(input.uniques.map(UniqueConstraint.from));
this.indexes = Object.freeze(input.indexes.map(Index.from));
this.foreignKeys = Object.freeze(input.foreignKeys.map(ForeignKey.from));
```

## Decision

Every IR node constructor that accepts nested nodes open-coded the same normalization — `x instanceof T ? x : new T(x)` — once per collection, so a constructor's body was mostly ceremony. `CheckConstraint` gained a `static from()` during the check-constraint work and its one line in `StorageTable` already read cleanly; the five collections beside it did not.

This gives the same factory to every node class that needed it and rewrites the call sites to use it: `StorageColumn`, `PrimaryKey` (both the contract and schema-IR classes — they are distinct types), `UniqueConstraint`, `Index`, `ForeignKey`, `ForeignKeyReference`, `SqlIndexIR`, `SqlCheckConstraintIR`.

Behaviour is identical — same normalization, same `Object.freeze` wrapping, same optional-field handling. No emitted contract changes (`fixtures:check` clean).

## Reviewer notes

- **`entity-kinds.ts` deliberately keeps its inline `instanceof`.** Those checks pair with the `*InputFromSerialized` converters, so the false branch is a deserialization step, not a constructor call — a different concern that a `from()` factory would misrepresent.
- **There are two `PrimaryKey` classes**, one in `@internal/sql-contract` and one in `@internal/sql-schema-ir`. Both needed the factory; `sql-table-ir.ts` uses the schema-IR one. Worth a glance that each file imports its own.
- The remaining `instanceof` matches in these packages are the factory bodies themselves, which is where the check now lives.

## Behavior changes & evidence

None — this is a pure readability refactor. Evidence is the unchanged suites below plus `fixtures:check`, which proves no emitted contract moved.

## Verification

- `pnpm -w build` — 86/86; `pnpm typecheck` — 165/165
- `@internal/sql-contract` 322 · `@internal/sql-schema-ir` 184 · `@internal/sql-contract-ts` 442 · `@internal/target-postgres` 1384 · `@internal/family-sql` 338 — all pass
- `pnpm lint` on both changed packages, `pnpm lint:deps`, `pnpm fixtures:check`, `node scripts/lint-casts.mjs` (delta 0) — all clean

## Alternatives considered

- **A shared generic helper** (`normalizeNode(T, value)`) instead of a per-class static — rejected: it needs the constructor passed as a value and reads worse at the call site than `Index.from`, and the static keeps the factory discoverable from the class it builds.
- **Leaving the constructors alone** — rejected: the inconsistency was already visible inside a single constructor body, where `checks` used a factory and its five siblings did not.

## Checklist

- [x] All commits carry DCO sign-off
- [x] I have read CONTRIBUTING.md
- [x] Behaviour-preserving refactor; existing suites cover it
- [x] Title follows the prevailing convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added convenient factory methods for creating or reusing SQL schema elements, including keys, indexes, constraints, columns, and foreign-key references.
  * Factories accept either existing instances or input data, simplifying schema definition and conversion workflows.

* **Refactor**
  * Improved normalization of nested table and constraint data while preserving existing behavior.

* **Tests**
  * Added coverage for factory creation, instance reuse, input conversion, and nested schema hydration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->