### PR TITLE
fix(client): make Prisma.Decimal relational operators compare numerically

### DIFF
--- a/packages/client-runtime-utils/src/index.test.ts
+++ b/packages/client-runtime-utils/src/index.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { Decimal } from './index'
+
+describe('Decimal relational operators', () => {
+  // Regression test for https://github.com/prisma/prisma/issues/29882
+  //
+  // decimal.js `valueOf()` returns a string, so `<`, `>`, `<=`, `>=` between two
+  // Decimals used to compare the decimal strings lexicographically:
+  //   new Decimal('10.1') < new Decimal('9.99')   // was true (10.1 > 9.99)
+  //   new Decimal('2') < new Decimal('10')        // was false (2 < 10)
+  it('compares by numeric value instead of by string', () => {
+    const d = (value: string) => new Decimal(value)
+
+    expect(d('10.1') < d('9.99')).toBe(false)
+    expect(d('2') < d('10')).toBe(true)
+    expect(d('9.99') >= d('10.1')).toBe(false)
+    expect(d('10.00') <= d('10.00')).toBe(true)
+    expect(d('1.5') > d('1.50')).toBe(false) // equal values, trailing zeros
+  })
+
+  it('keeps Number() coercion numeric', () => {
+    expect(Number(new Decimal('10.5'))).toBe(10.5)
+    expect(+new Decimal('10.5')).toBe(10.5)
+  })
+
+  it('keeps string coercion and JSON output unchanged', () => {
+    const d = new Decimal('10.10')
+
+    // decimal.js canonicalizes a trailing-zero precision to its shortest form;
+    // the point is that the valueOf override does NOT change string/JSON output.
+    expect(String(d)).toBe('10.1')
+    expect(`${d}`).toBe('10.1')
+    expect(d.toString()).toBe('10.1')
+    expect(d.toJSON()).toBe('10.1')
+    expect(JSON.stringify(new Decimal('2.50'))).toBe('"2.5"')
+  })
+})

