### PR TITLE
fix(cli): repair Type Check and Test on main (#29977 × #29978 crossfire)

### DIFF
--- a/packages/1-framework/3-tooling/cli/src/utils/cli-errors.ts
+++ b/packages/1-framework/3-tooling/cli/src/utils/cli-errors.ts
@@ -81,7 +81,7 @@ export {
  * settles the engine's envelope.
  */
 export class ActionableCliError extends CliStructuredError {
-  readonly nextActions: readonly NextAction[];
+  override readonly nextActions: readonly NextAction[];
 
   constructor(
     code: `${string}.${string}`,

--- a/packages/1-framework/3-tooling/cli/test/orm/load-config.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/orm/load-config.test.ts
@@ -106,7 +106,7 @@ describe('loadOrmConfig', () => {
       const loaded = await loadOrmConfig({ cwd: projectDir() });
 
       expect(loaded.diagnostics[0]?.diagnostic.nextActions).toEqual([
-        { kind: 'user-choice', label: "Run 'prisma-next init' to create a config file" },
+        { kind: 'run-command', label: 'Create a config file', command: '{bin} init' },
       ]);
     });
 


### PR DESCRIPTION
Main has failed Type Check and Test on every commit since #29977 merged. #29977 ("Errors carry typed next actions") and #29978 each passed CI on their own branches, but they conflict semantically:

1. #29977 added an optional `nextActions` member to `CliStructuredError` (`packages/1-framework/0-foundation/utils/src/structured-error.ts`). The subclass declaration `readonly nextActions` in `ActionableCliError` (`packages/1-framework/3-tooling/cli/src/utils/cli-errors.ts`) now shadows a base-class member, so `noImplicitOverride` rejects it (TS4114). Fix: add the `override` modifier.

2. #29977 changed `errorConfigFileNotFound` to attach a typed `run-command` action, invalidating the expectation in `test/orm/load-config.test.ts` that #29978 brought in (`{ kind: 'user-choice', label: "Run 'prisma-next init' to create a config file" }`). Fix: update the assertion to the shape the factory actually emits: `{ kind: 'run-command', label: 'Create a config file', command: '{bin} init' }`.

This PR is the minimal two-line repair. The in-flight s5-orm-* stack PRs each carry the same fixes.

Verified in `packages/1-framework/3-tooling/cli`: `pnpm typecheck`, `pnpm lint`, and `pnpm test` all pass (two known-flaky 500ms-timeout tests failed under load and pass in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)