### PR TITLE
test(cli): drop the node:fs/promises module mock from contract-emit

### DIFF
--- a/packages/1-framework/3-tooling/cli/test/control-api/contract-emit.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/control-api/contract-emit.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type * as configLoader from '@internal/config-loader';
@@ -11,20 +11,6 @@ import { disposeEmitQueue } from '../../src/utils/emit-queue';
 
 const mockedEmit = vi.fn<typeof import('@internal/emitter')['emit']>();
 
-vi.mock('node:fs/promises', async () => {
-  const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
-  return {
-    ...actual,
-    mkdir: vi.fn(actual.mkdir),
-    rename: vi.fn(actual.rename),
-    writeFile: vi.fn(actual.writeFile),
-  };
-});
-
-type FsModule = typeof import('node:fs/promises');
-
-const mockedRename = vi.mocked(rename);
-const mockedWriteFile = vi.mocked(writeFile);
 const emitDependencies = { emit: mockedEmit };
 
 function executeContractEmitWithMock(options: ContractEmitOptions) {
@@ -112,24 +98,16 @@ function createSuccessfulConfig(output: string) {
 
 describe('executeContractEmit', () => {
   let tmpDir = '';
-  let actualFs: FsModule;
 
   beforeEach(async () => {
-    actualFs = await vi.importActual<FsModule>('node:fs/promises');
     tmpDir = await mkdtemp(join(tmpdir(), 'contract-emit-'));
     mockedEmit.mockReset();
-    mockedRename.mockReset();
-    mockedWriteFile.mockReset();
-    mockedRename.mockImplementation(async (...args) => actualFs.rename(...args));
-    mockedWriteFile.mockImplementation(async (...args) => actualFs.writeFile(...args));
   });
 
   afterEach(async () => {
     if (tmpDir.length > 0) {
       await rm(tmpDir, { recursive: true, force: true });
     }
-    // isolate: false — avoid vi.restoreAllMocks(); it restores hoisted vi.mock
-    // modules from other test files loaded in this worker (e.g. node:child_process).
   });
 
   function emitOptions(config: configLoader.PrismaNextConfig, configPath = 'prisma.config.ts') {
@@ -248,8 +226,8 @@ describe('executeContractEmit', () => {
   describe('the import root the emitted files are written against', () => {
     async function emitInto(project: string, options: { readonly namesConfig: boolean }) {
       const outputJsonPath = join(tmpDir, project, 'generated/contract.json');
-      await actualFs.mkdir(join(tmpDir, project), { recursive: true });
-      await actualFs.writeFile(
+      await mkdir(join(tmpDir, project), { recursive: true });
+      await writeFile(
         join(tmpDir, project, 'package.json'),
         JSON.stringify({
           name: project,


### PR DESCRIPTION
`contract-emit.test.ts` was the last file in `control-api/` still mocking a module. It turns out the mock did nothing.

## The mock had no behaviour

Every test reset `rename` and `writeFile`, then set them to call the real implementations:

```ts
mockedRename.mockImplementation(async (...args) => actualFs.rename(...args));
mockedWriteFile.mockImplementation(async (...args) => actualFs.writeFile(...args));
```

Nothing asserted on either. Nothing made either fail. It was a module mock configured to be indistinguishable from the module it replaced.

What it did cost: the `vi.importActual` dance in `beforeEach`, an `actualFs` handle threaded through the file, and a comment in `afterEach` explaining why `vi.restoreAllMocks()` was unsafe here — upkeep for a mock with no behaviour, and one more file participating in the shared module registry that `isolate: false` gives us.

## The change

Use `node:fs/promises` directly. `emit` stays injected through the `ContractEmitDependencies` bag, which is already how this file avoids mocking the emitter, so no module mocks remain in it.

Net −22 lines.

## Result

| | files / tests | duration |
|---|---|---|
| before | 115 / 1420 | 7–12s |
| after | 115 / 1420 | 5.1–5.3s, 5 of 5 clean |

Same coverage, faster — the indirection cost more than it was worth. `lint` and `typecheck` pass.

## Context

`control-api/client.test.ts` was de-mocked the same way earlier; this finishes the pair. Module mocking is the exception in this package — 5 of 115 test files use `vi.mock` after this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated contract emission tests to create temporary directories and package files directly.
  - Simplified filesystem test setup while preserving temporary-directory cleanup and import-root coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->