### PR TITLE
TML-3215: Init test harness installs the fiction init now depends on

### DIFF
--- a/test/integration/test/cli.init-skill-distribution.integration.test.ts
+++ b/test/integration/test/cli.init-skill-distribution.integration.test.ts
@@ -166,6 +166,8 @@ function integrationTempRoot(): string {
  * binary, not a re-implementation. So the harness replaces `pnpm` on
  * `PATH` with a Node script that:
  *   - logs every invocation (for assertions on the install URL form)
+ *   - leaves behind the part of the "installed" project that init reads next
+ *     (a stub `@prisma/cli` with a `prisma-cli` bin — see the shim body)
  *   - forwards `pnpm dlx skills@latest add <args>` to the workspace's
  *     `node_modules/.bin/skills` invoked from the consumer's cwd.
  */
@@ -180,6 +182,7 @@ function createFakeDlxHarness(testDir: string): {
     join(fakeBinDir, 'pnpm'),
     `#!/usr/bin/env node
 import fs from 'node:fs';
+import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 
 const args = process.argv.slice(2);
@@ -187,10 +190,35 @@ const cwd = process.cwd();
 const logPath = process.env.TEST_FAKE_DLX_LOG;
 
 if (args[0] === 'add' || args[0] === 'install' || args[0] === 'prisma-next') {
+  if (args[0] !== 'prisma-next') {
+    materializePrismaCliStub(cwd);
+  }
   if (logPath) {
     fs.appendFileSync(logPath, JSON.stringify({ cwd, args, status: 0 }) + '\\n', 'utf8');
   }
   process.exit(0);
+}
+
+/**
+ * The shim reports a successful install without fetching anything, so the
+ * project it leaves behind has to contain what \`init\` reads next: init emits
+ * by spawning the project-local \`prisma-cli\` binary it resolves through
+ * \`@prisma/cli/package.json\`. Without this stub the emit step fails, init
+ * settles at exit 5, and the skill install this file is about never runs.
+ *
+ * The binary only has to exit 0 — no assertion here reads the emitted
+ * contract, and the emit path itself is covered by the CLI's own unit tests
+ * and by test/e2e/framework/test/init-emit-subprocess.test.ts.
+ */
+function materializePrismaCliStub(projectDir) {
+  const packageDir = path.join(projectDir, 'node_modules', '@prisma', 'cli');
+  fs.mkdirSync(packageDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(packageDir, 'package.json'),
+    JSON.stringify({ name: '@prisma/cli', version: '0.0.0-test', bin: { 'prisma-cli': 'bin.mjs' } }),
+    'utf8',
+  );
+  fs.writeFileSync(path.join(packageDir, 'bin.mjs'), 'process.exit(0);\\n', 'utf8');
 }
 
 if (args[0] === 'dlx' && (args[1] === 'skills' || args[1] === 'skills@latest') && args[2] === 'add') {


### PR DESCRIPTION
# Init test harness installs the fiction init now depends on

**Every non-inert PR currently fails Integration Tests.** #30018 made `init` emit through the project-local `@prisma/cli` binary — but `cli.init-skill-distribution.integration.test.ts`'s offline harness fakes `pnpm add`/`install` as recorded no-ops, so the package is never present and no environment can resolve it (`@prisma/cli` has zero entries in `pnpm-lock.yaml`). Init exits **5** ("scaffold written and installed; contract emit failed"), `settle(5)` returns before the skill-install block, and both of the test's cases fail (`expected 5 to be +0`; `expected [] to have a length of 3`). Reproduced byte-identically on pristine main.

Docs-only PRs appear green because the inert-diff detector skips the job's steps — which is why this hid behind seemingly-passing PRs.

## The fix

The harness's fiction now includes what init reads next: when the fake `pnpm` handles `add`/`install`, it materialises a stub `node_modules/@prisma/cli/` in the consumer cwd — a `package.json` (`bin: { "prisma-cli": "bin.mjs" }`, deliberately **no `exports` field** so the resolver's `@prisma/cli/package.json` specifier resolves) and a `bin.mjs` that exits 0. The `prisma-next` shim arm is excluded — only `add`/`install` claim to have installed something, so only they owe the fiction.

The stub does nothing beyond exiting 0 because no assertion in this file reads emitted output; the emit path itself is covered where it belongs — the CLI unit tests and `init-emit-subprocess.test.ts` that #30018 added. This test stays about skill distribution.

Both previously-failing cases pass (run twice for stability). The harness (`createFakeDlxHarness`) is used by this file only, so no other test is perturbed.

## Merge order note

This wants to land ahead of open feature branches' rebases — they stay red until they carry it, and nothing on them can fix it.

Refs: TML-3215

https://claude.ai/code/session_01NnNjsNcPMtbJZhnZz5Zzbe


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test coverage for skill initialization and distribution workflows.
  * Updated simulated package installation scenarios so initialization completes successfully during automated validation.
  * Added coverage to distinguish supported package variants and ensure expected behavior across installation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->