### PR TITLE
chore(deps): hold @codingame/monaco-vscode-* majors until monaco-languageclient moves

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,6 +67,35 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "vitest"
         update-types: ["version-update:semver-major"]
+      # vite majors are coordinated by hand too. The repo takes vite from the
+      # catalog, so a major moves every package at once.
+      - dependency-name: "vite"
+        update-types: ["version-update:semver-major"]
+      # apps/lsp-playground is a private dev tool: a Monaco editor wired to the
+      # language server, started by hand when working on PSL diagnostics. It
+      # ships to nobody, and its dependency churn is pure noise — the
+      # @codingame/monaco-vscode-* family alone opened two unmergeable major
+      # PRs in one week (#29942, #29943).
+      #
+      # Dependabot cannot exclude a workspace path, so the packages that only
+      # this app uses are ignored by name instead. Upgrade them by hand if the
+      # playground ever needs it. Two things to know before trying: the whole
+      # @codingame/monaco-vscode-* family shares one major version, and
+      # monaco-languageclient depends on 31 of those packages directly, so it
+      # decides which major the app can use. Its compatibility table records
+      # the major each release pins:
+      # https://github.com/TypeFox/monaco-languageclient/blob/main/docs/versions-and-history.md
+      - dependency-name: "@codingame/monaco-vscode-*"
+      - dependency-name: "monaco-editor"
+      - dependency-name: "monaco-languageclient"
+      - dependency-name: "vscode"
+      - dependency-name: "vscode-jsonrpc"
+      - dependency-name: "vscode-languageclient"
+      - dependency-name: "vscode-languageserver-protocol"
+      - dependency-name: "vscode-ws-jsonrpc"
+      - dependency-name: "ws"
+      - dependency-name: "@types/ws"
+      - dependency-name: "puppeteer-core"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## What

Add `@codingame/monaco-vscode-*` major bumps to Dependabot's ignore list, and record why.

## Why

Dependabot opened two separate major PRs this week — [#29942](https://github.com/prisma/prisma/pull/29942) (`editor-service-override` 25.1.2 → 35.0.0) and [#29943](https://github.com/prisma/prisma/pull/29943) (`keybindings-service-override` 34.1.3 → 35.0.0). Neither can be merged, and the reason is structural rather than a CI problem.

The `@codingame/monaco-vscode-*` packages all share one major version, and `monaco-languageclient` depends on 31 of them **directly**. So it installs its own copy of the family at whatever major its release pins — 10.7.0, the current stable, pins `^25.1.2` — regardless of what `apps/lsp-playground` declares. Bumping one package in the playground does not move it onto a newer family; it only adds another copy of `@codingame/monaco-vscode-api` beside the ones already installed. The lockfile already carries two (25.1.2 and 34.1.3) from earlier partial bumps.

Moving the family means upgrading `monaco-languageclient` itself, in a single PR that bumps it together with all nine packages the playground uses. Its [compatibility table](https://github.com/TypeFox/monaco-languageclient/blob/main/docs/versions-and-history.md) records the major each release pins.

Until then, Dependabot would re-open the same two unmergeable PRs every Monday. The ignore entry stops that; patch and minor updates still flow.

## Scope

One entry in `.github/dependabot.yml`, matching the existing precedent for `typescript` and `vitest`. The comment records what has to happen first, so whoever revisits it does not have to re-derive the dependency graph.

Closes #29942, closes #29943.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated dependency updates now skip major Vite upgrades and all updates for selected Monaco, VS Code, WebSocket, and Puppeteer packages.
  * These packages will be reviewed and upgraded manually to support coordinated compatibility updates and reduce unexpected changes in development tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->