### PR TITLE
docs(telemetry): opt out with the telemetry commands, not a text editor

### DIFF
--- a/docs/Telemetry.md
+++ b/docs/Telemetry.md
@@ -47,6 +47,8 @@ Your telemetry preference and the installation UUID live in a single per-user JS
 - **Unix (Linux, macOS):** `$XDG_CONFIG_HOME/prisma-next/config.json`, defaulting to `~/.config/prisma-next/config.json` when `$XDG_CONFIG_HOME` is unset. This follows the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/).
 - **Windows:** `%APPDATA%\prisma-next\config.json`, falling back to `%USERPROFILE%\AppData\Roaming\prisma-next\config.json`.
 
+The CLI writes this file for you: `prisma-next telemetry enable` / `disable` set the preference, and `prisma-next telemetry status` prints the resolved path along with what's currently in effect. The rest of this section describes what the file contains so you can read it — [the commands](#the-prisma-next-telemetry-command) are how you change it.
+
 After the first enabled run, the file looks like this:
 
 ```json
@@ -55,7 +57,7 @@ After the first enabled run, the file looks like this:
 }
 ```
 
-The first enabled run mints the `installationId` but does **not** write an `enableTelemetry` field — leaving it absent is what keeps telemetry on by default. If you make an explicit choice (`prisma-next telemetry enable` / `disable`, or a hand edit), the file also carries an explicit `enableTelemetry` value:
+The first enabled run mints the `installationId` but does **not** write an `enableTelemetry` field — leaving it absent is what keeps telemetry on by default. Once you make an explicit choice with `prisma-next telemetry enable` / `disable`, the file also carries an explicit `enableTelemetry` value:
 
 ```json
 {
@@ -66,14 +68,14 @@ The first enabled run mints the `installationId` but does **not** write an `enab
 
 Two fields matter to the CLI:
 
-- **`enableTelemetry`** (`boolean`, optional) — your explicit choice. `true` enables telemetry; `false` disables it; **absent means "on" (the opt-out default)**. The CLI only writes this field when you make an explicit choice (`prisma-next telemetry enable` / `disable`, or a hand edit); the default-on path never writes it.
+- **`enableTelemetry`** (`boolean`, optional) — your explicit choice. `true` enables telemetry; `false` disables it; **absent means "on" (the opt-out default)**. The CLI writes this field only when you make an explicit choice with `prisma-next telemetry enable` / `disable`; the default-on path never writes it.
 - **`installationId`** (`string`) — a v4 random UUID, minted locally on the first command that sends an event (the first enabled send). The CLI never rotates it on its own.
 
 Any other fields are tolerated and preserved across writes, so future Prisma Next versions can add new settings here without losing your existing data.
 
 ### Flipping your choice
 
-To turn telemetry off (or back on), run `prisma-next telemetry disable` / `prisma-next telemetry enable`, or edit the file in any text editor and change the `enableTelemetry` value. Either way the change takes effect on the next CLI invocation.
+To turn telemetry off (or back on), run `prisma-next telemetry disable` / `prisma-next telemetry enable`. The command writes the `enableTelemetry` value for you and the change takes effect on the next CLI invocation. `prisma-next telemetry status` reports what is in effect and why.
 
 ### Fully resetting
 
@@ -87,7 +89,7 @@ rm ~/.config/prisma-next/config.json
 Remove-Item "$env:APPDATA\prisma-next\config.json"
 ```
 
-Deleting the file returns you to the default (telemetry on). The next enabled command will reprint the one-time first-run notice and mint a fresh `installationId`. If your intent is to stay opted out, don't delete the file — run `prisma-next telemetry disable` (or keep `"enableTelemetry": false` in it), or use an [environment-variable opt-out](#1-environment-variables-runtime-only).
+Deleting the file returns you to the default (telemetry on). The next enabled command will reprint the one-time first-run notice and mint a fresh `installationId`. If your intent is to stay opted out, don't delete the file — run `prisma-next telemetry disable`, or use an [environment-variable opt-out](#1-environment-variables-runtime-only).
 
 ## How to opt out (or back in)
 
@@ -95,7 +97,7 @@ Telemetry can be disabled several independent ways. Any one is sufficient.
 
 ### The `prisma-next telemetry` command
 
-The friendliest path is the built-in command:
+The command exists so you never have to touch the config file yourself:
 
 ```bash
 prisma-next telemetry disable   # stores "enableTelemetry": false
