### PR TITLE
The engine becomes an exact peer of the toolchain, and a bin-less package smokes its cli entry

### DIFF
--- a/packages/1-framework/3-tooling/cli/package.json
+++ b/packages/1-framework/3-tooling/cli/package.json
@@ -34,7 +34,6 @@
     "@internal/psl-printer": "workspace:8.0.0-rc.1",
     "@internal/publish-surface": "workspace:8.0.0-rc.1",
     "@internal/utils": "workspace:8.0.0-rc.1",
-    "@prisma/cli-engine": "0.0.9",
     "arktype": "^2.2.2",
     "ci-info": "^4.3.1",
     "clipanion": "4.0.0-rc.4",
@@ -54,6 +53,7 @@
     "@internal/sql-contract-ts": "workspace:8.0.0-rc.1",
     "@internal/sql-operations": "workspace:8.0.0-rc.1",
     "@internal/sql-runtime": "workspace:8.0.0-rc.1",
+    "@prisma/cli-engine": "0.0.9",
     "@repo/test-utils": "workspace:8.0.0-rc.1",
     "@repo/tsconfig": "workspace:8.0.0-rc.1",
     "@repo/tsdown": "workspace:8.0.0-rc.1",
@@ -63,6 +63,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
+    "@prisma/cli-engine": "0.0.9",
     "typescript": ">=5.9"
   },
   "peerDependenciesMeta": {

--- a/packages/9-public/@prisma/orm-toolchain/package.json
+++ b/packages/9-public/@prisma/orm-toolchain/package.json
@@ -14,7 +14,6 @@
     "clean": "rm -rf dist src-gen"
   },
   "dependencies": {
-    "@prisma/cli-engine": "0.0.9",
     "@prisma/orm-framework": "workspace:8.0.0-rc.1",
     "@vercel/detect-agent": "^1.2.4",
     "arktype": "catalog:",
@@ -49,6 +48,7 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
+    "@prisma/cli-engine": "0.0.9",
     "typescript": ">=5.9",
     "vite": "^7.0.0 || ^8.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1296,9 +1296,6 @@ importers:
       '@internal/utils':
         specifier: workspace:8.0.0-rc.1
         version: link:../../0-foundation/utils
-      '@prisma/cli-engine':
-        specifier: 0.0.9
-        version: 0.0.9(magicast@0.5.3)
       arktype:
         specifier: ^2.2.2
         version: 2.2.3
@@ -1351,6 +1348,9 @@ importers:
       '@internal/sql-runtime':
         specifier: workspace:8.0.0-rc.1
         version: link:../../../2-sql/5-runtime
+      '@prisma/cli-engine':
+        specifier: 0.0.9
+        version: 0.0.9(magicast@0.5.3)
       '@repo/test-utils':
         specifier: workspace:8.0.0-rc.1
         version: link:../../../../test/utils

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -38,7 +38,7 @@
 // Wired into `.github/workflows/publish.yml` immediately after
 // `check:publish-deps`. Also runnable locally: `pnpm check:conformance`.
 
-import { execFileSync, spawnSync } from 'node:child_process';
+import { execFile, execFileSync, spawnSync } from 'node:child_process';
 import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { builtinModules } from 'node:module';
 import { join, resolve } from 'node:path';
@@ -291,16 +291,22 @@ export function computeOverrides({ rootName, packedByName }) {
 }
 
 /**
- * Checks that the `@prisma/cli-engine` pin is a single exact version,
- * identical across every packed publishable manifest that declares it and
- * the source `@internal/cli` manifest. Reports `no-subjects` when no
- * packed manifest declares the engine at all — a vacuous agreement is not
- * a pass. Pure; exported for tests.
+ * Checks the `@prisma/cli-engine` reference against ADR 0004 (recorded in
+ * prisma-cli, docs/architecture/adrs/0004-engine-version-pinning.md): a
+ * product CLI package declares the engine as an exact PEER dependency the
+ * consolidated CLI satisfies, never a dependency of its own — so one
+ * engine exists in any installed tree, and a mismatch fails at install
+ * time instead of resolving a second copy. Asserts the reference is a
+ * single exact version, sits in `peerDependencies` and nowhere else in a
+ * packed manifest, and agrees across every packed manifest and the source
+ * `@internal/cli` manifest. Reports `no-subjects` when no packed manifest
+ * declares the engine at all — a vacuous agreement is not a pass. Pure;
+ * exported for tests.
  *
  * @param {object} args
- * @param {Array<{ pkg: string; spec: string }>} args.packedPins
+ * @param {Array<{ pkg: string; spec: string; field?: string }>} args.packedPins
  * @param {{ pkg: string; spec: string | undefined }} args.sourcePin
- * @returns {Array<{ kind: 'no-subjects' | 'not-exact' | 'disagreement'; message: string }>}
+ * @returns {Array<{ kind: 'no-subjects' | 'not-exact' | 'wrong-field' | 'disagreement'; message: string }>}
  */
 export function findEnginePinViolations({ packedPins, sourcePin }) {
   if (packedPins.length === 0) {
@@ -310,6 +316,15 @@ export function findEnginePinViolations({ packedPins, sourcePin }) {
         message: `no packed publishable manifest declares ${ENGINE_PACKAGE}, so there is nothing to agree with ${sourcePin.pkg}`,
       },
     ];
+  }
+  const violationsForFields = [];
+  for (const { pkg, field } of packedPins) {
+    if (field !== undefined && field !== 'peerDependencies') {
+      violationsForFields.push({
+        kind: 'wrong-field',
+        message: `${pkg} declares ${ENGINE_PACKAGE} in ${field}; ADR 0004 requires an exact peerDependency and nothing else, or an install can resolve a second engine`,
+      });
+    }
   }
   const all = [...packedPins];
   if (typeof sourcePin.spec === 'string') {
@@ -337,7 +352,7 @@ export function findEnginePinViolations({ packedPins, sourcePin }) {
       message: `${ENGINE_PACKAGE} pins disagree: ${all.map((p) => `${p.pkg} pins ${p.spec}`).join(', ')}`,
     });
   }
