### PR TITLE
TML-3202: Prototype-polluting column names round-trip or refuse, never vanish (stacked on #30013)

### DIFF
--- a/docs/reference/error-reference.md
+++ b/docs/reference/error-reference.md
@@ -589,7 +589,7 @@ A lane terminal (SQL DSL `.build()`, ORM collection terminal) received an annota
 
 ### RUNTIME.AST_INVALID
 
-A lowered SQL AST is structurally invalid: a subquery projecting other than one column, an INSERT with zero rows, a missing column value, an empty onConflict column list or do-update-set, an UPDATE with no SET assignments, an INSERT target table absent from contract storage, or an AST node constructed with invalid arguments (empty FunctionSource column aliases, a CaseExpr with no branches). Raised by the Postgres and SQLite SQL renderers and by AST node construction in relational-core. Meta: `node`, `table`, `column`; construction sites carry node-specific fields.
+A lowered SQL AST is structurally invalid: a subquery projecting other than one column, an INSERT with zero rows, a missing column value, an empty onConflict column list or do-update-set, an UPDATE with no SET assignments, an INSERT target table absent from contract storage, or an AST node constructed with invalid arguments (empty FunctionSource column aliases, a CaseExpr with no branches, a raw query declaring a `__proto__` result column — a name that cannot survive as a column, so alias it in SQL and declare the alias). Raised by the Postgres and SQLite SQL renderers and by AST node construction in relational-core. Meta: `node`, `table`, `column`; construction sites carry node-specific fields.
 
 ### RUNTIME.AST_UNSUPPORTED
 

--- a/packages/2-sql/4-lanes/relational-core/src/ast/types.ts
+++ b/packages/2-sql/4-lanes/relational-core/src/ast/types.ts
@@ -2143,12 +2143,29 @@ export type RawQueryResult =
   | { readonly kind: 'rows'; readonly columns: Readonly<Record<string, RawQueryColumn>> }
   | { readonly kind: 'affected-count' };
 
+/**
+ * The one column name a declared result cannot carry. Writing `__proto__` onto
+ * an object literal sets that object's prototype instead of adding a property,
+ * so a column so named would disappear between the declaration and the decoded
+ * row — and the row type would still promise it. Every other name that shadows
+ * something on `Object.prototype` (`constructor`, `prototype`) is an ordinary
+ * own property when assigned, and passes through as declared.
+ */
+const RESERVED_RESULT_COLUMN = '__proto__';
+
 function frozenRawQueryResult(result: RawQueryResult): RawQueryResult {
   if (result.kind === 'affected-count') {
     return Object.freeze({ kind: 'affected-count' as const });
   }
   const columns: Record<string, RawQueryColumn> = {};
   for (const [name, column] of Object.entries(result.columns)) {
+    if (name === RESERVED_RESULT_COLUMN) {
+      throw structuredError(
+        'RUNTIME.AST_INVALID',
+        `A raw query result cannot declare a "${RESERVED_RESULT_COLUMN}" column: alias the column in SQL and declare the alias instead`,
+        { meta: { kind: 'raw-query', field: 'result.columns', column: name } },
+      );
+    }
     columns[name] = Object.freeze({ codecId: column.codecId, nullable: column.nullable });
   }
   return Object.freeze({ kind: 'rows' as const, columns: Object.freeze(columns) });

--- a/packages/2-sql/4-lanes/relational-core/src/expression.ts
+++ b/packages/2-sql/4-lanes/relational-core/src/expression.ts
@@ -224,8 +224,19 @@ export interface RawSqlBuilder {
  */
 export type RawRowSpecEntry = string | { readonly codecId: string; readonly nullable?: boolean };
 
+/**
+ * Declares the one column name a row spec cannot use. TypeScript types
+ * `{ __proto__: 'pg/int4@1' }` and `{ ['__proto__']: 'pg/int4@1' }` alike — as
+ * a spec with a `__proto__` column — while JavaScript keeps the key in neither
+ * object. Rejecting the name here is what makes the two agree; the AST refuses
+ * the computed form again at runtime, where it does arrive.
+ */
+export type NoReservedRowColumn = {
+  readonly __proto__?: 'A raw row spec cannot declare a __proto__ column: alias the column in SQL and declare the alias instead';
+};
+
 /** The declared result row of a raw query: result-column name to codec. */
-export type RawRowSpec = Readonly<Record<string, RawRowSpecEntry>>;
+export type RawRowSpec = Readonly<Record<string, RawRowSpecEntry>> & NoReservedRowColumn;
 
 /**
  * Row type minted for a {@link RawRowSpec}. Column names carry through; the
@@ -364,15 +375,22 @@ function templateParts(
   return parts;
 }
 
+/**
+ * Normalizes each authored entry to a {@link RawQueryColumn}. The record is
+ * assembled with `Object.fromEntries`, which defines each key as an own
+ * property: a spec built at runtime with a `__proto__` key reaches the AST,
+ * which refuses it by name, rather than silently setting the record's
+ * prototype and leaving the column to vanish.
+ */
 function resolveRowSpec(spec: RawRowSpec): Record<string, RawQueryColumn> {
-  const columns: Record<string, RawQueryColumn> = {};
-  for (const [name, entry] of Object.entries(spec)) {
-    columns[name] =
+  return Object.fromEntries(
+    Object.entries(spec).map(([name, entry]) => [
+      name,
       typeof entry === 'string'
         ? { codecId: entry, nullable: false }
-        : { codecId: entry.codecId, nullable: entry.nullable ?? false };
-  }
-  return columns;
+        : { codecId: entry.codecId, nullable: entry.nullable ?? false },
+    ]),
+  );
 }
 
 /**

--- a/packages/2-sql/4-lanes/relational-core/test/ast/raw-query.test.ts
+++ b/packages/2-sql/4-lanes/relational-core/test/ast/raw-query.test.ts
@@ -58,6 +58,47 @@ describe('ast/RawQueryAst', () => {
     });
   });
 
+  describe('column names that collide with object machinery', () => {
+    const protoColumns = Object.fromEntries([
+      ['__proto__', { codecId: 'pg/int4@1', nullable: false }],
+    ]) as Record<string, { codecId: string; nullable: boolean }>;
+
+    it('refuses a __proto__ column instead of dropping it', () => {
+      expect(() => RawQueryAst.rows(['select 1 as "__proto__"'], protoColumns)).toThrow(
+        /__proto__/,
+      );
+    });
+
+    it('names the offending column in the structured error', () => {
+      expect(() => RawQueryAst.rows(['select 1 as "__proto__"'], protoColumns)).toThrow(
+        expect.objectContaining({
+          code: 'RUNTIME.AST_INVALID',
+          meta: expect.objectContaining({ column: '__proto__' }),
+        }),
+      );
+    });
+
+    it('keeps a constructor column as an own property of the frozen record', () => {
+      const node = RawQueryAst.rows(['select 1 as "constructor"'], {
+        constructor: { codecId: 'pg/int4@1', nullable: false },
+        id: { codecId: 'pg/int4@1', nullable: false },
+      });
+      const result = node.result;
+      if (result.kind !== 'rows') throw new Error('expected a row-returning result');
+
+      expect(Object.keys(result.columns)).toEqual(['constructor', 'id']);
+      expect(result.columns['constructor']).toEqual({ codecId: 'pg/int4@1', nullable: false });
+    });
+
+    it('leaves the frozen column record on the ordinary object prototype', () => {
+      const node = RawQueryAst.rows(['select 1'], columns);
+      const result = node.result;
+      if (result.kind !== 'rows') throw new Error('expected a row-returning result');
+
+      expect(Object.getPrototypeOf(result.columns)).toBe(Object.prototype);
+    });
+  });
+
   describe('affected-count node', () => {
     it('carries the affected-count result marker and no columns', () => {
       const node = RawQueryAst.affectedCount(['update "user" set seen = now()']);

--- a/packages/2-sql/4-lanes/relational-core/test/expression/raw-statement.test-d.ts
+++ b/packages/2-sql/4-lanes/relational-core/test/expression/raw-statement.test-d.ts
@@ -96,3 +96,29 @@ test('the tag type inferred from createRawSql is the expression tag', () => {
 
   assertType<RawSqlTag>(tag);
 });
+
+// ── Column names that collide with object machinery ──────────────────────────
+
+test('a __proto__ column is rejected at the authoring site', () => {
+  // @ts-expect-error — a __proto__ key never survives as a row column
+  rawSql`select 1 as "__proto__"`.returnsRow({ __proto__: 'pg/int4@1' });
+});
+
+test('the computed form of a __proto__ column is rejected the same way', () => {
+  // @ts-expect-error — a __proto__ key never survives as a row column
+  rawSql`select 1 as "__proto__"`.returnsRow({ ['__proto__']: 'pg/int4@1' });
+});
+
+test('a constructor column is a column like any other', () => {
+  const plan = rawSql`select 1 as "constructor"`.returnsRow({ constructor: 'pg/int4@1' }).build();
+
+  assertType<SqlQueryPlan<{ constructor: unknown }>>(plan);
+});
+
+test('a row spec assembled at runtime is still accepted', () => {
+  const spec: Record<string, string> = { id: 'pg/int4@1' };
+
+  assertType<SqlQueryPlan<Record<string, unknown>>>(
+    rawSql`select id from "user"`.returnsRow(spec).build(),
+  );
+});

--- a/packages/2-sql/4-lanes/relational-core/test/expression/raw-statement.test.ts
+++ b/packages/2-sql/4-lanes/relational-core/test/expression/raw-statement.test.ts
@@ -84,6 +84,30 @@ describe('raw statement terminators', () => {
     });
   });
 
+  describe('row-spec column names that collide with object machinery', () => {
+    it('refuses a computed __proto__ key rather than losing it in normalization', () => {
+      const spec: Record<string, string> = Object.fromEntries([['__proto__', 'pg/int4@1']]);
+
+      expect(() => rawSql`select 1 as "__proto__"`.returnsRow(spec)).toThrow(
+        expect.objectContaining({
+          code: 'RUNTIME.AST_INVALID',
+          meta: expect.objectContaining({ column: '__proto__' }),
+        }),
+      );
+    });
+
+    it('normalizes a constructor column like any other', () => {
+      const plan = rawSql`select 1 as "constructor"`
+        .returnsRow({ constructor: 'pg/int4@1' })
+        .build();
+
+      expect((plan.ast as RawQueryAst).result).toEqual({
+        kind: 'rows',
+        columns: { constructor: { codecId: 'pg/int4@1', nullable: false } },
+      });
+    });
+  });
+
   describe('expression terminator alongside the statement terminators', () => {
     it('still produces a RawExpr from .returns()', () => {
       const expr = rawSql`now()`.returns('pg/timestamptz@1');

--- a/packages/2-sql/4-lanes/sql-builder/src/runtime/table-proxy-impl.ts
+++ b/packages/2-sql/4-lanes/sql-builder/src/runtime/table-proxy-impl.ts
@@ -93,10 +93,12 @@ export class TableProxyImpl<
    * value carries what the storage table states.
    */
   get columns(): TableProxy<C, NsId, Name, Alias, AvailableScope, QC>['columns'] {
-    const refs: Record<string, { codecId: string; nullable: boolean }> = {};
-    for (const [name, column] of Object.entries(this.#table.columns)) {
-      refs[name] = { codecId: column.codecId, nullable: column.nullable };
-    }
+    const refs = Object.fromEntries(
+      Object.entries(this.#table.columns).map(([name, column]) => [
+        name,
+        { codecId: column.codecId, nullable: column.nullable },
+      ]),
+    );
     return blindCast<
       TableProxy<C, NsId, Name, Alias, AvailableScope, QC>['columns'],
       "the storage table states each column's codec and nullability at runtime; the declared type is the contract's own statement about the same columns, which a runtime value cannot carry"

--- a/packages/2-sql/4-lanes/sql-builder/src/types/raw-query.ts
+++ b/packages/2-sql/4-lanes/sql-builder/src/types/raw-query.ts
@@ -1,6 +1,7 @@
 import type { ExtractCodecTypes } from '@internal/sql-contract/types';
 import type {
   Expression,
+  NoReservedRowColumn,
   RawAffectedCountQuery,
   RawRowQuery,
   RawSqlBuilder,
@@ -51,10 +52,15 @@ export type ContractRawSpecEntry<CT extends Record<string, { readonly output: un
   | { readonly codecId: keyof CT & string; readonly nullable?: boolean }
   | ContractColumnRef;
 
-/** A contract-bound row spec: result-column name to the codec that decodes it. */
+/**
+ * A contract-bound row spec: result-column name to the codec that decodes it.
+ * It inherits the target-agnostic spec's one reserved name, so `db.raw` refuses
+ * a `__proto__` column exactly where the contract-free tag does.
+ */
 export type ContractRawRowSpec<CT extends Record<string, { readonly output: unknown }>> = Readonly<
   Record<string, ContractRawSpecEntry<CT>>
->;
+> &
+  NoReservedRowColumn;
 
 type EntryScopeField<Entry> = Entry extends string
   ? { codecId: Entry; nullable: false }

--- a/packages/2-sql/4-lanes/sql-builder/test/runtime/raw-query.test.ts
+++ b/packages/2-sql/4-lanes/sql-builder/test/runtime/raw-query.test.ts
@@ -1,13 +1,15 @@
 import type { Contract as FrameworkContract } from '@internal/contract/types';
 import type { FamilyPackRef, TargetPackRef } from '@internal/framework-components/components';
-import type { SqlStorage } from '@internal/sql-contract/types';
+import { type SqlStorage, StorageTable } from '@internal/sql-contract/types';
 import { validateSqlContractFully } from '@internal/sql-contract/validators';
 import { defineContract } from '@internal/sql-contract-ts/contract-builder';
 import { type ParamRef, RawQueryAst } from '@internal/sql-relational-core/ast';
 import type { ExecutionContext } from '@internal/sql-relational-core/query-lane-context';
 import { describe, expect, it } from 'vitest';
 import { createTestSqlNamespace } from '../../../../1-core/contract/test/test-support';
+import type { BuilderContext } from '../../src/runtime/builder-base';
 import { sql } from '../../src/runtime/sql';
+import { TableProxyImpl } from '../../src/runtime/table-proxy-impl';
 import { contract as contractJson } from '../fixtures/contract';
 import type { Contract } from '../fixtures/generated/contract';
 
@@ -166,5 +168,46 @@ describe('reserved surface keys', () => {
         rawCodecInferer: { inferCodec: () => 'pg/text@1' },
       }),
     ).toThrow(expect.objectContaining({ code: 'ORM.NAMESPACE_RESERVED' }));
+  });
+});
+
+describe('storage column names that collide with object machinery', () => {
+  // A quoted SQL identifier may be anything, so storage can carry a column
+  // named `__proto__` — StorageTable keeps it as an own property, and the
+  // proxy has to report what storage states. The contract-builder DSL cannot
+  // express the name, so the getter is exercised against its own typed input.
+  const table = new StorageTable({
+    columns: Object.fromEntries([
+      ['id', { codecId: 'pg/text@1', nullable: false, nativeType: 'text' }],
+      ['__proto__', { codecId: 'pg/text@1', nullable: true, nativeType: 'text' }],
+    ]),
+    uniques: [],
+    indexes: [],
+    foreignKeys: [],
+  });
+
+  const proxy = () =>
+    new TableProxyImpl(
+      'Note',
+      table,
+      'Note',
+      { ...stubBase, storage: undefined } as unknown as BuilderContext,
+      'public',
+    );
+
+  it('reports a __proto__ column as an own property of the refs record', () => {
+    const columns = proxy().columns;
+    const byName = new Map(Object.entries(columns));
+
+    expect(Object.keys(columns)).toEqual(['id', '__proto__']);
+    expect(Object.hasOwn(columns, '__proto__')).toBe(true);
+    expect(byName.get('__proto__')).toEqual({ codecId: 'pg/text@1', nullable: true });
+  });
+
+  it('leaves the refs record frozen on the ordinary object prototype', () => {
+    const columns = proxy().columns;
+
+    expect(Object.getPrototypeOf(columns)).toBe(Object.prototype);
+    expect(Object.isFrozen(columns)).toBe(true);
   });
 });

--- a/packages/2-sql/4-lanes/sql-builder/test/types/raw-query.types.test-d.ts
+++ b/packages/2-sql/4-lanes/sql-builder/test/types/raw-query.types.test-d.ts
@@ -116,3 +116,17 @@ test('a column reference from the table proxy carries the contract codec id', ()
   expectTypeOf(users.columns.invited_by_id.nullable).toEqualTypeOf<true>();
   expectTypeOf(users.columns.id.nullable).toEqualTypeOf<false>();
 });