@@ -103,7 +105,7 @@ prisma-next telemetry enable    # stores "enableTelemetry": true (mints an insta
 prisma-next telemetry status    # reports whether telemetry is on, why, the config path, and whether an ID is stored
 ```
 
-`disable` and `enable` write the stored preference described in [The stored preference](#2-the-stored-preference) for you. `status` is read-only — it emits no event, mints no ID, and does not print your installation ID (only whether one exists). The `telemetry` command is itself exempt from telemetry, so running it never emits a usage event.
+`disable` and `enable` write the [stored preference](#2-the-stored-preference) for you — atomically, preserving every other field already in the file. `status` is read-only — it emits no event, mints no ID, and does not print your installation ID (only whether one exists). The `telemetry` command is itself exempt from telemetry, so running it never emits a usage event.
 
 ### 1. Environment variables (runtime-only)
 
@@ -123,7 +125,7 @@ Export them in your shell profile if you want them to apply to every Prisma Next
 
 ### 2. The stored preference
 
-`prisma-next telemetry disable` writes this for you; you can also set `enableTelemetry` to `false` in your `config.json` by hand:
+`prisma-next telemetry disable` records the choice in your `config.json`:
 
 ```json
 {
@@ -131,9 +133,9 @@ Export them in your shell profile if you want them to apply to every Prisma Next
 }
 ```
 
-This disables telemetry on every invocation until you change it back. Storing `false` does not mint an `installationId`, and if one was already minted on a prior enabled run it is left in place (deleting the file is the way to clear it).
+This disables telemetry on every invocation until `prisma-next telemetry enable` changes it back. Storing `false` does not mint an `installationId`, and if one was already minted on a prior enabled run it is left in place (deleting the file is the way to clear it).
 
-You can write this file before ever running the CLI — drop a `config.json` containing `{ "enableTelemetry": false }` at the path above and the CLI will never send an event or print the first-run notice.
+To opt out on a machine where the CLI has never run — a fresh image, a provisioning script, a container build — set one of the [environment variables](#1-environment-variables-runtime-only) instead. No config file has to exist first: with telemetry disabled the CLI sends nothing and prints no first-run notice.
 
 ## Disclosure
 

--- a/docs/Telemetry.md
+++ b/docs/Telemetry.md
@@ -47,7 +47,7 @@ Your telemetry preference and the installation UUID live in a single per-user JS
 - **Unix (Linux, macOS):** `$XDG_CONFIG_HOME/prisma-next/config.json`, defaulting to `~/.config/prisma-next/config.json` when `$XDG_CONFIG_HOME` is unset. This follows the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/).
 - **Windows:** `%APPDATA%\prisma-next\config.json`, falling back to `%USERPROFILE%\AppData\Roaming\prisma-next\config.json`.
 
-The CLI writes this file for you: `prisma-next telemetry enable` / `disable` set the preference, and `prisma-next telemetry status` prints the resolved path along with what's currently in effect. The rest of this section describes what the file contains so you can read it — [the commands](#the-prisma-next-telemetry-command) are how you change it.
+The CLI writes this file for you: `prisma-next telemetry enable` / `disable` set the preference, and `prisma-next telemetry status` prints the resolved path along with what's currently in effect. The rest of this section describes what the file contains so you can read it; [changing it](#how-to-opt-out-or-back-in) is what those commands are for.
 
 After the first enabled run, the file looks like this:
 

--- a/skills/prisma-8/references/quickstart.md
+++ b/skills/prisma-8/references/quickstart.md
@@ -180,7 +180,7 @@ pnpm dlx prisma-next init                          # interactive
 pnpm dlx prisma-next init --yes --target postgres --authoring psl
 ```
 