--- a/packages/client-runtime-utils/src/index.test.ts
+++ b/packages/client-runtime-utils/src/index.test.ts
@@ -4,19 +4,26 @@ import { Decimal } from './index'
 
 describe('Decimal relational operators', () => {
   // Regression test for https://github.com/prisma/prisma/issues/29882
-  //
-  // decimal.js `valueOf()` returns a string, so `<`, `>`, `<=`, `>=` between two
-  // Decimals used to compare the decimal strings lexicographically:
-  //   new Decimal('10.1') < new Decimal('9.99')   // was true (10.1 > 9.99)
-  //   new Decimal('2') < new Decimal('10')        // was false (2 < 10)
   it('compares by numeric value instead of by string', () => {
     const d = (value: string) => new Decimal(value)
 
     expect(d('10.1') < d('9.99')).toBe(false)
     expect(d('2') < d('10')).toBe(true)
     expect(d('9.99') >= d('10.1')).toBe(false)
-    expect(d('10.00') <= d('10.00')).toBe(true)
-    expect(d('1.5') > d('1.50')).toBe(false) // equal values, trailing zeros
+    expect(d('10.00') <= d('10')).toBe(true)
+    expect(d('1.5') > d('1.50')).toBe(false)
+  })
+
+  it('keeps large integers distinguishable and finite', () => {
+    const d = (value: string) => new Decimal(value)
+
+    // Integers beyond Number.MAX_SAFE_INTEGER: Number('9007199254740992') and
+    // Number('9007199254740993') are the same double, and Number('1e1000') is
+    // Infinity. Relational operators must still order them exactly.
+    expect(d('9007199254740992') < d('9007199254740993')).toBe(true)
+    expect(d('1e1000') < d('1e1001')).toBe(true)
+    expect(d('1e1000') > d('9e999')).toBe(true)
+    expect(Number.isFinite(Number(d('1e1000')))).toBe(false)
   })
 
   it('keeps Number() coercion numeric', () => {
@@ -27,8 +34,6 @@ describe('Decimal relational operators', () => {
   it('keeps string coercion and JSON output unchanged', () => {
     const d = new Decimal('10.10')
 
-    // decimal.js canonicalizes a trailing-zero precision to its shortest form;
-    // the point is that the valueOf override does NOT change string/JSON output.
     expect(String(d)).toBe('10.1')
     expect(`${d}`).toBe('10.1')
     expect(d.toString()).toBe('10.1')

--- a/packages/client-runtime-utils/src/index.ts
+++ b/packages/client-runtime-utils/src/index.ts
@@ -26,8 +26,20 @@ export * from './nullTypes'
  * https://github.com/prisma/prisma/issues/29882
  */
 export class Decimal extends DecimalJS {
-  [Symbol.toPrimitive](hint: 'default' | 'number' | 'string'): number | string {
-    if (hint === 'number') return Number(this.toString())
+  [Symbol.toPrimitive](hint: 'default' | 'number' | 'string'): number | bigint | string {
+    if (hint === 'number') {
+      const numeric = Number(this.toString())
+      // Number() is a double: it rounds integers beyond Number.MAX_SAFE_INTEGER
+      // (9007199254740992 and 9007199254740993 collapse to the same double) and
+      // overflows to Infinity past ~1.8e308 (1e1000 and 1e1001 both become
+      // Infinity). For those integers return an exact BigInt instead — JS
+      // relational operators compare Number/BigInt operands exactly, so
+      // `<`/`>`/`<=`/`>=` stay correct for large values too.
+      if (this.isInteger() && !Number.isSafeInteger(numeric)) {
+        return BigInt(this.toFixed(0))
+      }
+      return numeric
+    }
     return this.toString()
   }
 }

--- a/packages/client-runtime-utils/src/index.ts
+++ b/packages/client-runtime-utils/src/index.ts
@@ -1,4 +1,35 @@
+import { Decimal as DecimalJS } from 'decimal.js'
+
 export * from './errors'
 export * from './nullTypes'
-export { Decimal } from 'decimal.js'
+
+/**
+ * Prisma's `Decimal` (re-exported to users as `Prisma.Decimal`) is decimal.js,
+ * whose `valueOf()` returns a *string*. Relational operators (`<`, `>`, `<=`,
+ * `>=`) and `Number()` coerce operands with the `"number"` hint, which without
+ * this override falls back to `valueOf()`/`toString()` — so
+ * `new Decimal('10.1') < new Decimal('9.99')` compared the strings `'10.1' <
+ * '9.99'` and evaluated to `true` (the wrong answer).
+ *
+ * Overriding `Symbol.toPrimitive` (which takes precedence over `valueOf`)
+ * resolves the `"number"` hint to the actual numeric value while leaving the
+ * `"string"` and `"default"` hints on the existing string representation, so
+ * `toString()`, `toJSON()`, template literals, string concatenation and
+ * `JSON.stringify` are all unchanged. Only the comparison contexts that were
+ * wrong become numerically correct.
+ *
+ * The class subclasses `decimal.js` (which constructs internally via
+ * `x.constructor`, so subclassing is supported) rather than mutating the shared
+ * `decimal.js` prototype, so third-party `import Decimal from 'decimal.js'`
+ * usage in the same process is unaffected.
+ *
+ * https://github.com/prisma/prisma/issues/29882
+ */
+export class Decimal extends DecimalJS {
+  [Symbol.toPrimitive](hint: 'default' | 'number' | 'string'): number | string {
+    if (hint === 'number') return Number(this.toString())
+    return this.toString()
+  }
+}
+
 export { empty, join, raw, type RawValue, Sql, default as sql, type Value } from 'sql-template-tag'


### PR DESCRIPTION
Fixes #29882.

## Problem

`Prisma.Decimal` is `decimal.js`, and `Decimal.prototype.valueOf()` returns a **string**. TypeScript accepts relational operators between two `Decimal` operands, and at runtime the engine coerces both operands with the `"number"` hint, which falls back to `valueOf()`/`toString()`. The result is lexicographic string comparison:

```ts
import { Prisma } from '@prisma/client'
const d = (v: string) => new Prisma.Decimal(v)

d('10.1') < d('9.99')  // true  (wrong — 10.1 > 9.99)
d('2') < d('10')       // false (wrong — 2 < 10)
d('9.99') >= d('10.1') // true  (wrong)
```

A realistic victim is `balance >= price` for money amounts: it compiles cleanly under `--strict` and silently answers wrong, and because the failure depends on digit count it can sit green in tests (`2.50 < 10.00` happens to be right) and flip in production.

## Fix

The `Decimal` class re-exported by `@prisma/client-runtime-utils` (which the client runtime re-exports as `Prisma.Decimal`) now subclasses `decimal.js` and overrides `Symbol.toPrimitive` — which takes precedence over `valueOf` — so that the `"number"` hint resolves to the actual numeric value while the `"string"` and `"default"` hints keep the existing string representation:

- `d('10.1') < d('9.99')` → `10.1 < 9.99` → `false`
- `d('2') < d('10')` → `2 < 10` → `true`
- `Number(d)`, `+d` keep working (they were already numeric)
- `toString()`, `toJSON()`, template literals, string concatenation, `JSON.stringify` and `valueOf()` are **unchanged**

Large integers are handled exactly: values beyond `Number.MAX_SAFE_INTEGER` (e.g. `9007199254740992` vs `9007199254740993`) or past ~1.8e308 (`1e1000` vs `1e1001`) are returned as an exact `BigInt` for the `"number"` hint, and JS relational operators compare `Number`/`BigInt` operands exactly, so `d('1e1000') < d('1e1001')` is `true` rather than collapsing both to `Infinity`. Ordinary values keep the `Number` path, so `Number(d)` / `+d` behaviour is unchanged.

The change is localized: it is a subclass rather than a mutation of the shared `decimal.js` prototype (decimal.js constructs internally via `x.constructor`, so subclassing is supported), so third-party `import Decimal from 'decimal.js'` usage in the same process is unaffected. Note `Decimal.clone()` still returns a fresh base-class constructor (standard decimal.js semantics) and is outside the scope of this issue.

## Verification

Added `packages/client-runtime-utils/src/index.test.ts`:

- **RED** on `v7`: `expect(d('10.1') < d('9.99')).toBe(false)` fails — the operators compare the strings (`'10.1' < '9.99'`).
- **GREEN** with the fix: all assertions pass, including guards that lock in the non-behavior-change of `toString`/`toJSON`/template/`JSON.stringify`.

Run: `cd packages/client-runtime-utils && pnpm exec vitest run src/index.test.ts`

## Prior discussion

The issue thread weighs a docs warning, a lint rule, and overriding `valueOf()` to throw. This PR takes the middle path: the `"number"` hint becomes numeric instead of throwing, so existing correct call sites (`.toString()`, `.toJSON()`, `.lessThan()`/`.gte()`, `Number()`) are untouched and only the incorrect relational-operator comparisons change — from silently-wrong to numerically correct, matching the issue's stated expectation of "a numerically correct comparison".

Targets the `v7` stable line (the issue reproduces on 7.9.1 and the client runtime lives here). On `main` the repo has been restructured into the 8.0.0-rc packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed decimal comparisons so relational operators use numeric ordering rather than lexicographic string ordering.
  - Improved numeric coercion for large integer decimal values, preserving precision when converting to native numeric types.
  - Preserved existing `Number()` conversion behavior.
  - Maintained string, template, and JSON serialization behavior, including values with trailing zeros and extreme exponents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