+
+test('a __proto__ column is rejected on the contract-typed tag too', () => {
+  // @ts-expect-error — a __proto__ key never survives as a row column
+  db.raw`SELECT 1 AS "__proto__"`.returnsRow({ __proto__: 'pg/int4@1' });
+});
+
+test('a constructor column cannot be declared against the contract codec map', () => {
+  // TypeScript contextually types a `constructor` key from `Object`, so the
+  // codec id widens to `string` and no longer matches a key of the codec map.
+  // The rejection is the compiler's, not a rule this surface imposes: the
+  // contract-free tag takes the same spec and carries the column through.
+  // @ts-expect-error — the codec id cannot stay literal under this key
+  db.raw`SELECT 1 AS "constructor"`.returnsRow({ constructor: 'pg/int4@1' });
+});

--- a/packages/2-sql/5-runtime/test/raw-query-decode.test.ts
+++ b/packages/2-sql/5-runtime/test/raw-query-decode.test.ts
@@ -97,3 +97,40 @@ describe('raw-query row decoding', () => {
     expect(decoded).toEqual({ affectedRows: 3 });
   });
 });
+
+describe('column names that collide with object machinery', () => {
+  const oddNamesAst = RawQueryAst.rows(['select 1 as "constructor"'], {
+    constructor: { codecId: 'test/int@1', nullable: false },
+  });
+
+  it('keys the alias list and codec map by the declared name', () => {
+    const ctx = buildDecodeContext(oddNamesAst, contractCodecs);
+
+    expect(ctx.aliases).toEqual(['constructor']);
+    expect(ctx.codecs.get('constructor')?.id).toBe('test/int@1');
+  });
+
+  it('decodes a constructor column into an own property of the row', async () => {
+    const decoded = await decodeRow(
+      { constructor: 4 },
+      buildDecodeContext(oddNamesAst, contractCodecs),
+      {},
+    );
+
+    expect(Object.hasOwn(decoded, 'constructor')).toBe(true);
+    expect(decoded['constructor']).toBe(40);
+  });
+
+  it('ignores a __proto__ column the result carries but the spec does not declare', async () => {
+    const wireRow = Object.fromEntries([
+      ['id', 4],
+      ['email', 'a@b.example'],
+      ['__proto__', { polluted: true }],
+    ]);
+
+    const decoded = await decodeRow(wireRow, buildDecodeContext(rowsAst, contractCodecs), {});
+
+    expect(decoded).toEqual({ id: 40, email: 'decoded:a@b.example' });
+    expect(Object.getPrototypeOf(decoded)).toBe(Object.prototype);
+  });
+});

