### PR TITLE
init emits through the project-local prisma-cli binary

### DIFF
--- a/packages/1-framework/3-tooling/cli/src/orm/init-emit.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/init-emit.ts
@@ -1,27 +1,117 @@
-import { join } from 'pathe';
+import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'pathe';
+import { redactSecrets } from '../commands/init/redact-secrets';
+
+const STDERR_TAIL_LINES = 20;
 
 /**
- * Emits the contract for the project `init` has just scaffolded.
- *
- * The config file is the one this run wrote, so it is read here rather than
- * through `needs.config`: `init` runs where no config exists yet, and the
- * engine loads a section before the handler starts. The emitter and the config
- * loader are imported at execution time so a run that skips the install — and
- * therefore skips the emit — never pays for either.
+ * Test-only seam for the manifest resolution, mirroring probe-db's
+ * `requireFromBaseDir`: vitest wraps `createRequire` so resolution never
+ * fails under test even when the project has no `@prisma/cli` installed.
+ * Production callers omit it.
  */
-export async function emitScaffoldedContract(ctx: { readonly cwd: string }): Promise<void> {
-  const { executeContractEmit } = await import('../control-api/operations/contract-emit');
-  const { loadConfigForSections } = await import('@internal/config-loader');
-  const configPath = join(ctx.cwd, 'prisma.config.ts');
-  const loaded = await loadConfigForSections(configPath, [
-    'contract',
-    'family',
-    'target',
-    'adapter',
-    'extensions',
-  ]);
-  if (!loaded.ok) {
-    throw loaded.failure;
+export interface EmitOverrides {
+  readonly resolveFromBaseDir?: (baseDir: string, specifier: string) => string;
+}
+
+/**
+ * Emits the contract for the project `init` has just scaffolded, by spawning
+ * the project-local `prisma-cli` binary the install step put into
+ * `node_modules`. That binary and the installed `defineConfig` come from the
+ * same registry release, so the config loader that evaluates
+ * `prisma.config.ts` always matches the config format it was written
+ * with — running the emit in-process would evaluate the project's config with
+ * this (possibly newer) CLI's loader instead. Child output is captured, never
+ * inherited, so `--json` envelopes on stdout stay parseable.
+ */
+export async function emitScaffoldedContract(
+  ctx: { readonly cwd: string },
+  overrides: EmitOverrides = {},
+): Promise<void> {
+  const binPath = resolveProjectBin(ctx.cwd, overrides);
+  const result = await runCaptured(process.execPath, [binPath, 'contract', 'emit'], ctx.cwd);
+  if (result.exitCode !== 0) {
+    const output = result.stderr.trim().length > 0 ? result.stderr : result.stdout;
+    const cause =
+      result.exitCode === null
+        ? `was killed by signal ${result.signal ?? 'unknown'}`
+        : `exited with code ${result.exitCode}`;
+    throw new Error(`\`prisma-cli contract emit\` ${cause}: ${redactSecrets(tail(output))}`);
   }
-  await executeContractEmit({ config: loaded.value, cwd: ctx.cwd, configPath });
+}
+
+function resolveProjectBin(cwd: string, overrides: EmitOverrides): string {
+  const resolveFromBaseDir =
+    overrides.resolveFromBaseDir ??
+    ((baseDir: string, specifier: string) =>
+      createRequire(join(baseDir, 'package.json')).resolve(specifier));
+  let manifestPath: string;
+  try {
+    manifestPath = resolveFromBaseDir(cwd, '@prisma/cli/package.json');
+  } catch (error) {
+    throw new Error(
+      `\`@prisma/cli\` is not installed in this project (resolved from ${cwd}; cause: ${causeMessage(error)})`,
+    );
+  }
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+  } catch (error) {
+    throw new Error(
+      `the installed @prisma/cli manifest at ${manifestPath} is not valid JSON: ${causeMessage(error)}`,
+    );
+  }
+  const bin =
+    manifest !== null && typeof manifest === 'object' ? Reflect.get(manifest, 'bin') : undefined;
+  const binEntry =
+    typeof bin === 'string'
+      ? bin
+      : bin !== null && typeof bin === 'object'
+        ? Reflect.get(bin, 'prisma-cli')
+        : undefined;
+  if (typeof binEntry !== 'string') {
+    throw new Error(
+      `the installed @prisma/cli package at ${dirname(manifestPath)} declares no \`prisma-cli\` bin`,
+    );
+  }
+  return join(dirname(manifestPath), binEntry);
+}
+
+function runCaptured(
+  file: string,
+  args: readonly string[],
+  cwd: string,
+): Promise<{
+  readonly exitCode: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(file, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf-8');
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf-8');
+    });
+    child.on('error', (error) => {
+      reject(new Error(`could not run the project-local prisma-cli binary: ${error.message}`));
+    });
+    child.on('close', (code, signal) => {
+      resolve({ exitCode: code, signal, stdout, stderr });
+    });
+  });
+}
+
+function tail(text: string): string {
+  return text.trim().split('\n').slice(-STDERR_TAIL_LINES).join('\n');
+}
+
+function causeMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/1-framework/3-tooling/cli/src/orm/init-inputs.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/init-inputs.ts
@@ -110,8 +110,10 @@ async function askAuthoring(prompt: PromptSurface): Promise<AuthoringId> {
  * style.
  */
 async function askSchemaPath(prompt: PromptSurface, authoring: AuthoringId): Promise<string> {
+  const fallback = defaultSchemaPath(authoring);
   const answer = await prompt.text('Where should the schema file go?', {
-    default: defaultSchemaPath(authoring),
+    placeholder: fallback,
+    default: fallback,
   });
   return validateSchemaPath(answer, authoring);
 }

--- a/packages/1-framework/3-tooling/cli/test/orm/init-emit.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/orm/init-emit.test.ts
@@ -1,0 +1,216 @@
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { timeouts } from '@repo/test-utils';
+import { join } from 'pathe';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { emitScaffoldedContract } from '../../src/orm/init-emit';
+
+let projectDir: string;
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), 'init-emit-subprocess-'));
+  writeFileSync(
+    join(projectDir, 'package.json'),
+    JSON.stringify({ name: 'scaffolded-app', private: true, type: 'module' }),
+  );
+});
+
+afterEach(() => {
+  rmSync(projectDir, { recursive: true, force: true });
+});
+
+/**
+ * Installs a fake `@prisma/cli` package into the project's `node_modules`,
+ * with a bin entry pointing at the given script — the shape the registry
+ * package has, without the registry.
+ */
+function installFakePrismaCli(
+  binSource: string,
+  bin: string | Record<string, string> = { 'prisma-cli': './bin/prisma-cli.mjs' },
+): void {
+  const packageDir = join(projectDir, 'node_modules/@prisma/cli');
+  mkdirSync(join(packageDir, 'bin'), { recursive: true });
+  writeFileSync(
+    join(packageDir, 'package.json'),
+    JSON.stringify({
+      name: '@prisma/cli',
+      version: '0.0.0-test',
+      type: 'module',
+      bin,
+    }),
+  );
+  writeFileSync(join(packageDir, 'bin/prisma-cli.mjs'), binSource);
+}
+
+async function emitFailure(): Promise<Error> {
+  try {
+    await emitScaffoldedContract({ cwd: projectDir });
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error);
+    return error as Error;
+  }
+  throw new Error('emitScaffoldedContract resolved, expected it to reject');
+}
+
+describe('emitScaffoldedContract', () => {
+  it(
+    'runs the project-local prisma-cli bin with `contract emit` in the project directory',
+    async () => {
+      installFakePrismaCli(
+        [
+          "import { writeFileSync } from 'node:fs';",
+          "writeFileSync('emit-invocation.json', JSON.stringify({ argv: process.argv.slice(2), cwd: process.cwd() }));",
+          '',
+        ].join('\n'),
+      );
+
+      await emitScaffoldedContract({ cwd: projectDir });
+
+      const invocation = JSON.parse(
+        readFileSync(join(projectDir, 'emit-invocation.json'), 'utf-8'),
+      ) as { argv: string[]; cwd: string };
+      expect(invocation.argv).toEqual(['contract', 'emit']);
+      expect(realpathSync(invocation.cwd)).toBe(realpathSync(projectDir));
+    },
+    timeouts.databaseOperation,
+  );
+
+  it(
+    'throws the tail of the child stderr, redacted, when the child exits non-zero',
+    async () => {
+      const lines = Array.from({ length: 40 }, (_, i) => `line-${String(i).padStart(2, '0')}`);
+      installFakePrismaCli(
+        [
+          `for (const line of ${JSON.stringify(lines)}) process.stderr.write(line + '\\n');`,
+          "process.stderr.write('could not reach https://alice:hunter2@registry.example.com/\\n');",
+          'process.exit(3);',
+          '',
+        ].join('\n'),
+      );
+
+      const error = await emitFailure();
+
+      expect(error.message).toContain('line-39');
+      expect(error.message).not.toContain('line-00');
+      expect(error.message).toContain('***@registry.example.com');
+      expect(error.message).not.toContain('hunter2');
+      expect(error.message).toContain('3');
+    },
+    timeouts.databaseOperation,
+  );
+
+  it(
+    'falls back to the child stdout when stderr carried nothing',
+    async () => {
+      installFakePrismaCli(
+        [
+          "process.stdout.write('emit blew up, reported on stdout\\n');",
+          'process.exit(1);',
+          '',
+        ].join('\n'),
+      );
+
+      const error = await emitFailure();
+
+      expect(error.message).toContain('emit blew up, reported on stdout');
+    },
+    timeouts.databaseOperation,
+  );
+
+  it(
+    'accepts a string-form bin field',
+    async () => {
+      installFakePrismaCli(
+        [
+          "import { writeFileSync } from 'node:fs';",
+          "writeFileSync('emit-invocation.json', JSON.stringify({ argv: process.argv.slice(2) }));",
+          '',
+        ].join('\n'),
+        './bin/prisma-cli.mjs',
+      );
+
+      await emitScaffoldedContract({ cwd: projectDir });
+
+      const invocation = JSON.parse(
+        readFileSync(join(projectDir, 'emit-invocation.json'), 'utf-8'),
+      ) as { argv: string[] };
+      expect(invocation.argv).toEqual(['contract', 'emit']);
+    },
+    timeouts.databaseOperation,
+  );
+
+  it(
+    'names the signal when the child is killed instead of exiting',
+    async () => {
+      installFakePrismaCli("process.kill(process.pid, 'SIGKILL');\n");
+
+      const error = await emitFailure();
+
+      expect(error.message).toContain('SIGKILL');
+    },
+    timeouts.databaseOperation,
+  );
+
+  it(
+    'names the manifest path when the installed manifest is not valid JSON',
+    async () => {
+      // Real resolution already rejects a corrupt package.json ("Invalid
+      // package config"), so the parse branch is reached via the seam, which
+      // hands back the corrupt manifest path directly.
+      const manifestPath = join(projectDir, 'package.json');
+      writeFileSync(manifestPath, '{ not json');
+
+      const error = await emitScaffoldedContract(
+        { cwd: projectDir },
+        { resolveFromBaseDir: () => manifestPath },
+      ).catch((thrown: unknown) => thrown);
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain(manifestPath);
+      expect((error as Error).message).toMatch(/not valid JSON/);
+    },
+    timeouts.databaseOperation,
+  );
+
+  it(
+    'reports that @prisma/cli is not installed when resolution fails',
+    async () => {
+      // vitest wraps `createRequire` and resolves the workspace @prisma/cli
+      // package from any directory, so a genuinely missing install cannot be
+      // produced with real resolution here — the seam stands in for the
+      // MODULE_NOT_FOUND a real Node process raises.
+      const error = await emitScaffoldedContract(
+        { cwd: projectDir },
+        {
+          resolveFromBaseDir: () => {
+            throw new Error("Cannot find module '@prisma/cli/package.json'");
+          },
+        },
+      ).catch((thrown: unknown) => thrown);
+
+      expect(error).toBeInstanceOf(Error);
+      const message = (error as Error).message;
+      expect(message).toMatch(/`@prisma\/cli` is not installed/);
+      expect(message).toContain(projectDir);
+      expect(message).toContain("Cannot find module '@prisma/cli/package.json'");
+    },
+    timeouts.databaseOperation,
+  );
+
+  it(
+    'reports an installed @prisma/cli that declares no bin',
+    async () => {
+      const packageDir = join(projectDir, 'node_modules/@prisma/cli');
+      mkdirSync(packageDir, { recursive: true });
+      writeFileSync(
+        join(packageDir, 'package.json'),
+        JSON.stringify({ name: '@prisma/cli', version: '0.0.0-test' }),
+      );
+
+      const error = await emitFailure();
+
+      expect(error.message).toMatch(/declares no `prisma-cli` bin/);
+    },
+    timeouts.databaseOperation,
+  );
+});