-  return violations;
+  return [...violationsForFields, ...violations];
 }
 
 const JS_FILE_RE = /\.m?js$/;
@@ -448,8 +463,33 @@ async function loadOrmConfigSection() {
 }
 
 function readSourceCliEnginePin() {
+  // ADR 0004 (prisma-cli): the engine is an exact PEER of the CLI
+  // packages; @internal/cli's peer is where the toolchain's published
+  // peer comes from, so that is the source of truth to agree with.
   const manifest = JSON.parse(readFileSync(SOURCE_CLI_MANIFEST, 'utf-8'));
-  return manifest.dependencies?.[ENGINE_PACKAGE];
+  return manifest.peerDependencies?.[ENGINE_PACKAGE];
+}
+
+async function importEntry({ sandboxDir, specifier, timeoutMs }) {
+  return new Promise((resolvePromise) => {
+    execFile(
+      process.execPath,
+      ['--input-type=module', '-e', `await import(${JSON.stringify(specifier)});`],
+      { cwd: sandboxDir, timeout: timeoutMs, killSignal: 'SIGKILL' },
+      (error, stdout, stderr) => {
+        if (error === null) {
+          resolvePromise({ exitCode: 0, stdout, stderr, timedOut: false });
+          return;
+        }
+        resolvePromise({
+          exitCode: typeof error.code === 'number' ? error.code : null,
+          stdout: stdout ?? '',
+          stderr: stderr ?? '',
+          timedOut: error.killed === true,
+        });
+      },
+    );
+  });
 }
 
 async function installSandbox({ sandboxDir, rootName, rootTarball, overrides }) {
@@ -511,6 +551,7 @@ const DEFAULT_IO = {
   readSourceCliEnginePin,
   installSandbox,
   runBin,
+  importEntry,
   stdoutWrite: (s) => process.stdout.write(s),
   stderrWrite: (s) => process.stderr.write(s),
 };
@@ -541,6 +582,7 @@ export async function runCheck({ argv = process.argv.slice(2), io = {} } = {}) {
     readSourceCliEnginePin: readSourcePin,
     installSandbox: install,
     runBin: startBin,
+    importEntry: importEntryInSandbox,
     stdoutWrite,
     stderrWrite,
   } = { ...DEFAULT_IO, ...io };
@@ -686,12 +728,28 @@ export async function runCheck({ argv = process.argv.slice(2), io = {} } = {}) {
     } else {
       const bins = declaredBins(toolchain.manifest);
       if (bins.length === 0) {
-        findings.push({
-          check: 'tarball',
-          kind: 'no-subjects',
-          subject: TOOLCHAIN_PACKAGE,
-          summary: 'the packed manifest has no bin entries, so no executable was started',
+        // The toolchain stopped publishing a bin when the unified
+        // prisma-cli replaced prisma-next (#30005). The sandbox smoke
+        // for a bin-less package is importing its published CLI entry
+        // in a fresh node: the anti-vacuity guarantee survives — a
+        // package whose entry cannot even import fails here — without
+        // demanding an executable nobody ships.
+        const run = await importEntryInSandbox({
+          sandboxDir,
+          specifier: `${TOOLCHAIN_PACKAGE}/cli`,
+          timeoutMs: BIN_TIMEOUT_MS,
         });
+        if (run.timedOut || run.exitCode !== 0) {
+          findings.push({
+            check: 'tarball',
+            kind: 'bin-failed',
+            subject: TOOLCHAIN_PACKAGE,
+            summary: run.timedOut
+              ? `importing ${TOOLCHAIN_PACKAGE}/cli in the sandbox timed out`
+              : `importing ${TOOLCHAIN_PACKAGE}/cli in the sandbox exited ${run.exitCode}`,
+            detail: `stdout:\n${run.stdout}\nstderr:\n${run.stderr}`,
+          });
+        }
       }
       for (const [binName, relPath] of bins) {
         const run = await startBin({
@@ -726,7 +784,7 @@ export async function runCheck({ argv = process.argv.slice(2), io = {} } = {}) {
   for (const [name, { manifest }] of packedByName) {
     for (const field of SHIPPED_DEP_FIELDS) {
       const spec = manifest[field]?.[ENGINE_PACKAGE];
-      if (typeof spec === 'string') packedPins.push({ pkg: name, spec });
+      if (typeof spec === 'string') packedPins.push({ pkg: name, spec, field });
     }
   }
   const sourcePin = { pkg: '@internal/cli', spec: readSourcePin() };

--- a/scripts/check-conformance.test.mjs
+++ b/scripts/check-conformance.test.mjs
@@ -325,7 +325,8 @@ describe('runCheck', () => {
       readPackedManifest: () => ({
         name: '@prisma/orm-toolchain',
         version: '8.0.0-rc.1',
-        dependencies: { declared: '1.0.0', '@prisma/cli-engine': '0.0.9' },
+        dependencies: { declared: '1.0.0' },
+        peerDependencies: { '@prisma/cli-engine': '0.0.9' },
         bin: { 'prisma-next': './dist/bin__prisma-next.mjs' },
       }),
       readPackedJsSources: () => new Map([['dist/index.mjs', cleanJs]]),
@@ -440,7 +441,8 @@ describe('runCheck', () => {
       readPackedManifest: () => ({
         name: '@prisma/orm-toolchain',
         version: '8.0.0-rc.1',
-        dependencies: { declared: '1.0.0', '@prisma/cli-engine': '0.0.9' },
+        dependencies: { declared: '1.0.0' },
+        peerDependencies: { '@prisma/cli-engine': '0.0.9' },
         bin: { 'prisma-next': './dist/bin__prisma-next.mjs', other: './dist/other.mjs' },
       }),
       runBin: async (...args) => {
@@ -454,6 +456,22 @@ describe('runCheck', () => {
       './dist/bin__prisma-next.mjs',
       './dist/other.mjs',
     ]);
+  });
+
+  it('an engine in a packed dependencies field is a wrong-field finding, per ADR 0004', async () => {
+    const stdoutWrite = recorder();
+    const io = makeIo({
+      readPackedManifest: () => ({
+        name: '@prisma/orm-toolchain',
+        version: '8.0.0-rc.1',
+        dependencies: { declared: '1.0.0', '@prisma/cli-engine': '0.0.9' },
+        bin: { 'prisma-next': './dist/bin__prisma-next.mjs' },
+      }),
+      stdoutWrite,
+    });
+    assert.equal(await runCheck({ argv: ['--json'], io }), 1);
+    const payload = JSON.parse(stdoutWrite.calls[0][0]);
+    assert.ok(payload.findings.some((f) => f.kind === 'wrong-field'));
   });
 
   it('fails when the engine pin disagrees between a packed manifest and the source cli', async () => {
@@ -480,9 +498,9 @@ describe('runCheck', () => {
         version: '8.0.0-rc.1',
         dependencies: {
           declared: '1.0.0',
-          '@prisma/cli-engine': '0.0.9',
           '@prisma/orm-framework': '8.0.0-rc.1',
         },
+        peerDependencies: { '@prisma/cli-engine': '0.0.9' },
         bin: { 'prisma-next': './dist/bin__prisma-next.mjs' },
       },
       'prisma-orm-framework-8.0.0-rc.1.tgz': {
@@ -516,6 +534,43 @@ describe('runCheck', () => {
       '@prisma/orm-framework@8.0.0-rc.1':
         'file:/fake/.conformance/tarballs/prisma-orm-framework-8.0.0-rc.1.tgz',
     });
+  });
+
+  it('a manifest with no bin smokes the published cli entry instead', async () => {
+    const importEntry = recorder();
+    const io = makeIo({
+      readPackedManifest: () => ({
+        name: '@prisma/orm-toolchain',
+        version: '8.0.0-rc.1',
+        dependencies: { declared: '1.0.0' },
+        peerDependencies: { '@prisma/cli-engine': '0.0.9' },
+      }),
+      importEntry: async (...args) => {
+        importEntry(...args);
+        return { exitCode: 0, stdout: '', stderr: '', timedOut: false };
+      },
+    });
+    assert.equal(await runCheck({ argv: [], io }), 0);
+    assert.equal(importEntry.calls.length, 1);
+    assert.equal(importEntry.calls[0][0].specifier, '@prisma/orm-toolchain/cli');
+  });
+
+  it('a failing entry import in the sandbox is a finding', async () => {
+    const io = makeIo({
+      readPackedManifest: () => ({
+        name: '@prisma/orm-toolchain',
+        version: '8.0.0-rc.1',
+        dependencies: { declared: '1.0.0' },
+        peerDependencies: { '@prisma/cli-engine': '0.0.9' },
+      }),
+      importEntry: async () => ({
+        exitCode: 1,
+        stdout: '',
+        stderr: 'ERR_MODULE_NOT_FOUND',
+        timedOut: false,
+      }),
+    });
+    assert.equal(await runCheck({ argv: [], io }), 1);
   });
 });
 


### PR DESCRIPTION
## Before and after

Before, `@prisma/orm-toolchain` carried `@prisma/cli-engine` as an ordinary dependency:

```text
$ npm ls @prisma/cli-engine        # any tree where pins drift
`-- prisma CLI
  +-- @prisma/cli-engine@8.0.0-rc.1
  `-- @prisma/orm-toolchain
    `-- @prisma/cli-engine@0.0.9   # a silent second engine
```

After, the engine is an exact **peerDependency**: npm resolves a peer against the ancestor, so exactly one engine exists in any tree it can assemble, and a version conflict fails at install time instead of resolving a second copy.

## The decision

This is the prisma/prisma share of **ADR 0004** (prisma-cli, `docs/architecture/adrs/0004-engine-version-pinning.md`, operator-settled 2026-08-13): product CLI packages declare the engine as an exact peer the consolidated CLI satisfies; product libraries carry no engine relationship; ranges are the post-GA destination behind a written compatibility contract, not now — during the rc line the engine breaks its consumers deliberately, so the peer stays exact. No package split is needed here: applications never install `orm-toolchain` directly (its vite plugin reaches them as a forwarded export of `@prisma/orm-postgres`), so the toolchain already is the ORM's CLI package.

## How the change is routed

Through the manifest generator's own rules, not around them: `@internal/cli` moves the engine from `dependencies` to `peerDependencies` (keeping a `devDependency` so the workspace resolves it for builds and tests), and shell-build's validator then expects exactly that peer on the published `@prisma/orm-toolchain` manifest, which changes the same way. `pnpm build` — where the validator runs — passes unchanged.

`scripts/check-conformance.mjs` follows the strategy: the source-of-truth pin is now `@internal/cli`'s peer, and an engine appearing in any packed `dependencies` field is a new `wrong-field` finding, so a regression to the old shape fails the publish.

## Found red on main, fixed here

#30005 retired the `prisma-next` bin but left the conformance check requiring bin entries, so `pnpm check:conformance` — a publish blocker — currently fails on `main` with "the packed manifest has no bin entries". A bin-less package's sandbox smoke now imports its published `/cli` entry in a fresh node instead: the anti-vacuity guarantee survives (a package whose entry cannot import fails loudly) without demanding an executable nobody ships.

## Verification

- `node --test scripts/check-conformance.test.mjs` — 43/43 (3 new: the wrong-field finding, the bin-less entry smoke, the failing-entry finding).
- `pnpm check:conformance` end to end — exit 0: packs all publishable packages, sweeps packed imports, runs the shipped orm validator over the hostile corpus, installs the toolchain tarball into the sandbox (the exact peer resolves from the registry), imports `@prisma/orm-toolchain/cli` in a fresh node, and every engine reference agrees at `0.0.9`.
- `pnpm check:publish-deps` — exit 0. `pnpm build` — exit 0.
- `pnpm test:scripts` — 77 failures that reproduce identically on a clean `origin/main` checkout (upgrade-coverage and worktree-hygiene scripts, unrelated); this change adds 3 passing tests and no failures.

## The follow-up this enables

In prisma-cli, once composer's split package also carries the peer: the shell's conformance check evolves from pin-equality to peer-satisfaction and deletes its recorded exception list — the moment mismatches become impossible to ship rather than merely detected.

## Alternatives considered

**Hand-editing only the published manifest.** The validator would reject it: expected peers are derived from the bundled internals, so the internal package's manifest is the source of truth — changing it is the sanctioned route.

**A version range now.** Removes the repin train, but promises compatibility the rc-line engine deliberately does not offer. Recorded in ADR 0004 as the post-GA destination.

**Keeping the bin requirement and exempting the toolchain.** An exemption list for a package that will never have a bin again is a permanent exception; smoking the published entry asserts something real instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected CLI engine dependency handling so it is provided as a peer dependency rather than bundled at runtime.
  * Improved validation to detect incorrect dependency placement and version mismatches.
  * Enhanced command-line package checks, including better reporting when CLI entry points fail to load.

* **Tests**
  * Expanded conformance coverage for valid peer dependencies, misplaced engine declarations, and CLI entry-point failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->