### PR TITLE
fix(cli): repair main after the typed-next-actions collision

### DIFF
--- a/packages/1-framework/3-tooling/cli/src/utils/cli-errors.ts
+++ b/packages/1-framework/3-tooling/cli/src/utils/cli-errors.ts
@@ -81,7 +81,7 @@ export {
  * settles the engine's envelope.
  */
 export class ActionableCliError extends CliStructuredError {
-  readonly nextActions: readonly NextAction[];
+  override readonly nextActions: readonly NextAction[];
 
   constructor(
     code: `${string}.${string}`,

--- a/packages/1-framework/3-tooling/cli/test/orm/load-config.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/orm/load-config.test.ts
@@ -106,7 +106,7 @@ describe('loadOrmConfig', () => {
       const loaded = await loadOrmConfig({ cwd: projectDir() });
 
       expect(loaded.diagnostics[0]?.diagnostic.nextActions).toEqual([
-        { kind: 'user-choice', label: "Run 'prisma-next init' to create a config file" },
+        { kind: 'run-command', label: 'Create a config file', command: '{bin} init' },
       ]);
     });
 


### PR DESCRIPTION
## main is red

Type Check and Test have failed on every commit on `main` since [#29977](https://github.com/prisma/prisma/pull/29977) landed. Nothing can go green until this is fixed, including the Dependabot PRs currently queued.

## What happened

Two PRs that were each green on their own collided in the merge queue.

**Type Check.** [#29973](https://github.com/prisma/prisma/pull/29973) added `ActionableCliError` with its own `nextActions` field. [#29977](https://github.com/prisma/prisma/pull/29977) then added `nextActions` to the base `CliStructuredError`. That turns the subclass field into an override, so `tsc` raises:

```
src/utils/cli-errors.ts(84,12): error TS4114: This member must have an 'override' modifier
because it overrides a member in the base class 'CliStructuredError'.
```

Adding the modifier is the whole fix — narrowing the base's optional `nextActions?` to a required field is a legal override.

**Test.** #29977 also retyped the config-file-not-found remediation, from a `user-choice` carrying prose to a `run-command` carrying a templated `{bin} init`. `control.ts` now emits:

```ts
nextActions: [{ kind: 'run-command', label: 'Create a config file', command: '{bin} init' }]
```

The assertion in `test/orm/load-config.test.ts` still expected the shape that replaced, so it failed against the new production value. This points it at what #29977 emits, matching the assertion #29977's own `next-actions.test.ts` already uses for the same factory.

## Verified

`pnpm typecheck` is clean across the workspace. `@internal/cli` passes 1603 tests, `@internal/errors` 124.