-> **Telemetry is opt-out.** The CLI collects anonymous usage data by default. Every command — including `init` — prints a one-time notice to **stderr** on first use, then sends; there is no interactive consent prompt. Opt out anytime by running `prisma-next telemetry disable`, with `DO_NOT_TRACK=1` or `PRISMA_NEXT_DISABLE_TELEMETRY=1`, or by setting `"enableTelemetry": false` in your user config (`prisma-next` config dir, **not** `prisma-next.config.ts`). Run `prisma-next telemetry status` to see what's currently in effect. This is relevant for agent-driven runs — the CLI records that an agent invoked it. What's collected, the per-user config path, and how to fully reset are documented in `docs/Telemetry.md`.
+> **Telemetry is opt-out.** The CLI collects anonymous usage data by default. Every command — including `init` — prints a one-time notice to **stderr** on first use, then sends; there is no interactive consent prompt. Opt out anytime by running `prisma-next telemetry disable`, or with `DO_NOT_TRACK=1` or `PRISMA_NEXT_DISABLE_TELEMETRY=1`. The command stores `"enableTelemetry": false` in your user config for you (the `prisma-next` config dir, **not** `prisma-next.config.ts`). Run `prisma-next telemetry status` to see what's currently in effect. This is relevant for agent-driven runs — the CLI records that an agent invoked it. What's collected, the per-user config path, and how to fully reset are documented in `docs/Telemetry.md`.
 
 The flags `init` accepts (run `prisma-next init --help` for the source of truth):
 


### PR DESCRIPTION
## Linked issue

n/a — small docs change. Prompted by the engine-side telemetry work now underway; see the note at the end about what this PR deliberately does *not* pre-document.

## At a glance

`docs/Telemetry.md`, "Flipping your choice", before:

> To turn telemetry off (or back on), run `prisma-next telemetry disable` / `prisma-next telemetry enable`, or edit the file in any text editor and change the `enableTelemetry` value.

After:

> To turn telemetry off (or back on), run `prisma-next telemetry disable` / `prisma-next telemetry enable`. The command writes the `enableTelemetry` value for you and the change takes effect on the next CLI invocation. `prisma-next telemetry status` reports what is in effect and why.

## Decision

`prisma-next telemetry enable | disable | status` have been in the CLI the whole time. They exist so nobody has to open a JSON file to change their telemetry preference. The telemetry page was still teaching the JSON file as an equal route in three places — one of them told readers they could pre-create the file before ever running the CLI.

Hand-editing is now documented as what the file *is*, not as something you should do. The distinction the page holds throughout: **describing the file is useful reference material; recommending that users write to it is not.** `telemetry status` prints the file's path, so a reader who lands on it needs to know what the fields mean.

Nothing about where the file lives, what it contains, or how the fields resolve is removed.

## How it fits together

1. **"The user-level config file"** opens with one new sentence saying who writes it: the commands set the preference, `status` prints the resolved path, and the section that follows describes the contents so you can *read* them. The path bullets, the JSON samples, and the `enableTelemetry` / `installationId` field definitions are all untouched.
2. **Two field descriptions** dropped their "…or a hand edit" parenthetical. They now say the CLI writes `enableTelemetry` when you make an explicit choice with `enable` / `disable`.
3. **"Flipping your choice"** stops offering the text editor (shown above).
4. **"Fully resetting"** no longer offers `keep "enableTelemetry": false in it` as an alternative to running `disable`.
5. **"The `prisma-next telemetry` command"** now says plainly why it exists, and notes that `enable` / `disable` write the preference atomically and preserve every other field in the file — which is the concrete reason to prefer them over an editor.
6. **"2. The stored preference"** keeps the JSON sample as *what `disable` writes*, and the paragraph telling readers to drop a pre-made `config.json` on disk is replaced. Provisioning a machine where the CLI has never run is a real need, and the environment variables already serve it — they work before any config file exists and suppress the first-run notice too.