--- a/packages/1-framework/3-tooling/cli/test/orm/init-inputs.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/orm/init-inputs.test.ts
@@ -1,0 +1,85 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import type { PromptSurface } from '@prisma/cli-engine';
+import { join } from 'pathe';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { type InitFlagValues, resolveInitInputs } from '../../src/orm/init-inputs';
+
+let projectDir: string;
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), 'orm-init-inputs-'));
+});
+
+afterEach(() => {
+  rmSync(projectDir, { recursive: true, force: true });
+});
+
+function flags(overrides: Partial<InitFlagValues> = {}): InitFlagValues {
+  return {
+    target: 'postgres',
+    authoring: 'psl',
+    schemaPath: undefined,
+    writeEnv: true,
+    probeDb: false,
+    strictProbe: false,
+    skipInstall: true,
+    skipSkills: true,
+    keepPreviousFacade: false,
+    ...overrides,
+  };
+}
+
+interface TextCall {
+  readonly question: string;
+  readonly opts: { readonly placeholder?: string; readonly default?: string } | undefined;
+}
+
+function recordingPrompt(): { readonly prompt: PromptSurface; readonly textCalls: TextCall[] } {
+  const textCalls: TextCall[] = [];
+  const prompt: PromptSurface = {
+    confirm: async () => false,
+    consent: async () => false,
+    select: async () => {
+      throw new Error('unexpected select prompt');
+    },
+    text: async (question, opts) => {
+      textCalls.push({ question, opts });
+      return opts?.default ?? '';
+    },
+    browserWait: async () => undefined,
+  };
+  return { prompt, textCalls };
+}
+
+describe('the schema-path prompt', () => {
+  it('passes the default schema path as both placeholder and default', async () => {
+    const { prompt, textCalls } = recordingPrompt();
+
+    const inputs = await resolveInitInputs({ cwd: projectDir, flags: flags(), prompt });
+
+    expect(textCalls).toEqual([
+      {
+        question: 'Where should the schema file go?',
+        opts: { placeholder: 'src/prisma/contract.prisma', default: 'src/prisma/contract.prisma' },
+      },
+    ]);
+    expect(inputs.schemaPath).toBe('src/prisma/contract.prisma');
+  });
+
+  it('offers the TypeScript default under typescript authoring', async () => {
+    const { prompt, textCalls } = recordingPrompt();
+
+    const inputs = await resolveInitInputs({
+      cwd: projectDir,
+      flags: flags({ authoring: 'typescript' }),
+      prompt,
+    });
+
+    expect(textCalls[0]?.opts).toEqual({
+      placeholder: 'src/prisma/contract.ts',
+      default: 'src/prisma/contract.ts',
+    });
+    expect(inputs.schemaPath).toBe('src/prisma/contract.ts');
+  });
+});

