### PR TITLE
chore(scripts): stop asking for a declaration on dependency-only diffs

### DIFF
--- a/scripts/check-upgrade-coverage.mjs
+++ b/scripts/check-upgrade-coverage.mjs
@@ -54,6 +54,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
+import { basename } from 'node:path';
 import { argv, cwd, exit, stderr, stdout } from 'node:process';
 import { fileURLToPath } from 'node:url';
 
@@ -325,6 +326,8 @@ const DEPENDENCY_MAPS = [
   'optionalDependencies',
 ];
 
+const BIOME_CONFIG_NAMES = new Set(['biome.json', 'biome.jsonc']);
+
 /** Key-sorted JSON, so a reordered manifest compares equal to itself. */
 function canonicalJson(value) {
   if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
@@ -364,14 +367,14 @@ function isTranslationIrrelevant(repoRoot, prev, head, path) {
   // An added or deleted file is a structural change, not a version move.
   if (before === null || after === null) return false;
 
-  if (path === 'package.json' || path.endsWith('/package.json')) {
+  if (basename(path) === 'package.json') {
     try {
       return manifestShapeIgnoringVersions(before) === manifestShapeIgnoringVersions(after);
     } catch {
       return false;
     }
   }
-  if (path.endsWith('biome.jsonc') || path.endsWith('biome.json')) {
+  if (BIOME_CONFIG_NAMES.has(basename(path))) {
     const blankSchema = (text) => text.replace(/"\$schema"\s*:\s*"[^"]*"/g, '"$schema":""');
     return blankSchema(before) === blankSchema(after);
   }

--- a/scripts/check-upgrade-coverage.mjs
+++ b/scripts/check-upgrade-coverage.mjs
@@ -318,6 +318,66 @@ function diffAllChangedPaths(repoRoot, prev, head) {
   return new Set(out.split('\n').filter(Boolean));
 }
 
+const DEPENDENCY_MAPS = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies',
+];
+
+/** Key-sorted JSON, so a reordered manifest compares equal to itself. */
+function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (value !== null && typeof value === 'object') {
+    const entries = Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`);
+    return `{${entries.join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+/** The manifest with every dependency *version* blanked; names are kept. */
+function manifestShapeIgnoringVersions(text) {
+  const parsed = JSON.parse(text);
+  for (const map of DEPENDENCY_MAPS) {
+    const deps = parsed[map];
+    if (deps !== null && typeof deps === 'object' && !Array.isArray(deps)) {
+      parsed[map] = Object.fromEntries(Object.keys(deps).map((name) => [name, '']));
+    }
+  }
+  return canonicalJson(parsed);
+}
+
+/**
+ * Whether a changed file can carry no downstream translation.
+ *
+ * Two shapes qualify, both of which a dependency bot produces by the dozen: a
+ * manifest where only dependency versions moved, and a lint config where only
+ * the `$schema` URL moved. Adding or removing a dependency does not qualify —
+ * a name appearing or disappearing can signal an API change, so it still wants
+ * a human to say so.
+ */
+function isTranslationIrrelevant(repoRoot, prev, head, path) {
+  const before = tryReadFileAtRef(repoRoot, prev, path);
+  const after = tryReadFileAtRef(repoRoot, head, path);
+  // An added or deleted file is a structural change, not a version move.
+  if (before === null || after === null) return false;
+
+  if (path === 'package.json' || path.endsWith('/package.json')) {
+    try {
+      return manifestShapeIgnoringVersions(before) === manifestShapeIgnoringVersions(after);
+    } catch {
+      return false;
+    }
+  }
+  if (path.endsWith('biome.jsonc') || path.endsWith('biome.json')) {
+    const blankSchema = (text) => text.replace(/"\$schema"\s*:\s*"[^"]*"/g, '"$schema":""');
+    return blankSchema(before) === blankSchema(after);
+  }
+  return false;
+}
+
 function diffPaths(repoRoot, prev, head, pathspecs) {
   const args = ['diff', '--name-only', `${prev}..${head}`, '--'];
   args.push(...pathspecs);
@@ -462,7 +522,12 @@ export function runCheck({ repoRoot, head, prev }) {
   // line-oriented and tells the author exactly which directories the
   // gate wants.
   for (const { substrate, pathspec, skillPkg } of COVERAGE_SUBSTRATES) {
-    const substrateDiff = diffPaths(repoRoot, prev, head, [pathspec]);
+    // A diff that only moves dependency versions or a `$schema` URL has
+    // nothing for a consumer to translate, so it does not put the substrate
+    // in scope at all.
+    const substrateDiff = diffPaths(repoRoot, prev, head, [pathspec]).filter(
+      (path) => !isTranslationIrrelevant(repoRoot, prev, head, path),
+    );
     if (substrateDiff.length === 0) continue;
     for (const transition of coverageChain) {
       const requiredDir = `${skillPkg}/upgrades/${transition}`;

--- a/scripts/check-upgrade-coverage.test.mjs
+++ b/scripts/check-upgrade-coverage.test.mjs
@@ -954,3 +954,86 @@ describe('check-upgrade-coverage — per-PR correspondence rule', () => {
     assert.match(result.stderr, /per-pr-declaration/);
   });
 });
+
+describe('check-upgrade-coverage — dependency-only substrate diffs need no declaration', () => {
+  function seedTransitionDir() {
+    writePackageJson('0.7.0');
+    writeRepoFile(
+      'skills/prisma-next-upgrade/upgrades/0.7-to-0.8/instructions.md',
+      '---\nfrom: "0.7"\nto: "0.8"\nchanges: []\n---\n',
+    );
+    writeRepoFile(
+      'skills/prisma-8-extension-upgrade/upgrades/0.7-to-0.8/instructions.md',
+      '---\nfrom: "0.7"\nto: "0.8"\nchanges: []\n---\n',
+    );
+  }
+
+  function exampleManifest(deps) {
+    return `${JSON.stringify({ name: 'demo', devDependencies: deps }, null, 2)}\n`;
+  }
+
+  it('a version-only bump in an example manifest passes without touching instructions.md', () => {
+    seedTransitionDir();
+    writeRepoFile('examples/demo/package.json', exampleManifest({ vite: '^6.0.0' }));
+    commitAll('prev');
+    const prev = git('rev-parse', 'HEAD');
+    writeRepoFile('examples/demo/package.json', exampleManifest({ vite: '^8.1.4' }));
+    commitAll('head — dependency version bump only');
+    const result = runScript(['--prev', prev, '--head', 'HEAD']);
+    assert.equal(result.status, 0, result.stderr);
+  });
+
+  it('a $schema realignment in an extension biome config passes without touching instructions.md', () => {
+    seedTransitionDir();
+    const config = (v) =>
+      `{\n  // linter config\n  "$schema": "https://biomejs.dev/schemas/${v}/schema.json"\n}\n`;
+    writeRepoFile('packages/3-extensions/pgvector/biome.jsonc', config('2.5.7'));
+    commitAll('prev');
+    const prev = git('rev-parse', 'HEAD');
+    writeRepoFile('packages/3-extensions/pgvector/biome.jsonc', config('2.5.8'));
+    commitAll('head — schema URL realignment only');
+    const result = runScript(['--prev', prev, '--head', 'HEAD']);
+    assert.equal(result.status, 0, result.stderr);
+  });
+
+  it('adding a dependency still requires a declaration', () => {
+    seedTransitionDir();
+    writeRepoFile('examples/demo/package.json', exampleManifest({ vite: '^8.1.4' }));
+    commitAll('prev');
+    const prev = git('rev-parse', 'HEAD');
+    writeRepoFile('examples/demo/package.json', exampleManifest({ vite: '^8.1.4', zod: '^3.0.0' }));
+    commitAll('head — new dependency');
+    const result = runScript(['--prev', prev, '--head', 'HEAD']);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /per-pr-declaration/);
+  });
+
+  it('a source change alongside a version bump still requires a declaration', () => {
+    seedTransitionDir();
+    writeRepoFile('examples/demo/package.json', exampleManifest({ vite: '^6.0.0' }));
+    writeRepoFile('examples/demo/src/main.ts', 'export const a = 1;\n');
+    commitAll('prev');
+    const prev = git('rev-parse', 'HEAD');
+    writeRepoFile('examples/demo/package.json', exampleManifest({ vite: '^8.1.4' }));
+    writeRepoFile('examples/demo/src/main.ts', 'export const a = 2;\n');
+    commitAll('head — bump plus source');
+    const result = runScript(['--prev', prev, '--head', 'HEAD']);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /per-pr-declaration/);
+  });
+
+  it('a non-dependency manifest field still requires a declaration', () => {
+    seedTransitionDir();
+    writeRepoFile('examples/demo/package.json', exampleManifest({ vite: '^8.1.4' }));
+    commitAll('prev');
+    const prev = git('rev-parse', 'HEAD');
+    writeRepoFile(
+      'examples/demo/package.json',
+      `${JSON.stringify({ name: 'demo', scripts: { build: 'vite build' }, devDependencies: { vite: '^8.1.4' } }, null, 2)}\n`,
+    );
+    commitAll('head — scripts added');
+    const result = runScript(['--prev', prev, '--head', 'HEAD']);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /per-pr-declaration/);
+  });
+});

--- a/scripts/check-upgrade-coverage.test.mjs
+++ b/scripts/check-upgrade-coverage.test.mjs
@@ -996,6 +996,31 @@ describe('check-upgrade-coverage — dependency-only substrate diffs need no dec
     assert.equal(result.status, 0, result.stderr);
   });
 
+  it('a filename merely ending in biome.json is not a biome config', () => {
+    seedTransitionDir();
+    const config = (v) => `{\n  "$schema": "https://biomejs.dev/schemas/${v}/schema.json"\n}\n`;
+    writeRepoFile('examples/demo/notbiome.json', config('2.5.7'));
+    commitAll('prev');
+    const prev = git('rev-parse', 'HEAD');
+    writeRepoFile('examples/demo/notbiome.json', config('2.5.8'));
+    commitAll('head — a non-biome file whose name ends in biome.json');
+    const result = runScript(['--prev', prev, '--head', 'HEAD']);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /per-pr-declaration/);
+  });
+
+  it('a filename merely ending in package.json is not a manifest', () => {
+    seedTransitionDir();
+    writeRepoFile('examples/demo/not-package.json', '{"devDependencies":{"vite":"^6.0.0"}}\n');
+    commitAll('prev');
+    const prev = git('rev-parse', 'HEAD');
+    writeRepoFile('examples/demo/not-package.json', '{"devDependencies":{"vite":"^8.1.4"}}\n');
+    commitAll('head — a non-manifest file whose name ends in package.json');
+    const result = runScript(['--prev', prev, '--head', 'HEAD']);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /per-pr-declaration/);
+  });
+
   it('adding a dependency still requires a declaration', () => {
     seedTransitionDir();
     writeRepoFile('examples/demo/package.json', exampleManifest({ vite: '^8.1.4' }));


### PR DESCRIPTION
## The problem

Every grouped Dependabot PR that touches `examples/` has needed a hand-written `changes: []` line before it could go green. Six times in the last four weekly batches: [#29939](https://github.com/prisma/prisma/pull/29939), [#29940](https://github.com/prisma/prisma/pull/29940), [#29965](https://github.com/prisma/prisma/pull/29965), [#29967](https://github.com/prisma/prisma/pull/29967), [#30031](https://github.com/prisma/prisma/pull/30031), [#30037](https://github.com/prisma/prisma/pull/30037).

The line always says the same thing, because a dependency version bump has nothing a consumer could translate. The check is asking a question whose answer is fixed by the shape of the diff.

## The change

Two diff shapes no longer put a substrate in scope:

- a **manifest** where only dependency *versions* moved
- a **lint config** where only the `$schema` URL moved

Both are what a dependency bot produces by the dozen, and neither can carry a downstream translation.

Comparison is structural rather than textual: the manifest is parsed, dependency values are blanked while their names are kept, and both sides are canonicalised with sorted keys — so a reordered manifest compares equal to itself, and a real edit anywhere else still shows up.

## Deliberately still in scope

| change | still needs a declaration |
|---|---|
| dependency version moves | no |
| `$schema` URL moves | no |
| **adding or removing a dependency** | **yes** — a name appearing or disappearing can signal an API change |
| **any other manifest field** (`scripts`, `exports`, …) | **yes** |
| **any source change alongside the bump** | **yes** |
| added or deleted files | **yes** — structural, not a version move |

The check keeps asking a human wherever a human might actually have something to say.

## Verified

Five new tests cover both exemptions and all three "still strict" cases; the suite is 71 passing.

A/B against the real [#30037](https://github.com/prisma/prisma/pull/30037) diff — its 10 dependency bumps plus the 65-file `biome.jsonc` `$schema` realignment, with the declaration commit removed:

```
unpatched → [per-pr-declaration] PR touches examples/ but did not record an upgrade
patched   → exit 0
```

`lint:code` and `test:scripts` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Upgrade coverage checks now ignore dependency version-only changes in package manifests and `$schema`-only configuration updates.
  * Added and deleted files, dependency additions or removals, source changes, and other manifest modifications remain covered by the checks.

* **Tests**
  * Added coverage for dependency-only updates and related scenarios to ensure upgrade declarations are required when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->