### PR TITLE
test(integration): give database tests the same budget as their hooks

### DIFF
--- a/test/integration/vitest.config.ts
+++ b/test/integration/vitest.config.ts
@@ -49,9 +49,14 @@ export default defineConfig({
       enabled: true,
       include: ['test/**/*.test-d.ts'],
     },
-    testTimeout: timeouts.default,
-    // Hook timeout needs to be higher than default (100ms) because beforeEach/afterEach
-    // hooks often perform filesystem operations (creating/cleaning test directories)
+    // These tests talk to a database, so they get the same budget as the hooks
+    // below. `timeouts.default` is 100ms, which CI's TEST_TIMEOUT_MULTIPLIER
+    // turns into the 200ms that `timeouts.vitestPackageDefault` is documented
+    // as existing to avoid — and a test killed mid-insert leaves its rows
+    // behind, so the next test fails on a UNIQUE violation and the real cause
+    // is two failures away.
+    testTimeout: timeouts.databaseOperation,
+    // Hooks perform filesystem operations (creating/cleaning test directories)
     hookTimeout: timeouts.databaseOperation,
     // Covers ordinary CI flakiness ("Connection terminated unexpectedly").
     // Note it cannot cover the JIT abort above: that kills the worker fork


### PR DESCRIPTION
## An unrelated PR going red

[#30031](https://github.com/prisma/prisma/pull/30031) bumps three dependency versions — `esbuild`, `evlog`, `next` — and failed Integration Tests with:

```
FAIL test/sql-orm-client/sqlite-include-canonical-json.test.ts
Error: Test timed out in 200ms.

FAIL test/sql-orm-client/sqlite-include-canonical-json.test.ts
Error: UNIQUE constraint failed: canon_readings.id
```

Two failures, one cause. The test was killed mid-insert, its rows survived, and the next test collided with them — so the real reason is one failure removed from the one you read first.

## Why 200ms

The suite ran every test on `timeouts.default`, which is 100ms. CI sets `TEST_TIMEOUT_MULTIPLIER: 2`, making it 200 — and `timeouts.vitestPackageDefault` is documented as existing precisely to avoid that:

> Vitest `testTimeout` / `hookTimeout` when a package uses mostly local I/O but CI sets `TEST_TIMEOUT_MULTIPLIER` (e.g. 2): **100ms × multiplier is a common false failure (Vitest reports 200ms)**.

The hooks in this same config already take `timeouts.databaseOperation` for the same database work. Only the tests were held to 100ms.

## The change

`testTimeout: timeouts.default` → `timeouts.databaseOperation`, matching the `hookTimeout` immediately below it.

Two things say this is the right bound rather than a bigger hammer:

- **272 files in this suite already pass an explicit `timeouts.*`** — the per-file workaround for a default that never fitted a suite talking to a database.
- Locally the `sql-orm-client` tests spend **310s across 315 cases**. A 100ms per-test budget was never the real bound; it only ever fired on whichever test lost the scheduling race.

## Verified

`pnpm --filter integration-tests test sql-orm-client` — 41 files, 315 tests, all passing. `lint:code` passes.

## Related

Same 200ms class as `render-typescript.roundtrip.test.ts` in `@internal/adapter-postgres`, which failed the same way earlier today on a different Dependabot PR. That one is a `beforeEach` doing filesystem work under the package's own default and is not covered here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated database integration tests to use the appropriate database-operation timeout.
  * Clarified test behavior for database cleanup and cascading failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->