### PR TITLE
TML-3204: Closed-transaction guard pinned on both prepared bridges

### DIFF
--- a/packages/2-sql/5-runtime/test/prepared-closed-transaction.test.ts
+++ b/packages/2-sql/5-runtime/test/prepared-closed-transaction.test.ts
@@ -1,0 +1,153 @@
+import type { SqlDriver, SqlExecuteRequest } from '@internal/sql-relational-core/ast';
+import { RawQueryAst } from '@internal/sql-relational-core/ast';
+import type { AffectedCount } from '@internal/sql-relational-core/expression';
+import type { SqlQueryPlan } from '@internal/sql-relational-core/plan';
+import { planFromAst } from '@internal/sql-relational-core/plan';
+import { describe, expect, it, vi } from 'vitest';
+import type { RuntimeQueryable } from '../src/sql-runtime';
+import { withTransaction } from '../src/sql-runtime';
+import {
+  createStubAdapter,
+  createTestContext,
+  createTestContract,
+  createTestRuntime,
+  createTestStackInstance,
+} from './utils';
+
+/**
+ * The transaction facade invalidates its context once the callback returns,
+ * and every operation on it refuses afterwards. These pin the refusal on the
+ * two prepared-statement bridges, which reach the driver by a different route
+ * than `tx.query` / `tx.execute` and so need their own guard.
+ */
+
+const contract = createTestContract({ storageHash: 'prepared-closed-transaction' });
+
+function createRecordingDriver(): { driver: SqlDriver; driverCalls: SqlExecuteRequest[] } {
+  const driverCalls: SqlExecuteRequest[] = [];
+
+  const record = (request: SqlExecuteRequest): void => {
+    driverCalls.push(request);
+  };
+
+  const transaction = {
+    query: vi.fn().mockImplementation(async function* (request: SqlExecuteRequest) {
+      record(request);
+      yield { id: 1, email: 'a@b.example' };
+    }),
+    execute: vi.fn().mockImplementation(async (request: SqlExecuteRequest) => {
+      record(request);
+      return { affectedRows: 1 };
+    }),
+    commit: vi.fn().mockResolvedValue(undefined),
+    rollback: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const connection = {
+    query: vi.fn().mockImplementation(async function* (request: SqlExecuteRequest) {
+      record(request);
+      yield { id: 1, email: 'a@b.example' };
+    }),
+    execute: vi.fn().mockImplementation(async (request: SqlExecuteRequest) => {
+      record(request);
+      return { affectedRows: 1 };
+    }),
+    release: vi.fn().mockResolvedValue(undefined),
+    destroy: vi.fn().mockResolvedValue(undefined),
+    beginTransaction: vi.fn().mockResolvedValue(transaction),
+  };
+
+  const driver: SqlDriver = {
+    query: vi.fn().mockImplementation(async function* (request: SqlExecuteRequest) {
+      record(request);
+      yield { id: 1, email: 'a@b.example' };
+    }),
+    execute: vi.fn().mockImplementation(async (request: SqlExecuteRequest) => {
+      record(request);
+      return { affectedRows: 1 };
+    }),
+    connect: vi.fn().mockResolvedValue(undefined),
+    acquireConnection: vi.fn().mockResolvedValue(connection),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+
+  return { driver, driverCalls };
+}
+
+function setup() {
+  const { driver, driverCalls } = createRecordingDriver();
+  const runtime = createTestRuntime({
+    stackInstance: createTestStackInstance(),
+    context: createTestContext(contract, createStubAdapter()),
+    driver,
+    verifyMarker: false,
+  });
+
+  return { runtime, driverCalls };
+}
+
+function rowsPlan(): SqlQueryPlan<{ id: unknown; email: unknown }> {
+  return planFromAst(
+    RawQueryAst.rows(['select id, email from "user"'], {
+      id: { codecId: 'pg/int4@1', nullable: false },
+      email: { codecId: 'pg/text@1', nullable: false },
+    }),
+    contract,
+  );
+}
+
+function affectedCountPlan(): SqlQueryPlan<AffectedCount> {
+  return planFromAst(RawQueryAst.affectedCount(['update "user" set seen = now()']), contract);
+}
+
+/**
+ * Runs a transaction that ends the way `ending` names, and hands back the
+ * context it left behind.
+ */
+async function endedTransaction(
+  runtime: Parameters<typeof withTransaction>[0],
+  ending: 'commit' | 'rollback',
+): Promise<RuntimeQueryable> {
+  let escaped: RuntimeQueryable | undefined;
+
+  const run = withTransaction(runtime, async (tx) => {
+    escaped = tx;
+    if (ending === 'rollback') throw new Error('callback failed');
+  });
+
+  if (ending === 'rollback') {
+    await expect(run).rejects.toThrow('callback failed');
+  } else {
+    await run;
+  }
+
+  if (!escaped) throw new Error('the callback never ran');
+  return escaped;
+}
+
+describe.each(['commit', 'rollback'] as const)(
+  'prepared statements against a transaction ended by %s',
+  (ending) => {
+    it('refuses to query and leaves the driver alone', async () => {
+      const { runtime, driverCalls } = setup();
+      const prepared = await runtime.prepare({}, () => rowsPlan());
+      const tx = await endedTransaction(runtime, ending);
+
+      expect(() => prepared.query(tx, {})).toThrow(
+        expect.objectContaining({ code: 'RUNTIME.TRANSACTION_CLOSED' }),
+      );
+      expect(driverCalls).toEqual([]);
+    });
+
+    it('refuses to execute and leaves the driver alone', async () => {
+      const { runtime, driverCalls } = setup();
+      const prepared = await runtime.prepare({}, () => affectedCountPlan());
+      const tx = await endedTransaction(runtime, ending);
+
+      expect(() => prepared.execute(tx, {})).toThrow(
+        expect.objectContaining({ code: 'RUNTIME.TRANSACTION_CLOSED' }),
+      );
+      expect(driverCalls).toEqual([]);
+    });
+  },
+);


### PR DESCRIPTION
# Closed-transaction guard pinned on both prepared bridges

Stacked on #30014 → #30013 → #30011 → #30006 → #29997. Sixth and final PR of the stack.

The guarded transaction facade refuses prepared consumption after the transaction ends — on both bridges (`prepared.query`, `prepared.execute`) — but neither guard had a test. This PR is that test: four cases ({query, execute} × {commit, rollback}), each asserting `RUNTIME.TRANSACTION_CLOSED` **and** that nothing reached the driver by any route (one recorder shared across the root, connection, and transaction levels).

Test-only; no production code touched. Points verified in review:

- The test drives the *guarded* facade (the `withTransaction` context carrying `invalidated`), not the unguarded `wrapTransaction` sibling — the easy mistake that would have made four green tests assert nothing.
- The guard is ending-indifferent (`invalidated` sets in the callback's `finally` before commit/rollback runs); the 2×2 pins that as held fact rather than implementation trivia.
- Red-first discrimination: with the two bridge guards locally suppressed, all four cases fail; the suppressed state is provably not in the commit.

One observation recorded and ticketed (TML-3210): the execute bridge throws synchronously despite declaring `Promise<SqlStatementStats>` — these tests deliberately pin that shape with `toThrow`, and the ticket explains the pin for whoever trips it.

Refs: TML-3204

https://claude.ai/code/session_01NnNjsNcPMtbJZhnZz5Zzbe


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for prepared queries and execute operations attempted after a transaction is committed or rolled back.
  * Verified these operations return the appropriate transaction-closed error and do not invoke the database driver.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->