### PR TITLE
TML-3201: Turbo typecheck depends on the package's own build

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -38,8 +38,13 @@
       "outputs": ["coverage/**"],
       "env": ["TEST_TIMEOUT_MULTIPLIER"]
     },
+    // `build` as well as `^build`: several packages import their own published
+    // subpaths (e.g. `@internal/extension-pgvector/pack`), which resolve into
+    // their own dist. Without the self-edge those typechecks read whatever dist
+    // happens to be on disk — TS2307 when it is absent, a stale cache replay
+    // when it is not.
     "typecheck": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "build"],
       "inputs": ["src/**", "test/**", "tsconfig.json"]
     },
     "lint": {


### PR DESCRIPTION
# Turbo typecheck depends on the package's own build

Main-based cleanup, one line in `turbo.json`.

## The defect — worse than the ticket knew

The ticket blamed cold-cache races. The truth: `typecheck` had `dependsOn: ["^build"]` (dependencies' builds) but never the package's **own** `build` — yet several packages import their own published subpaths (e.g. `@internal/extension-pgvector/pack` from inside pgvector's own `test/**`), which resolve through their own `dist/`. Two consequences, both deterministic:

- **False reds** when anything had just removed or regenerated a `dist` (fresh checkouts, `fixtures:emit`) — the recurring `TS2307 Cannot find module '@internal/…'` that cost a recent campaign a dozen spurious re-runs.
- **False greens**, the graver half: `dist/**` is not among typecheck's inputs, so deleting a package's own dist changes no hash — turbo replays a cached exit 0 over a dist that does not exist (reproduced: `FULL TURBO` pass with the directory absent; `--force` on the same state fails).

## The fix and its cost

`"typecheck": { "dependsOn": ["^build", "build"] }`. The own-build hash now participates and turbo restores outputs before replaying — both failure modes close.

Measured cost: **+3 tasks** (leaf packages only — `^build` already covered every non-leaf), warm no-op unchanged within noise (242ms → 225ms, both FULL TURbo), full-run delta inside run-to-run variance. No lighter edge exists: `build` is a single tsdown invocation emitting `.mjs` + `.d.mts` together, with no split dts task to depend on instead.

## Surfaced, ticketed, deliberately not annexed

- **TML-3212** — `test` has the identical missing self-edge; `turbo.json` carries four per-package overrides that are this defect worked around by hand four times. (Different consequence: `test.inputs` includes `dist/**`, so it fails loudly rather than false-greening — the general fix is owed, at lower severity.)
- **TML-3213** — `integration-tests` imports `@prisma/orm-postgres`/`orm-mongo` declared in no dependency list; a manifest defect no turbo edge can fix, and the third `TS2307` class from the campaign.

Refs: TML-3201

https://claude.ai/code/session_01NnNjsNcPMtbJZhnZz5Zzbe


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build and type-check task sequencing to ensure package-local builds are completed when needed.
  * Added documentation clarifying build requirements for internal package paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->