--- a/packages/1-framework/3-tooling/cli/test/orm/init-scaffold.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/orm/init-scaffold.test.ts
@@ -38,6 +38,26 @@ function scaffoldArgv(...extra: string[]): string[] {
 
 const SKIP_ALL = ['--skip-install', '--skip-skills'] as const;
 
+/**
+ * The emit step spawns the project-local `@prisma/cli` bin, which the mocked
+ * package-manager runner never installs — seed a no-op stand-in for runs that
+ * do not pass `--skip-install`.
+ */
+function installFakeProjectLocalCli(dir: string): void {
+  const packageDir = join(dir, 'node_modules/@prisma/cli');
+  mkdirSync(join(packageDir, 'bin'), { recursive: true });
+  writeFileSync(
+    join(packageDir, 'package.json'),
+    JSON.stringify({
+      name: '@prisma/cli',
+      version: '0.0.0-test',
+      type: 'module',
+      bin: { 'prisma-cli': './bin/prisma-cli.mjs' },
+    }),
+  );
+  writeFileSync(join(packageDir, 'bin/prisma-cli.mjs'), '');
+}
+
 function envelopeOf(run: { readonly json: readonly { readonly kind: string }[] }) {
   const terminal = run.json.at(-1);
   return terminal !== undefined && terminal.kind === 'result'
@@ -211,6 +231,7 @@ describe('init scaffold', () => {
           `${JSON.stringify({ name: 'app', devDependencies: { '@types/node': '^18' } }, null, 2)}\n`,
           'utf-8',
         );
+        installFakeProjectLocalCli(projectDir);
 
         const run = await harness().run(scaffoldArgv('--skip-skills'), { cwd: projectDir });
 

--- a/test/e2e/framework/test/init-emit-subprocess.test.ts
+++ b/test/e2e/framework/test/init-emit-subprocess.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Pins the init emit invariant end to end: the shipped bin's `init` command
+ * emits the scaffolded contract by spawning the *project-local* `@prisma/cli`
+ * bin as a child process in the scaffold directory — never by loading the
+ * project's config in-process with the running CLI's own loader. A revert to
+ * in-process emit makes the fake project-local bin unnecessary, so its
+ * sentinel file never appears and this suite fails.
+ *
+ * The project's `node_modules/@prisma/cli` is a fake package whose
+ * `prisma-cli` bin records its argv and cwd; the package-manager install step
+ * is satisfied by a PATH shim `npm` that exits 0, so `init` reaches the emit
+ * step without the network.
+ */
+
+import { execFile } from 'node:child_process';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { timeouts } from '@repo/test-utils';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI_BIN = resolve(__dirname, '../../../../packages/1-framework/3-tooling/cli/dist/bin.mjs');
+
+let projectDir: string;
+let shimDir: string;
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), 'pn-init-emit-e2e-'));
+  writeFileSync(
+    join(projectDir, 'package.json'),
+    JSON.stringify({ name: 'init-emit-e2e-app', version: '0.0.0', private: true, type: 'module' }),
+  );
+  // A lockfile makes package-manager detection choose npm, which the PATH
+  // shim below intercepts — the install step "succeeds" without the network.
+  writeFileSync(
+    join(projectDir, 'package-lock.json'),
+    JSON.stringify({ name: 'init-emit-e2e-app', lockfileVersion: 3 }),
+  );
+  shimDir = join(projectDir, '.pm-shims');
+  mkdirSync(shimDir, { recursive: true });
+  const npmShim = join(shimDir, 'npm');
+  writeFileSync(npmShim, '#!/bin/sh\nexit 0\n');
+  chmodSync(npmShim, 0o755);
+});
+
+afterEach(() => {
+  rmSync(projectDir, { recursive: true, force: true });
+});
+
+function installFakePrismaCli(binSource: string): void {
+  const packageDir = join(projectDir, 'node_modules', '@prisma', 'cli');
+  mkdirSync(join(packageDir, 'bin'), { recursive: true });
+  writeFileSync(
+    join(packageDir, 'package.json'),
+    JSON.stringify({
+      name: '@prisma/cli',
+      version: '0.0.0-test',
+      type: 'module',
+      bin: { 'prisma-cli': './bin/prisma-cli.mjs' },
+    }),
+  );
+  writeFileSync(join(packageDir, 'bin/prisma-cli.mjs'), binSource);
+}
+
+interface InitRun {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+async function runInit(): Promise<InitRun> {
+  const env = {
+    ...process.env,
+    PATH: `${shimDir}${delimiter}${process.env['PATH'] ?? ''}`,
+    DO_NOT_TRACK: '1',
+  };
+  const argv = [
+    CLI_BIN,
+    'init',
+    '--target',
+    'postgres',
+    '--authoring',
+    'psl',
+    '--schema-path',
+    'prisma/contract.prisma',
+    '--yes',
+    '--skip-skills',
+    '--json',
+  ];
+  try {
+    const { stdout, stderr } = await execFileAsync('node', argv, { cwd: projectDir, env });
+    return { exitCode: 0, stdout, stderr };
+  } catch (error) {
+    const failed = error as { code?: number; stdout?: string; stderr?: string };
+    if (typeof failed.code !== 'number') {
+      throw error;
+    }
+    return { exitCode: failed.code, stdout: failed.stdout ?? '', stderr: failed.stderr ?? '' };
+  }
+}
+
+/** The terminal frame of the bin's json stream — one NDJSON object per line. */
+function settledFrame(stdout: string): unknown {
+  const lines = stdout.split('\n').filter((line) => line.trim() !== '');
+  const last = lines.at(-1);
+  expect(last, `no json frames on stdout:\n${stdout}`).toBeDefined();
+  return JSON.parse(last ?? '');
+}
+
+describe('init emit through the project-local prisma-cli bin (process e2e)', () => {
+  it(
+    'runs node_modules/@prisma/cli with `contract emit` as a child process in the scaffold directory',
+    async () => {
+      installFakePrismaCli(
+        [
+          "import { writeFileSync } from 'node:fs';",
+          "writeFileSync('emit-invocation.json', JSON.stringify({ argv: process.argv.slice(2), script: process.argv[1], cwd: process.cwd(), pid: process.pid }));",
+          '',
+        ].join('\n'),
+      );
+
+      const run = await runInit();
+
+      expect(run.exitCode, `stdout:\n${run.stdout}\nstderr:\n${run.stderr}`).toBe(0);
+      const invocation = JSON.parse(
+        readFileSync(join(projectDir, 'emit-invocation.json'), 'utf-8'),
+      ) as { argv: string[]; script: string; cwd: string };
+      expect(invocation.argv).toEqual(['contract', 'emit']);
+      expect(realpathSync(invocation.cwd)).toBe(realpathSync(projectDir));
+      expect(realpathSync(invocation.script)).toBe(
+        realpathSync(join(projectDir, 'node_modules', '@prisma', 'cli', 'bin', 'prisma-cli.mjs')),
+      );
+      expect(JSON.stringify(settledFrame(run.stdout))).toContain('"contractEmitted":true');
+    },
+    timeouts.spinUpDbServer,
+  );
+
+  it(
+    'surfaces the failing child bin stderr tail in the CLI.INIT_EMIT_FAILED diagnostic',
+    async () => {
+      installFakePrismaCli(
+        [
+          "process.stderr.write('emit-e2e-marker: scaffolded emit exploded\\n');",
+          'process.exit(3);',
+          '',
+        ].join('\n'),
+      );
+
+      const run = await runInit();
+
+      expect(run.exitCode, `stdout:\n${run.stdout}\nstderr:\n${run.stderr}`).toBe(5);
+      const frame = JSON.stringify(settledFrame(run.stdout));
+      expect(frame).toContain('CLI.INIT_EMIT_FAILED');
+      expect(frame).toContain('emit-e2e-marker: scaffolded emit exploded');
+      expect(frame).toContain('exited with code 3');
+    },
+    timeouts.spinUpDbServer,
+  );
+});


### PR DESCRIPTION
## Linked issue

n/a — operator bug report (no ticket). `npx @prisma/cli@next init` fails at the emit step on a freshly scaffolded project.

## At a glance

```
▸ Emit the contract
✘ Emit the contract
✘ [CLI.INIT_EMIT_FAILED] Failed to emit contract
  why: `prisma-next contract emit` failed: Config is not a defineConfig result
```

That is what every `init` run against the published packages produced (reproduced with `@prisma/cli@8.0.0-rc.2` on 2026-08-13). With this PR, the emit step runs the scaffolded project's own CLI, and the same scenario completes with `contractEmitted: true`.

## Decision

`init`'s contract-emit step now runs the **project-local `@prisma/cli` binary** that `init` itself just installed, as a captured subprocess — instead of loading the scaffolded config in-process with the running CLI's bundled config-loader. Two smaller fixes ride along:

1. The schema-path prompt shows its default as placeholder text (previously the prompt looked blank until a keypress).
2. `init`'s failure message for a failed emit now carries the redacted tail of the child's stderr, so the real cause is visible.

## How it fits together

1. The scaffolded config's `defineConfig` imports come from the packages `init` installs from the registry (`@prisma/cli-engine` for the outer config, the ORM facade for the `orm` section). Since #29936, `defineConfig` stamps a config-format version marker and the config loader rejects configs without it.
2. `init` used to evaluate that config **in-process**, so the marker was checked by the *running CLI's* bundled loader against a marker stamped by the *project's installed* `defineConfig`. Any skew between the two turns a perfectly good scaffold into `CONFIG.VERSION_MARKER_MISSING`. The skew is real: npm's `@prisma/cli@8.0.0-rc.1` was built five days after (and from a much newer commit than) the `8.0.0-rc.1` ORM packages, so the CLI checked a marker the installed `defineConfig` never wrote.
3. [init-emit.ts](packages/1-framework/3-tooling/cli/src/orm/init-emit.ts) now resolves the scaffolded project's `@prisma/cli` package with `createRequire` from the scaffold directory (same pattern as the `--probe-db` driver resolution), reads its `prisma-cli` bin entry, and spawns `process.execPath <bin> contract emit` in the project. Loader and `defineConfig` now always come from the same installed release, so the marker check cannot skew.
4. Prompt fix: [init-inputs.ts](packages/1-framework/3-tooling/cli/src/orm/init-inputs.ts) passes `placeholder` alongside `default`, so the engine renders the default as ghost text and an empty submit accepts it.

## Reviewer notes

- Child stdio is captured (`['ignore','pipe','pipe']`), never inherited, so `--json` envelopes on stdout stay parseable; the child is spawned on `process.execPath` with the resolved bin script (no `node_modules/.bin` shims, Windows-safe), and failure text passes through `redactSecrets` before entering the structured error (connection strings can appear in emit output).
- Resolving via the `@prisma/cli` package manifest (not `.bin`) keeps the resolution unambiguous regardless of what bins other installed packages declare.
- `emitScaffoldedContract` gained an optional test-only `resolveFromBaseDir` seam: vitest wraps `createRequire` so registry-resolution failures cannot be produced under the runner (a plain `node` process fails correctly). Same precedent as `probe-db.ts`'s `requireFromBaseDir`.
- A side effect worth knowing: the scaffolded project's module graph (dotenv, target package, driver) no longer executes inside the CLI process. This also removes the lingering-handle behaviour observed in the original report, where the CLI did not exit after the failed emit.
- Deliberately out of scope: pinning the scaffold's dependency versions to the CLI's baked version (the outer `@prisma/cli` reuses version strings across different builds, so a pin can resolve to the wrong artifact), any change to the marker-check semantics, and the publish-cadence skew between `@prisma/cli` and this repo's packages (different repo; that skew is what shipped the bug).

## Testing performed

- Package gates in `packages/1-framework/3-tooling/cli`: `pnpm typecheck`, `pnpm test`, `pnpm build`, `pnpm lint`; repo-root `pnpm lint:deps`; e2e workspace `pnpm typecheck` + full `pnpm test` (21 files, 115 tests).
- New unit tests: [init-emit.test.ts](packages/1-framework/3-tooling/cli/test/orm/init-emit.test.ts) (spawn args/cwd against a fixture project with a fake `@prisma/cli`, stderr-tail + redaction on failure, stdout fallback, signal-kill message, not-installed, no-bin, string-form bin, corrupt manifest) and [init-inputs.test.ts](packages/1-framework/3-tooling/cli/test/orm/init-inputs.test.ts) (placeholder + default).
- **E2E regression proof**: [init-emit-subprocess.test.ts](test/e2e/framework/test/init-emit-subprocess.test.ts) runs the real built CLI's `init` in a temp project pre-seeded with a fake project-local `@prisma/cli` whose bin records its invocation. It asserts the emit ran the project-local bin (`contract emit`, correct cwd, `contractEmitted: true`) and that a failing child surfaces `CLI.INIT_EMIT_FAILED` with the child's stderr and exit code. Reverting to in-process emit makes both cases fail (verified by simulating the revert).
- Manual end-to-end: ran the built CLI's `init --target postgres --authoring typescript` in a fresh directory against the **published** registry packages (the exact failing scenario) — exit 0, `contractEmitted: true`, clean process exit.

## Skill update

n/a — no user-facing surface changes (same commands, flags, and error codes; the emit step's failure text now carries the child's stderr tail).

## Alternatives considered

- **Pin the installed packages to the CLI's own version.** Rejected: the outer `@prisma/cli` is published from a different repo and has reused the `8.0.0-rc.1` version string for a build five days newer than this repo's `8.0.0-rc.1` packages, so a pin derived from the baked version can resolve to the wrong (older) artifact and reintroduce the same failure.
- **Relax the version-marker check.** Rejected: a config stamped by a pre-marker `defineConfig` is indistinguishable from a plain object or a classic-Prisma config, which is exactly what the check exists to reject.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco). The DCO status check will block merge if any commit is missing a `Signed-off-by:` trailer.
- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and the change is scoped to one logical concern.
- [x] Tests are updated (or `n/a` if the change is doc-only / refactor with no behavioural delta).
- [ ] The PR title is in `TML-NNNN: <sentence-case title>` form — no Linear ticket exists for this operator-reported bug; title is descriptive instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ORM initialization now runs contract generation using the project’s local Prisma CLI.
  * Improved diagnostics report actionable details when contract generation fails.
  * Schema prompts now show authoring-specific default paths.

* **Bug Fixes**
  * Improved handling of CLI output, errors, exit codes, signals, and credential redaction.

* **Tests**
  * Added coverage for successful generation, failures, schema defaults, and local CLI setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->