### PR TITLE
ORM commands now state all four output channels instead of letting the engine fill them in

### DIFF
--- a/packages/1-framework/3-tooling/cli/src/orm/contract/emit.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/contract/emit.ts
@@ -42,6 +42,7 @@ function emitPresentations(inputs: {
 }): Presentations {
   const { document, cwd } = inputs;
   return {
+    next: () => [],
     human: (): readonly Block[] => [
       {
         kind: 'fields',

--- a/packages/1-framework/3-tooling/cli/src/orm/contract/infer.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/contract/infer.ts
@@ -38,6 +38,8 @@ function inferPresentations(inputs: {
 }): Presentations {
   const { document, database } = inputs;
   return {
+    stdout: () => [],
+    next: () => [],
     human: (): readonly Block[] => [
       ...(database === undefined
         ? []

--- a/packages/1-framework/3-tooling/cli/src/orm/db/init.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/db/init.ts
@@ -30,6 +30,7 @@ function initPresentations(inputs: {
 }): Presentations {
   const { document, database, dryRun } = inputs;
   return {
+    stdout: () => [],
     human: (): readonly Block[] => [
       {
         kind: 'fields',

--- a/packages/1-framework/3-tooling/cli/src/orm/db/schema.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/db/schema.ts
@@ -124,6 +124,8 @@ function schemaPresentations(inputs: {
 }): Presentations {
   const { document, schemaView, database } = inputs;
   return {
+    stdout: () => [],
+    next: () => [],
     human: (): readonly Block[] => [
       ...(database === undefined
         ? []

--- a/packages/1-framework/3-tooling/cli/src/orm/db/sign.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/db/sign.ts
@@ -61,6 +61,8 @@ function signPresentations(inputs: {
 }): Presentations {
   const marker = inputs.document.marker;
   return {
+    stdout: () => [],
+    next: () => [],
     human: (): readonly Block[] => [
       inputs.header,
       { kind: 'summary', status: 'ok', text: 'Database signed' },
@@ -90,6 +92,8 @@ function refusedPresentations(inputs: {
   readonly header: Block;
 }): Presentations {
   return {
+    stdout: () => [],
+    next: () => [],
     human: (): readonly Block[] => [
       inputs.header,
       ...schemaFindingBlocks({ result: inputs.document, unclaimed: [], strict: false }),

--- a/packages/1-framework/3-tooling/cli/src/orm/db/update.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/db/update.ts
@@ -41,6 +41,7 @@ function updatePresentations(inputs: {
 }): Presentations {
   const { document, database, dryRun } = inputs;
   return {
+    stdout: () => [],
     human: (): readonly Block[] => [
       {
         kind: 'fields',

--- a/packages/1-framework/3-tooling/cli/src/orm/db/verify.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/db/verify.ts
@@ -240,6 +240,8 @@ function verifyPresentations(inputs: {
   const warnings = document.schema?.warnings ?? [];
   const unclaimed = document.unclaimed ?? [];
   return {
+    stdout: () => [],
+    next: () => [],
     human: (): readonly Block[] => [
       inputs.header,
       { kind: 'summary', status: document.ok ? 'ok' : 'error', text: document.summary },
@@ -303,6 +305,8 @@ function schemaPresentations(inputs: {
   readonly strict: boolean;
 }): Presentations {
   return {
+    stdout: () => [],
+    next: () => [],
     human: (): readonly Block[] => [
       inputs.header,
       ...schemaFindingBlocks({

--- a/packages/1-framework/3-tooling/cli/src/orm/format.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/format.ts
@@ -12,6 +12,8 @@ const NOTHING_TO_FORMAT = 'Nothing to format (contract source is not PSL).';
 function formatPresentations(document: FormatOperationResult, cwd: string): Presentations {
   const path = document.path;
   return {
+    stdout: () => [],
+    next: () => [],
     human: (): readonly Block[] =>
       document.formatted && path !== undefined
         ? [

--- a/packages/1-framework/3-tooling/cli/src/orm/init-blocks.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/init-blocks.ts
@@ -82,6 +82,7 @@ export function initPresentations(inputs: {
 }): Presentations {
   const { document } = inputs;
   return {
+    stdout: () => [],
     human: (): readonly Block[] => [
       {
         kind: 'fields',

--- a/packages/1-framework/3-tooling/cli/src/orm/migrate.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/migrate.ts
@@ -98,6 +98,8 @@ function showPresentations(inputs: {
   const { document, graph, runList } = inputs;
   const count = document.migrations.length;
   return {
+    stdout: () => [],
+    next: () => [],
     human: (): readonly Block[] => [
       {
         kind: 'fields',
@@ -134,6 +136,7 @@ function applyPresentations(inputs: {
   const { document } = inputs;
   const advanced = document.advancedRef;
   return {
+    stdout: () => [],
     human: (): readonly Block[] => [
       {
         kind: 'fields',

--- a/packages/1-framework/3-tooling/cli/src/orm/migration/check.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/migration/check.ts
@@ -70,6 +70,8 @@ function checkPresentations(inputs: {
       ? inputs.document.summary
       : `${inputs.document.summary}  (space: ${inputs.resolvedSpaceId})`;
   return {
+    stdout: () => [],
+    next: () => [],
     human: (): readonly Block[] => [
       {
         kind: 'fields',

--- a/packages/1-framework/3-tooling/cli/src/orm/migration/graph.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/migration/graph.ts
@@ -51,6 +51,8 @@ function graphPresentations(inputs: {
 }): Presentations {
   const { tree, dot, legend } = inputs;
   return {
+    stdout: () => [],
+    next: () => [],
     human: (): readonly Block[] => [
       {
         kind: 'fields',

--- a/packages/1-framework/3-tooling/cli/src/orm/migration/list.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/migration/list.ts
@@ -28,6 +28,8 @@ function listPresentations(inputs: {
 }): Presentations {
   const legend = inputs.legend;
   return {
+    stdout: () => [],
+    next: () => [],
     human: (): readonly Block[] => [
       {
         kind: 'fields',

--- a/packages/1-framework/3-tooling/cli/src/orm/migration/log.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/migration/log.ts
@@ -82,6 +82,8 @@ function logPresentations(inputs: {
 }): Presentations {
   const grid = inputs.grid;
   return {
+    stdout: () => [],
+    next: () => [],
     human: (): readonly Block[] => [
       ...(inputs.database === undefined
         ? []

--- a/packages/1-framework/3-tooling/cli/src/orm/migration/new.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/migration/new.ts
@@ -20,6 +20,7 @@ function newPresentations(inputs: {
   const { document } = inputs;
   const migrationTs = join(document.dir, 'migration.ts');
   return {
+    stdout: () => [],
     human: (): readonly Block[] => [
       {
         kind: 'fields',

--- a/packages/1-framework/3-tooling/cli/src/orm/migration/plan.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/migration/plan.ts
@@ -163,6 +163,7 @@ function planPresentations(inputs: {
   readonly name: string | undefined;
 }): Presentations {
   return {
+    stdout: () => [],
     human: (): readonly Block[] => [
       {
         kind: 'fields',

--- a/packages/1-framework/3-tooling/cli/src/orm/migration/show.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/migration/show.ts
@@ -106,6 +106,8 @@ function showPresentations(inputs: {
 }): Presentations {
   const migration = inputs.document.migration;
   return {
+    stdout: () => [],
+    next: () => [],
     human: (): readonly Block[] => [
       {
         kind: 'fields',

--- a/packages/1-framework/3-tooling/cli/src/orm/migration/status.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/migration/status.ts
@@ -184,6 +184,8 @@ function statusPresentations(inputs: {
 }): Presentations {
   const legend = inputs.legend;
   return {
+    stdout: () => [],
+    next: () => [],
     human: (): readonly Block[] => [
       {
         kind: 'fields',

--- a/packages/1-framework/3-tooling/cli/src/orm/ref/delete.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/ref/delete.ts
@@ -9,6 +9,8 @@ import { normalizeError } from '../normalize-error';
 
 function deletePresentations(document: RefDeleteResult): Presentations {
   return {
+    stdout: () => [],
+    next: () => [],
     human: (): readonly Block[] => [
       {
         kind: 'summary',

--- a/packages/1-framework/3-tooling/cli/src/orm/ref/list.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/ref/list.ts
@@ -41,6 +41,8 @@ function refsGrid(refs: Refs): Block {
 
 function listPresentations(document: RefListResult): Presentations {
   return {
+    stdout: () => [],
+    next: () => [],
     human: (): readonly Block[] =>
       Object.keys(document.refs).length === 0
         ? [{ kind: 'summary', status: 'info', text: EMPTY_MESSAGE }]

--- a/packages/1-framework/3-tooling/cli/src/orm/ref/set.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/ref/set.ts
@@ -9,6 +9,8 @@ import { normalizeError } from '../normalize-error';
 
 function setPresentations(document: RefSetResult): Presentations {
   return {
+    stdout: () => [],
+    next: () => [],
     human: (): readonly Block[] => [
       {
         kind: 'summary',

--- a/packages/1-framework/3-tooling/cli/test/orm/define-command.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/orm/define-command.test.ts
@@ -125,7 +125,12 @@ describe('defineOrmCommand', () => {
               ok(
                 ctx.present(
                   { data: { count: 1 }, exitCode: 0 },
-                  { human: () => [], json: () => ({ ok: true }) },
+                  {
+                    human: () => [],
+                    stdout: () => [],
+                    json: () => ({ ok: true }),
+                    next: () => [],
+                  },
                 ),
               ),
           }),


### PR DESCRIPTION
Here is the entire change, repeated across 21 files:

```diff
  // src/orm/migration/list.ts
  function listPresentations(inputs: { … }): Presentations {
    return {
      human: (): readonly Block[] => [
        { kind: 'fields', rail: true, rows: [ … ] },
        { kind: 'drawing', lines: toneDrawing(inputs.tree) },
      ],
+     stdout: () => [],
+     next: () => [],
      json: () => inputs.list,
    };
  }
```

## What those four things are

Every CLI command hands the engine four ways of reporting what it did, and the engine uses the ones the run needs:

| | what it is | who reads it |
| --- | --- | --- |
| `human` | the blocks a person sees, on stderr | someone at a terminal |
| `stdout` | plain data lines, on stdout | a pipe, a script |
| `json` | the `result` inside the `--json` envelope | a program parsing output |
| `next` | suggested follow-up commands | the person, after the command finishes |

Today `human` is required and the other three are optional. When a command leaves one out, the engine substitutes a default — an empty list for `stdout` and `next`.

## The decision

**The engine is dropping those defaults and requiring all four.** A command will state what it publishes on each channel rather than inheriting it by omission.

This PR does that stating for the ORM commands. Nothing else changes.

## Why it matters, concretely

Once the engine stops substituting, it calls whatever the command declared. Our commands declare two of the four, so it calls functions that are not there:

```
$ prisma migration list
# exit 2
```

That is `stdout` in human mode — the default for anyone at a terminal — and `next` in both modes. It affects the 21 command files in this diff.

Worth noting how it was found, because it says something about our coverage: **this package's own suite passes either way.** It never sees the engine version it will be mounted against. The failure only appears when you run the assembled `prisma` binary, which neither repo tests today.

## Behaviour is identical

Every added `stdout` and `next` returns the same empty array the engine was already substituting. This is a no-op at runtime, on purpose.

What it buys is visibility. `stdout` is the channel a script reads, and today every ORM command returns nothing on it — not as a decision, but because nobody wrote one. After this, that gap is a visible `() => []` in each file, and a command that ought to emit machine-readable lines can be given them one at a time, deliberately and reviewably.

## Timing: this does not wait on anything

The three fields are optional in the engine we pin (`0.0.9`) and in the newest published engine (`8.0.0-rc.1`, on the `next` tag) alike. The version that requires them is not published yet — it is [prisma-cli#171](https://github.com/prisma/prisma-cli/pull/171), still open. So this can merge and ship now, and the engine can then require the fields without breaking us.

## How I know nothing was missed

I made the four fields required in the installed engine's type declarations and typechecked the package against that — the exact condition the new engine imposes. Zero errors across `src/` afterwards, and it caught one site a grep had missed: a fixture in `test/orm/define-command.test.ts`. The declarations were then restored, so nothing in this diff touches `node_modules`.

`pnpm build`, `typecheck` and `lint` clean; **155 test files, 1943 tests passing.**

## Alternatives considered

**Handle it in prisma-cli instead, by calling the missing channels defensively.** That shim exists today and works. Rejected as the permanent answer: it stands in for a declaration we can simply write in our own code, and it keeps the engine guessing on behalf of every ORM command we add from here.

**Wait for the strict engine to publish and do this together with the version bump.** Rejected: the fields are optional in every published engine, so this ships now. Waiting only keeps the consumer shimmed for longer and couples two releases that need not be coupled.

**Bump the engine pin from `0.0.9` to `8.0.0-rc.1` in the same PR.** Worth doing — an install of `@prisma/cli` currently carries two copies of the engine because this package pins `0.0.9` while prisma-cli builds `8.0.0-rc.1` — but it is a large version jump with its own surface changes, and it is not needed to make the presentations correct. Kept separate so this diff stays a reviewable no-op.

**Give the commands real `stdout` output now rather than `() => []`.** Rejected for this PR. What `migration list` should print to a pipe is a genuine per-command design question and a behaviour change deserving its own review. `() => []` is exactly what ships today, which keeps this diff a no-op reviewable in one pass.
