### PR TITLE
docs(errors): document MIGRATION.CONSENT_PLAN_MISMATCH to unbreak Lint on main

### DIFF
--- a/docs/reference/error-reference.md
+++ b/docs/reference/error-reference.md
@@ -835,6 +835,10 @@ A `migration check` failure row: a contract space's declared database target dif
 
 A `migration check` failure row: a migration's `from` hash is not produced by any other migration (and is not the empty state), so the migration is unreachable in the graph. Delete it or re-emit a connecting migration.
 
+### MIGRATION.CONSENT_PLAN_MISMATCH
+
+An apply carrying consent was refused because the plan recomputed for it is not the plan that was consented to. `db update` recomputes the plan at apply time and compares its hash against the one the consent was given for; a mismatch means the schema, the contract, or the database moved in between, so applying would carry out operations nobody agreed to. Re-run the command and review the freshly planned operations before consenting again. Meta: `consentedPlanHash`, `planHash`.
+
 ### MIGRATION.CONTRACT_DESERIALIZATION_FAILED
 
 A contract JSON on disk failed to deserialize into a valid contract: either a snapshot-store entry read while migration tooling resolved a contract at a ref or hash, or the emitted `contract.json` read as the fallback source by `db sign` / `db update --to` (invalid JSON, or a value that is not a JSON object). Re-emit the owning migration package (or re-run `prisma-next contract emit` for the emitted contract), or restore the file from version control. Meta: `filePath`, `message`. Also raised by `migration new` when the emitted `contract.json` fails to deserialize; that site has no meta and attaches the deserialization failure as `cause`.


### PR DESCRIPTION
## main is red

`check:error-reference` fails on `origin/main`, so the Lint job fails on every open PR:

```
error-reference is missing 1 of 284 known codes:
  MIGRATION.CONSENT_PLAN_MISMATCH
```

`ERROR_CODE_CONSENT_PLAN_MISMATCH` is defined in `@internal/errors` (`src/execution.ts`) and raised by `db update`, but `docs/reference/error-reference.md` never gained an entry for it.

## The fix

One entry, placed alphabetically between `MIGRATION.CHECK_UNREACHABLE_MIGRATION` and `MIGRATION.CONTRACT_DESERIALIZATION_FAILED`, written from the factory and its raise site: `db update` recomputes the plan at apply time and compares its hash against the one consent was given for; a mismatch means applying would carry out operations nobody agreed to.

`pnpm check:error-reference` now reports all 284 codes; `pnpm lint:docs` passes.

## Found via

[#29967](https://github.com/prisma/prisma/pull/29967), a Dependabot PR whose Lint job failed on this despite its diff touching only two example `package.json` files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a reference for the `MIGRATION.CONSENT_PLAN_MISMATCH` error.
  * Documented that migrations are rejected when the apply-time plan differs from the previously approved plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->