### PR TITLE
TML-3206: Codec ids are checked where they are authored (stacked on #30006)

### DIFF
--- a/examples/prisma-8-demo/test/codec-id-ergonomics.types.test-d.ts
+++ b/examples/prisma-8-demo/test/codec-id-ergonomics.types.test-d.ts
@@ -1,0 +1,25 @@
+/**
+ * Type-test: codec ids are completed and checked where they are authored.
+ *
+ * These run against the demo's emitted contract, whose codec map resolves for
+ * real, so they pin what a user meets: an id the contract carries keeps its
+ * literal, and one it does not carry is refused at the call site.
+ */
+
+import { expectTypeOf, test } from 'vitest';
+import { db } from '../src/prisma/db';
+
+test('a contract-bound fragment keeps its codec id literal', () => {
+  const expr = db.sql.raw`now()`.returns('pg/timestamptz@1');
+  expectTypeOf(expr.returnType.codecId).toEqualTypeOf<'pg/timestamptz@1'>();
+});
+
+test('a contract-bound fragment rejects an id the contract does not carry', () => {
+  // @ts-expect-error — unknown codec id
+  db.sql.raw`now()`.returns('pg/nope@1');
+});
+
+test('a prepared declaration rejects an id the contract does not carry', async () => {
+  // @ts-expect-error — unknown codec id in the declaration
+  await db.prepare({ id: 'pg/nope@1' }, () => null as never);
+});

--- a/packages/2-sql/4-lanes/sql-builder/src/types/raw-query.ts
+++ b/packages/2-sql/4-lanes/sql-builder/src/types/raw-query.ts
@@ -1,5 +1,6 @@
 import type { ExtractCodecTypes } from '@internal/sql-contract/types';
 import type {
+  Expression,
   RawAffectedCountQuery,
   RawRowQuery,
   RawSqlBuilder,
@@ -94,6 +95,21 @@ export type RawRowFor<
  */
 export interface ContractRawBuilder<CodecTypes extends Record<string, { readonly output: unknown }>>
   extends RawSqlBuilder {
+  /**
+   * The expression terminator, narrowed to the contract's codec ids. The
+   * target-agnostic tag takes any string, because the contract-free lane has
+   * no map to key against; a contract-bound fragment does, so the ids it can
+   * name are the ones the contract carries — and naming them makes them
+   * complete at the call site.
+   */
+  returns<S extends keyof CodecTypes & string>(
+    spec: S,
+  ): Expression<{ codecId: S; nullable: false }>;
+  returns<S extends keyof CodecTypes & string, N extends boolean = false>(spec: {
+    readonly codecId: S;
+    readonly nullable?: N;
+  }): Expression<{ codecId: S; nullable: N }>;
+
   returnsRow<Spec extends ContractRawRowSpec<CodecTypes>>(
     spec: Spec,
   ): RawRowQuery<RawRowFor<Spec, CodecTypes>>;

--- a/packages/2-sql/4-lanes/sql-builder/test/types/raw-spec-literals.types.test-d.ts
+++ b/packages/2-sql/4-lanes/sql-builder/test/types/raw-spec-literals.types.test-d.ts
@@ -44,3 +44,29 @@ test('an id the contract does not carry is rejected at the call site', () => {
   // @ts-expect-error — the entry names a codec the contract's map has no row for
   raw.returnsRow({ total: 'syn/nonexistent@1' });
 });
+
+// ── The fragment terminator on the contract-bound tag ────────────────────────
+
+test('a fragment codec id keeps its literal through .returns()', () => {
+  const expr = raw.returns('syn/int8@1');
+
+  expectTypeOf(expr.returnType.codecId).toEqualTypeOf<'syn/int8@1'>();
+  expectTypeOf(expr.returnType.nullable).toEqualTypeOf<false>();
+});
+
+test('the object form of .returns() keeps its literal and its nullability', () => {
+  const expr = raw.returns({ codecId: 'syn/text@1', nullable: true });
+
+  expectTypeOf(expr.returnType.codecId).toEqualTypeOf<'syn/text@1'>();
+  expectTypeOf(expr.returnType.nullable).toEqualTypeOf<true>();
+});
+
+test('a fragment naming an id the contract does not carry is rejected', () => {
+  // @ts-expect-error — the fragment names a codec the contract's map has no row for
+  raw.returns('syn/nonexistent@1');
+});
+
+test('the object form rejects an unknown id too', () => {
+  // @ts-expect-error — same rejection through the descriptor form
+  raw.returns({ codecId: 'syn/nonexistent@1' });
+});

--- a/packages/3-extensions/postgres/src/runtime/postgres.ts
+++ b/packages/3-extensions/postgres/src/runtime/postgres.ts
@@ -65,11 +65,7 @@ export interface PostgresClient<TContract extends Contract<SqlStorage>> {
   connect(bindingInput?: PostgresBindingInput): Promise<Runtime>;
   runtime(): Runtime;
   transaction<R>(fn: (tx: PostgresTransactionContext<TContract>) => PromiseLike<R>): Promise<R>;
-  prepare<
-    D extends Declaration<CT>,
-    Row,
-    CT extends CodecTypesBase = ExtractCodecTypes<TContract> & CodecTypesBase,
-  >(
+  prepare<D extends Declaration<CT>, Row, CT extends CodecTypesBase = ExtractCodecTypes<TContract>>(
     declaration: D,
     callback: (sql: Db<TContract>, params: BindSiteParams<D>) => SqlQueryPlan<Row>,
   ): Promise<PreparedFor<ParamsFromDeclaration<D, CT>, Row>>;
@@ -332,7 +328,7 @@ export default function postgres<TContract extends Contract<SqlStorage>>(
     prepare<
       D extends Declaration<CT>,
       Row,
-      CT extends CodecTypesBase = ExtractCodecTypes<TContract> & CodecTypesBase,
+      CT extends CodecTypesBase = ExtractCodecTypes<TContract>,
     >(
       declaration: D,
       callback: (sql: Db<TContract>, params: BindSiteParams<D>) => SqlQueryPlan<Row>,

--- a/packages/3-extensions/sqlite/src/runtime/sqlite.ts
+++ b/packages/3-extensions/sqlite/src/runtime/sqlite.ts
@@ -76,11 +76,7 @@ export interface SqliteClient<TContract extends Contract<SqlStorage>> {
   readonly stack: SqlExecutionStackWithDriver<SqliteTargetId>;
   connect(bindingInput?: { readonly path: string }): Promise<Runtime>;
   runtime(): Runtime;
-  prepare<
-    D extends Declaration<CT>,
-    Row,
-    CT extends CodecTypesBase = ExtractCodecTypes<TContract> & CodecTypesBase,
-  >(
+  prepare<D extends Declaration<CT>, Row, CT extends CodecTypesBase = ExtractCodecTypes<TContract>>(
     declaration: D,
     callback: (sql: UnboundSql<TContract>, params: BindSiteParams<D>) => SqlQueryPlan<Row>,
   ): Promise<PreparedFor<ParamsFromDeclaration<D, CT>, Row>>;
@@ -289,7 +285,7 @@ export default function sqlite<TContract extends Contract<SqlStorage>>(
     prepare<
       D extends Declaration<CT>,
       Row,
-      CT extends CodecTypesBase = ExtractCodecTypes<TContract> & CodecTypesBase,
+      CT extends CodecTypesBase = ExtractCodecTypes<TContract>,
     >(
       declaration: D,
       callback: (sql: UnboundSql<TContract>, params: BindSiteParams<D>) => SqlQueryPlan<Row>,

--- a/skills/prisma-8-extension-upgrade/upgrades/8.0.0-rc.1-to-8.0.0-rc.2/instructions.md
+++ b/skills/prisma-8-extension-upgrade/upgrades/8.0.0-rc.1-to-8.0.0-rc.2/instructions.md
@@ -324,6 +324,22 @@ changes:
         - "preparedStatementQuery"
         - "PreparedStatement<ParamsFromDeclaration"
       anyMatch: true
+  - id: prepare-defaults-to-the-contract-codec-map
+    summary: |
+      A facade that redeclares `prepare()` should default its codec-map parameter to
+      `ExtractCodecTypes<TContract>` alone. Intersecting it with `CodecTypesBase` — the shape
+      the in-tree facades used — collapses `keyof CT` to `string` through that type's index
+      signature, which costs a caller every codec-id completion in the declaration and lets an
+      id no registry carries typecheck. Drop the intersection; the `CT extends CodecTypesBase`
+      constraint stays and nothing else in the signature changes. If your facade exposes a
+      contract-bound raw tag, its `.returns()` now narrows to the contract's ids the same way,
+      with no change on your side; a contract-free tag keeps accepting any string.
+    detection:
+      glob: "**/*.{ts,mts,cts}"
+      contains:
+        - "ExtractCodecTypes<TContract> & CodecTypesBase"
+        - "CodecTypesBase ="
+      anyMatch: true
 ---
 
 # 8.0.0-rc.1 → 8.0.0-rc.2 — Extension-author upgrade instructions
@@ -705,3 +721,24 @@ it must now also install `preparedStatementExecute` beside it, routing to the sa
 Both symbols come from `@internal/sql-runtime/internal/prepared-query`. A scope missing the
 execute bridge typechecks but throws on the bridge invariant the first time someone executes a
 prepared statement against it.
+
+## `prepare-defaults-to-the-contract-codec-map`
+
+```ts
+// Before — the index signature on CodecTypesBase widens keyof CT to string
+CT extends CodecTypesBase = ExtractCodecTypes<TContract> & CodecTypesBase,
+
+// After
+CT extends CodecTypesBase = ExtractCodecTypes<TContract>,
+```
+
+Only the default changes. The constraint, `Declaration<CT>`, `ParamsFromDeclaration`, and the
+returned prepared handle are all as they were, and what infers at existing call sites is
+unchanged — this is about what the caller is offered and what the compiler refuses. With the
+intersection in place, `prepare({ id: 'pg/int4' }, ...)` typechecks and then fails at
+execution with `RUNTIME.PARAM_REF_MISSING_CODEC`; without it, the wrong id is a compile
+error and the right ones complete.
+
+The same narrowing reaches `.returns()` on a contract-bound raw tag through
+`@internal/sql-builder`, so a facade that re-exposes that tag inherits it without doing
+anything. Tags built for a contract-free lane are deliberately left open.

--- a/skills/prisma-next-upgrade/upgrades/8.0.0-rc.1-to-8.0.0-rc.2/instructions.md
+++ b/skills/prisma-next-upgrade/upgrades/8.0.0-rc.1-to-8.0.0-rc.2/instructions.md
@@ -255,6 +255,24 @@ changes:
         - '@@schema("raw")'
         - '"raw": {'
       anyMatch: true
+  - id: codec-ids-are-checked-where-they-are-authored
+    summary: |
+      A codec id you write in a prepared declaration or in a contract-bound raw fragment is
+      now checked against your contract's codec map, so an id the contract does not carry is
+      a compile error where before it compiled and failed at execution with
+      `RUNTIME.PARAM_REF_MISSING_CODEC`. The usual cause is an unversioned id:
+      `db.prepare({ id: 'pg/int4' }, ...)` becomes `db.prepare({ id: 'pg/int4@1' }, ...)`, and
+      `fns.raw\`...\`.returns('pg/text')` becomes `.returns('pg/text@1')`. Take the id from your
+      emitted `contract.d.ts` — every id it carries now completes at both positions, so the
+      editor offers the correct spelling rather than accepting a wrong one. Raw fragments
+      built through a contract-free lane are unaffected; they have no map to check against.
+    detection:
+      glob: "**/*.{ts,tsx,mts,cts}"
+      contains:
+        - "prepare({"
+        - ".returns('pg/"
+        - ".returns(\"pg/"
+      anyMatch: true
 ---
 
 # 8.0.0-rc.1 → 8.0.0-rc.2 — User upgrade instructions
@@ -540,3 +558,29 @@ model Event {
 Then re-emit the contract, and plan the rename against the database as you would any
 other namespace rename — the physical schema still carries the old name until a plan moves it.
 Only `raw` is reserved; no other namespace name is affected.
+
+## `codec-ids-are-checked-where-they-are-authored`
+
+Two places where you write a codec id by hand now check it against the codec map your
+contract emitted: the declaration passed to `db.prepare(...)`, and `.returns(...)` on a raw
+fragment built from a contract-bound tag.
+
+```ts
+// Before: compiled, then failed at execution with RUNTIME.PARAM_REF_MISSING_CODEC
+await db.prepare({ id: 'pg/int4' }, (sql, params) => ...);
+const upper = fns.raw`UPPER(${f.email})`.returns('pg/text');
+
+// After: the id is the one your contract carries
+await db.prepare({ id: 'pg/int4@1' }, (sql, params) => ...);
+const upper = fns.raw`UPPER(${f.email})`.returns('pg/text@1');
+```
+
+The compile error is the messenger, not the injury: an id no codec registry carries could
+never have executed. If a declaration or fragment of yours stops compiling, the id in it was
+already wrong at runtime.
+
+Read the correct spelling off your emitted `contract.d.ts`, or let the editor offer it — the
+ids now complete at both positions, which is the other half of this change.
+
+A raw fragment built through a contract-free lane keeps accepting any string: that lane has
+no contract map to check an id against.


### PR DESCRIPTION
# Codec ids are checked where they are authored

Stacked on #30006 (prepared-execute), atop #29997 (whole-query raw). Third PR of the stack.

PR #29997 gave `.returnsRow()` codec-id autocompletion and literal preservation. This PR brings the two remaining authoring surfaces to parity:

- **Fragment terminator** — the contract-bound raw tag's `.returns()` now constrains its spec to the contract's codec-id union (`keyof CodecTypes & string`, both the bare-id and `{ codecId, nullable }` forms). Known ids complete; unknown ids are compile errors. The contract-free lane deliberately keeps open strings — it has no map to key against (the same lane split ADR 247 records for `.returnsRow()`).
- **Prepared declarations** — the facades' `prepare()` defaults dropped the `& CodecTypesBase` intersection whose index signature collapsed `keyof CT` to `string`. The constraint, `Declaration<CT>`, `ParamsFromDeclaration`, and the returned handle are unchanged; only the default narrows, so declarations now complete known ids and refuse unknown ones.

## Type-level break, deliberately

A downstream `prepare({ id: 'pg/int4' }, …)` or `.returns('pg/text')` (unversioned/unregistered id) compiled before and does not now. That code was already broken at execution — `RUNTIME.PARAM_REF_MISSING_CODEC` — so the compile error is the messenger, not the injury. Upgrade declarations recorded for **both audiences**: users (`codec-ids-are-checked-where-they-are-authored`) and extension authors (`prepare-defaults-to-the-contract-codec-map`), each with best-effort detection globs whose catch/miss envelope is stated in the entry.

## Verification

Pins are deliberately immune to the fixture `any`-poisoning found during the investigation (TML-3207): the sql-builder pin asserts against a local synthetic codec map; the end-to-end pin (both surfaces, including `prepare()` unknown-id rejection) lives in the demo against its *real* emitted contract — the only package whose codec map currently resolves. If a map ever collapses to `any`, the `@ts-expect-error` cases become unused, which is itself a compile error: these tests cannot silently assert nothing. The demo home for the facade pin is temporary; TML-3207 carries its repatriation once the facade fixture is un-poisoned.

Out of scope, tracked: the fixture repairs themselves (TML-3207, widened to an all-packages sweep after this slice found the same poisoning in `@internal/postgres`'s fixture).

Refs: TML-3206

https://claude.ai/code/session_01NnNjsNcPMtbJZhnZz5Zzbe


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contract-bound SQL fragments now validate codec IDs and preserve their declared nullability.
  * Prepared database declarations provide improved codec ID validation and autocomplete based on the contract.

* **Bug Fixes**
  * Invalid codec IDs are rejected at compile time instead of failing during execution.
  * Contract-free raw fragments remain unrestricted.

* **Documentation**
  * Added upgrade guidance for codec ID validation and updated `prepare()` declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->