The `skills/prisma-8` quickstart carried the same hand-edit clause in its telemetry callout; it goes the same way, keeping the per-user vs. `prisma-next.config.ts` distinction it was making.

## Reviewer notes

- **Nothing shipped-behaviour-facing moved.** No filesystem path, no environment-variable name, no wording inside the verbatim first-run notice, and no `prisma-next` command prefix changed. Token counts for each of those are identical before and after; the only increase is `prisma-next telemetry`, which gains two mentions because the commands are now the route.
- **The first-run notice still mentions setting `"enableTelemetry": false` yourself.** That block is quoted verbatim from the shipped binary and is left exactly as-is, so the page keeps matching what users actually see on stderr. The notice's wording is one of the things changing on the engine side.
- **Coming, and deliberately not written here:** when this CLI ports onto the shared Prisma CLI engine, the config directory becomes `prisma` rather than `prisma-next`, the opt-out variable becomes `PRISMA_DISABLE_TELEMETRY`, and the first-run notice drops its hand-edit clause. None of that has shipped in the `prisma-next` CLI this page describes, so documenting it now would make the page wrong for the binary people are running. It lands with the port.
- **Anchors.** One new intra-page link, pointing at `#how-to-opt-out-or-back-in`. It first pointed at the commands section's own slug, and `lint:legacy-name` was right to reject that: the rule allows a bare `prisma-next` only when the character after it is neither a word character nor a hyphen, and `#the-prisma-next-telemetry-command` is followed by `-telemetry-command`. That is also why the two command spellings in the same sentence pass. Every existing heading and anchor is unchanged, so `#2-the-stored-preference` and `#1-environment-variables-runtime-only` still resolve from their inbound links.
- **Second file.** `skills/prisma-8/references/quickstart.md` is one sentence, included so the ruling isn't applied in only half the places a reader meets it. Easy to drop if you'd rather keep this to `docs/Telemetry.md`.

## Testing performed

- Docs-only change; no suites apply.
- `pnpm lint:legacy-name` (`node scripts/lint-legacy-name.mjs`) — passes, on the exact tree pushed.
- `pnpm lint:docs` (`scripts/validate-package-readmes.mjs`) — passes; its warnings are pre-existing and concern mongo package READMEs untouched here.
- Verified every intra-page anchor in `docs/Telemetry.md` resolves to a heading that exists.
- Diffed the frozen surfaces (config paths, `PRISMA_NEXT_DISABLE_TELEMETRY`, `DO_NOT_TRACK`, `%APPDATA%`, `$XDG_CONFIG_HOME`, `prisma-next.config.ts`, the notice block) against `main`: byte-identical.
- The repo has no markdown linter or link checker in CI to run against `docs/`.

## Skill update

`skills/prisma-8/references/quickstart.md` — the telemetry callout's opt-out routes now match the page. No CLI surface, flag, config field, or error code changed, so no other skill content is affected.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the DCO.
- [x] I read CONTRIBUTING.md and the change is scoped to one logical concern.
- [x] Tests are updated — n/a, doc-only with no behavioural delta.
- [ ] The PR title is in `TML-NNNN: <sentence-case title>` form — no Linear ticket; follows the `docs(<scope>):` form used by recent docs PRs (#29958, #29957, #29925).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that telemetry preferences are managed through CLI commands rather than manual configuration edits.
  * Documented telemetry status behavior, preservation of unrelated settings, and default-on behavior.
  * Added guidance for resetting telemetry and installation identity by deleting the configuration.
  * Updated opt-out instructions to use the telemetry disable command or environment-variable settings for provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
