### PR TITLE
test(cli): isolate only the two files whose emitter mocks collide

### DIFF
--- a/packages/1-framework/3-tooling/cli/vitest.config.ts
+++ b/packages/1-framework/3-tooling/cli/vitest.config.ts
@@ -1,24 +1,64 @@
 import { timeouts } from '@repo/test-utils';
 import { defineConfig } from 'vitest/config';
 
+/**
+ * `control-api/client.test.ts` and `control-api/contract-emit.test.ts` both
+ * `vi.mock('@internal/emitter')` and then configure the shared mock instance in
+ * their own `beforeEach`. Under `isolate: false` every file shares one module
+ * registry, so whichever of the two runs first supplies the module both of them
+ * see: the other gets a mock it never configured, the real `emit` runs, and it
+ * fails with `Cannot destructure property 'storageHash' of 'contract.storage'`.
+ * File order decides who loses, which is why it read as a flake locally and as a
+ * fixed failure on CI's ordering.
+ *
+ * These two get their own isolated project, so they no longer share a registry
+ * with each other. Isolating the whole package fixes it too but costs ~4x (8s →
+ * 33s); this leaves the other 113 files sharing one registry and runs in the
+ * same time as before.
+ */
+const COLLIDING_MOCK_FILES = [
+  'test/control-api/client.test.ts',
+  'test/control-api/contract-emit.test.ts',
+];
+
+const shared = {
+  globals: true,
+  environment: 'node' as const,
+  // Note: do not change to 'threads', it will cause the failure
+  // `TypeError: process.chdir() is not supported in workers`.
+  pool: 'forks' as const,
+  maxWorkers: 1,
+  fileParallelism: false,
+  sequence: { groupOrder: 1 },
+  testTimeout: timeouts.vitestPackageDefault,
+  hookTimeout: timeouts.vitestPackageDefault,
+  setupFiles: ['./test/setup.ts'],
+  env: {
+    CI: 'true',
+    NO_COLOR: '1',
+  },
+};
+
 export default defineConfig({
   test: {
-    globals: true,
-    environment: 'node',
-    // Note: do not change to 'threads', it will cause the failure
-    // `TypeError: process.chdir() is not supported in workers`.
-    pool: 'forks',
-    maxWorkers: 1,
-    isolate: false,
-    fileParallelism: false,
-    sequence: { groupOrder: 1 },
-    testTimeout: timeouts.vitestPackageDefault,
-    hookTimeout: timeouts.vitestPackageDefault,
-    setupFiles: ['./test/setup.ts'],
-    env: {
-      CI: 'true',
-      NO_COLOR: '1',
-    },
+    projects: [
+      {
+        test: {
+          ...shared,
+          name: 'cli',
+          exclude: ['**/node_modules/**', '**/dist/**', ...COLLIDING_MOCK_FILES],
+          isolate: false,
+        },
+      },
+      {
+        test: {
+          ...shared,
+          name: 'cli-isolated-mocks',
+          include: COLLIDING_MOCK_FILES,
+          isolate: true,
+        },
+      },
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## `Test` fails intermittently on any PR that runs it

On bare `origin/main`, nothing changed, three runs of the CLI suite:

| run | result |
|---|---|
| 1 | **10 failed** / 1410 passed |
| 2 | 1420 passed |
| 3 | 1420 passed |

The victim moves between `control-api/client.test.ts` and `control-api/contract-emit.test.ts`. On CI it is less forgiving — [#29996](https://github.com/prisma/prisma/pull/29996) lost six reruns in a row.

## Why

Both files `vi.mock('@internal/emitter')` and then configure the shared mock instance in their own `beforeEach`:

```ts
// client.test.ts
vi.mock('@internal/emitter', () => ({ emit: vi.fn(async () => ({ … })) }));

// contract-emit.test.ts
vi.mock('@internal/emitter', async () => ({ ...(await vi.importActual(…)), emit: vi.fn() }));
```

Under `isolate: false` every file shares one module registry, so whichever of the two runs first supplies the module both of them see. The other gets a mock it never configured, the real `emit` runs, and it fails with `Cannot destructure property 'storageHash' of 'contract.storage' as it is undefined`. File order decides who loses — hence random locally, fixed on CI's ordering.

## The fix, and what it costs

Those two files get their own isolated project; the other 113 keep sharing one registry.

| approach | files / tests | duration | stability |
|---|---|---|---|
| today (`isolate: false`) | 115 / 1420 | 7–12s | 1 of 3 runs failed |
| isolate the whole package | 115 / 1420 | 33s | clean, but ~4x slower |
| **isolate the two files** | **115 / 1420** | **5.8–6.6s** | **5 of 5 clean** |

Same file and test counts as today, and no slower — the isolated pair is small enough that splitting them out costs nothing measurable.

Two approaches I tried and rejected:

- **Isolating the whole package.** Works, but ~4x on every local run for the sake of two files.
- **Making the two mock factories identical.** Does not work at all — the interference is the shared *instance*, not the shape, so it only relocates the failure to `client.test.ts`.

## Found via

[#29967](https://github.com/prisma/prisma/pull/29967), a Dependabot PR whose diff is two lines in example `package.json` files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by isolating scenarios that could interfere with one another.
  * Preserved shared test behavior where appropriate while preventing mock-related conflicts in affected checks.
  * Added documentation describing test behavior and known interactions.
  * Test runs may take slightly longer because selected scenarios now run with additional isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->