### PR TITLE
chore: remove the stale legacy-test comment

### DIFF
--- a/test/integration/test/contract-builder.test.ts
+++ b/test/integration/test/contract-builder.test.ts
@@ -488,8 +488,5 @@ describe('builder integration', () => {
         },
       });
     });
-
-    // TODO: The following 4 validation tests tested legacy chain builder validation logic (parentTable/childTable/through matching). In the new DSL, these constraints are enforced structurally by rel.belongsTo/hasMany/manyToMany and cannot be violated. Equivalent DSL validation tests exist in contract-builder.dsl.test.ts (e.g., "rejects belongsTo relations whose field arity does not match the target", "rejects hasMany
-    // relations whose child fields do not match the parent identity arity", "rejects many-to-many relations whose through mappings do not match anchor arity").
   });
 });


### PR DESCRIPTION
## Linked issue

n/a — supersedes #29926, which found this comment.

## Summary

@EmaToplek spotted that this comment was stale and rewrote it as a block comment in #29926. The find was right; the conclusion should be to delete it rather than reword it, so this replaces that PR. Credit for noticing it is theirs.

The comment explained that four chain-builder validation tests were removed from this block, and pointed at their replacements. Both halves of that job are already done better elsewhere.

**The replacements exist and are named exactly** — `rejects belongsTo relations whose field arity does not match the target`, `rejects hasMany relations whose child fields do not match the parent identity arity`, and `rejects many-to-many relations whose through mappings do not match anchor arity`, all in [`packages/2-sql/2-authoring/contract-ts/test/contract-builder.dsl.test.ts`](https://github.com/prisma/prisma/blob/main/packages/2-sql/2-authoring/contract-ts/test/contract-builder.dsl.test.ts). Any of those titles finds them. The removal itself is in the history, so `git log -S parentTable` recovers the reasoning in full.

What the comment adds on top of that is a maintenance liability:

- It names a file in **another package** by bare filename, which reads as a sibling of this one. A reader follows it to `test/integration/test/`, where no such file exists — I did exactly that while checking this.
- Nothing verifies the three titles it quotes still exist. A rename makes it quietly wrong, and no test or lint would notice.

A comment describing code that is not here, in a package that is not this one, verified by nothing, is worth less than the blank space. This also matches the repo convention in [`CLAUDE.md`](https://github.com/prisma/prisma/blob/main/CLAUDE.md): don't add comments if avoidable, and prefer links to canonical docs over long comments.

## Testing performed

Comment-only deletion — three lines removed (one blank, two comment), nothing added, verified mechanically against the diff. The enclosing `describe` still holds its tests, so no block is left empty.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed outdated internal test documentation.
  * No user-visible behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->