--- a/test/integration/test/raw-query.integration.test.ts
+++ b/test/integration/test/raw-query.integration.test.ts
@@ -163,6 +163,28 @@ describe('integration: whole-query raw statements', { timeout: timeouts.database
     expect(rows).toEqual([{ invited_count: 2 }]);
   });
 
+  it('refuses a __proto__ column before the statement reaches the database', () => {
+    const spec: Record<string, string> = Object.fromEntries([['__proto__', 'pg/int4@1']]);
+
+    expect(() => rawSql()`SELECT 1 AS "__proto__"`.returnsRow(spec)).toThrow(
+      expect.objectContaining({
+        code: 'RUNTIME.AST_INVALID',
+        meta: expect.objectContaining({ column: '__proto__' }),
+      }),
+    );
+  });
+
+  it('round-trips a column named constructor', async () => {
+    const plan = rawSql()`SELECT id AS "constructor" FROM users WHERE id = ${1}`
+      .returnsRow({ constructor: 'pg/int4@1' })
+      .build();
+
+    const rows = await runtime.query(plan);
+
+    expect(rows).toEqual([{ constructor: 1 }]);
+    expect(Object.hasOwn(rows[0] as object, 'constructor')).toBe(true);
+  });
+
   it('raises RUNTIME.RAW_ROW_COLUMN_MISSING when the result omits a declared column', async () => {
     const plan = rawSql()`SELECT id FROM users WHERE id = ${1}`
       .returnsRow({ id: 'pg/int4@1', name: 'pg/text@1' })


### PR DESCRIPTION
# Prototype-polluting column names: round-trip or refuse, never vanish

Stacked on #30013 → #30011 → #30006 → #29997. Fifth PR of the stack.

A raw row spec (or result column) named `__proto__` silently vanished: bracket assignment onto a plain object literal hits the inherited setter, the key never becomes an own property, and the record is quietly re-parented. This PR sweeps the raw path so the name either round-trips faithfully or is refused loudly.

## The semantics, and why

- **Only `__proto__` is defective.** `constructor` and `prototype` create ordinary own properties and round-trip fine (pinned: `SELECT id AS "constructor"` decodes to `{ constructor: 1 }` as an own property).
- **A faithful `__proto__` round-trip is unpromisable**: TypeScript types the literal form (`{ __proto__: … }`) and the computed form identically, but JavaScript delivers the key to our code only in the computed form — and even a carried value is dropped by the first `Object.assign` copy downstream. So the raw path **refuses loudly**, at two composing levels:
  - **Type level** — the spec type's `__proto__` slot is a guidance string, so the compiler itself prints the remedy: *alias the column in SQL and declare the alias instead*. Runtime-assembled `Record<string, string>` specs deliberately remain reachable…
  - **Runtime** — …because `RawQueryAst` construction refuses the name with `RUNTIME.AST_INVALID` (existing code; its reference entry now enumerates this cause). `resolveRowSpec` assembles with `Object.fromEntries` so the key *arrives* to be refused rather than vanishing en route.
- **The table proxy's `columns` getter survives it instead** (same `Object.fromEntries` mechanism): the proxy reports what storage states — a `__proto__` column is a legal quoted identifier — and a surviving `users.columns['__proto__']` reference is precisely the escape hatch the refusal message instructs the author to use (alias in SQL, declare the alias). Refusing at both layers would have made that guidance unfollowable.

The decode context (array + Maps) and the adapters (parts-walking) were audited and are safe by construction. Everything tests-first; enforcement revert-checked (`TS2578` when the type guard is removed).

## Defect family, mapped while sweeping

- Raw specs + proxy getter: **fixed here**.
- Projection aliases + sibling column-keyed AST records: pre-existing, same shape, deliberately not annexed — TML-3208 (the universal fixes are real design decisions: null-prototype rows change every row's observable shape; per-row defineProperty taxes the hottest loop).
- The contract-builder DSL mangles a `__proto__` field name into `[object Object]` before any of this code sees it — found while writing the proxy test (which therefore constructs a real `StorageTable` directly, per the cannot-be-authored allowance): TML-3209.
- One benign quirk pinned truthfully: `db.raw` cannot declare a `constructor` *spec key* — TypeScript's contextual typing from `Object` widens the codec id (a consequence of the codec-id narrowing in #30011, documented by a negative test); the contract-free lane carries it fine.

Refs: TML-3202

https://claude.ai/code/session_01NnNjsNcPMtbJZhnZz5Zzbe


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Raw queries now reject `__proto__` result columns with a clear validation error and guidance to use an SQL alias.
  * Special column names such as `constructor` are preserved and handled safely across query building and result decoding.
  * Query results no longer risk prototype corruption from object-internal column names.

* **Documentation**
  * Updated the error reference with details about invalid `__proto__` result columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->