### PR TITLE
Adopt @prisma/cli-engine 0.1.1, the engine's first independently versioned line

### DIFF
--- a/packages/1-framework/3-tooling/cli/package.json
+++ b/packages/1-framework/3-tooling/cli/package.json
@@ -53,7 +53,7 @@
     "@internal/sql-contract-ts": "workspace:8.0.0-rc.1",
     "@internal/sql-operations": "workspace:8.0.0-rc.1",
     "@internal/sql-runtime": "workspace:8.0.0-rc.1",
-    "@prisma/cli-engine": "0.0.9",
+    "@prisma/cli-engine": "0.1.0",
     "@repo/test-utils": "workspace:8.0.0-rc.1",
     "@repo/tsconfig": "workspace:8.0.0-rc.1",
     "@repo/tsdown": "workspace:8.0.0-rc.1",
@@ -63,7 +63,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@prisma/cli-engine": "0.0.9",
+    "@prisma/cli-engine": "0.1.0",
     "typescript": ">=5.9"
   },
   "peerDependenciesMeta": {

--- a/packages/1-framework/3-tooling/cli/package.json
+++ b/packages/1-framework/3-tooling/cli/package.json
@@ -53,7 +53,7 @@
     "@internal/sql-contract-ts": "workspace:8.0.0-rc.1",
     "@internal/sql-operations": "workspace:8.0.0-rc.1",
     "@internal/sql-runtime": "workspace:8.0.0-rc.1",
-    "@prisma/cli-engine": "0.1.0",
+    "@prisma/cli-engine": "0.1.1",
     "@repo/test-utils": "workspace:8.0.0-rc.1",
     "@repo/tsconfig": "workspace:8.0.0-rc.1",
     "@repo/tsdown": "workspace:8.0.0-rc.1",
@@ -63,7 +63,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@prisma/cli-engine": "0.1.0",
+    "@prisma/cli-engine": "0.1.1",
     "typescript": ">=5.9"
   },
   "peerDependenciesMeta": {

--- a/packages/1-framework/3-tooling/cli/src/orm/cli.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/cli.ts
@@ -4,7 +4,6 @@ import { createCli, telemetryCommandGroup } from '@prisma/cli-engine';
 import { version as CLI_VERSION } from '../../package.json' with { type: 'json' };
 import { createControlClient } from '../control-api/client';
 import type { CreateControlClient } from '../control-api/types';
-import { isCI } from '../utils/is-ci';
 import { contractEmitCommand } from './contract/emit';
 import { contractInferCommand } from './contract/infer';
 import { createDbInitCommand } from './db/init';
@@ -122,8 +121,20 @@ export function createOrmCli(): Cli {
  * Everything environmental the engine is given, adapted from the host process
  * once. The engine owns signal policy; the bin is dumb wiring.
  */
+/** Bun and Deno both announce themselves in process.versions; nothing
+ *  else does, so an absent marker means Node. */
+function describeHost(proc: HostProcess): Runtime['host'] {
+  const name = (['bun', 'deno'] as const).find((candidate) => proc.versions[candidate]) ?? 'node';
+  return {
+    runtime: { name, version: proc.versions[name] ?? proc.version },
+    platform: proc.platform,
+    arch: proc.arch,
+  };
+}
+
 export function runtimeFromProcess(proc: HostProcess): Runtime {
   return {
+    host: describeHost(proc),
     stdout: { write: (text) => void proc.stdout.write(text) },
     // The terminal width the drawings get to use, read once with everything
     // else the runtime carries.
@@ -140,7 +151,6 @@ export function runtimeFromProcess(proc: HostProcess): Runtime {
       stdout: proc.stdout.isTTY === true,
       stderr: proc.stderr.isTTY === true,
     },
-    isCI: isCI(),
     exit: (code) => proc.exit(code),
     onSignal: (callback) => {
       const onInterrupt = () => callback('SIGINT');

--- a/packages/1-framework/3-tooling/cli/test/orm/cli.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/orm/cli.test.ts
@@ -187,6 +187,10 @@ function processWithUnreadableCwd(stderr: string[]): HostProcess {
   return {
     argv: ['node', 'prisma-next', 'migration', 'list'],
     env: {},
+    version: 'v24.0.0',
+    versions: { node: '24.0.0' },
+    platform: 'linux',
+    arch: 'x64',
     cwd: () => {
       throw new Error('ENOENT: uv_cwd');
     },

--- a/packages/1-framework/3-tooling/cli/test/orm/contract-emit.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/orm/contract-emit.test.ts
@@ -181,10 +181,15 @@ describe('contract emit', () => {
     });
   });
 
-  it('writes the emitted paths to stdout and the prose to stderr', async () => {
-    const run = await harness().run(['contract', 'emit'], {
+  it('writes the emitted paths to a piped stdout and the prose to stderr', async () => {
+    // Engine 0.1.0's output model: a piped stdout defaults the format
+    // to json (sniffFormat), and both-streams-TTY human suppresses the
+    // stdout mirror to avoid drawing twice on one screen. The scenario
+    // this test pins — human prose on stderr, machine lines on a piped
+    // stdout — is now the explicit `--format human` pipe case.
+    const run = await harness().run(['contract', 'emit', '--format', 'human'], {
       cwd: PROJECT_DIR,
-      isTty: { stdout: true, stderr: true },
+      isTty: { stderr: true },
     });
 
     expect(run.presented?.presentation.stdout).toEqual([

--- a/packages/3-extensions/paradedb/package.json
+++ b/packages/3-extensions/paradedb/package.json
@@ -35,7 +35,7 @@
     "@internal/operations": "workspace:8.0.0-rc.1",
     "@internal/sql-contract-ts": "workspace:8.0.0-rc.1",
     "@internal/target-postgres": "workspace:8.0.0-rc.1",
-    "@prisma/cli-engine": "0.0.9",
+    "@prisma/cli-engine": "0.1.0",
     "@repo/test-utils": "workspace:8.0.0-rc.1",
     "@repo/tsconfig": "workspace:8.0.0-rc.1",
     "@repo/tsdown": "workspace:8.0.0-rc.1",

--- a/packages/3-extensions/paradedb/package.json
+++ b/packages/3-extensions/paradedb/package.json
@@ -35,7 +35,7 @@
     "@internal/operations": "workspace:8.0.0-rc.1",
     "@internal/sql-contract-ts": "workspace:8.0.0-rc.1",
     "@internal/target-postgres": "workspace:8.0.0-rc.1",
-    "@prisma/cli-engine": "0.1.0",
+    "@prisma/cli-engine": "0.1.1",
     "@repo/test-utils": "workspace:8.0.0-rc.1",
     "@repo/tsconfig": "workspace:8.0.0-rc.1",
     "@repo/tsdown": "workspace:8.0.0-rc.1",

--- a/packages/3-extensions/pgvector/package.json
+++ b/packages/3-extensions/pgvector/package.json
@@ -40,7 +40,7 @@
     "@internal/postgres": "workspace:8.0.0-rc.1",
     "@internal/postgres-codec-testkit": "workspace:8.0.0-rc.1",
     "@internal/sql-contract-ts": "workspace:8.0.0-rc.1",
-    "@prisma/cli-engine": "0.1.0",
+    "@prisma/cli-engine": "0.1.1",
     "@repo/test-utils": "workspace:8.0.0-rc.1",
     "@repo/tsconfig": "workspace:8.0.0-rc.1",
     "@repo/tsdown": "workspace:8.0.0-rc.1",

--- a/packages/3-extensions/pgvector/package.json
+++ b/packages/3-extensions/pgvector/package.json
@@ -40,7 +40,7 @@
     "@internal/postgres": "workspace:8.0.0-rc.1",
     "@internal/postgres-codec-testkit": "workspace:8.0.0-rc.1",
     "@internal/sql-contract-ts": "workspace:8.0.0-rc.1",
-    "@prisma/cli-engine": "0.0.9",
+    "@prisma/cli-engine": "0.1.0",
     "@repo/test-utils": "workspace:8.0.0-rc.1",
     "@repo/tsconfig": "workspace:8.0.0-rc.1",
     "@repo/tsdown": "workspace:8.0.0-rc.1",

--- a/packages/3-extensions/postgis/package.json
+++ b/packages/3-extensions/postgis/package.json
@@ -38,7 +38,7 @@
     "@internal/operations": "workspace:8.0.0-rc.1",
     "@internal/postgres": "workspace:8.0.0-rc.1",
     "@internal/sql-contract-ts": "workspace:8.0.0-rc.1",
-    "@prisma/cli-engine": "0.1.0",
+    "@prisma/cli-engine": "0.1.1",
     "@repo/test-utils": "workspace:8.0.0-rc.1",
     "@repo/tsconfig": "workspace:8.0.0-rc.1",
     "@repo/tsdown": "workspace:8.0.0-rc.1",

--- a/packages/3-extensions/postgis/package.json
+++ b/packages/3-extensions/postgis/package.json
@@ -38,7 +38,7 @@
     "@internal/operations": "workspace:8.0.0-rc.1",
     "@internal/postgres": "workspace:8.0.0-rc.1",
     "@internal/sql-contract-ts": "workspace:8.0.0-rc.1",
-    "@prisma/cli-engine": "0.0.9",
+    "@prisma/cli-engine": "0.1.0",
     "@repo/test-utils": "workspace:8.0.0-rc.1",
     "@repo/tsconfig": "workspace:8.0.0-rc.1",
     "@repo/tsdown": "workspace:8.0.0-rc.1",

--- a/packages/3-extensions/supabase/package.json
+++ b/packages/3-extensions/supabase/package.json
@@ -48,7 +48,7 @@
     "@internal/operations": "workspace:8.0.0-rc.1",
     "@internal/psl-printer": "workspace:8.0.0-rc.1",
     "@internal/sql-contract-psl": "workspace:8.0.0-rc.1",
-    "@prisma/cli-engine": "0.0.9",
+    "@prisma/cli-engine": "0.1.0",
     "@repo/test-utils": "workspace:8.0.0-rc.1",
     "@repo/tsconfig": "workspace:8.0.0-rc.1",
     "@repo/tsdown": "workspace:8.0.0-rc.1",

--- a/packages/3-extensions/supabase/package.json
+++ b/packages/3-extensions/supabase/package.json
@@ -48,7 +48,7 @@
     "@internal/operations": "workspace:8.0.0-rc.1",
     "@internal/psl-printer": "workspace:8.0.0-rc.1",
     "@internal/sql-contract-psl": "workspace:8.0.0-rc.1",
-    "@prisma/cli-engine": "0.1.0",
+    "@prisma/cli-engine": "0.1.1",
     "@repo/test-utils": "workspace:8.0.0-rc.1",
     "@repo/tsconfig": "workspace:8.0.0-rc.1",
     "@repo/tsdown": "workspace:8.0.0-rc.1",

--- a/packages/9-public/@prisma/orm-toolchain/package.json
+++ b/packages/9-public/@prisma/orm-toolchain/package.json
@@ -48,7 +48,7 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "@prisma/cli-engine": "0.0.9",
+    "@prisma/cli-engine": "0.1.0",
     "typescript": ">=5.9",
     "vite": "^7.0.0 || ^8.0.0"
   },

--- a/packages/9-public/@prisma/orm-toolchain/package.json
+++ b/packages/9-public/@prisma/orm-toolchain/package.json
@@ -48,7 +48,7 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "@prisma/cli-engine": "0.1.0",
+    "@prisma/cli-engine": "0.1.1",
     "typescript": ">=5.9",
     "vite": "^7.0.0 || ^8.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1349,8 +1349,8 @@ importers:
         specifier: workspace:8.0.0-rc.1
         version: link:../../../2-sql/5-runtime
       '@prisma/cli-engine':
-        specifier: 0.0.9
-        version: 0.0.9(magicast@0.5.3)
+        specifier: 0.1.0
+        version: 0.1.0(magicast@0.5.3)
       '@repo/test-utils':
         specifier: workspace:8.0.0-rc.1
         version: link:../../../../test/utils
@@ -3037,8 +3037,8 @@ importers:
         specifier: workspace:8.0.0-rc.1
         version: link:../../3-targets/3-targets/postgres
       '@prisma/cli-engine':
-        specifier: 0.0.9
-        version: 0.0.9(magicast@0.5.3)
+        specifier: 0.1.0
+        version: 0.1.0(magicast@0.5.3)
       '@repo/test-utils':
         specifier: workspace:8.0.0-rc.1
         version: link:../../../test/utils
@@ -3125,8 +3125,8 @@ importers:
         specifier: workspace:8.0.0-rc.1
         version: link:../../2-sql/2-authoring/contract-ts
       '@prisma/cli-engine':
-        specifier: 0.0.9
-        version: 0.0.9(magicast@0.5.3)
+        specifier: 0.1.0
+        version: 0.1.0(magicast@0.5.3)
       '@repo/test-utils':
         specifier: workspace:8.0.0-rc.1
         version: link:../../../test/utils
@@ -3207,8 +3207,8 @@ importers:
         specifier: workspace:8.0.0-rc.1
         version: link:../../2-sql/2-authoring/contract-ts
       '@prisma/cli-engine':
-        specifier: 0.0.9
-        version: 0.0.9(magicast@0.5.3)
+        specifier: 0.1.0
+        version: 0.1.0(magicast@0.5.3)
       '@repo/test-utils':
         specifier: workspace:8.0.0-rc.1
         version: link:../../../test/utils
@@ -3556,8 +3556,8 @@ importers:
         specifier: workspace:8.0.0-rc.1
         version: link:../../2-sql/2-authoring/contract-psl
       '@prisma/cli-engine':
-        specifier: 0.0.9
-        version: 0.0.9(magicast@0.5.3)
+        specifier: 0.1.0
+        version: 0.1.0(magicast@0.5.3)
       '@repo/test-utils':
         specifier: workspace:8.0.0-rc.1
         version: link:../../../test/utils
@@ -5040,8 +5040,8 @@ importers:
   packages/9-public/@prisma/orm-toolchain:
     dependencies:
       '@prisma/cli-engine':
-        specifier: 0.0.9
-        version: 0.0.9(magicast@0.5.3)
+        specifier: 0.1.0
+        version: 0.1.0(magicast@0.5.3)
       '@prisma/orm-framework':
         specifier: workspace:8.0.0-rc.1
         version: link:../orm-framework
@@ -5180,8 +5180,8 @@ importers:
   test/e2e/framework/test/fixtures:
     dependencies:
       '@prisma/cli-engine':
-        specifier: 0.0.9
-        version: 0.0.9(magicast@0.5.3)
+        specifier: 0.1.0
+        version: 0.1.0(magicast@0.5.3)
       '@prisma/orm-extension-arktype-json':
         specifier: workspace:8.0.0-rc.1
         version: link:../../../../../packages/9-public/@prisma/orm-extension-arktype-json
@@ -5198,8 +5198,8 @@ importers:
   test/e2e/framework/test/sqlite/fixtures:
     dependencies:
       '@prisma/cli-engine':
-        specifier: 0.0.9
-        version: 0.0.9(magicast@0.5.3)
+        specifier: 0.1.0
+        version: 0.1.0(magicast@0.5.3)
       '@prisma/orm-sqlite':
         specifier: workspace:8.0.0-rc.1
         version: link:../../../../../../packages/9-public/@prisma/orm-sqlite
@@ -5364,8 +5364,8 @@ importers:
         specifier: workspace:8.0.0-rc.1
         version: link:../../packages/2-mongo-family/6-transport/mongo-lowering
       '@prisma/cli-engine':
-        specifier: 0.0.9
-        version: 0.0.9(magicast@0.5.3)
+        specifier: 0.1.0
+        version: 0.1.0(magicast@0.5.3)
       '@repo/test-utils':
         specifier: workspace:8.0.0-rc.1
         version: link:../utils
@@ -5472,8 +5472,8 @@ importers:
         specifier: workspace:8.0.0-rc.1
         version: link:../../../../../../packages/1-framework/0-foundation/utils
       '@prisma/cli-engine':
-        specifier: 0.0.9
-        version: 0.0.9(magicast@0.5.3)
+        specifier: 0.1.0
+        version: 0.1.0(magicast@0.5.3)
       '@prisma/orm-extension-pgvector':
         specifier: workspace:8.0.0-rc.1
         version: link:../../../../../../packages/9-public/@prisma/orm-extension-pgvector
@@ -5547,8 +5547,8 @@ importers:
         specifier: workspace:8.0.0-rc.1
         version: link:../../../../../../packages/1-framework/0-foundation/utils
       '@prisma/cli-engine':
-        specifier: 0.0.9
-        version: 0.0.9(magicast@0.5.3)
+        specifier: 0.1.0
+        version: 0.1.0(magicast@0.5.3)
       '@prisma/orm-extension-pgvector':
         specifier: workspace:8.0.0-rc.1
         version: link:../../../../../../packages/9-public/@prisma/orm-extension-pgvector
@@ -7209,6 +7209,10 @@ packages:
 
   '@prisma/cli-engine@0.0.9':
     resolution: {integrity: sha512-OiAolWJBhgwVXJ+0aJ9uERplJkxXsKNaUSaUXNDYGvdEoq5c0365OZbGMH5fTmFpqPlPv7MwZga3WkN6ldQyjQ==}
+    engines: {node: '>=22.12.0'}
+
+  '@prisma/cli-engine@0.1.0':
+    resolution: {integrity: sha512-ZbusMHsOOnaXELmLqG7uSgdYdXZdjPbRb4N88HrrBTfoVkrR6vr0cqcZ91xjC8piWstWPZ6bainlfNrd51hpsQ==}
     engines: {node: '>=22.12.0'}
 
   '@prisma/compute-sdk@0.38.0':
@@ -12593,6 +12597,19 @@ snapshots:
       '@prisma/management-api-sdk': 1.55.0
       '@stricli/core': 1.3.0
       c12: 3.3.4(magicast@0.5.3)
+      colorette: 2.0.20
+      package-manager-detector: 1.8.0
+      string-width: 8.2.2
+    transitivePeerDependencies:
+      - magicast
+
+  '@prisma/cli-engine@0.1.0(magicast@0.5.3)':
+    dependencies:
+      '@clack/prompts': 1.5.0
+      '@prisma/management-api-sdk': 1.55.0
+      '@stricli/core': 1.3.0
+      c12: 3.3.4(magicast@0.5.3)
+      ci-info: 4.4.0
       colorette: 2.0.20
       package-manager-detector: 1.8.0
       string-width: 8.2.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1349,8 +1349,8 @@ importers:
         specifier: workspace:8.0.0-rc.1
         version: link:../../../2-sql/5-runtime
       '@prisma/cli-engine':
-        specifier: 0.1.0
-        version: 0.1.0(magicast@0.5.3)
+        specifier: 0.1.1
+        version: 0.1.1(magicast@0.5.3)
       '@repo/test-utils':
         specifier: workspace:8.0.0-rc.1
         version: link:../../../../test/utils
@@ -3037,8 +3037,8 @@ importers:
         specifier: workspace:8.0.0-rc.1
         version: link:../../3-targets/3-targets/postgres
       '@prisma/cli-engine':
-        specifier: 0.1.0
-        version: 0.1.0(magicast@0.5.3)
+        specifier: 0.1.1
+        version: 0.1.1(magicast@0.5.3)
       '@repo/test-utils':
         specifier: workspace:8.0.0-rc.1
         version: link:../../../test/utils
@@ -3125,8 +3125,8 @@ importers:
         specifier: workspace:8.0.0-rc.1
         version: link:../../2-sql/2-authoring/contract-ts
       '@prisma/cli-engine':
-        specifier: 0.1.0
-        version: 0.1.0(magicast@0.5.3)
+        specifier: 0.1.1
+        version: 0.1.1(magicast@0.5.3)
       '@repo/test-utils':
         specifier: workspace:8.0.0-rc.1
         version: link:../../../test/utils
@@ -3207,8 +3207,8 @@ importers:
         specifier: workspace:8.0.0-rc.1
         version: link:../../2-sql/2-authoring/contract-ts
       '@prisma/cli-engine':
-        specifier: 0.1.0
-        version: 0.1.0(magicast@0.5.3)
+        specifier: 0.1.1
+        version: 0.1.1(magicast@0.5.3)
       '@repo/test-utils':
         specifier: workspace:8.0.0-rc.1
         version: link:../../../test/utils
@@ -3556,8 +3556,8 @@ importers:
         specifier: workspace:8.0.0-rc.1
         version: link:../../2-sql/2-authoring/contract-psl
       '@prisma/cli-engine':
-        specifier: 0.1.0
-        version: 0.1.0(magicast@0.5.3)
+        specifier: 0.1.1
+        version: 0.1.1(magicast@0.5.3)
       '@repo/test-utils':
         specifier: workspace:8.0.0-rc.1
         version: link:../../../test/utils
@@ -5040,8 +5040,8 @@ importers:
   packages/9-public/@prisma/orm-toolchain:
     dependencies:
       '@prisma/cli-engine':
-        specifier: 0.1.0
-        version: 0.1.0(magicast@0.5.3)
+        specifier: 0.1.1
+        version: 0.1.1(magicast@0.5.3)
       '@prisma/orm-framework':
         specifier: workspace:8.0.0-rc.1
         version: link:../orm-framework
@@ -5180,8 +5180,8 @@ importers:
   test/e2e/framework/test/fixtures:
     dependencies:
       '@prisma/cli-engine':
-        specifier: 0.1.0
-        version: 0.1.0(magicast@0.5.3)
+        specifier: 0.1.1
+        version: 0.1.1(magicast@0.5.3)
       '@prisma/orm-extension-arktype-json':
         specifier: workspace:8.0.0-rc.1
         version: link:../../../../../packages/9-public/@prisma/orm-extension-arktype-json
@@ -5198,8 +5198,8 @@ importers:
   test/e2e/framework/test/sqlite/fixtures:
     dependencies:
       '@prisma/cli-engine':
-        specifier: 0.1.0
-        version: 0.1.0(magicast@0.5.3)
+        specifier: 0.1.1
+        version: 0.1.1(magicast@0.5.3)
       '@prisma/orm-sqlite':
         specifier: workspace:8.0.0-rc.1
         version: link:../../../../../../packages/9-public/@prisma/orm-sqlite
@@ -5364,8 +5364,8 @@ importers:
         specifier: workspace:8.0.0-rc.1
         version: link:../../packages/2-mongo-family/6-transport/mongo-lowering
       '@prisma/cli-engine':
-        specifier: 0.1.0
-        version: 0.1.0(magicast@0.5.3)
+        specifier: 0.1.1
+        version: 0.1.1(magicast@0.5.3)
       '@repo/test-utils':
         specifier: workspace:8.0.0-rc.1
         version: link:../utils
@@ -5472,8 +5472,8 @@ importers:
         specifier: workspace:8.0.0-rc.1
         version: link:../../../../../../packages/1-framework/0-foundation/utils
       '@prisma/cli-engine':
-        specifier: 0.1.0
-        version: 0.1.0(magicast@0.5.3)
+        specifier: 0.1.1
+        version: 0.1.1(magicast@0.5.3)
       '@prisma/orm-extension-pgvector':
         specifier: workspace:8.0.0-rc.1
         version: link:../../../../../../packages/9-public/@prisma/orm-extension-pgvector
@@ -5547,8 +5547,8 @@ importers:
         specifier: workspace:8.0.0-rc.1
         version: link:../../../../../../packages/1-framework/0-foundation/utils
       '@prisma/cli-engine':
-        specifier: 0.1.0
-        version: 0.1.0(magicast@0.5.3)
+        specifier: 0.1.1
+        version: 0.1.1(magicast@0.5.3)
       '@prisma/orm-extension-pgvector':
         specifier: workspace:8.0.0-rc.1
         version: link:../../../../../../packages/9-public/@prisma/orm-extension-pgvector
@@ -7211,8 +7211,8 @@ packages:
     resolution: {integrity: sha512-OiAolWJBhgwVXJ+0aJ9uERplJkxXsKNaUSaUXNDYGvdEoq5c0365OZbGMH5fTmFpqPlPv7MwZga3WkN6ldQyjQ==}
     engines: {node: '>=22.12.0'}
 
-  '@prisma/cli-engine@0.1.0':
-    resolution: {integrity: sha512-ZbusMHsOOnaXELmLqG7uSgdYdXZdjPbRb4N88HrrBTfoVkrR6vr0cqcZ91xjC8piWstWPZ6bainlfNrd51hpsQ==}
+  '@prisma/cli-engine@0.1.1':
+    resolution: {integrity: sha512-2W3a4MEpXhjYbDl+TjXsf6/B1auoQ+TCsTgRUN0IpO+qnWqVzEqo00uzkIx6xkL9FcBVNwJGOihLjQG3S5Gtgg==}
     engines: {node: '>=22.12.0'}
 
   '@prisma/compute-sdk@0.38.0':
@@ -12603,13 +12603,12 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@prisma/cli-engine@0.1.0(magicast@0.5.3)':
+  '@prisma/cli-engine@0.1.1(magicast@0.5.3)':
     dependencies:
       '@clack/prompts': 1.5.0
       '@prisma/management-api-sdk': 1.55.0
       '@stricli/core': 1.3.0
       c12: 3.3.4(magicast@0.5.3)
-      ci-info: 4.4.0
       colorette: 2.0.20
       package-manager-detector: 1.8.0
       string-width: 8.2.2

--- a/skills/prisma-8-extension-upgrade/upgrades/8.0.0-rc.1-to-8.0.0-rc.2/instructions.md
+++ b/skills/prisma-8-extension-upgrade/upgrades/8.0.0-rc.1-to-8.0.0-rc.2/instructions.md
@@ -340,6 +340,19 @@ changes:
         - "ExtractCodecTypes<TContract> & CodecTypesBase"
         - "CodecTypesBase ="
       anyMatch: true
+  - id: cli-engine-moves-to-0-1-1
+    summary: |
+      `@prisma/cli-engine` now versions independently of the CLI's release line and has moved
+      to `0.1.1` (it was `0.0.9` while it versioned in lockstep). An extension only sees this
+      if it writes a `prisma.config.ts`, which imports `defineConfig` from the engine: bump the
+      `@prisma/cli-engine` devDependency to `0.1.1`. No API an extension uses changed —
+      `defineConfig` is as it was. 0.1.1 fixes the engine reading ci-info's vendor table at
+      runtime, which broke config evaluation under Bun in any process that also loaded ci-info.
+    detection:
+      glob: "**/package.json"
+      contains:
+        - "@prisma/cli-engine"
+      anyMatch: true
 ---
 
 # 8.0.0-rc.1 → 8.0.0-rc.2 — Extension-author upgrade instructions

--- a/test/e2e/framework/test/fixtures/package.json
+++ b/test/e2e/framework/test/fixtures/package.json
@@ -5,7 +5,7 @@
   "version": "8.0.0-rc.1",
   "description": "The Postgres fixture of the e2e suite. Its own manifest because emission reads the nearest one to decide which package names generated files import, and this suite exercises two databases whose halves must not name each other's facade.",
   "dependencies": {
-    "@prisma/cli-engine": "0.1.0",
+    "@prisma/cli-engine": "0.1.1",
     "@prisma/orm-extension-arktype-json": "workspace:8.0.0-rc.1",
     "@prisma/orm-extension-pgvector": "workspace:8.0.0-rc.1",
     "@prisma/orm-postgres": "workspace:8.0.0-rc.1",

--- a/test/e2e/framework/test/fixtures/package.json
+++ b/test/e2e/framework/test/fixtures/package.json
@@ -5,7 +5,7 @@
   "version": "8.0.0-rc.1",
   "description": "The Postgres fixture of the e2e suite. Its own manifest because emission reads the nearest one to decide which package names generated files import, and this suite exercises two databases whose halves must not name each other's facade.",
   "dependencies": {
-    "@prisma/cli-engine": "0.0.9",
+    "@prisma/cli-engine": "0.1.0",
     "@prisma/orm-extension-arktype-json": "workspace:8.0.0-rc.1",
     "@prisma/orm-extension-pgvector": "workspace:8.0.0-rc.1",
     "@prisma/orm-postgres": "workspace:8.0.0-rc.1",

--- a/test/e2e/framework/test/sqlite/fixtures/package.json
+++ b/test/e2e/framework/test/sqlite/fixtures/package.json
@@ -5,7 +5,7 @@
   "version": "8.0.0-rc.1",
   "description": "The SQLite fixture of the e2e suite. Its own manifest because emission reads the nearest one to decide which package names generated files import, and this suite exercises two databases whose halves must not name each other's facade.",
   "dependencies": {
-    "@prisma/cli-engine": "0.0.9",
+    "@prisma/cli-engine": "0.1.0",
     "@prisma/orm-sqlite": "workspace:8.0.0-rc.1"
   }
 }

--- a/test/e2e/framework/test/sqlite/fixtures/package.json
+++ b/test/e2e/framework/test/sqlite/fixtures/package.json
@@ -5,7 +5,7 @@
   "version": "8.0.0-rc.1",
   "description": "The SQLite fixture of the e2e suite. Its own manifest because emission reads the nearest one to decide which package names generated files import, and this suite exercises two databases whose halves must not name each other's facade.",
   "dependencies": {
-    "@prisma/cli-engine": "0.1.0",
+    "@prisma/cli-engine": "0.1.1",
     "@prisma/orm-sqlite": "workspace:8.0.0-rc.1"
   }
 }

--- a/test/integration/package.json
+++ b/test/integration/package.json
@@ -74,7 +74,7 @@
     "@internal/framework-components": "workspace:8.0.0-rc.1",
     "@internal/middleware-cache": "workspace:8.0.0-rc.1",
     "@internal/mongo-lowering": "workspace:8.0.0-rc.1",
-    "@prisma/cli-engine": "0.0.9",
+    "@prisma/cli-engine": "0.1.0",
     "@repo/test-utils": "workspace:8.0.0-rc.1",
     "@repo/tsconfig": "workspace:8.0.0-rc.1",
     "@types/pg": "catalog:",

--- a/test/integration/package.json
+++ b/test/integration/package.json
@@ -74,7 +74,7 @@
     "@internal/framework-components": "workspace:8.0.0-rc.1",
     "@internal/middleware-cache": "workspace:8.0.0-rc.1",
     "@internal/mongo-lowering": "workspace:8.0.0-rc.1",
-    "@prisma/cli-engine": "0.1.0",
+    "@prisma/cli-engine": "0.1.1",
     "@repo/test-utils": "workspace:8.0.0-rc.1",
     "@repo/tsconfig": "workspace:8.0.0-rc.1",
     "@types/pg": "catalog:",

--- a/test/integration/test/fixtures/cli/cli-e2e-test-app/package.json
+++ b/test/integration/test/fixtures/cli/cli-e2e-test-app/package.json
@@ -19,7 +19,7 @@
     "@internal/target-mongo": "workspace:8.0.0-rc.1",
     "@internal/target-postgres": "workspace:8.0.0-rc.1",
     "@internal/utils": "workspace:8.0.0-rc.1",
-    "@prisma/cli-engine": "0.0.9",
+    "@prisma/cli-engine": "0.1.0",
     "@prisma/orm-extension-pgvector": "workspace:8.0.0-rc.1",
     "@prisma/orm-mongo": "workspace:8.0.0-rc.1",
     "@prisma/orm-postgres": "workspace:8.0.0-rc.1",

--- a/test/integration/test/fixtures/cli/cli-e2e-test-app/package.json
+++ b/test/integration/test/fixtures/cli/cli-e2e-test-app/package.json
@@ -19,7 +19,7 @@
     "@internal/target-mongo": "workspace:8.0.0-rc.1",
     "@internal/target-postgres": "workspace:8.0.0-rc.1",
     "@internal/utils": "workspace:8.0.0-rc.1",
-    "@prisma/cli-engine": "0.1.0",
+    "@prisma/cli-engine": "0.1.1",
     "@prisma/orm-extension-pgvector": "workspace:8.0.0-rc.1",
     "@prisma/orm-mongo": "workspace:8.0.0-rc.1",
     "@prisma/orm-postgres": "workspace:8.0.0-rc.1",

--- a/test/integration/test/fixtures/cli/cli-integration-test-app/package.json
+++ b/test/integration/test/fixtures/cli/cli-integration-test-app/package.json
@@ -20,7 +20,7 @@
     "@internal/target-mongo": "workspace:8.0.0-rc.1",
     "@internal/target-postgres": "workspace:8.0.0-rc.1",
     "@internal/utils": "workspace:8.0.0-rc.1",
-    "@prisma/cli-engine": "0.1.0",
+    "@prisma/cli-engine": "0.1.1",
     "@prisma/orm-extension-pgvector": "workspace:8.0.0-rc.1",
     "@prisma/orm-mongo": "workspace:8.0.0-rc.1",
     "@prisma/orm-postgres": "workspace:8.0.0-rc.1",

--- a/test/integration/test/fixtures/cli/cli-integration-test-app/package.json
+++ b/test/integration/test/fixtures/cli/cli-integration-test-app/package.json
@@ -20,7 +20,7 @@
     "@internal/target-mongo": "workspace:8.0.0-rc.1",
     "@internal/target-postgres": "workspace:8.0.0-rc.1",
     "@internal/utils": "workspace:8.0.0-rc.1",
-    "@prisma/cli-engine": "0.0.9",
+    "@prisma/cli-engine": "0.1.0",
     "@prisma/orm-extension-pgvector": "workspace:8.0.0-rc.1",
     "@prisma/orm-mongo": "workspace:8.0.0-rc.1",
     "@prisma/orm-postgres": "workspace:8.0.0-rc.1",


### PR DESCRIPTION
## Before and after

```text
# before: two engine generations in the wild
@prisma/orm-toolchain peers @prisma/cli-engine@0.0.9
prisma-cli ships           @prisma/cli-engine@0.1.1

# after
$ pnpm check:conformance
OK — … every @prisma/cli-engine pin agrees.        # at 0.1.1
```

## The decision

Engine `0.1.1` is the current release under ADR 0004's decoupled versioning (prisma-cli, ruled 2026-08-13): an engine version now means "the engine changed". This PR is prisma/prisma's half of the tandem — every engine reference moves to `0.1.1`, and the family adapts to the API changes accumulated since `0.0.9`.

## The adaptations, all to deliberate engine changes

- **`Runtime.host` (new, required)**: what the process runs on, read once by the bin, taken by commands from `ctx.host`. Wired with the same bun/deno/node detection the prisma-cli bin uses.
- **`Runtime.isCI` (removed)**: the engine detects CI itself; the optional `isCIOverride` is for hosts where detection cannot be right, which this is not. `ci-info` stays for telemetry's own use.
- **`HostProcess` grew `version`/`versions`/`platform`/`arch`**: test fakes updated.
- **One test changed meaning**: the 0.1.x output model suppresses the stdout mirror when both streams are TTYs on one device, and a piped stdout without a format flag defaults to json. The scenario the test pins — human prose on stderr, machine lines on a piped stdout — is now the explicit `--format human` pipe case, and the test says so.

## Verification (exit codes)

`pnpm build` 0 · `pnpm typecheck` 0 · `@internal/cli` tests 1420/1420 · `pnpm check:conformance` 0 (all pins agree at 0.1.1) · `pnpm check:publish-deps` 0 · `pnpm test:scripts` 413/413.

## Alternatives considered

**Pin the new engine without adapting** — does not compile; the engine's type changes are the mechanism that forces honest adoption. **Keep `isCI` via the override** — the override exists for hosts where detection cannot work; using it here would preserve a fork of the detection table the engine deliberately centralised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved CLI runtime detection for Node.js, Bun, and Deno.
  - Runtime information now includes the detected version, platform, and architecture.

- **Bug Fixes**
  - Improved CLI behavior when run from an unreadable working directory.
  - Piped command output now handles explicit human-readable formatting more reliably.
  - Improved compatibility when using the CLI with Bun.

- **Documentation**
  - Added upgrade guidance for extensions using `prisma.config.ts`.

- **Tests**
  - Expanded coverage for runtime metadata and piped-output scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

