### PR TITLE
Publishes notify prisma-cli so the CLI repins and ships a dev build automatically

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -243,7 +243,7 @@ jobs:
             echo "PRISMA_CLI_DISPATCH_PAT is not configured; skipping (the daily backstop covers this)."
             exit 0
           fi
-          curl -sf -X POST \
+          curl -sSf --connect-timeout 10 --max-time 30 -X POST \
             -H "Authorization: Bearer $DISPATCH_PAT" \
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/prisma/prisma-cli/dispatches \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -225,3 +225,26 @@ jobs:
               --notes-file "docs/releases/v$VERSION.md" \
               $PRERELEASE_FLAG
           fi
+
+      # Tell prisma-cli a family package shipped, so its auto-repin
+      # workflow can open the repin PR that deploys a dev CLI carrying
+      # this publish (prisma-cli docs/oss/versioning.md, operator ruling
+      # 2026-08-13). Guarded on the PAT and never fails the publish: the
+      # repin has a daily scheduled backstop in prisma-cli, so a missed
+      # dispatch delays it by at most a day.
+      - name: Notify prisma-cli
+        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.dry-run != 'true' }}
+        continue-on-error: true
+        env:
+          DISPATCH_PAT: ${{ secrets.PRISMA_CLI_DISPATCH_PAT }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if [ -z "$DISPATCH_PAT" ]; then
+            echo "PRISMA_CLI_DISPATCH_PAT is not configured; skipping (the daily backstop covers this)."
+            exit 0
+          fi
+          curl -sf -X POST \
+            -H "Authorization: Bearer $DISPATCH_PAT" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/prisma/prisma-cli/dispatches \
+            -d "{\"event_type\":\"family-published\",\"client_payload\":{\"repo\":\"prisma/prisma\",\"version\":\"$VERSION\"}}"


### PR DESCRIPTION
One workflow step. After a real publish, send a `repository_dispatch` (`family-published`) to prisma-cli, whose auto-repin workflow opens an auto-merge repin PR that deploys a `dev` version of the consolidated CLI — per the operator's 2026-08-13 ruling recorded in prisma-cli's ADR 0004 and `docs/oss/versioning.md`.

Guarded on the `PRISMA_CLI_DISPATCH_PAT` secret (skips with a log line when unset) and `continue-on-error`, so it can never fail a publish. prisma-cli runs the same repin daily as a backstop, so a missed dispatch delays the repin by at most a day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic notifications after successful, non-dry-run publishes.
  * Notifications include the published version and are skipped when notification credentials are unavailable.
  * Publishing continues normally if notification delivery fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->