### PR TITLE
TML-2521: Clear four of the eight expiring coverage exemptions with real unit tests

### DIFF
--- a/coverage.config.json
+++ b/coverage.config.json
@@ -48,15 +48,6 @@
       "notes": "Direct branch-coverage tests for the new authoring helpers tracked as a follow-up before 0.9 release."
     },
     {
-      "package": "2-sql/3-tooling/emitter",
-      "reason": "M9 target-extensible-IR refactor added emitter-side handling for target-contributed entity types. src/index.ts coverage dropped marginally (91.84% statements / 89.47% branches against 97/93 thresholds) — exercised end-to-end through emitter-hook fixtures.",
-      "addedDate": "2026-05-16",
-      "expiryDays": 90,
-      "assignee": null,
-      "linear": "TML-2521",
-      "notes": "Direct emitter-index branch tests tracked as a follow-up."
-    },
-    {
       "package": "2-sql/4-lanes/relational-core",
       "reason": "M9 target-extensible-IR refactor touched codec-ref-for-column.ts, expression.ts, and middleware/param-ref-mutator.ts with small coverage drops (1-7% below threshold). Behaviour verified through downstream SQL builder and runtime integration tests.",
       "addedDate": "2026-05-16",

--- a/coverage.config.json
+++ b/coverage.config.json
@@ -39,15 +39,6 @@
       "notes": "vitest.config.ts excludes the IR class-only files from coverage (mirroring the existing pack-types.ts pattern); validators.ts and index-type-validation.ts remain under-covered pending dedicated branch-coverage tests."
     },
     {
-      "package": "2-sql/1-core/schema-ir",
-      "reason": "M9 target-extensible-IR refactor lifted SQL Schema IR shapes to IR classes (primary-key.ts, sql-column-ir.ts, sql-foreign-key-ir.ts, sql-index-ir.ts, sql-schema-ir.ts, sql-table-ir.ts, sql-unique-ir.ts). They are exercised through schema verify/planner integration paths rather than direct unit tests today.",
-      "addedDate": "2026-05-16",
-      "expiryDays": 90,
-      "assignee": null,
-      "linear": "TML-2521",
-      "notes": "Per-class unit tests tracked as a follow-up before 0.9 release."
-    },
-    {
       "package": "2-sql/2-authoring/contract-ts",
       "reason": "M9 target-extensible-IR refactor reshaped build-contract.ts, composed-authoring-helpers.ts, config-types.ts, contract-builder.ts, and contract-warnings.ts to thread polymorphic storage type entries and composed authoring contributions through the SQL contract-ts builder. Coverage delta is small (1-5% below threshold) and falls on new authoring branches exercised through integration paths.",
       "addedDate": "2026-05-16",

--- a/coverage.config.json
+++ b/coverage.config.json
@@ -48,15 +48,6 @@
       "notes": "Direct branch-coverage tests for the new authoring helpers tracked as a follow-up before 0.9 release."
     },
     {
-      "package": "2-sql/4-lanes/relational-core",
-      "reason": "M9 target-extensible-IR refactor touched codec-ref-for-column.ts, expression.ts, and middleware/param-ref-mutator.ts with small coverage drops (1-7% below threshold). Behaviour verified through downstream SQL builder and runtime integration tests.",
-      "addedDate": "2026-05-16",
-      "expiryDays": 90,
-      "assignee": null,
-      "linear": "TML-2521",
-      "notes": "Direct unit tests for the new branches tracked as a follow-up before 0.9 release."
-    },
-    {
       "package": "3-mongo-target/1-mongo-target",
       "reason": "M9 target-extensible-IR refactor formed the target-mongo package alongside its family residence. Per-target unit coverage is not yet present; the target is exercised through mongo-family integration tests and the retail-store/mongo-blog-leaderboard examples.",
       "addedDate": "2026-05-16",

--- a/coverage.config.json
+++ b/coverage.config.json
@@ -30,15 +30,6 @@
       "notes": "Recovery requires either reorganising coverage scopes (so integration tests count toward this package's report) or adding equivalent unit-level tests inside the package that don't need pgvector fixtures."
     },
     {
-      "package": "1-framework/2-authoring/contract",
-      "reason": "M9 target-extensible-IR refactor introduced composed-helpers-scaffolding.ts (currently 0%) — module-level scaffolding exercised through composed authoring flows in target packages rather than direct unit tests at the framework layer. Per-module unit coverage tracked as a follow-up before 0.9 release.",
-      "addedDate": "2026-05-16",
-      "expiryDays": 90,
-      "assignee": null,
-      "linear": "TML-2521",
-      "notes": "Coverage will recover once dedicated unit tests for the scaffolding helpers land; meanwhile composed-helpers behaviour is verified end-to-end in target-pack integration tests."
-    },
-    {
       "package": "2-sql/1-core/contract",
       "reason": "M9 target-extensible-IR refactor introduced new SQL Contract IR classes (postgres-enum-storage-entry.ts, sql-storage.ts, storage-column.ts, storage-table.ts, storage-type-instance.ts, unique-constraint.ts) and grew validators.ts to handle polymorphic storage type entries. IR classes are exercised through integration paths (contract-ts builder, family serializer round-trips, target-postgres hydration); per-class direct unit tests and additional validator branch coverage tracked as a follow-up before 0.9 release.",
       "addedDate": "2026-05-16",

--- a/packages/1-framework/2-authoring/contract/test/composed-helpers-scaffolding.test.ts
+++ b/packages/1-framework/2-authoring/contract/test/composed-helpers-scaffolding.test.ts
@@ -1,0 +1,119 @@
+import type {
+  AuthoringEntityContext,
+  AuthoringEntityTypeDescriptor,
+  AuthoringEntityTypeNamespace,
+} from '@internal/framework-components/authoring';
+import { describe, expect, it } from 'vitest';
+import { createEntityHelpersFromNamespace } from '../src/composed-helpers-scaffolding';
+
+type Helper = (...args: readonly unknown[]) => unknown;
+
+function helperAt(surface: Record<string, unknown>, path: string): Helper {
+  const resolved = path
+    .split('.')
+    .reduce<unknown>((node, key) => (node as Record<string, unknown>)[key], surface);
+  if (typeof resolved !== 'function') {
+    throw new Error(`expected a helper at "${path}", found ${typeof resolved}`);
+  }
+  return resolved as Helper;
+}
+
+const ctx: AuthoringEntityContext = { family: 'sql', target: 'postgres' };
+
+const badgeDescriptor: AuthoringEntityTypeDescriptor = {
+  kind: 'entity',
+  discriminator: 'badge',
+  output: {
+    factory: (input: { readonly label: string }, factoryCtx: AuthoringEntityContext) => ({
+      label: input.label,
+      family: factoryCtx.family,
+      target: factoryCtx.target,
+    }),
+  },
+};
+
+const labelDescriptor: AuthoringEntityTypeDescriptor = {
+  kind: 'entity',
+  discriminator: 'label',
+  args: [{ kind: 'string', name: 'text' }],
+  output: { template: { text: { kind: 'arg', index: 0 } } },
+};
+
+describe('createEntityHelpersFromNamespace', () => {
+  describe('given a namespace of leaf descriptors and nested namespaces', () => {
+    const helpers = createEntityHelpersFromNamespace(
+      { badge: badgeDescriptor, pg: { label: labelDescriptor } },
+      { ctx },
+    );
+
+    it('mirrors the namespace tree as callables', () => {
+      expect(helpers).toEqual({
+        badge: expect.any(Function),
+        pg: { label: expect.any(Function) },
+      });
+    });
+
+    it('invokes a factory-output descriptor with the input and the authoring context', () => {
+      expect(helperAt(helpers, 'badge')({ label: 'gold' })).toEqual({
+        label: 'gold',
+        family: 'sql',
+        target: 'postgres',
+      });
+    });
+
+    it('resolves a template-output descriptor against the supplied arguments', () => {
+      expect(helperAt(helpers, 'pg.label')('hello')).toEqual({ text: 'hello' });
+    });
+
+    it('reports argument errors under the dotted namespace path', () => {
+      expect(() => helperAt(helpers, 'pg.label')()).toThrow(
+        expect.objectContaining({
+          code: 'CONTRACT.ARGUMENT_INVALID',
+          message: 'pg.label expects 1 argument(s), received 0',
+        }),
+      );
+    });
+  });
+
+  describe('given entries that are not leaf descriptors', () => {
+    it('recurses into an object whose kind is not entity', () => {
+      const namespace = {
+        legacy: { kind: 'preset', discriminator: 'legacy', nested: badgeDescriptor },
+      } as unknown as AuthoringEntityTypeNamespace;
+
+      expect(createEntityHelpersFromNamespace(namespace, { ctx })).toEqual({
+        legacy: { nested: expect.any(Function) },
+      });
+    });
+
+    it('recurses into an entity object whose discriminator is absent or empty', () => {
+      const namespace = {
+        unnamed: { kind: 'entity', discriminator: '', nested: badgeDescriptor },
+        undiscriminated: { kind: 'entity', nested: badgeDescriptor },
+      } as unknown as AuthoringEntityTypeNamespace;
+
+      expect(createEntityHelpersFromNamespace(namespace, { ctx })).toEqual({
+        unnamed: { nested: expect.any(Function) },
+        undiscriminated: { nested: expect.any(Function) },
+      });
+    });
+
+    it('drops primitive, null, and array entries', () => {
+      const namespace = {
+        text: 'not-a-descriptor',
+        count: 7,
+        missing: null,
+        list: [badgeDescriptor],
+        badge: badgeDescriptor,
+      } as unknown as AuthoringEntityTypeNamespace;
+
+      expect(createEntityHelpersFromNamespace(namespace, { ctx })).toEqual({
+        badge: expect.any(Function),
+      });
+    });
+  });
+
+  it('returns an empty surface for an empty namespace', () => {
+    expect(createEntityHelpersFromNamespace({}, { ctx })).toEqual({});
+  });
+});

--- a/packages/1-framework/2-authoring/contract/test/enum-type.test.ts
+++ b/packages/1-framework/2-authoring/contract/test/enum-type.test.ts
@@ -1,8 +1,115 @@
 import { isStructuredError } from '@internal/utils/structured-error';
 import { describe, expect, it } from 'vitest';
-import { enumType, member } from '../src/enum-type';
+import {
+  bindEnumType,
+  ENUM_TYPE_HANDLE_BRAND,
+  type EnumTypeHandle,
+  enumType,
+  isEnumTypeHandle,
+  member,
+} from '../src/enum-type';
 
 const textCodec = { codecId: 'pg/text@1', nativeType: 'text' };
+
+describe('member', () => {
+  it('defaults the value to the name', () => {
+    expect(member('Active')).toEqual({ name: 'Active', value: 'Active' });
+  });
+
+  it('keeps an explicit value', () => {
+    expect(member('Active', 3)).toEqual({ name: 'Active', value: 3 });
+  });
+});
+
+describe('a declared enum type', () => {
+  const Role = enumType('Role', textCodec, member('User', 'user'), member('Admin', 'admin'));
+  const wideRole: EnumTypeHandle = Role;
+
+  it('carries the codec, the ordered members, and the accessor map', () => {
+    expect(Role).toEqual({
+      [ENUM_TYPE_HANDLE_BRAND]: true,
+      enumName: 'Role',
+      codecId: 'pg/text@1',
+      nativeType: 'text',
+      enumMembers: [
+        { name: 'User', value: 'user' },
+        { name: 'Admin', value: 'admin' },
+      ],
+      values: ['user', 'admin'],
+      names: ['User', 'Admin'],
+      members: { User: 'user', Admin: 'admin' },
+      has: expect.any(Function),
+      nameOf: expect.any(Function),
+      ordinalOf: expect.any(Function),
+    });
+  });
+
+  it('answers membership, name, and ordinal lookups by value', () => {
+    expect({
+      hasDeclared: wideRole.has('admin'),
+      hasUndeclared: wideRole.has('ghost'),
+      nameOfDeclared: wideRole.nameOf('admin'),
+      nameOfUndeclared: wideRole.nameOf('ghost'),
+      ordinalOfDeclared: wideRole.ordinalOf('admin'),
+      ordinalOfUndeclared: wideRole.ordinalOf('ghost'),
+    }).toEqual({
+      hasDeclared: true,
+      hasUndeclared: false,
+      nameOfDeclared: 'Admin',
+      nameOfUndeclared: undefined,
+      ordinalOfDeclared: 1,
+      ordinalOfUndeclared: -1,
+    });
+  });
+
+  it('freezes the member views it exposes', () => {
+    expect({
+      values: Object.isFrozen(Role.values),
+      names: Object.isFrozen(Role.names),
+      enumMembers: Object.isFrozen(Role.enumMembers),
+      members: Object.isFrozen(Role.members),
+    }).toEqual({ values: true, names: true, enumMembers: true, members: true });
+  });
+
+  it('is recognized as an enum type handle', () => {
+    expect(isEnumTypeHandle(Role)).toBe(true);
+  });
+});
+
+describe('isEnumTypeHandle', () => {
+  it('rejects values that do not carry the brand', () => {
+    const candidates = [null, undefined, 'Role', 42, {}, { [ENUM_TYPE_HANDLE_BRAND]: false }];
+
+    expect(candidates.map(isEnumTypeHandle)).toEqual([false, false, false, false, false, false]);
+  });
+});
+
+describe('bindEnumType', () => {
+  it('builds the same handle through the codec-bound signature', () => {
+    const boundEnumType = bindEnumType<{ 'pg/int4@1': { input: number } }>();
+
+    const Level = boundEnumType(
+      'Level',
+      { codecId: 'pg/int4@1', nativeType: 'int4' },
+      member('Low', 1),
+      member('High', 2),
+    );
+
+    expect({
+      enumName: Level.enumName,
+      codecId: Level.codecId,
+      nativeType: Level.nativeType,
+      values: Level.values,
+      members: Level.members,
+    }).toEqual({
+      enumName: 'Level',
+      codecId: 'pg/int4@1',
+      nativeType: 'int4',
+      values: [1, 2],
+      members: { Low: 1, High: 2 },
+    });
+  });
+});
 
 describe('enumType validation errors', () => {
   it('rejects an enum with no members with CONTRACT.ENUM_INVALID', () => {

--- a/packages/2-sql/1-core/schema-ir/test/naming.test.ts
+++ b/packages/2-sql/1-core/schema-ir/test/naming.test.ts
@@ -3,14 +3,126 @@ import { describe, expect, it } from 'vitest';
 
 import {
   assertWireNamePrefixLength,
+  composeCheckWirePrefix,
   computeCheckContentHash,
   computeIndexContentHash,
+  defaultIndexName,
   formatWireName,
+  nameOf,
+  namingOf,
+  namingOfLiveName,
+  normalizeIndexOptionValue,
   normalizeSqlBody,
+  parseNaming,
   parseWireName,
   truncateToWireNamePrefixBytes,
   WIRE_NAME_PREFIX_MAX_BYTES,
 } from '../src/exports/naming';
+
+describe('defaultIndexName', () => {
+  it('joins the table and column tuple into the conventional suffix', () => {
+    expect(defaultIndexName('users', ['tenant_id', 'email'])).toBe('users_tenant_id_email_idx');
+  });
+});
+
+describe('the naming union', () => {
+  describe('nameOf / namingOf round-trip', () => {
+    it('an exact name keeps its author-owned spelling', () => {
+      const naming = namingOf('users_pkey', undefined);
+
+      expect(naming).toEqual({ kind: 'exact', name: 'users_pkey' });
+      expect(nameOf(naming)).toBe('users_pkey');
+    });
+
+    it('a wire name splits back into the prefix it was built from', () => {
+      const naming = namingOf('users_email_idx_ab12cd34', 'users_email_idx');
+
+      expect(naming).toEqual({
+        kind: 'wire',
+        prefix: 'users_email_idx',
+        hash: 'ab12cd34',
+      });
+      expect(nameOf(naming)).toBe('users_email_idx_ab12cd34');
+    });
+  });
+
+  describe('parseNaming (flat data from outside the process)', () => {
+    it('reads a wire name back when the declared prefix agrees', () => {
+      expect(parseNaming('p_read_ab12cd34', 'p_read')).toEqual({
+        kind: 'wire',
+        prefix: 'p_read',
+        hash: 'ab12cd34',
+      });
+    });
+
+    it('treats an absent prefix as an exact name', () => {
+      expect(parseNaming('handwritten', undefined)).toEqual({
+        kind: 'exact',
+        name: 'handwritten',
+      });
+    });
+
+    it('rejects a declared prefix that disagrees with the name', () => {
+      expect(() => parseNaming('p_read_ab12cd34', 'p_write')).toThrow(
+        '"p_read_ab12cd34": prefix "p_write" does not match the wire name',
+      );
+    });
+
+    it('rejects a declared prefix on a name with no hash suffix', () => {
+      expect(() => parseNaming('handwritten', 'handwritten')).toThrow(
+        'does not match the wire name',
+      );
+    });
+  });
+
+  describe('namingOfLiveName (a name read out of the catalog)', () => {
+    it('claims the wire arm for a wire-shaped name', () => {
+      expect(namingOfLiveName('users_email_idx_ab12cd34')).toEqual({
+        kind: 'wire',
+        prefix: 'users_email_idx',
+        hash: 'ab12cd34',
+      });
+    });
+
+    it('claims the exact arm for anything else', () => {
+      expect(namingOfLiveName('users_pkey')).toEqual({ kind: 'exact', name: 'users_pkey' });
+    });
+  });
+});
+
+describe('composeCheckWirePrefix', () => {
+  it('spells the membership and element-not-null kinds distinctly', () => {
+    expect({
+      membership: composeCheckWirePrefix('User', 'role', 'membership'),
+      elementNotNull: composeCheckWirePrefix('User', 'tags', 'elementNotNull'),
+    }).toEqual({
+      membership: 'User_role_check',
+      elementNotNull: 'User_tags_elem_not_null',
+    });
+  });
+
+  it('truncates a derived prefix to the wire-name byte budget', () => {
+    const prefix = composeCheckWirePrefix('t'.repeat(60), 'column', 'membership');
+
+    expect(new TextEncoder().encode(prefix).length).toBe(WIRE_NAME_PREFIX_MAX_BYTES);
+  });
+});
+
+describe('normalizeIndexOptionValue', () => {
+  it('canonicalizes every boolean spelling the catalog may reprint', () => {
+    expect({
+      trueValues: [true, 'true', 'on'].map(normalizeIndexOptionValue),
+      falseValues: [false, 'false', 'off'].map(normalizeIndexOptionValue),
+    }).toEqual({
+      trueValues: ['on', 'on', 'on'],
+      falseValues: ['off', 'off', 'off'],
+    });
+  });
+
+  it('String()-coerces everything else', () => {
+    expect([70, '70', null].map(normalizeIndexOptionValue)).toEqual(['70', '70', 'null']);
+  });
+});
 
 describe('formatWireName', () => {
   it('joins prefix and hash with an underscore', () => {

--- a/packages/2-sql/1-core/schema-ir/test/node-annotations.test.ts
+++ b/packages/2-sql/1-core/schema-ir/test/node-annotations.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import { SqlColumnIR } from '../src/ir/sql-column-ir';
+import { SqlForeignKeyIR } from '../src/ir/sql-foreign-key-ir';
+import { SqlIndexIR } from '../src/ir/sql-index-ir';
+import { SqlSchemaIR } from '../src/ir/sql-schema-ir';
+import { SqlTableIR } from '../src/ir/sql-table-ir';
+import { SqlUniqueIR } from '../src/ir/sql-unique-ir';
+
+const annotations = { 'prisma/rls': { enabled: true } };
+
+const withAnnotations = {
+  SqlColumnIR: () =>
+    new SqlColumnIR({ name: 'id', nativeType: 'int4', nullable: false, annotations }),
+  SqlForeignKeyIR: () =>
+    new SqlForeignKeyIR({
+      columns: ['user_id'],
+      referencedTable: 'users',
+      referencedColumns: ['id'],
+      annotations,
+    }),
+  SqlUniqueIR: () => new SqlUniqueIR({ columns: ['email'], annotations }),
+  SqlIndexIR: () =>
+    new SqlIndexIR({
+      naming: { kind: 'exact', name: 'users_email_idx' },
+      columns: ['email'],
+      where: undefined,
+      unique: false,
+      partial: false,
+      type: undefined,
+      options: undefined,
+      annotations,
+      dependsOn: undefined,
+    }),
+  SqlTableIR: () =>
+    new SqlTableIR({
+      name: 'users',
+      columns: {},
+      foreignKeys: [],
+      uniques: [],
+      indexes: [],
+      annotations,
+    }),
+  SqlSchemaIR: () => new SqlSchemaIR({ tables: {}, annotations }),
+} as const;
+
+const withoutAnnotations = {
+  SqlColumnIR: () => new SqlColumnIR({ name: 'id', nativeType: 'int4', nullable: false }),
+  SqlForeignKeyIR: () =>
+    new SqlForeignKeyIR({
+      columns: ['user_id'],
+      referencedTable: 'users',
+      referencedColumns: ['id'],
+    }),
+  SqlUniqueIR: () => new SqlUniqueIR({ columns: ['email'] }),
+  SqlIndexIR: () =>
+    new SqlIndexIR({
+      naming: { kind: 'exact', name: 'users_email_idx' },
+      columns: ['email'],
+      where: undefined,
+      unique: false,
+      partial: false,
+      type: undefined,
+      options: undefined,
+      annotations: undefined,
+      dependsOn: undefined,
+    }),
+  SqlTableIR: () =>
+    new SqlTableIR({ name: 'users', columns: {}, foreignKeys: [], uniques: [], indexes: [] }),
+  SqlSchemaIR: () => new SqlSchemaIR({ tables: {} }),
+} as const;
+
+const nodeNames = Object.keys(withAnnotations) as (keyof typeof withAnnotations)[];
+
+describe('annotations on schema IR nodes', () => {
+  it.each(nodeNames)('%s carries supplied annotations into serialization', (name) => {
+    const node = withAnnotations[name]();
+
+    expect(JSON.parse(JSON.stringify(node))).toMatchObject({ annotations });
+  });
+
+  it.each(nodeNames)('%s leaves annotations absent when none are supplied', (name) => {
+    expect('annotations' in withoutAnnotations[name]()).toBe(false);
+  });
+
+  it.each(nodeNames)('%s equality ignores annotations', (name) => {
+    expect(withAnnotations[name]().isEqualTo(withoutAnnotations[name]())).toBe(true);
+  });
+});

--- a/packages/2-sql/1-core/schema-ir/test/resolved-default-equality.test.ts
+++ b/packages/2-sql/1-core/schema-ir/test/resolved-default-equality.test.ts
@@ -1,0 +1,106 @@
+import type { ColumnDefault, ColumnDefaultLiteralInputValue } from '@internal/contract/types';
+import { describe, expect, it } from 'vitest';
+
+import { resolvedDefaultsEqual } from '../src/ir/resolved-default-equality';
+
+const literal = (value: ColumnDefaultLiteralInputValue): ColumnDefault => ({
+  kind: 'literal',
+  value,
+});
+
+const fn = (expression: string): ColumnDefault => ({ kind: 'function', expression });
+
+describe('resolvedDefaultsEqual', () => {
+  describe('across kinds', () => {
+    it('a literal never equals a function', () => {
+      expect(resolvedDefaultsEqual(literal('now'), fn('now()'))).toBe(false);
+    });
+
+    it('a kind outside the union compares unequal rather than throwing', () => {
+      const rogue = { kind: 'sequence', value: 1 } as unknown as ColumnDefault;
+
+      expect(resolvedDefaultsEqual(rogue, rogue)).toBe(false);
+    });
+  });
+
+  describe('function defaults', () => {
+    it('ignores case and whitespace', () => {
+      expect(resolvedDefaultsEqual(fn('NOW( )'), fn('now()'))).toBe(true);
+    });
+
+    it('fires on a materially different expression', () => {
+      expect(resolvedDefaultsEqual(fn('now()'), fn('clock_timestamp()'))).toBe(false);
+    });
+  });
+
+  describe('literal defaults', () => {
+    it('compares primitives by identity', () => {
+      expect({
+        same: resolvedDefaultsEqual(literal(7), literal(7)),
+        different: resolvedDefaultsEqual(literal(7), literal(8)),
+      }).toEqual({ same: true, different: false });
+    });
+
+    it('compares two objects canonically, so key order does not matter', () => {
+      expect(resolvedDefaultsEqual(literal({ a: 1, b: 2 }), literal({ b: 2, a: 1 }))).toBe(true);
+    });
+
+    it('compares an object against its JSON text in either position', () => {
+      expect({
+        objectFirst: resolvedDefaultsEqual(literal({ a: 1 }), literal('{"a":1}')),
+        stringFirst: resolvedDefaultsEqual(literal('{"a":1}'), literal({ a: 1 })),
+      }).toEqual({ objectFirst: true, stringFirst: true });
+    });
+
+    it('treats unparseable text against an object as unequal', () => {
+      expect({
+        objectFirst: resolvedDefaultsEqual(literal({ a: 1 }), literal('not json')),
+        stringFirst: resolvedDefaultsEqual(literal('not json'), literal({ a: 1 })),
+      }).toEqual({ objectFirst: false, stringFirst: false });
+    });
+
+    it('fires on two objects with different contents', () => {
+      expect(resolvedDefaultsEqual(literal({ a: 1 }), literal({ a: 2 }))).toBe(false);
+    });
+  });
+
+  describe('temporal literals', () => {
+    const nativeType = 'timestamptz';
+
+    it('normalizes a Date against the ISO instant it denotes', () => {
+      expect(
+        resolvedDefaultsEqual(
+          literal(new Date('2026-01-01T00:00:00.000Z')),
+          literal('2026-01-01T00:00:00.000Z'),
+          nativeType,
+        ),
+      ).toBe(true);
+    });
+
+    it('normalizes two spellings of the same instant under a temporal native type', () => {
+      expect(
+        resolvedDefaultsEqual(
+          literal('2026-01-01T00:00:00Z'),
+          literal('2026-01-01T00:00:00.000Z'),
+          nativeType,
+        ),
+      ).toBe(true);
+    });
+
+    it('leaves the spellings alone without a temporal native type', () => {
+      expect(
+        resolvedDefaultsEqual(
+          literal('2026-01-01T00:00:00Z'),
+          literal('2026-01-01T00:00:00.000Z'),
+          'text',
+        ),
+      ).toBe(false);
+    });
+
+    it('leaves an unparseable string alone under a temporal native type', () => {
+      expect(resolvedDefaultsEqual(literal('not a date'), literal('not a date'), nativeType)).toBe(
+        true,
+      );
+    });
+  });
+});

--- a/packages/2-sql/1-core/schema-ir/test/schema-node-kinds.test.ts
+++ b/packages/2-sql/1-core/schema-ir/test/schema-node-kinds.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  RelationalSchemaNodeKind,
+  relationalNodeEntityKind,
+  relationalNodeGranularity,
+} from '../src/ir/schema-node-kinds';
+
+describe('relationalNodeGranularity', () => {
+  it('rejects a kind outside the relational vocabulary, naming the kind', () => {
+    expect(() => relationalNodeGranularity('postgres-policy')).toThrow(
+      'relationalNodeGranularity: unrecognized relational node kind "postgres-policy"',
+    );
+  });
+});
+
+describe('relationalNodeEntityKind', () => {
+  it('maps the table kind to the storage entity it keys', () => {
+    expect(relationalNodeEntityKind(RelationalSchemaNodeKind.table)).toBe('table');
+  });
+
+  it('returns undefined for relational kinds nested under a table', () => {
+    const nested = [
+      RelationalSchemaNodeKind.column,
+      RelationalSchemaNodeKind.columnDefault,
+      RelationalSchemaNodeKind.primaryKey,
+      RelationalSchemaNodeKind.foreignKey,
+      RelationalSchemaNodeKind.unique,
+      RelationalSchemaNodeKind.index,
+      RelationalSchemaNodeKind.check,
+      RelationalSchemaNodeKind.schema,
+    ];
+
+    expect(nested.map(relationalNodeEntityKind)).toEqual(nested.map(() => undefined));
+  });
+
+  it('returns undefined for a target-specific kind rather than throwing', () => {
+    expect(relationalNodeEntityKind('postgres-namespace')).toBeUndefined();
+  });
+});

--- a/packages/2-sql/1-core/schema-ir/test/sql-flat-tree-diffable.test.ts
+++ b/packages/2-sql/1-core/schema-ir/test/sql-flat-tree-diffable.test.ts
@@ -50,6 +50,42 @@ describe('flat tree diffability (SqlSchemaIR / SqlTableIR)', () => {
     ]);
   });
 
+  describe('given plain-data input rather than constructed nodes', () => {
+    const fromPlainData = new SqlSchemaIR({
+      tables: {
+        users: {
+          name: 'users',
+          columns: { id: { name: 'id', nativeType: 'int4', nullable: false } },
+          foreignKeys: [
+            { columns: ['org_id'], referencedTable: 'orgs', referencedColumns: ['id'] },
+          ],
+          uniques: [{ columns: ['email'] }],
+          indexes: [],
+        },
+      },
+    });
+
+    const users = Object.values(fromPlainData.tables)[0];
+
+    it('normalises the whole tree into IR classes', () => {
+      expect({
+        table: users instanceof SqlTableIR,
+        childKinds: users?.children().map((child) => child.nodeKind),
+      }).toEqual({
+        table: true,
+        childKinds: ['sql-column', 'sql-foreign-key', 'sql-unique'],
+      });
+    });
+
+    it('leaves an absent primary key and absent checks out of children', () => {
+      expect(users?.children().map((child) => child.id)).toEqual([
+        'column:id',
+        'foreign-key:org_id->.orgs(id)',
+        'unique:email',
+      ]);
+    });
+  });
+
   it('SqlTableIR isEqualTo is identity by name', () => {
     const sameName = new SqlTableIR({
       name: 'users',

--- a/packages/2-sql/1-core/schema-ir/test/sql-index-ir.test.ts
+++ b/packages/2-sql/1-core/schema-ir/test/sql-index-ir.test.ts
@@ -166,6 +166,45 @@ describe('SqlIndexIR', () => {
         }),
       ).toBe(true);
     });
+
+    it("columnPresence 'matching' compares the tuple when both sides carry columns", () => {
+      const email = wireNamed({ name: NAME, columns: ['email'] });
+      const strictness = { columnPresence: 'matching', bodies: 'ignored' } as const;
+
+      expect({
+        sameTuple: email.contentEquals(exact({ name: NAME, columns: ['email'] }), strictness),
+        differentTuple: email.contentEquals(exact({ name: NAME, columns: ['name'] }), strictness),
+      }).toEqual({ sameTuple: true, differentTuple: false });
+    });
+
+    it("columnPresence 'matching' pairs two expression nodes on their bodies", () => {
+      const expression = exact({ name: 'expr_idx', expression: 'lower(email)' });
+      const strictness = { columnPresence: 'matching', bodies: 'verbatim' } as const;
+
+      expect({
+        sameBody: expression.contentEquals(
+          exact({ name: 'expr_idx', expression: 'lower(email)' }),
+          strictness,
+        ),
+        differentBody: expression.contentEquals(
+          exact({ name: 'expr_idx', expression: 'upper(email)' }),
+          strictness,
+        ),
+      }).toEqual({ sameBody: true, differentBody: false });
+    });
+
+    it('option bags with different key sets are unequal', () => {
+      const oneOption = wireNamed({ name: NAME, columns: ['email'], options: { fillfactor: 70 } });
+
+      expect({
+        extraKey: oneOption.isEqualTo(
+          exact({ name: NAME, columns: ['email'], options: { fillfactor: 70, fastupdate: true } }),
+        ),
+        renamedKey: oneOption.isEqualTo(
+          exact({ name: NAME, columns: ['email'], options: { deduplicate_items: 70 } }),
+        ),
+      }).toEqual({ extraKey: false, renamedKey: false });
+    });
   });
 
   describe('isEqualTo — both modes (structural attributes)', () => {

--- a/packages/2-sql/1-core/schema-ir/test/sql-schema-ir-node.test.ts
+++ b/packages/2-sql/1-core/schema-ir/test/sql-schema-ir-node.test.ts
@@ -8,6 +8,7 @@ import { SqlColumnIR } from '../src/ir/sql-column-ir';
 import { SqlForeignKeyIR } from '../src/ir/sql-foreign-key-ir';
 import { SqlIndexIR } from '../src/ir/sql-index-ir';
 import { SqlSchemaIR } from '../src/ir/sql-schema-ir';
+import { assertNode, defineNonEnumerable } from '../src/ir/sql-schema-ir-node';
 import { SqlTableIR } from '../src/ir/sql-table-ir';
 import { SqlUniqueIR } from '../src/ir/sql-unique-ir';
 
@@ -119,6 +120,59 @@ describe('SqlSchemaIRNode discriminants', () => {
       nullable: false,
       nodeKind: 'sql-column',
     });
+  });
+});
+
+describe('assertNode', () => {
+  it('names the expected class and the kind it got instead', () => {
+    const column = new SqlColumnIR({ name: 'id', nativeType: 'int4', nullable: false });
+
+    expect(() => assertNode(column, 'SqlIndexIR', SqlIndexIR.is)).toThrow(
+      'Expected a SqlIndexIR but got nodeKind=sql-column',
+    );
+  });
+
+  it('reports an absent node rather than dereferencing it', () => {
+    expect(() => assertNode(undefined, 'SqlIndexIR', SqlIndexIR.is)).toThrow(
+      'Expected a SqlIndexIR but got nodeKind=undefined',
+    );
+  });
+
+  it('passes a node the predicate accepts', () => {
+    const index = new SqlIndexIR({
+      naming: { kind: 'exact', name: 'users_email_idx' },
+      columns: ['email'],
+      where: undefined,
+      unique: false,
+      partial: false,
+      type: undefined,
+      options: undefined,
+      annotations: undefined,
+      dependsOn: undefined,
+    });
+
+    expect(() => assertNode(index, 'SqlIndexIR', SqlIndexIR.is)).not.toThrow();
+  });
+});
+
+describe('defineNonEnumerable', () => {
+  it('defines a readable, non-enumerable property', () => {
+    const target: { marker?: string } = {};
+
+    defineNonEnumerable(target, 'marker', 'present');
+
+    expect({ value: target.marker, keys: Object.keys(target) }).toEqual({
+      value: 'present',
+      keys: [],
+    });
+  });
+
+  it('leaves the property absent for an undefined value', () => {
+    const target: { marker?: string } = {};
+
+    defineNonEnumerable(target, 'marker', undefined);
+
+    expect('marker' in target).toBe(false);
   });
 });
 

--- a/packages/2-sql/2-authoring/contract-ts/test/build-contract.error-paths.test.ts
+++ b/packages/2-sql/2-authoring/contract-ts/test/build-contract.error-paths.test.ts
@@ -1,0 +1,104 @@
+import type { FamilyPackRef, TargetPackRef } from '@internal/framework-components/components';
+import { describe, expect, it } from 'vitest';
+import { createTestSqlNamespace } from '../../../1-core/contract/test/test-support';
+import { defineContract, type field, type model, type rel } from '../src/contract-builder';
+
+const sqlFamilyPack = {
+  kind: 'family',
+  id: 'sql',
+  familyId: 'sql',
+  version: '0.0.1',
+  authoring: {
+    field: {
+      text: { kind: 'fieldPreset', output: { codecId: 'pg/text@1', nativeType: 'text' } },
+    },
+  },
+} as const satisfies FamilyPackRef<'sql'>;
+
+const postgresTargetPack = {
+  kind: 'target',
+  id: 'postgres',
+  familyId: 'sql',
+  targetId: 'postgres',
+  version: '0.0.1',
+  defaultNamespaceId: 'public',
+} as const satisfies TargetPackRef<'sql', 'postgres'>;
+
+type Helpers = {
+  readonly field: { text: () => ReturnType<typeof field.column> };
+  readonly model: typeof model;
+  readonly rel: typeof rel;
+};
+
+function build(
+  body: (helpers: Helpers) => { models: Record<string, unknown>; enums?: Record<string, unknown> },
+) {
+  return defineContract(
+    {
+      family: sqlFamilyPack,
+      target: postgresTargetPack,
+      createNamespace: createTestSqlNamespace,
+    },
+    body as unknown as Parameters<typeof defineContract>[1],
+  );
+}
+
+describe('relation targets', () => {
+  it('rejects a relation to a model the contract does not declare', () => {
+    expect(() =>
+      build((helpers) => ({
+        models: {
+          Post: helpers.model('Post', {
+            fields: { id: helpers.field.text(), authorId: helpers.field.text() },
+            relations: { author: helpers.rel.belongsTo('Author', { from: 'authorId', to: 'id' }) },
+          }),
+        },
+      })),
+    ).toThrow(
+      expect.objectContaining({
+        code: 'CONTRACT.MODEL_UNKNOWN',
+        message: expect.stringContaining('references unknown model "Author"'),
+      }),
+    );
+  });
+
+  it('rejects a junction table that is not a declared model', () => {
+    expect(() =>
+      build((helpers) => ({
+        models: {
+          Post: helpers.model('Post', { fields: { id: helpers.field.text() } }),
+          Tag: helpers.model('Tag', {
+            fields: { id: helpers.field.text() },
+            relations: {
+              posts: helpers.rel.manyToMany('Post', {
+                through: 'PostTag',
+                from: 'tagId',
+                to: 'postId',
+              }),
+            },
+          }),
+        },
+      })),
+    ).toThrow(
+      expect.objectContaining({
+        code: 'CONTRACT.MODEL_UNKNOWN',
+        message: 'Relation "Tag.posts" references unknown through model "PostTag"',
+      }),
+    );
+  });
+
+  it('rejects a relation to a model in a namespace that does not carry it', () => {
+    expect(() =>
+      build((helpers) => ({
+        models: {
+          Post: helpers.model('Post', {
+            fields: { id: helpers.field.text(), authorId: helpers.field.text() },
+            relations: {
+              author: helpers.rel.belongsTo('other.Author', { from: 'authorId', to: 'id' }),
+            },
+          }),
+        },
+      })),
+    ).toThrow(expect.objectContaining({ code: 'CONTRACT.MODEL_UNKNOWN' }));
+  });
+});

--- a/packages/2-sql/2-authoring/contract-ts/test/contract-builder.entrypoint.test.ts
+++ b/packages/2-sql/2-authoring/contract-ts/test/contract-builder.entrypoint.test.ts
@@ -66,6 +66,21 @@ describe('defineContract runtime guards', () => {
       code: 'CONTRACT.PACK_FAMILY_MISMATCH',
     },
     {
+      name: 'a target pack from another family',
+      run: () =>
+        defineContract({
+          family: sqlFamilyPack,
+          target: { ...postgresTargetPack, familyId: 'document' } as unknown as TargetPackRef<
+            'sql',
+            'postgres'
+          >,
+          createNamespace: createTestSqlNamespace,
+          models: {},
+        }),
+      error: 'target pack "postgres" targets family "document" but contract family is "sql".',
+      code: 'CONTRACT.PACK_FAMILY_MISMATCH',
+    },
+    {
       name: 'non-extension pack refs in extensions',
       run: () =>
         defineContract({

--- a/packages/2-sql/2-authoring/contract-ts/test/cross-space-relation.test.ts
+++ b/packages/2-sql/2-authoring/contract-ts/test/cross-space-relation.test.ts
@@ -308,7 +308,13 @@ describe('F-relfk: cross-space belongsTo().sql({ fk }) produces a cross-space FK
     expect(fks[0]!.onDelete).toBe('cascade');
   });
 
-  it('relation-derived FK carries every declared fk option', () => {
+  const profileWithFkOptions = (fk: {
+    readonly name?: string;
+    readonly onDelete?: 'restrict';
+    readonly onUpdate?: 'cascade';
+    readonly constraint?: boolean;
+    readonly index?: boolean;
+  }) => {
     const ExtUser = buildSyntheticSupabaseAuthUser();
 
     const Profile = model('Profile', {
@@ -317,15 +323,7 @@ describe('F-relfk: cross-space belongsTo().sql({ fk }) produces a cross-space FK
         userId: field.column(int4Column),
       },
     }).relations({
-      user: rel.belongsTo(ExtUser, { from: 'userId', to: 'id' }).sql({
-        fk: {
-          name: 'profile_user_fk',
-          onDelete: 'restrict',
-          onUpdate: 'cascade',
-          constraint: true,
-          index: false,
-        },
-      }),
+      user: rel.belongsTo(ExtUser, { from: 'userId', to: 'id' }).sql({ fk }),
     });
 
     const contract = defineContract({
@@ -336,15 +334,48 @@ describe('F-relfk: cross-space belongsTo().sql({ fk }) produces a cross-space FK
       models: { Profile },
     });
 
-    const profileTable = Object.values(contract.storage.namespaces)
-      .flatMap((ns) => Object.values(ns.entries.table ?? {}))
-      .find((t) => t !== undefined);
+    return Object.values(contract.storage.namespaces)
+      .flatMap((ns) => Object.entries(ns.entries.table ?? {}))
+      .find(([name]) => name === 'Profile')?.[1];
+  };
+
+  it('relation-derived FK carries the declared name and referential actions', () => {
+    const profileTable = profileWithFkOptions({
+      name: 'profile_user_fk',
+      onDelete: 'restrict',
+      onUpdate: 'cascade',
+    });
 
     expect(profileTable?.foreignKeys[0]).toMatchObject({
       name: 'profile_user_fk',
       onDelete: 'restrict',
       onUpdate: 'cascade',
       target: { spaceId: 'supabase', namespaceId: 'auth' },
+    });
+  });
+
+  it('constraint and index decide what the table carries, rather than riding on the FK node', () => {
+    const withIndex = profileWithFkOptions({ constraint: true, index: true });
+    const withoutIndex = profileWithFkOptions({ constraint: true, index: false });
+    const withoutConstraint = profileWithFkOptions({ constraint: false, index: false });
+
+    expect({
+      indexed: {
+        foreignKeys: withIndex?.foreignKeys.length,
+        indexes: withIndex?.indexes.map((index) => index.columns),
+      },
+      unindexed: {
+        foreignKeys: withoutIndex?.foreignKeys.length,
+        indexes: withoutIndex?.indexes.length,
+      },
+      unconstrained: {
+        foreignKeys: withoutConstraint?.foreignKeys.length,
+        indexes: withoutConstraint?.indexes.length,
+      },
+    }).toEqual({
+      indexed: { foreignKeys: 1, indexes: [['userId']] },
+      unindexed: { foreignKeys: 1, indexes: 0 },
+      unconstrained: { foreignKeys: 0, indexes: 0 },
     });
   });
 });

--- a/packages/2-sql/2-authoring/contract-ts/test/cross-space-relation.test.ts
+++ b/packages/2-sql/2-authoring/contract-ts/test/cross-space-relation.test.ts
@@ -355,27 +355,24 @@ describe('F-relfk: cross-space belongsTo().sql({ fk }) produces a cross-space FK
   });
 
   it('constraint and index decide what the table carries, rather than riding on the FK node', () => {
-    const withIndex = profileWithFkOptions({ constraint: true, index: true });
-    const withoutIndex = profileWithFkOptions({ constraint: true, index: false });
-    const withoutConstraint = profileWithFkOptions({ constraint: false, index: false });
+    const shape = (options: { readonly constraint: boolean; readonly index: boolean }) => {
+      const table = profileWithFkOptions(options);
+      return {
+        foreignKeys: table?.foreignKeys.length,
+        indexes: table?.indexes.map((index) => index.columns),
+      };
+    };
 
     expect({
-      indexed: {
-        foreignKeys: withIndex?.foreignKeys.length,
-        indexes: withIndex?.indexes.map((index) => index.columns),
-      },
-      unindexed: {
-        foreignKeys: withoutIndex?.foreignKeys.length,
-        indexes: withoutIndex?.indexes.length,
-      },
-      unconstrained: {
-        foreignKeys: withoutConstraint?.foreignKeys.length,
-        indexes: withoutConstraint?.indexes.length,
-      },
+      both: shape({ constraint: true, index: true }),
+      constraintOnly: shape({ constraint: true, index: false }),
+      indexOnly: shape({ constraint: false, index: true }),
+      neither: shape({ constraint: false, index: false }),
     }).toEqual({
-      indexed: { foreignKeys: 1, indexes: [['userId']] },
-      unindexed: { foreignKeys: 1, indexes: 0 },
-      unconstrained: { foreignKeys: 0, indexes: 0 },
+      both: { foreignKeys: 1, indexes: [['userId']] },
+      constraintOnly: { foreignKeys: 1, indexes: [] },
+      indexOnly: { foreignKeys: 0, indexes: [['userId']] },
+      neither: { foreignKeys: 0, indexes: [] },
     });
   });
 });

--- a/packages/2-sql/2-authoring/contract-ts/test/cross-space-relation.test.ts
+++ b/packages/2-sql/2-authoring/contract-ts/test/cross-space-relation.test.ts
@@ -307,6 +307,46 @@ describe('F-relfk: cross-space belongsTo().sql({ fk }) produces a cross-space FK
     expect(fks[0]!.target.spaceId).toBe('supabase');
     expect(fks[0]!.onDelete).toBe('cascade');
   });
+
+  it('relation-derived FK carries every declared fk option', () => {
+    const ExtUser = buildSyntheticSupabaseAuthUser();
+
+    const Profile = model('Profile', {
+      fields: {
+        id: field.column(int4Column).id(),
+        userId: field.column(int4Column),
+      },
+    }).relations({
+      user: rel.belongsTo(ExtUser, { from: 'userId', to: 'id' }).sql({
+        fk: {
+          name: 'profile_user_fk',
+          onDelete: 'restrict',
+          onUpdate: 'cascade',
+          constraint: true,
+          index: false,
+        },
+      }),
+    });
+
+    const contract = defineContract({
+      family: bareFamilyPack,
+      target: postgresTargetPack,
+      createNamespace: createTestSqlNamespace,
+      extensions: { supabase: supabasePack },
+      models: { Profile },
+    });
+
+    const profileTable = Object.values(contract.storage.namespaces)
+      .flatMap((ns) => Object.values(ns.entries.table ?? {}))
+      .find((t) => t !== undefined);
+
+    expect(profileTable?.foreignKeys[0]).toMatchObject({
+      name: 'profile_user_fk',
+      onDelete: 'restrict',
+      onUpdate: 'cascade',
+      target: { spaceId: 'supabase', namespaceId: 'auth' },
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/2-sql/2-authoring/contract-ts/test/entities-namespace.exemplar.test.ts
+++ b/packages/2-sql/2-authoring/contract-ts/test/entities-namespace.exemplar.test.ts
@@ -148,6 +148,44 @@ describe('entities namespace — synthetic pack exemplar', () => {
     });
   });
 
+  it('rejects a contributed entity type that would shadow a built-in helper', () => {
+    const collidingPack = {
+      ...demoEntitiesExtensionPack,
+      authoring: {
+        entityTypes: {
+          model: {
+            kind: 'entity',
+            discriminator: 'demo-entity',
+            output: { factory: (input: DemoEntityInput): DemoEntity => new DemoEntity(input) },
+          },
+        },
+      },
+    } as unknown as ExtensionPackRef<'sql', 'postgres'>;
+
+    expect(() =>
+      defineContract(
+        {
+          family: sqlFamilyPack,
+          target: postgresTargetPack,
+          createNamespace: createTestSqlNamespace,
+          extensions: { demo: collidingPack },
+        },
+        (helpers) => ({
+          models: {
+            Marker: helpers.model('Marker', { fields: { id: helpers.field.text() } }),
+          },
+        }),
+      ),
+    ).toThrow(
+      expect.objectContaining({
+        code: 'CONTRACT.PACK_CONTRIBUTION_INVALID',
+        message: expect.stringContaining(
+          '"model" collide with the reserved built-in helper key(s)',
+        ),
+      }),
+    );
+  });
+
   it('omitting the contributing pack removes the helper from the helpers surface', () => {
     defineContract(
       {

--- a/packages/2-sql/3-tooling/emitter/test/emitter-hook.aggregate-types.test.ts
+++ b/packages/2-sql/3-tooling/emitter/test/emitter-hook.aggregate-types.test.ts
@@ -123,8 +123,12 @@ describe('emitted AggregateTypes', () => {
       codecDescriptors: CONTRIBUTED,
     });
 
-    expect(emitted.indexOf('readonly count:')).toBeLessThan(emitted.indexOf('readonly min:'));
-    expect(emitted.indexOf('readonly min:')).toBeLessThan(emitted.indexOf('readonly sum:'));
+    const positions = ['readonly count:', 'readonly min:', 'readonly sum:'].map((key) =>
+      emitted.indexOf(key),
+    );
+
+    expect(positions.every((position) => position >= 0)).toBe(true);
+    expect(positions).toEqual([...positions].sort((left, right) => left - right));
   });
 
   it('refuses to emit a result type for a codec two traits both claim', () => {

--- a/packages/2-sql/3-tooling/emitter/test/emitter-hook.aggregate-types.test.ts
+++ b/packages/2-sql/3-tooling/emitter/test/emitter-hook.aggregate-types.test.ts
@@ -117,6 +117,16 @@ describe('emitted AggregateTypes', () => {
     expect(emitted).not.toContain('pg/varchar@1');
   });
 
+  it('emits several operations in name order', () => {
+    const emitted = aggregateTypesFor({
+      aggregateDescriptors: [SUM_INT2, COUNT, MIN_TEXTUAL],
+      codecDescriptors: CONTRIBUTED,
+    });
+
+    expect(emitted.indexOf('readonly count:')).toBeLessThan(emitted.indexOf('readonly min:'));
+    expect(emitted.indexOf('readonly min:')).toBeLessThan(emitted.indexOf('readonly sum:'));
+  });
+
   it('refuses to emit a result type for a codec two traits both claim', () => {
     expect(() =>
       aggregateTypesFor({

--- a/packages/2-sql/3-tooling/emitter/test/emitter-hook.field-resolution.test.ts
+++ b/packages/2-sql/3-tooling/emitter/test/emitter-hook.field-resolution.test.ts
@@ -1,0 +1,193 @@
+import type { Contract, ContractModelBase } from '@internal/contract/types';
+import { UNBOUND_NAMESPACE_ID } from '@internal/framework-components/ir';
+import { describe, expect, it } from 'vitest';
+import { sqlEmission } from '../src/index';
+import { createEmitterTestContract as createContract } from './create-emitter-test-contract';
+
+const column = {
+  id: { nativeType: 'uuid', codecId: 'pg/uuid@1', nullable: false },
+  role: {
+    nativeType: 'text',
+    codecId: 'pg/text@1',
+    nullable: false,
+    valueSet: {
+      namespaceId: UNBOUND_NAMESPACE_ID,
+      entityKind: 'valueSet',
+      entityName: 'Role',
+    },
+  },
+  amount: {
+    nativeType: 'numeric',
+    codecId: 'pg/numeric@1',
+    nullable: false,
+    typeParams: { precision: 10, scale: 2 },
+  },
+  viaRef: { nativeType: 'numeric', codecId: 'pg/numeric@1', nullable: false, typeRef: 'money' },
+  danglingRef: {
+    nativeType: 'numeric',
+    codecId: 'pg/numeric@1',
+    nullable: false,
+    typeRef: 'missing',
+  },
+} as const;
+
+function contractWith(parts: {
+  readonly storageFields: Record<string, { readonly column: string }>;
+  readonly valueSets?: Record<string, unknown>;
+}): { contract: Contract; model: ContractModelBase } {
+  const contract = createContract({
+    domain: {
+      namespaces: {
+        [UNBOUND_NAMESPACE_ID]: {
+          models: {
+            User: {
+              fields: {},
+              relations: {},
+              storage: {
+                namespaceId: UNBOUND_NAMESPACE_ID,
+                table: 'user',
+                fields: parts.storageFields,
+              },
+            },
+          },
+        },
+      },
+    },
+    storage: {
+      namespaces: {
+        [UNBOUND_NAMESPACE_ID]: {
+          id: UNBOUND_NAMESPACE_ID,
+          entries: {
+            table: {
+              user: { columns: column, uniques: [], indexes: [], foreignKeys: [] },
+            },
+            ...(parts.valueSets !== undefined ? { valueSet: parts.valueSets } : {}),
+          },
+        },
+      },
+      types: { money: { codecId: 'pg/numeric@1', typeParams: { precision: 19, scale: 4 } } },
+    },
+  });
+  const models = Object.values(contract.domain.namespaces)[0]?.models ?? {};
+  const model = Object.values(models)[0] as ContractModelBase;
+  return { contract, model };
+}
+
+const resolveTypeParams = (fieldName: string, fixture: ReturnType<typeof contractWith>) =>
+  sqlEmission.resolveFieldTypeParams?.('User', fieldName, fixture.model, fixture.contract);
+
+const resolveValueSet = (fieldName: string, fixture: ReturnType<typeof contractWith>) =>
+  sqlEmission.resolveFieldValueSet?.('User', fieldName, fixture.model, fixture.contract);
+
+describe('resolveFieldTypeParams', () => {
+  const fixture = contractWith({
+    storageFields: {
+      amount: { column: 'amount' },
+      viaRef: { column: 'viaRef' },
+      dangling: { column: 'danglingRef' },
+      missingColumn: { column: 'nope' },
+    },
+  });
+
+  it('reads the type params off the column', () => {
+    expect(resolveTypeParams('amount', fixture)).toEqual({ precision: 10, scale: 2 });
+  });
+
+  it('follows a typeRef into the shared storage type', () => {
+    expect(resolveTypeParams('viaRef', fixture)).toEqual({ precision: 19, scale: 4 });
+  });
+
+  it('resolves to nothing when the pieces are missing', () => {
+    expect({
+      unmappedField: resolveTypeParams('unmapped', fixture),
+      missingColumn: resolveTypeParams('missingColumn', fixture),
+      danglingTypeRef: resolveTypeParams('dangling', fixture),
+    }).toEqual({
+      unmappedField: undefined,
+      missingColumn: undefined,
+      danglingTypeRef: undefined,
+    });
+  });
+
+  it('resolves to nothing when the model names a table the storage does not have', () => {
+    const missingTable = contractWith({ storageFields: { amount: { column: 'amount' } } });
+    const model = {
+      ...missingTable.model,
+      storage: {
+        namespaceId: UNBOUND_NAMESPACE_ID,
+        table: 'absent',
+        fields: { amount: { column: 'amount' } },
+      },
+    } as ContractModelBase;
+
+    expect(
+      sqlEmission.resolveFieldTypeParams?.('User', 'amount', model, missingTable.contract),
+    ).toBeUndefined();
+  });
+
+  it('resolves to nothing when the model carries no storage namespace', () => {
+    const fixtureWithoutNamespace = contractWith({
+      storageFields: { amount: { column: 'amount' } },
+    });
+    const model = {
+      ...fixtureWithoutNamespace.model,
+      storage: { table: 'user', fields: { amount: { column: 'amount' } } },
+    } as ContractModelBase;
+
+    expect(
+      sqlEmission.resolveFieldTypeParams?.(
+        'User',
+        'amount',
+        model,
+        fixtureWithoutNamespace.contract,
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe('resolveFieldValueSet', () => {
+  const fixture = contractWith({
+    storageFields: {
+      role: { column: 'role' },
+      id: { column: 'id' },
+      missingColumn: { column: 'nope' },
+    },
+    valueSets: { Role: { kind: 'valueSet', values: ['user', 'admin'] } },
+  });
+
+  it('returns the referenced values with the column codec', () => {
+    expect(resolveValueSet('role', fixture)).toEqual({
+      encodedValues: ['user', 'admin'],
+      codecId: 'pg/text@1',
+    });
+  });
+
+  it('resolves to nothing when the field, column, or value set is absent', () => {
+    const danglingValueSet = contractWith({
+      storageFields: { role: { column: 'role' } },
+    });
+
+    expect({
+      unmappedField: resolveValueSet('unmapped', fixture),
+      missingColumn: resolveValueSet('missingColumn', fixture),
+      columnWithoutValueSet: resolveValueSet('id', fixture),
+      unresolvableValueSet: resolveValueSet('role', danglingValueSet),
+    }).toEqual({
+      unmappedField: undefined,
+      missingColumn: undefined,
+      columnWithoutValueSet: undefined,
+      unresolvableValueSet: undefined,
+    });
+  });
+
+  it('resolves to nothing when the model carries no storage namespace', () => {
+    const model = {
+      ...fixture.model,
+      storage: { table: 'user', fields: { role: { column: 'role' } } },
+    } as ContractModelBase;
+
+    expect(
+      sqlEmission.resolveFieldValueSet?.('User', 'role', model, fixture.contract),
+    ).toBeUndefined();
+  });
+});

--- a/packages/2-sql/3-tooling/emitter/test/emitter-hook.validation-paths.test.ts
+++ b/packages/2-sql/3-tooling/emitter/test/emitter-hook.validation-paths.test.ts
@@ -220,7 +220,11 @@ describe('getStorageTypeExports', () => {
       }),
     );
 
-    expect(exports).toContain('readonly role:');
-    expect(exports).not.toContain('"user" | "admin"');
+    expect(exports).toBe(
+      [
+        'export type StorageColumnTypes = { readonly app: { readonly user: { readonly role: CodecTypes["pg/text@1"]["output"] } } };',
+        'export type StorageColumnInputTypes = { readonly app: { readonly user: { readonly role: CodecTypes["pg/text@1"]["input"] } } };',
+      ].join('\n'),
+    );
   });
 });

--- a/packages/2-sql/3-tooling/emitter/test/emitter-hook.validation-paths.test.ts
+++ b/packages/2-sql/3-tooling/emitter/test/emitter-hook.validation-paths.test.ts
@@ -1,0 +1,226 @@
+import { UNBOUND_NAMESPACE_ID } from '@internal/framework-components/ir';
+import { describe, expect, it } from 'vitest';
+import { sqlEmission } from '../src/index';
+import { createEmitterTestContract as createContract } from './create-emitter-test-contract';
+
+const idColumn = { id: { nativeType: 'uuid', codecId: 'pg/uuid@1', nullable: false } };
+const userTable = { columns: idColumn, uniques: [], indexes: [], foreignKeys: [] };
+
+function contractWithModelStorage(storage: Record<string, unknown>) {
+  return createContract({
+    domain: {
+      namespaces: {
+        app: {
+          models: { User: { fields: {}, relations: {}, storage } },
+        },
+      },
+    },
+    storage: {
+      namespaces: {
+        app: { id: 'app', entries: { table: { user: userTable } } },
+      },
+    },
+  });
+}
+
+describe('validateTypes', () => {
+  it('passes when there is no storage to walk', () => {
+    expect(() => sqlEmission.validateTypes(createContract({ storage: {} }), {})).not.toThrow();
+  });
+
+  it('rejects a column with no codec id', () => {
+    const contract = createContract({
+      storage: { tables: { user: { columns: { id: { nativeType: 'uuid' } } } } },
+    });
+
+    expect(() => sqlEmission.validateTypes(contract, {})).toThrow(
+      'Column "id" in table "user" is missing codecId',
+    );
+  });
+
+  it('rejects a codec id outside the ns/name@version shape', () => {
+    const contract = createContract({
+      storage: { tables: { user: { columns: { id: { nativeType: 'uuid', codecId: 'uuid' } } } } },
+    });
+
+    expect(() => sqlEmission.validateTypes(contract, {})).toThrow(
+      'has invalid codec ID format "uuid"',
+    );
+  });
+});
+
+describe('validateStructure', () => {
+  it('rejects a contract from another family', () => {
+    expect(() => sqlEmission.validateStructure(createContract({ targetFamily: 'mongo' }))).toThrow(
+      'Expected targetFamily "sql", got "mongo"',
+    );
+  });
+
+  it('rejects a model with no storage table', () => {
+    expect(() =>
+      sqlEmission.validateStructure(contractWithModelStorage({ namespaceId: 'app', fields: {} })),
+    ).toThrow('Model "app:User" is missing storage.table');
+  });
+
+  it('rejects a model with no storage namespace', () => {
+    expect(() =>
+      sqlEmission.validateStructure(
+        contractWithModelStorage({ namespaceId: undefined, table: 'user', fields: {} }),
+      ),
+    ).toThrow('Model "app:User" is missing storage.namespaceId');
+  });
+
+  it('rejects a model whose storage namespace disagrees with its domain namespace', () => {
+    expect(() =>
+      sqlEmission.validateStructure(
+        contractWithModelStorage({ namespaceId: 'other', table: 'user', fields: {} }),
+      ),
+    ).toThrow('Model "app:User" storage.namespaceId "other" does not match domain namespace "app"');
+  });
+
+  it('rejects a model with no storage fields', () => {
+    expect(() =>
+      sqlEmission.validateStructure(
+        contractWithModelStorage({ namespaceId: 'app', table: 'user', fields: {} }),
+      ),
+    ).toThrow('Model "app:User" is missing storage.fields');
+  });
+
+  it('rejects a table with no uniques array', () => {
+    const contract = createContract({
+      storage: { tables: { user: { columns: idColumn, indexes: [], foreignKeys: [] } } },
+    });
+
+    expect(() => sqlEmission.validateStructure(contract)).toThrow(
+      'Table "user" is missing required field "uniques" (must be an array)',
+    );
+  });
+});
+
+describe('storage type emission for namespace kinds', () => {
+  function storageTypeFor(namespaces: Record<string, unknown>): string {
+    return sqlEmission.generateStorageType(
+      createContract({
+        domain: { namespaces: { [UNBOUND_NAMESPACE_ID]: { models: {} } } },
+        storage: { namespaces },
+      }),
+      'StorageHash',
+    );
+  }
+
+  it('spells a bound schema namespace as a postgres schema', () => {
+    const dts = storageTypeFor({
+      app: { id: 'app', kind: 'schema', entries: { table: { user: userTable } } },
+    });
+
+    expect(dts).toContain('readonly kind: "postgres-schema"');
+  });
+
+  it('spells the unbound schema namespace distinctly', () => {
+    const dts = storageTypeFor({
+      [UNBOUND_NAMESPACE_ID]: {
+        id: UNBOUND_NAMESPACE_ID,
+        kind: 'schema',
+        entries: { table: { user: userTable } },
+      },
+    });
+
+    expect(dts).toContain('readonly kind: "postgres-unbound-schema"');
+  });
+
+  it('emits an empty namespace map as Record<string, never>', () => {
+    expect(storageTypeFor({})).toContain('Record<string, never>');
+  });
+
+  it('orders namespaces and their value sets by name', () => {
+    const dts = storageTypeFor({
+      zeta: { id: 'zeta', kind: 'schema', entries: { table: { audit: userTable } } },
+      alpha: {
+        id: 'alpha',
+        kind: 'schema',
+        entries: {
+          table: { user: userTable },
+          valueSet: {
+            Status: { kind: 'valueSet', values: ['on', 'off'] },
+            Role: { kind: 'valueSet', values: ['user', 'admin'] },
+          },
+        },
+      },
+    });
+
+    expect(dts.indexOf('alpha')).toBeLessThan(dts.indexOf('zeta'));
+    expect(dts.indexOf('Role')).toBeLessThan(dts.indexOf('Status'));
+  });
+});
+
+describe('getStorageTypeExports', () => {
+  it('resolves to nothing without storage namespaces', () => {
+    expect(sqlEmission.getStorageTypeExports(createContract({ storage: {} }))).toBeUndefined();
+  });
+
+  it('orders the column type maps by namespace name', () => {
+    const exports = sqlEmission.getStorageTypeExports(
+      createContract({
+        storage: {
+          namespaces: {
+            zeta: { id: 'zeta', entries: { table: { audit: userTable } } },
+            alpha: { id: 'alpha', entries: { table: { user: userTable } } },
+          },
+        },
+      }),
+    );
+
+    expect(exports?.indexOf('alpha')).toBeLessThan(exports?.indexOf('zeta') ?? -1);
+  });
+
+  it('emits both column type maps as Record<string, never> for an empty namespace map', () => {
+    const exports = sqlEmission.getStorageTypeExports(
+      createContract({ storage: { namespaces: {} } }),
+    );
+
+    expect(exports).toBe(
+      [
+        'export type StorageColumnTypes = Record<string, never>;',
+        'export type StorageColumnInputTypes = Record<string, never>;',
+      ].join('\n'),
+    );
+  });
+
+  it('falls back to the codec type when a column names a value set the storage does not carry', () => {
+    const exports = sqlEmission.getStorageTypeExports(
+      createContract({
+        storage: {
+          namespaces: {
+            app: {
+              id: 'app',
+              entries: {
+                table: {
+                  user: {
+                    columns: {
+                      role: {
+                        nativeType: 'text',
+                        codecId: 'pg/text@1',
+                        nullable: false,
+                        valueSet: {
+                          namespaceId: 'app',
+                          entityKind: 'valueSet',
+                          entityName: 'Missing',
+                        },
+                      },
+                    },
+                    uniques: [],
+                    indexes: [],
+                    foreignKeys: [],
+                  },
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(exports).toContain('readonly role:');
+    expect(exports).not.toContain('"user" | "admin"');
+  });
+});

--- a/packages/2-sql/4-lanes/relational-core/test/ast/ddl-node-brand.test.ts
+++ b/packages/2-sql/4-lanes/relational-core/test/ast/ddl-node-brand.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { DdlNode, isDdlNode } from '../../src/exports/ast';
+
+class TargetContributedDdlNode extends DdlNode {
+  readonly kind = 'target-contributed';
+}
+
+describe('isDdlNode', () => {
+  it('recognizes a DdlNode subclass the family core has never heard of', () => {
+    expect(isDdlNode(new TargetContributedDdlNode())).toBe(true);
+  });
+
+  it('rejects values that do not answer the brand', () => {
+    const candidates = [null, undefined, 'create table', 42, {}, { isDdlNode: true }];
+
+    expect(candidates.map(isDdlNode)).toEqual([false, false, false, false, false, false]);
+  });
+});
+
+describe('DdlNode', () => {
+  it('collects no param refs by default', () => {
+    expect(new TargetContributedDdlNode().collectParamRefs()).toEqual([]);
+  });
+});

--- a/packages/2-sql/4-lanes/relational-core/test/codec-ref-for-column.test.ts
+++ b/packages/2-sql/4-lanes/relational-core/test/codec-ref-for-column.test.ts
@@ -2,6 +2,7 @@ import {
   SqlStorage,
   type SqlStorage as SqlStorageType,
   StorageTable,
+  toStorageTypeInstance,
 } from '@internal/sql-contract/types';
 import { blindCast } from '@internal/utils/casts';
 import { describe, expect, it } from 'vitest';
@@ -106,6 +107,97 @@ describe('codecRefForStorageColumn', () => {
     expect(codecRefForStorageColumn(storage, 'public', 'session', 'status')).toEqual({
       codecId: 'pg/enum@1',
       typeParams: { typeName: 'aal_level' },
+    });
+  });
+
+  it('returns undefined for an unknown table', () => {
+    const storage = new SqlStorage({
+      storageHash: STORAGE_HASH,
+      namespaces: {
+        public: createTestSqlNamespace({
+          id: 'public',
+          entries: { table: { users: usersTable('email_addr', 'pg/text@1') } },
+        }),
+      },
+    });
+
+    expect(codecRefForStorageColumn(storage, 'public', 'absent', 'email_addr')).toBeUndefined();
+  });
+
+  describe('typeRef columns', () => {
+    type StorageTypes = NonNullable<ConstructorParameters<typeof SqlStorage>[0]['types']>;
+
+    function storageWithTypeRef(types: StorageTypes | undefined, typeRef = 'money'): SqlStorage {
+      return new SqlStorage({
+        storageHash: STORAGE_HASH,
+        namespaces: {
+          public: createTestSqlNamespace({
+            id: 'public',
+            entries: {
+              table: {
+                invoice: new StorageTable({
+                  columns: {
+                    amount: {
+                      codecId: 'pg/numeric@1',
+                      nativeType: 'numeric',
+                      nullable: false,
+                      typeRef,
+                    },
+                  },
+                  uniques: [],
+                  indexes: [],
+                  foreignKeys: [],
+                }),
+              },
+            },
+          }),
+        },
+        ...(types !== undefined ? { types } : {}),
+      });
+    }
+
+    it('takes the codec and type params from the referenced storage type', () => {
+      const storage = storageWithTypeRef({
+        money: toStorageTypeInstance({
+          codecId: 'pg/numeric@1',
+          nativeType: 'numeric',
+          typeParams: { precision: 19 },
+        }),
+      });
+
+      expect(codecRefForStorageColumn(storage, 'public', 'invoice', 'amount')).toEqual({
+        codecId: 'pg/numeric@1',
+        typeParams: { precision: 19 },
+      });
+    });
+
+    it('omits type params when the referenced type declares none', () => {
+      const storage = storageWithTypeRef({
+        money: toStorageTypeInstance({ codecId: 'pg/numeric@1', nativeType: 'numeric' }),
+      });
+
+      expect(codecRefForStorageColumn(storage, 'public', 'invoice', 'amount')).toEqual({
+        codecId: 'pg/numeric@1',
+      });
+    });
+
+    it('returns undefined when the storage carries no matching type', () => {
+      expect({
+        noTypesBlock: codecRefForStorageColumn(
+          storageWithTypeRef(undefined),
+          'public',
+          'invoice',
+          'amount',
+        ),
+        danglingRef: codecRefForStorageColumn(
+          storageWithTypeRef({
+            other: toStorageTypeInstance({ codecId: 'pg/numeric@1', nativeType: 'numeric' }),
+          }),
+          'public',
+          'invoice',
+          'amount',
+        ),
+      }).toEqual({ noTypesBlock: undefined, danglingRef: undefined });
     });
   });
 });

--- a/packages/2-sql/4-lanes/relational-core/test/contract-free/column.test.ts
+++ b/packages/2-sql/4-lanes/relational-core/test/contract-free/column.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import { DdlColumn, FunctionColumnDefault, LiteralColumnDefault } from '../../src/exports/ast';
-import { col, fn, lit } from '../../src/exports/contract-free';
+import {
+  checkExpression,
+  col,
+  fn,
+  foreignKey,
+  lit,
+  primaryKey,
+  unique,
+} from '../../src/exports/contract-free';
 
 describe('contract-free column helpers', () => {
   it('lit produces a frozen LiteralColumnDefault', () => {
@@ -45,5 +53,81 @@ describe('contract-free column helpers', () => {
 
   it('rejects invalid literal input', () => {
     expect(() => lit(Symbol('x') as unknown as string)).toThrow(/Invalid column default literal/);
+  });
+});
+
+describe('contract-free table constraint helpers', () => {
+  it('primaryKey carries its column tuple, named or anonymous', () => {
+    expect({
+      anonymous: { ...primaryKey(['id']) },
+      named: { ...primaryKey(['tenant_id', 'id'], { name: 'user_pkey' }) },
+    }).toEqual({
+      anonymous: { kind: 'primary-key', columns: ['id'], name: undefined },
+      named: { kind: 'primary-key', columns: ['tenant_id', 'id'], name: 'user_pkey' },
+    });
+  });
+
+  it('foreignKey carries its referenced coordinates and referential actions', () => {
+    expect({
+      ...foreignKey(['user_id'], 'user', ['id'], {
+        name: 'post_user_fk',
+        onDelete: 'cascade',
+        onUpdate: 'restrict',
+      }),
+    }).toEqual({
+      kind: 'foreign-key',
+      columns: ['user_id'],
+      refTable: 'user',
+      refColumns: ['id'],
+      name: 'post_user_fk',
+      onDelete: 'cascade',
+      onUpdate: 'restrict',
+    });
+  });
+
+  it('foreignKey leaves the referential actions undeclared when none are given', () => {
+    expect({ ...foreignKey(['user_id'], 'user', ['id']) }).toEqual({
+      kind: 'foreign-key',
+      columns: ['user_id'],
+      refTable: 'user',
+      refColumns: ['id'],
+      name: undefined,
+      onDelete: undefined,
+      onUpdate: undefined,
+    });
+  });
+
+  it('unique carries its column tuple, named or anonymous', () => {
+    expect({
+      anonymous: { ...unique(['email']) },
+      named: { ...unique(['email'], { name: 'user_email_key' }) },
+    }).toEqual({
+      anonymous: { kind: 'unique', columns: ['email'], name: undefined },
+      named: { kind: 'unique', columns: ['email'], name: 'user_email_key' },
+    });
+  });
+
+  it('checkExpression carries its name and predicate verbatim', () => {
+    expect({ ...checkExpression('user_age_check', 'age >= 0') }).toEqual({
+      kind: 'check-expression',
+      name: 'user_age_check',
+      expression: 'age >= 0',
+    });
+  });
+
+  it('freezes every constraint and copies caller-owned column arrays', () => {
+    const columns = ['id'];
+    const constraint = primaryKey(columns);
+    columns.push('tenant_id');
+
+    expect({
+      frozen: [
+        primaryKey(['id']),
+        foreignKey(['user_id'], 'user', ['id']),
+        unique(['email']),
+        checkExpression('c', 'x > 0'),
+      ].map(Object.isFrozen),
+      columnsUnaffected: constraint.columns,
+    }).toEqual({ frozen: [true, true, true, true], columnsUnaffected: ['id'] });
   });
 });

--- a/packages/2-sql/4-lanes/relational-core/test/contract-free/table.test.ts
+++ b/packages/2-sql/4-lanes/relational-core/test/contract-free/table.test.ts
@@ -330,4 +330,19 @@ describe('table().select()', () => {
     const ast = tbl.select(tbl.id).where(tbl.id.eq(5)).build();
     expect(ast.where?.kind).toBe('binary');
   });
+
+  it('.orderBy() defaults to ascending and accumulates in call order', () => {
+    const ast = tbl.select(tbl.id).orderBy(tbl.name).orderBy(tbl.id, 'desc').build();
+
+    expect(ast.orderBy?.map((item) => item.dir)).toEqual(['asc', 'desc']);
+  });
+
+  it('.orderBy() composes with .where()', () => {
+    const ast = tbl.select(tbl.id).where(tbl.id.eq(5)).orderBy(tbl.id, 'desc').build();
+
+    expect({ where: ast.where?.kind, order: ast.orderBy?.length }).toEqual({
+      where: 'binary',
+      order: 1,
+    });
+  });
 });

--- a/packages/2-sql/4-lanes/relational-core/test/contract-free/table.test.ts
+++ b/packages/2-sql/4-lanes/relational-core/test/contract-free/table.test.ts
@@ -334,7 +334,15 @@ describe('table().select()', () => {
   it('.orderBy() defaults to ascending and accumulates in call order', () => {
     const ast = tbl.select(tbl.id).orderBy(tbl.name).orderBy(tbl.id, 'desc').build();
 
-    expect(ast.orderBy?.map((item) => item.dir)).toEqual(['asc', 'desc']);
+    expect(
+      ast.orderBy?.map((item) => ({
+        column: (item.expr as unknown as ColumnRef).column,
+        dir: item.dir,
+      })),
+    ).toEqual([
+      { column: 'name', dir: 'asc' },
+      { column: 'id', dir: 'desc' },
+    ]);
   });
 
   it('.orderBy() composes with .where()', () => {


### PR DESCRIPTION
## Linked issue

Refs [TML-2521](https://linear.app/prisma-company/issue/TML-2521/pr1-polymorphic-ir-entities-mechanism-postgres-enum-exemplar) — the target-extensible-IR PR that filed these coverage exemptions on 2026-05-16.

## At a glance

`coverage.config.json` carries time-limited coverage exemptions. Eight were filed by the target-extensible-IR refactor on the same day and all expire **2026-08-14**, at which point `pnpm coverage:packages` stops warning and starts failing:

```
❌ EXPIRED COVERAGE WARNINGS - CI BLOCKED
The following warning-only packages have EXPIRED and must be resolved:

  • 1-framework/2-authoring/contract
    Added: 2026-05-16 | Expired: 2026-08-14 (0 days ago)
    Reason: M9 target-extensible-IR refactor introduced composed-helpers-scaffolding.ts (currently 0%) …
```

Each exemption's stated recovery plan was "per-module unit tests, tracked as a follow-up before 0.9". This PR writes those tests for four of the eight and deletes their exemptions.

## Decision

Clear the expiring exemptions by earning the coverage back rather than renewing the expiry. Four packages are done and their entries are gone from `coverage.config.json`, so a future regression in that code is a hard CI failure instead of a silently-tolerated one:

| Package | Was | Now | Thresholds |
| --- | --- | --- | --- |
| `1-framework/2-authoring/contract` | 40% stmts / 38% branches | **100 / 100** | 95 / 95 |
| `2-sql/1-core/schema-ir` | 92 / 87 | **100 / 98** | 95 / 95 |
| `2-sql/3-tooling/emitter` | 94 / 87 | **99 / 93** | 97 / 93 |
| `2-sql/4-lanes/relational-core` | 94 / 92 | **98 / 95** | 96 / 95 |

This is a test-only change. No production code is modified.

## What is not done

Four exemptions remain, and three of them still expire on 2026-08-14. They need a decision before that date — either more of this work, or a renewal with an honest reason:

- **`2-sql/2-authoring/contract-ts`** — moved from 89.6% to 90.4% branches against a 94 threshold. Tests landed here for the relation-target and pack-guard errors. What is left is concentrated in `build-contract.ts`, whose uncovered paths are mostly guards sitting behind earlier validation: authoring a relation to an unknown model fails in the DSL long before `assertTargetModel` sees it, and the pack-entity name-collision guards need a target pack that contributes real entity types, not a synthetic stub. Reaching 95/94 means either building that richer fixture or reconsidering whether those guards should be assertions.
- **`3-mongo-target/1-mongo-target`** — 97.9 / 94.6 against a 100-across-the-board threshold. The remaining gaps are seven specific branches (thin descriptor methods on `control-target.ts`, one widening check in `mongo-planner.ts`, `stripUndefinedDeep`, the unbound-database path in the contract serializer). Tractable, just not started.
- **`3-mongo-target/2-mongo-adapter`** — 78.7 / 72.2 against 95 / 90. `lowering.ts` alone is 63% over ~680 lines. This is the largest single piece of work left.
- **`2-sql/1-core/contract`** — 83.1 / 75.4 against 91 / 85. Not started.

The two entries filed on other dates (`1-framework/0-foundation/contract`, `3-targets/3-targets/sqlite`, `3-extensions/sql-orm-client`, `1-framework/3-tooling/cli`) are untouched here. Worth knowing: the CLI one expires 2026-08-16, two days after this cohort.

## Reviewer notes

- The tests are written against behavior, not structure. The scaffolding suite was mutation-checked: removing the dotted-path threading, the array guard, the empty-discriminator check, or the `kind` check each fails a distinct named test.
- Removing an exemption is the part with teeth — these four packages now have to hold their thresholds on every future PR.
- A stale build in the worktree made most packages look broken on the first sweep (`Cannot find package '@internal/sql-schema-ir/naming'`, `settleAggregateOverloads is not a function`). That was `pnpm install && pnpm build`, not a real failure; all suites pass on a current build.
- Some uncovered lines are unreachable through the public surface by construction — `resolveFieldTypeParams`'s `if (!storage) return undefined` cannot fire for a contract that has storage. I left those alone rather than contorting a test to reach them.

## Testing performed

- `pnpm --filter <pkg> test:coverage` on final HEAD for all five packages touched. The four cleared packages exit 0 with no threshold errors.
- Per-package `typecheck` and `lint` for every package touched.

## Skill update

n/a — internal only. No user-facing surface changes.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco).
- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and the change is scoped to one logical concern.
- [x] Tests are updated.
- [x] The PR title is in `TML-NNNN: <sentence-case title>` form.
- [x] The **Skill update** section above is filled in.

## Alternatives considered

- **Renew the expiry dates.** The exemptions have already run a full 90-day cycle and the recovery note on each says the same thing: write the unit tests. Renewing buys another 90 days of the same debt. It is still the right call for whatever is left on 2026-08-14 — but with a specific reason, not the original one.
- **Widen each package's vitest `coverage.exclude` to skip the unmeasured files.** That makes the report green without making the code tested, and it is harder to notice later than a dated entry in `coverage.config.json`.
- **Reorganize coverage scopes so integration tests count toward per-package reports.** This is the right answer for packages whose code is genuinely exercised end-to-end elsewhere — the mongo adapter especially. It is a change to the coverage harness rather than a test-writing task, and it does not fit in a PR against a three-day deadline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for framework entity helpers, enum handling, SQL naming, annotations, defaults, schema nodes, and index comparisons.
  * Added validation tests for invalid relationships, incompatible contract configurations, reserved helper collisions, and missing models.
  * Added regression coverage for cross-space foreign keys, deterministic emitter ordering, field resolution, storage types, and validation paths.
  * Added tests for relational constraints, table ordering, node branding, defensive copying, and query composition.
* **Chores**
  * Removed warning-only coverage exceptions across framework and SQL components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->