### PR TITLE
Enable prisma7 publishing

### DIFF
--- a/packages/prisma7/package.json
+++ b/packages/prisma7/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prisma7",
   "version": "0.0.0",
-  "private": true,
+  "private": false,
   "description": "Compatibility wrapper for running the Prisma 7 CLI",
   "license": "Apache-2.0",
   "author": "Prisma Data, Inc.",

--- a/scripts/ci/publish.ts
+++ b/scripts/ci/publish.ts
@@ -158,7 +158,12 @@ function getPrismaDependencies(dependencies?: { [name: string]: string }): strin
   if (!dependencies) {
     return []
   }
-  return Object.keys(dependencies).filter((d) => d.startsWith('@prisma') && !d.startsWith('@prisma/studio'))
+  return Object.keys(dependencies).filter(
+    (dependency) =>
+      (dependency.startsWith('@prisma') && !dependency.startsWith('@prisma/studio')) ||
+      dependency === 'prisma' ||
+      dependency === 'prisma7',
+  )
 }
 
 function getCircularDependencies(packages: Packages): string[][] {


### PR DESCRIPTION
Enables the `prisma7` compatibility wrapper to participate in the existing Prisma 7 publication pipeline.

## Changes

- **Publish ordering:** Extend the existing Prisma dependency classifier to recognize the unscoped `prisma` and `prisma7` package names, making the declared `prisma7 -> prisma` edge visible to the current topological sorter.
- **Package visibility:** Remove the private flag from `packages/prisma7/package.json` so the existing publish loop no longer skips the wrapper.

## Why

The publisher already handles workspace discovery, versioning, topological publication, and selective retries. It only lacked awareness of unscoped Prisma-owned dependency names. This keeps the existing pipeline intact; pnpm continues to convert `workspace:*` to the matching exact version when packing and publishing.

**Scope:** No custom release policy, manifest rewriting, new release workflow, or additional package-manager test matrix.

**Verification:** Prettier, ESLint through the commit hook, and `git diff --check`. No new tests were added for this dependency-classifier/package-metadata change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Prisma 7 package can now be published.
  * Automated publishing now includes the Prisma and Prisma 7 packages alongside eligible Prisma packages.

* **Bug Fixes**
  * Maintained the exclusion of Prisma Studio from automated publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->