### PR TITLE
test(ci): the bin-less sandbox smoke covers every published entry point, not just /cli

### DIFF
--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -419,6 +419,10 @@ export function packedEntrySpecifiers(manifest) {
 }
 
 /**
+ * Conditions Node can resolve to an ES module for `await import(...)`, in the
+ * order Node considers them. `require` is absent because a CommonJS-only
+ * target is not what this check imports.
+ *
  * @param {unknown} target
  * @returns {boolean}
  */
@@ -426,7 +430,7 @@ function importableTarget(target) {
   if (typeof target === 'string') return true;
   if (!target || typeof target !== 'object') return false;
   if (Array.isArray(target)) return target.some(importableTarget);
-  return ['import', 'module', 'default', 'node'].some((condition) =>
+  return ['node-addons', 'node', 'import', 'module', 'default'].some((condition) =>
     importableTarget(/** @type {Record<string, unknown>} */ (target)[condition]),
   );
 }

--- a/scripts/check-conformance.mjs
+++ b/scripts/check-conformance.mjs
@@ -22,7 +22,9 @@
 //      (b) The `@prisma/orm-toolchain` tarball installs into a clean
 //      sandbox at `.conformance/` (npm, `--ignore-scripts`, workspace
 //      siblings supplied as version-qualified `file:` overrides) and every
-//      packed `bin` entry starts under plain `node <path> --version`.
+//      packed `bin` entry starts under plain `node <path> --version`. A
+//      package that publishes no bin has every subpath in its packed
+//      `exports` map imported in a fresh node instead.
 //      (c) The `@prisma/cli-engine` pin is a single exact version,
 //      identical across every packed publishable manifest that declares it
 //      and the source `@internal/cli` manifest.
@@ -381,6 +383,55 @@ export function declaredBins(manifest) {
 }
 
 /**
+ * Import specifiers for every subpath the manifest exports, sorted, as a
+ * consumer would write them: `@prisma/orm-toolchain/emitter`, not a file
+ * path. Skips `./package.json` (data, not a module), wildcard subpaths
+ * (they name no single module), and any export whose resolved target is
+ * not importable.
+ *
+ * `exports` has three shapes that all mean "the package root and nothing
+ * else": a string, an array fallback, and a bare conditions object. Only
+ * the fourth — an object whose keys are `.`-prefixed subpaths — enumerates
+ * more than the root. Pure / side-effect-free; exported for tests.
+ *
+ * @param {Record<string, unknown>} manifest
+ * @returns {string[]}
+ */
+export function packedEntrySpecifiers(manifest) {
+  const name = String(manifest.name ?? '');
+  const exports = manifest.exports;
+  if (typeof exports === 'string') return [name];
+  if (!exports || typeof exports !== 'object') return [];
+  if (Array.isArray(exports)) return importableTarget(exports) ? [name] : [];
+
+  const entries = Object.entries(exports);
+  if (!entries.some(([key]) => key.startsWith('.'))) {
+    return importableTarget(exports) ? [name] : [];
+  }
+
+  const specifiers = [];
+  for (const [subpath, target] of entries) {
+    if (subpath === './package.json' || subpath.includes('*')) continue;
+    if (!importableTarget(target)) continue;
+    specifiers.push(subpath === '.' ? name : `${name}/${subpath.replace(/^\.\//, '')}`);
+  }
+  return specifiers.sort();
+}
+
+/**
+ * @param {unknown} target
+ * @returns {boolean}
+ */
+function importableTarget(target) {
+  if (typeof target === 'string') return true;
+  if (!target || typeof target !== 'object') return false;
+  if (Array.isArray(target)) return target.some(importableTarget);
+  return ['import', 'module', 'default', 'node'].some((condition) =>
+    importableTarget(/** @type {Record<string, unknown>} */ (target)[condition]),
+  );
+}
+
+/**
  * CommonJS files inside the tarball. The lexer sweep reads ES modules;
  * a `.cjs` file's `require()` calls are function calls, not imports, so
  * the sweep cannot see them. Every publishable package is
@@ -730,25 +781,43 @@ export async function runCheck({ argv = process.argv.slice(2), io = {} } = {}) {
       if (bins.length === 0) {
         // The toolchain stopped publishing a bin when the unified
         // prisma-cli replaced prisma-next (#30005). The sandbox smoke
-        // for a bin-less package is importing its published CLI entry
+        // for a bin-less package is importing its published entry points
         // in a fresh node: the anti-vacuity guarantee survives — a
-        // package whose entry cannot even import fails here — without
+        // package whose entries cannot even import fails here — without
         // demanding an executable nobody ships.
-        const run = await importEntryInSandbox({
-          sandboxDir,
-          specifier: `${TOOLCHAIN_PACKAGE}/cli`,
-          timeoutMs: BIN_TIMEOUT_MS,
-        });
-        if (run.timedOut || run.exitCode !== 0) {
+        //
+        // Every exported subpath is smoked, not just `/cli`. The import
+        // purity sweep reads the imports inside packed files; it cannot
+        // see an exports subpath whose target file never made it into the
+        // tarball, and that entry is unreachable for every consumer who
+        // writes it.
+        const specifiers = packedEntrySpecifiers(toolchain.manifest);
+        if (specifiers.length === 0) {
           findings.push({
             check: 'tarball',
-            kind: 'bin-failed',
+            kind: 'no-subjects',
             subject: TOOLCHAIN_PACKAGE,
-            summary: run.timedOut
-              ? `importing ${TOOLCHAIN_PACKAGE}/cli in the sandbox timed out`
-              : `importing ${TOOLCHAIN_PACKAGE}/cli in the sandbox exited ${run.exitCode}`,
-            detail: `stdout:\n${run.stdout}\nstderr:\n${run.stderr}`,
+            summary:
+              'the packed manifest has neither a bin nor an importable export, so nothing was run',
           });
+        }
+        for (const specifier of specifiers) {
+          const run = await importEntryInSandbox({
+            sandboxDir,
+            specifier,
+            timeoutMs: BIN_TIMEOUT_MS,
+          });
+          if (run.timedOut || run.exitCode !== 0) {
+            findings.push({
+              check: 'tarball',
+              kind: 'entry-failed',
+              subject: TOOLCHAIN_PACKAGE,
+              summary: run.timedOut
+                ? `importing ${specifier} in the sandbox timed out`
+                : `importing ${specifier} in the sandbox exited ${run.exitCode}`,
+              detail: `stdout:\n${run.stdout}\nstderr:\n${run.stderr}`,
+            });
+          }
         }
       }
       for (const [binName, relPath] of bins) {
@@ -807,7 +876,8 @@ function report({ findings, json, stdoutWrite, stderrWrite }) {
     stderrWrite(
       '\nOK — packed output imports only declared packages, the shipped orm validator\n' +
         `     survives the hostile corpus, the ${TOOLCHAIN_PACKAGE} tarball installs\n` +
-        `     clean and its bins start, and every ${ENGINE_PACKAGE} pin agrees.\n`,
+        '     clean and its bins start or its entry points import, and every\n' +
+        `     ${ENGINE_PACKAGE} pin agrees.\n`,
     );
   } else {
     stderrWrite(`\nFAIL — ${findings.length} conformance finding(s):\n`);

--- a/scripts/check-conformance.test.mjs
+++ b/scripts/check-conformance.test.mjs
@@ -10,6 +10,7 @@ import {
   HOSTILE_INPUTS,
   isSectionValidation,
   packageRootOf,
+  packedEntrySpecifiers,
   runCheck,
 } from './check-conformance.mjs';
 
@@ -536,7 +537,7 @@ describe('runCheck', () => {
     });
   });
 
-  it('a manifest with no bin smokes the published cli entry instead', async () => {
+  it('a manifest with no bin smokes every published entry point', async () => {
     const importEntry = recorder();
     const io = makeIo({
       readPackedManifest: () => ({
@@ -544,6 +545,11 @@ describe('runCheck', () => {
         version: '8.0.0-rc.1',
         dependencies: { declared: '1.0.0' },
         peerDependencies: { '@prisma/cli-engine': '0.0.9' },
+        exports: {
+          './cli': './dist/cli.mjs',
+          './emitter': './dist/emitter.mjs',
+          './package.json': './package.json',
+        },
       }),
       importEntry: async (...args) => {
         importEntry(...args);
@@ -551,26 +557,141 @@ describe('runCheck', () => {
       },
     });
     assert.equal(await runCheck({ argv: [], io }), 0);
-    assert.equal(importEntry.calls.length, 1);
-    assert.equal(importEntry.calls[0][0].specifier, '@prisma/orm-toolchain/cli');
+    assert.deepEqual(
+      importEntry.calls.map((c) => c[0].specifier),
+      ['@prisma/orm-toolchain/cli', '@prisma/orm-toolchain/emitter'],
+    );
   });
 
-  it('a failing entry import in the sandbox is a finding', async () => {
+  it('a failing entry import in the sandbox is a finding that names the entry', async () => {
+    const stdoutWrite = recorder();
     const io = makeIo({
       readPackedManifest: () => ({
         name: '@prisma/orm-toolchain',
         version: '8.0.0-rc.1',
         dependencies: { declared: '1.0.0' },
         peerDependencies: { '@prisma/cli-engine': '0.0.9' },
+        exports: { './cli': './dist/cli.mjs', './emitter': './dist/emitter.mjs' },
       }),
-      importEntry: async () => ({
-        exitCode: 1,
-        stdout: '',
-        stderr: 'ERR_MODULE_NOT_FOUND',
-        timedOut: false,
-      }),
+      importEntry: async ({ specifier }) =>
+        specifier.endsWith('/emitter')
+          ? { exitCode: 1, stdout: '', stderr: 'ERR_MODULE_NOT_FOUND', timedOut: false }
+          : { exitCode: 0, stdout: '', stderr: '', timedOut: false },
+      stdoutWrite,
     });
-    assert.equal(await runCheck({ argv: [], io }), 1);
+    assert.equal(await runCheck({ argv: ['--json'], io }), 1);
+    const payload = JSON.parse(stdoutWrite.calls[0][0]);
+    const failed = payload.findings.filter((f) => f.kind === 'entry-failed');
+    assert.equal(failed.length, 1);
+    assert.match(failed[0].summary, /@prisma\/orm-toolchain\/emitter/);
+    assert.match(failed[0].detail, /ERR_MODULE_NOT_FOUND/);
+  });
+
+  it('a bin-less manifest that exports nothing importable is a finding (anti-vacuity)', async () => {
+    const stdoutWrite = recorder();
+    const io = makeIo({
+      readPackedManifest: () => ({
+        name: '@prisma/orm-toolchain',
+        version: '8.0.0-rc.1',
+        dependencies: { declared: '1.0.0' },
+        peerDependencies: { '@prisma/cli-engine': '0.0.9' },
+        exports: { './package.json': './package.json' },
+      }),
+      stdoutWrite,
+    });
+    assert.equal(await runCheck({ argv: ['--json'], io }), 1);
+    const payload = JSON.parse(stdoutWrite.calls[0][0]);
+    assert.ok(
+      payload.findings.some((f) => f.check === 'tarball' && f.kind === 'no-subjects'),
+      'expected a tarball no-subjects finding',
+    );
+  });
+});
+
+describe('packedEntrySpecifiers', () => {
+  it('joins each exported subpath onto the package name, sorted', () => {
+    assert.deepEqual(
+      packedEntrySpecifiers({
+        name: '@prisma/orm-toolchain',
+        exports: { './emitter': './dist/emitter.mjs', './cli': './dist/cli.mjs' },
+      }),
+      ['@prisma/orm-toolchain/cli', '@prisma/orm-toolchain/emitter'],
+    );
+  });
+
+  it('names the package itself for the root export', () => {
+    assert.deepEqual(packedEntrySpecifiers({ name: 'x', exports: { '.': './dist/index.mjs' } }), [
+      'x',
+    ]);
+  });
+
+  it('skips ./package.json, which is data rather than a module', () => {
+    assert.deepEqual(
+      packedEntrySpecifiers({
+        name: 'x',
+        exports: { './a': './dist/a.mjs', './package.json': './package.json' },
+      }),
+      ['x/a'],
+    );
+  });
+
+  it('skips wildcard subpaths, which name no single module', () => {
+    assert.deepEqual(
+      packedEntrySpecifiers({
+        name: 'x',
+        exports: { './a': './dist/a.mjs', './g/*': './dist/g/*' },
+      }),
+      ['x/a'],
+    );
+  });
+
+  it('reads the import condition of a conditional export', () => {
+    assert.deepEqual(
+      packedEntrySpecifiers({
+        name: 'x',
+        exports: { './a': { types: './dist/a.d.mts', import: './dist/a.mjs' } },
+      }),
+      ['x/a'],
+    );
+  });
+
+  it('skips an export with no importable target', () => {
+    assert.deepEqual(
+      packedEntrySpecifiers({
+        name: 'x',
+        exports: { './a': { types: './dist/a.d.mts' }, './b': null, './c': './dist/c.mjs' },
+      }),
+      ['x/c'],
+    );
+  });
+
+  it('treats the string shorthand as the root export', () => {
+    assert.deepEqual(packedEntrySpecifiers({ name: 'x', exports: './dist/index.mjs' }), ['x']);
+  });
+
+  it('treats a bare conditions object as the root export, not as subpaths', () => {
+    assert.deepEqual(
+      packedEntrySpecifiers({
+        name: 'x',
+        exports: { types: './dist/index.d.mts', import: './dist/index.mjs' },
+      }),
+      ['x'],
+    );
+  });
+
+  it('treats an array fallback as the root export', () => {
+    assert.deepEqual(
+      packedEntrySpecifiers({ name: 'x', exports: ['./dist/index.mjs', './dist/fallback.mjs'] }),
+      ['x'],
+    );
+  });
+
+  it('yields nothing for a bare conditions object with no importable condition', () => {
+    assert.deepEqual(packedEntrySpecifiers({ name: 'x', exports: { types: './x.d.mts' } }), []);
+  });
+
+  it('yields nothing for a manifest with no exports', () => {
+    assert.deepEqual(packedEntrySpecifiers({ name: 'x' }), []);
   });
 });
 

--- a/scripts/check-conformance.test.mjs
+++ b/scripts/check-conformance.test.mjs
@@ -679,6 +679,17 @@ describe('packedEntrySpecifiers', () => {
     );
   });
 
+  it('recognises node-addons, which Node resolves before node', () => {
+    assert.deepEqual(
+      packedEntrySpecifiers({ name: 'x', exports: { 'node-addons': './dist/native.mjs' } }),
+      ['x'],
+    );
+    assert.deepEqual(
+      packedEntrySpecifiers({ name: 'x', exports: { './a': { 'node-addons': './dist/a.mjs' } } }),
+      ['x/a'],
+    );
+  });
+
   it('treats an array fallback as the root export', () => {
     assert.deepEqual(
       packedEntrySpecifiers({ name: 'x', exports: ['./dist/index.mjs', './dist/fallback.mjs'] }),


### PR DESCRIPTION
## Linked issue

No Linear ticket. Follows [#30009](https://github.com/prisma/prisma/pull/30009), which introduced the bin-less sandbox smoke this widens.

## At a glance

Delete one file from the built toolchain — simulating a packaging mistake that drops a `dist` file from the tarball:

```bash
rm packages/9-public/@prisma/orm-toolchain/dist/emitter.mjs
pnpm check:conformance
```

The publish check passes:

```text
OK — packed output imports only declared packages, the shipped orm validator
     survives the hostile corpus, the @prisma/orm-toolchain tarball installs
     clean and its bins start, and every @prisma/cli-engine pin agrees.
```

`@prisma/orm-toolchain/emitter` is a declared, published export that no consumer can import, and the publish path says the tarball is fine. After this PR:

```text
FAIL — 1 conformance finding(s):

  [tarball/entry-failed] @prisma/orm-toolchain
    importing @prisma/orm-toolchain/emitter in the sandbox exited 1
```

## Why the gap exists

Two checks look like they should already cover this, and neither does.

**Import purity** parses every packed `.js`/`.mjs` file and verifies its bare specifiers are declared. It reads imports *inside* files that shipped. It has nothing to say about an `exports` subpath whose target file did not ship.

**The bin-less sandbox smoke**, added by #30009 when #30005 retired the `prisma-next` bin, installs the tarball into a clean sandbox and imports one hardcoded entry — `@prisma/orm-toolchain/cli`. That was the right call for unbreaking the publish, and it proves the package installs and its main entry loads. The other 34 subpaths in the `exports` map are just as published and just as reachable by a consumer, and nothing looks at them.

## Decision

Smoke every subpath in the packed `exports` map, not one of them.

```js
// what the sandbox now imports, each in a fresh node, from inside the clean install
await import('@prisma/orm-toolchain/cli');
await import('@prisma/orm-toolchain/emitter');
await import('@prisma/orm-toolchain/migration-tools/graph');
// … 32 more
```

The bin loop is untouched: a package that ships a `bin` still starts every one under plain node. Only the bin-less path widens, and the anti-vacuity rule moves with the subjects — a manifest with neither a bin nor an importable export is now a `no-subjects` finding, so a run that checked nothing still cannot pass.

## How it works

`packedEntrySpecifiers(manifest)` turns the packed `exports` map into the specifiers a consumer writes. Node's `exports` field has four legal shapes and only one of them enumerates more than the package root, so the helper distinguishes them: a string, an array fallback, and a bare conditions object all mean "the root and nothing else"; only an object with `.`-prefixed keys lists subpaths. Within a subpath map it skips `./package.json` (data, not a module), wildcard subpaths (they name no single module), and any export whose resolved target has no importable condition.

Each specifier is imported through #30009's existing `importEntry` seam, one fresh node per entry. That costs about 5 seconds on top of a 19-second check.

## Reviewer notes

**This PR started as something else, and the history is worth knowing.** I opened it to fix `Publish to npm` being red on `main` — my local `origin/main` was four days stale, and #30009 had already fixed that red before I began. The original diff replaced the bin machinery wholesale. That was wrong twice over: the fix was redundant, and deleting a bin runner #30009 had deliberately kept was unnecessary. This is a rewrite on top of current `main`, scoped to the one thing that is genuinely still missing.

**The claim was tested in both directions, on the same tarball.** Deleting `dist/emitter.mjs` and running the check from `main`: exit 0. Running this branch against the same broken build: exit 1, with a single finding naming `@prisma/orm-toolchain/emitter` — and only one, which confirms no other check in the file notices. The file was restored and the clean run re-confirmed.

**One earlier version of `packedEntrySpecifiers` was wrong and CodeRabbit caught it.** It treated every `exports` key as a subpath, so a bare conditions object such as `{ import: './dist/index.mjs' }` produced `x/import`. The published toolchain uses a subpath map, so no real run was ever affected — but the helper was wrong, and the shape handling above is the fix. Three tests cover the root-only forms.

## Behaviour changes & evidence

- **Every published entry point of a bin-less package is imported from a clean install.** `scripts/check-conformance.mjs` — evidence: `pnpm check:conformance` exits 0 against a real build and 1 against one with a deliberately unreachable export; unit coverage in `a manifest with no bin smokes every published entry point` and `a failing entry import in the sandbox is a finding that names the entry`.
- **A manifest with neither a bin nor an importable export is a finding.** Evidence: the `no-subjects` case in `check-conformance.test.mjs`.
- **`packedEntrySpecifiers` handles all four `exports` shapes.** Evidence: 11 cases covering subpath maps, the root export, the string shorthand, conditions objects, array fallbacks, wildcards, `./package.json`, and targets with nothing importable.

## Verification

- `node --test scripts/check-conformance.test.mjs` — 55/55 (12 new)
- `pnpm check:conformance` — exit 0 against a full local build, 24s
- `pnpm build` — clean
- Biome ran over both files via lint-staged at commit

Not run: the package test suites. This touches one build script that nothing imports.

## Compatibility

None. A CI-only script; nothing ships or imports it.

## Follow-up, not fixed here

`Deploy telemetry-backend` is failing on `main` with `CONFIG.EVALUATION_FAILED: DATABASE_URL must be set`. It is a missing workflow secret, unrelated to this change, and needs someone with access to the repository's environment settings.

## Alternatives considered

- **Leave it at `/cli`.** Defensible — the main entry loading is most of the value, and a dropped `dist` file is a rare mistake. Rejected because the cost is 5 seconds in a job that already takes 24, and the failure it catches is silent and ships to users.
- **Check that each `exports` target exists in the tarball, without importing it.** Cheaper and catches the missing-file case, but not a target that exists and throws on load or resolves through a broken conditional. Importing subsumes it.
- **One node process importing all 35 entries.** Saves 34 interpreter starts, but one entry with a hanging top-level side effect would take the whole sweep down, and it would abandon #30009's `importEntry` seam for no gain worth having.
- **Smoke every publishable package's entry points, not just the toolchain's.** The natural next step, and a bigger change: the check installs only the toolchain tarball today, so this would need a sandbox per package. Worth doing separately if the appetite is there.

## Checklist

- [x] All commits carry DCO sign-off
- [x] I have read CONTRIBUTING.md
- [x] Tests added for every behaviour change, with the central claim proven in both directions
- [x] Title follows the prevailing convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conformance validation across all importable package entry points.
  * Added clearer reporting for failed imports, empty entry sets, and timed-out checks.
  * Improved handling of conditional, wildcard, root, fallback, and non-importable exports.
  * Retained startup checks for packages that provide command-line tools.

* **Tests**
  * Expanded coverage for multiple export entries, missing entries, package metadata exclusions, and import failures.
  * Updated checks for modern package export configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->