### PR TITLE
feat: whole-query raw gets its own lane at db.raw.sql (TML-3214)

### DIFF
--- a/packages/2-sql/4-lanes/sql-builder/src/exports/types.ts
+++ b/packages/2-sql/4-lanes/sql-builder/src/exports/types.ts
@@ -11,5 +11,6 @@ export type {
 } from '../types/db';
 export type { GroupedQuery } from '../types/grouped-query';
 export type { DeleteQuery, InsertQuery, UpdateQuery } from '../types/mutation-query';
+export type { ContractRawTag, RawLane, RawTagFor } from '../types/raw-query';
 export type { SelectQuery } from '../types/select-query';
 export type { TableProxy } from '../types/table-proxy';

--- a/packages/2-sql/4-lanes/sql-builder/src/runtime/index.ts
+++ b/packages/2-sql/4-lanes/sql-builder/src/runtime/index.ts
@@ -2,4 +2,5 @@ export type { Db } from '../types/db';
 export { ExpressionImpl } from './expression-impl';
 export { createFieldProxy } from './field-proxy';
 export { createAggregateFunctions, createFunctions } from './functions';
+export { createRawLane, type RawLaneOptions } from './raw-lane';
 export { type SqlOptions, sql } from './sql';

--- a/packages/2-sql/4-lanes/sql-builder/src/runtime/raw-lane.ts
+++ b/packages/2-sql/4-lanes/sql-builder/src/runtime/raw-lane.ts
@@ -1,0 +1,33 @@
+import type { Contract } from '@internal/contract/types';
+import type { SqlStorage } from '@internal/sql-contract/types';
+import { createRawSql, type RawCodecInferer } from '@internal/sql-relational-core/expression';
+import type { ExecutionContext } from '@internal/sql-relational-core/query-lane-context';
+import { blindCast } from '@internal/utils/casts';
+import type { TableProxyContract } from '../types/db';
+import type { RawLane, RawTagFor } from '../types/raw-query';
+
+export interface RawLaneOptions<C extends Contract<SqlStorage> & TableProxyContract> {
+  readonly context: ExecutionContext<C>;
+  readonly rawCodecInferer: RawCodecInferer;
+}
+
+/**
+ * Builds the raw lane a client exposes as `db.raw`.
+ *
+ * The tag binds the adapter's codec inferer and the contract here, once. An
+ * authoring site then carries only its template, its row spec, and a
+ * terminator.
+ *
+ * The row type is phantom: no value holds it. The target-agnostic tag types it
+ * as `unknown`, and the contract says what each declared column decodes to.
+ */
+export function createRawLane<C extends Contract<SqlStorage> & TableProxyContract>(
+  options: RawLaneOptions<C>,
+): RawLane<C> {
+  const tag = blindCast<
+    RawTagFor<C>,
+    'the row type is phantom, so no value can prove it. The builder is the same one either way. Only the contract says what the declared columns decode to'
+  >(createRawSql(options.rawCodecInferer, { contract: options.context.contract }));
+
+  return Object.freeze({ sql: tag });
+}

--- a/packages/2-sql/4-lanes/sql-builder/src/types/raw-query.ts
+++ b/packages/2-sql/4-lanes/sql-builder/src/types/raw-query.ts
@@ -122,7 +122,7 @@ export interface ContractRawBuilder<CodecTypes extends Record<string, { readonly
   affectedCount(): RawAffectedCountQuery;
 }
 
-/** The contract-bound raw tag, as `db.raw` exposes it. */
+/** The contract-bound raw tag, as `db.raw.sql` exposes it. */
 export type ContractRawTag<CodecTypes extends Record<string, { readonly output: unknown }>> = (
   strings: TemplateStringsArray,
   ...values: RawSqlInterpolation[]
@@ -130,3 +130,17 @@ export type ContractRawTag<CodecTypes extends Record<string, { readonly output: 
 
 /** The raw tag for a contract, with its codec-type map already applied. */
 export type RawTagFor<C extends TableProxyContract> = ContractRawTag<ExtractCodecTypes<C>>;
+
+/**
+ * The raw lane, addressed as `db.raw`. It holds the whole-query statement tag
+ * under `sql`.
+ *
+ * Editors key their SQL highlighting on that name, and a raw plan's
+ * `lane: 'raw'` already uses it.
+ *
+ * The lane is one key wide on purpose. Anything else raw authoring needs can
+ * join it later, without moving the address again.
+ */
+export type RawLane<C extends TableProxyContract> = {
+  readonly sql: RawTagFor<C>;
+};

--- a/packages/3-extensions/postgres/src/runtime/postgres.ts
+++ b/packages/3-extensions/postgres/src/runtime/postgres.ts
@@ -4,10 +4,10 @@ import type { Contract } from '@internal/contract/types';
 import postgresDriver from '@internal/driver-postgres/runtime';
 import { instantiateExecutionStack } from '@internal/framework-components/execution';
 import { sql as sqlBuilder } from '@internal/sql-builder/runtime';
-import type { Db } from '@internal/sql-builder/types';
+import type { Db, RawLane } from '@internal/sql-builder/types';
 import type { ExtractCodecTypes, SqlStorage } from '@internal/sql-contract/types';
 import { orm as ormBuilder } from '@internal/sql-orm-client';
-import type { CodecTypesBase, RawSqlTag } from '@internal/sql-relational-core/expression';
+import type { CodecTypesBase } from '@internal/sql-relational-core/expression';
 import type { SqlQueryPlan } from '@internal/sql-relational-core/plan';
 import type {
   BindSiteParams,
@@ -58,7 +58,7 @@ export interface PostgresClient<TContract extends Contract<SqlStorage>> {
   readonly orm: OrmClient<TContract>;
   readonly enums: NamespacedEnums<TContract>;
   readonly nativeEnums: NamespacedNativeEnums<TContract>;
-  readonly raw: RawSqlTag;
+  readonly raw: RawLane<TContract>;
   readonly context: ExecutionContext<TContract>;
   readonly contract: TContract;
   readonly stack: SqlExecutionStackWithDriver<PostgresTargetId>;

--- a/packages/3-extensions/postgres/src/static/postgres-static.ts
+++ b/packages/3-extensions/postgres/src/static/postgres-static.ts
@@ -1,11 +1,10 @@
 import postgresAdapter from '@internal/adapter-postgres/runtime';
 import { buildNamespacedEnums, type NamespacedEnums } from '@internal/contract/enum-accessor';
 import type { Contract } from '@internal/contract/types';
-import { sql } from '@internal/sql-builder/runtime';
-import type { Db } from '@internal/sql-builder/types';
+import { createRawLane, sql } from '@internal/sql-builder/runtime';
+import type { Db, RawLane } from '@internal/sql-builder/types';
 import type { SqlStorage } from '@internal/sql-contract/types';
-import type { RawCodecInferer, RawSqlTag } from '@internal/sql-relational-core/expression';
-import { createRawSql } from '@internal/sql-relational-core/expression';
+import type { RawCodecInferer } from '@internal/sql-relational-core/expression';
 import type { ExecutionContext, SqlRuntimeExtensionDescriptor } from '@internal/sql-runtime';
 import { createExecutionContext, createSqlExecutionStack } from '@internal/sql-runtime';
 import postgresTarget, { PostgresContractSerializer } from '@internal/target-postgres/runtime';
@@ -19,7 +18,7 @@ export interface PostgresStaticContext<TContract extends Contract<SqlStorage>> {
   readonly enums: NamespacedEnums<TContract>;
   readonly nativeEnums: NamespacedNativeEnums<TContract>;
   readonly sql: Db<TContract>;
-  readonly raw: RawSqlTag;
+  readonly raw: RawLane<TContract>;
 }
 
 export function buildPostgresStaticContext<TContract extends Contract<SqlStorage>>(
@@ -27,7 +26,7 @@ export function buildPostgresStaticContext<TContract extends Contract<SqlStorage
   rawCodecInferer: RawCodecInferer,
 ): PostgresStaticContext<TContract> {
   const sqlDb: Db<TContract> = sql<TContract>({ context, rawCodecInferer });
-  const raw: RawSqlTag = createRawSql(rawCodecInferer);
+  const raw: RawLane<TContract> = createRawLane<TContract>({ context, rawCodecInferer });
   const enums = Object.freeze(buildNamespacedEnums<TContract>(context.contract.domain));
   const nativeEnums = blindCast<
     NamespacedNativeEnums<TContract>,

--- a/packages/3-extensions/postgres/test/postgres.static.test.ts
+++ b/packages/3-extensions/postgres/test/postgres.static.test.ts
@@ -41,9 +41,10 @@ describe('postgresStatic({ contractJson })', () => {
     expect(typeof result.sql).toBe('object');
   });
 
-  it('raw is a tagged template function', () => {
+  it('raw is the lane holding the statement tag', () => {
     const result = postgresStatic<typeof contract>({ contractJson: contract });
-    expect(typeof result.raw).toBe('function');
+    expect(typeof result.raw).toBe('object');
+    expect(typeof result.raw.sql).toBe('function');
   });
 
   it('enums matches what buildNamespacedEnums produces', () => {

--- a/packages/3-extensions/postgres/test/raw-lane.test.ts
+++ b/packages/3-extensions/postgres/test/raw-lane.test.ts
@@ -1,0 +1,50 @@
+import { validateSqlContractFully } from '@internal/sql-contract/validators';
+import { type ParamRef, RawQueryAst } from '@internal/sql-relational-core/ast';
+import { describe, expect, it } from 'vitest';
+import postgresStatic from '../src/static/postgres-static';
+import type { Contract } from './fixtures/generated/contract';
+import contractJson from './fixtures/generated/contract.json' with { type: 'json' };
+
+const contract = validateSqlContractFully<Contract>(contractJson);
+const db = () => postgresStatic<Contract>({ contractJson: contract });
+
+/** Interpolated values ride the node's param refs. A plan lists them once lowered. */
+const paramValues = (ast: RawQueryAst): unknown[] =>
+  ast.collectParamRefs().map((ref) => (ref as ParamRef).value);
+
+describe('the raw lane on the client', () => {
+  it('builds a plan from a template the way a caller writes one', () => {
+    const client = db();
+    const users = client.sql.public.users;
+
+    const plan = client.raw.sql`SELECT id, email FROM users WHERE invited_by_id = ${1}`
+      .returnsRow({ id: users.columns.id, email: users.columns.email })
+      .build();
+
+    expect(plan.ast).toBeInstanceOf(RawQueryAst);
+    expect(plan.meta.lane).toBe('raw');
+    expect(plan.meta.target).toBe('postgres');
+    expect(paramValues(plan.ast as RawQueryAst)).toEqual([1]);
+  });
+
+  it('carries the declared columns onto the node', () => {
+    const plan = db().raw.sql`SELECT count(*) AS n FROM users`
+      .returnsRow({ n: 'pg/int8@1' })
+      .build();
+    const ast = plan.ast as RawQueryAst;
+
+    expect(ast.result).toEqual({
+      kind: 'rows',
+      columns: { n: { codecId: 'pg/int8@1', nullable: false } },
+    });
+  });
+
+  it('builds an affected-count plan from the mutation terminator', () => {
+    const plan = db().raw.sql`UPDATE users SET name = ${'Ada'} WHERE id = ${1}`
+      .affectedCount()
+      .build();
+
+    expect((plan.ast as RawQueryAst).result).toEqual({ kind: 'affected-count' });
+    expect(paramValues(plan.ast as RawQueryAst)).toEqual(['Ada', 1]);
+  });
+});

--- a/packages/3-extensions/postgres/test/raw-lane.types.test-d.ts
+++ b/packages/3-extensions/postgres/test/raw-lane.types.test-d.ts
@@ -1,0 +1,48 @@
+/**
+ * Type-test: the raw lane, authored from the client the way a caller reaches
+ * it. Each spec entry goes through `db.raw.sql`, and the contract resolves
+ * what every declared column decodes to.
+ */
+
+import type { ResultType } from '@internal/framework-components/runtime';
+import type { AffectedCount } from '@internal/sql-relational-core/expression';
+import type { SqlQueryPlan } from '@internal/sql-relational-core/plan';
+import { expectTypeOf, test } from 'vitest';
+import type { PostgresClient } from '../src/runtime/postgres';
+import type { Contract } from './fixtures/generated/contract';
+
+declare const db: PostgresClient<Contract>;
+
+test('a row spec resolves each column through the contract codec map', () => {
+  const users = db.sql.public.users;
+
+  const plan = db.raw.sql`
+    SELECT u.id, u.email, count(p.id) AS post_count
+    FROM users u JOIN posts p ON p.user_id = u.id
+    WHERE u.invited_by_id = ${1}
+    GROUP BY u.id, u.email
+  `
+    .returnsRow({
+      id: users.columns.id,
+      email: users.columns.email,
+      post_count: 'pg/int8@1',
+    })
+    .build();
+  type Row = ResultType<typeof plan>;
+
+  expectTypeOf<Row['id']>().toEqualTypeOf<number>();
+  expectTypeOf<Row['email']>().toEqualTypeOf<string>();
+  expectTypeOf<Row['post_count']>().toEqualTypeOf<bigint>();
+  expectTypeOf<keyof Row>().toEqualTypeOf<'id' | 'email' | 'post_count'>();
+});
+
+test('the affected-count terminator builds the branded row', () => {
+  const plan = db.raw.sql`UPDATE users SET name = ${'Ada'} WHERE id = ${1}`.affectedCount().build();
+
+  expectTypeOf(plan).toEqualTypeOf<SqlQueryPlan<AffectedCount>>();
+});
+
+test('an unknown codec id is rejected at the lane', () => {
+  // @ts-expect-error — 'pg/nope@1' is not a key of the contract's codec map
+  db.raw.sql`SELECT 1 AS one`.returnsRow({ one: 'pg/nope@1' });
+});

--- a/packages/3-extensions/sqlite/src/runtime/sqlite.ts
+++ b/packages/3-extensions/sqlite/src/runtime/sqlite.ts
@@ -5,10 +5,10 @@ import sqliteDriver from '@internal/driver-sqlite/runtime';
 import { instantiateExecutionStack } from '@internal/framework-components/execution';
 import { UNBOUND_NAMESPACE_ID } from '@internal/framework-components/ir';
 import { sql as sqlBuilder } from '@internal/sql-builder/runtime';
-import type { Db } from '@internal/sql-builder/types';
+import type { Db, RawLane } from '@internal/sql-builder/types';
 import type { ExtractCodecTypes, SqlStorage } from '@internal/sql-contract/types';
 import { orm as ormBuilder } from '@internal/sql-orm-client';
-import type { CodecTypesBase, RawSqlTag } from '@internal/sql-relational-core/expression';
+import type { CodecTypesBase } from '@internal/sql-relational-core/expression';
 import type { SqlQueryPlan } from '@internal/sql-relational-core/plan';
 import type {
   BindSiteParams,
@@ -70,7 +70,7 @@ export interface SqliteClient<TContract extends Contract<SqlStorage>> {
   readonly sql: UnboundSql<TContract>;
   readonly orm: UnboundOrm<TContract>;
   readonly enums: SqliteStaticContext<TContract>['enums'];
-  readonly raw: RawSqlTag;
+  readonly raw: RawLane<TContract>;
   readonly context: ExecutionContext<TContract>;
   readonly contract: TContract;
   readonly stack: SqlExecutionStackWithDriver<SqliteTargetId>;

--- a/packages/3-extensions/sqlite/src/static/sqlite-static.ts
+++ b/packages/3-extensions/sqlite/src/static/sqlite-static.ts
@@ -2,11 +2,10 @@ import sqliteAdapter from '@internal/adapter-sqlite/runtime';
 import { buildNamespacedEnums, type NamespacedEnums } from '@internal/contract/enum-accessor';
 import type { Contract } from '@internal/contract/types';
 import { UNBOUND_NAMESPACE_ID } from '@internal/framework-components/ir';
-import { sql } from '@internal/sql-builder/runtime';
-import type { Db } from '@internal/sql-builder/types';
+import { createRawLane, sql } from '@internal/sql-builder/runtime';
+import type { Db, RawLane } from '@internal/sql-builder/types';
 import type { SqlStorage } from '@internal/sql-contract/types';
-import type { RawCodecInferer, RawSqlTag } from '@internal/sql-relational-core/expression';
-import { createRawSql } from '@internal/sql-relational-core/expression';
+import type { RawCodecInferer } from '@internal/sql-relational-core/expression';
 import type { ExecutionContext, SqlRuntimeExtensionDescriptor } from '@internal/sql-runtime';
 import { createExecutionContext, createSqlExecutionStack } from '@internal/sql-runtime';
 import sqliteTarget, { SqliteContractSerializer } from '@internal/target-sqlite/runtime';
@@ -24,7 +23,7 @@ export interface SqliteStaticContext<TContract extends Contract<SqlStorage>> {
   readonly contract: TContract;
   readonly enums: UnboundEnums<TContract>;
   readonly sql: UnboundSql<TContract>;
-  readonly raw: RawSqlTag;
+  readonly raw: RawLane<TContract>;
 }
 
 export function buildSqliteStaticContext<TContract extends Contract<SqlStorage>>(
@@ -37,7 +36,7 @@ export function buildSqliteStaticContext<TContract extends Contract<SqlStorage>>
     UnboundSql<TContract>,
     'Db<TContract> indexed by a literal key widens NsId to string; TableProxy is invariant in NsId via insert()/update() parameter positions, so the indexed-access type cannot be proven to match the literal-keyed Namespace without this cast'
   >(sqlNamespace);
-  const raw: RawSqlTag = createRawSql(rawCodecInferer);
+  const raw: RawLane<TContract> = createRawLane<TContract>({ context, rawCodecInferer });
   const enums = Object.freeze(buildNamespacedEnums<TContract>(context.contract.domain))[
     UNBOUND_NAMESPACE_ID
   ];

--- a/packages/3-extensions/sqlite/test/sqlite.static.test.ts
+++ b/packages/3-extensions/sqlite/test/sqlite.static.test.ts
@@ -57,9 +57,10 @@ describe('sqliteStatic({ contractJson })', () => {
     expect(typeof result.sql).toBe('object');
   });
 
-  it('raw is a tagged template function', () => {
+  it('raw is the lane holding the statement tag', () => {
     const result = sqliteStatic<typeof contract>({ contractJson: contract });
-    expect(typeof result.raw).toBe('function');
+    expect(typeof result.raw).toBe('object');
+    expect(typeof result.raw.sql).toBe('function');
   });
 
   it('SqliteStaticContext type exposes context, contract, enums, sql, raw', () => {

--- a/skills/prisma-8-extension-upgrade/upgrades/8.0.0-rc.3-to-8.0.0-rc.4/instructions.md
+++ b/skills/prisma-8-extension-upgrade/upgrades/8.0.0-rc.3-to-8.0.0-rc.4/instructions.md
@@ -1,0 +1,97 @@
+---
+from: "8.0.0-rc.3"
+to: "8.0.0-rc.4"
+changes:
+  - id: facades-compose-the-raw-lane
+    summary: |
+      A facade no longer gets the whole-query raw tag from the builder. `Db<C>` is a pure
+      namespace map now, so the `raw` key it used to answer is gone, and the tag is composed at
+      client build instead.
+
+      Build it with `createRawLane({ context, rawCodecInferer })` from
+      `@internal/sql-builder/runtime`, typed `RawLane<TContract>` from
+      `@internal/sql-builder/types`, and expose it as your client's `raw`. Callers then write
+      ``client.raw.sql`SELECT ...` ``. A client that binds per role or per scope builds one lane
+      per bound context, the way it already builds one `sql` per context. A static context —
+      the no-runtime shape that returns `context`, `contract` and `sql` — builds one too and
+      returns it as `raw`.
+
+      If your `raw` property was the contract-free expression tag (`createRawSql(inferer)`), it
+      changes shape from a callable to `{ sql }`. That breaks your own surface, so note it in
+      your release.
+    detection:
+      glob: "**/*.{ts,mts,cts}"
+      regex:
+        - 'createRawSql\('
+        - 'RawSqlTag'
+        # `fns.raw` is a fragment call site and is deliberately excluded:
+        # fragments are unchanged by this release.
+        - '(?<!(?<![\w$])fns)\.raw`'
+      anyMatch: true
+  - id: reserved-raw-namespace-check-removed
+    summary: |
+      `sql()` no longer refuses a contract whose storage declares a namespace named `raw`, and
+      `ORM.NAMESPACE_RESERVED` leaves the error catalogue. Nothing raises the code now, so drop
+      any branch that matched it: a test asserting the refusal, a doc listing the code, an
+      error mapping of your own.
+    detection:
+      glob: "**/*.{ts,mts,cts,md}"
+      contains:
+        - "ORM.NAMESPACE_RESERVED"
+      anyMatch: true
+---
+
+# 8.0.0-rc.3 → 8.0.0-rc.4 — Extension-author upgrade instructions
+
+## `facades-compose-the-raw-lane`
+
+`Db<C>` is a namespace map and nothing else, so a facade composes the whole-query raw tag itself
+and exposes it as the raw lane:
+
+```ts
+import { createRawLane, sql } from '@internal/sql-builder/runtime';
+import type { Db, RawLane } from '@internal/sql-builder/types';
+
+const sqlDb: Db<TContract> = sql<TContract>({ context, rawCodecInferer });
+const raw: RawLane<TContract> = createRawLane<TContract>({ context, rawCodecInferer });
+```
+
+Callers reach the tag at `client.raw.sql`. A client that binds per role or per scope builds one
+lane per bound context, exactly as it already builds one `sql` per context.
+
+A static context does the same. If your facade ships a no-runtime surface — the shape that
+returns `context`, `contract`, `sql` and friends without opening a connection — build the lane
+there too and return it as `raw`:
+
+```ts
+export interface YourStaticContext<TContract extends Contract<SqlStorage>> {
+  readonly sql: Db<TContract>;
+  readonly raw: RawLane<TContract>;
+  // …context, contract, enums
+}
+
+const raw: RawLane<TContract> = createRawLane<TContract>({ context, rawCodecInferer });
+```
+
+Its `raw` property changes type from the contract-free tag to `RawLane<TContract>`, the same
+change the connected client makes, so a consumer reads both surfaces the same way.
+
+Two shapes change for your consumers. Anyone who wrote ``client.sql.raw`...` `` writes
+``client.raw.sql`...` ``. Anyone who called `client.raw` as an expression tag calls
+`client.raw.sql`...`.returns(codecId)` instead, or `fns.raw` inside a builder callback. Both are
+breaking changes to your own surface, so note them in your release.
+
+The detector looks for `createRawSql(`, `RawSqlTag`, and `raw` used as a tag. It skips the
+receiver `fns` exactly, including `x.fns.raw`, because that is a fragment call site and needs no
+change. A receiver that merely ends in those letters, such as `myfns.raw`, still matches, as
+does a functions object aliased to another name.
+
+## `reserved-raw-namespace-check-removed`
+
+`sql()` used to refuse a contract whose storage declared a namespace named `raw`, raising
+`ORM.NAMESPACE_RESERVED` at client construction. The check is gone with the constraint it
+enforced: the lane is composed by the client, not answered by the namespace map, so no contract
+can shadow it.
+
+Drop any branch that matched the code — a test asserting the refusal, an error mapping, a doc
+that lists it. The code no longer exists in the catalogue, and nothing raises it.

--- a/skills/prisma-next-upgrade/upgrades/8.0.0-rc.3-to-8.0.0-rc.4/instructions.md
+++ b/skills/prisma-next-upgrade/upgrades/8.0.0-rc.3-to-8.0.0-rc.4/instructions.md
@@ -1,0 +1,117 @@
+---
+from: "8.0.0-rc.3"
+to: "8.0.0-rc.4"
+changes:
+  - id: raw-moves-to-its-own-lane
+    summary: |
+      Whole-query raw SQL moves address: ``db.sql.raw`SELECT ...` `` becomes
+      ``db.raw.sql`SELECT ...` ``. Everything after the template is unchanged.
+      `.returnsRow(spec)`, `.affectedCount()`, `.returns(codecId)`, and splicing a
+      row-returning statement into another template all behave as they did.
+
+      The client's `raw` property changes shape in the same move. It was a tagged template you
+      could call directly for an expression fragment. It is now the raw lane, an object whose
+      `sql` key holds the statement tag.
+
+      An author who called `db.raw` as a fragment tag has two replacements. Use `fns.raw`
+      inside a builder callback, which is where fragments belong. Or terminate the lane's tag
+      with `.returns(codecId)` for the same expression, now bound to the contract.
+    detection:
+      glob: "**/*.{ts,tsx,mts,cts}"
+      regex:
+        # The old whole-query address, on any receiver.
+        - '\.sql\.raw`'
+        # The client tag being repurposed. `fns.raw` is a fragment call site and
+        # is deliberately excluded: fragments are unchanged by this release.
+        - '(?<!(?<![\w$])fns)\.raw`'
+      anyMatch: true
+  - id: raw-is-no-longer-a-reserved-namespace
+    summary: |
+      A storage namespace named `raw` is allowed again. 8.0.0-rc.2 and 8.0.0-rc.3 refused such a contract when
+      the client was built, with `ORM.NAMESPACE_RESERVED`, because the SQL surface answered
+      `db.sql.raw` with the raw tag. The tag has moved to `db.raw.sql`, so nothing a contract
+      declares can collide with it.
+
+      If you renamed a namespace to get past that error, you may rename it back:
+      `@@schema("raw")` is an ordinary name, reachable as `db.sql.raw.<table>`. Re-emit the
+      contract afterwards, then plan the rename against the database as you would any other
+      namespace rename. The physical schema keeps the name it has until a plan moves it.
+      Renaming back is optional: a namespace you renamed away stays valid.
+    detection:
+      glob: "**/*.{prisma,json}"
+      contains:
+        - "ORM.NAMESPACE_RESERVED"
+        - '@@schema("raw")'
+      anyMatch: true
+---
+
+# 8.0.0-rc.3 → 8.0.0-rc.4 — User upgrade instructions
+
+## `raw-moves-to-its-own-lane`
+
+Whole-query raw SQL has its own front door. The tag that sat inside the namespace map is now a
+lane on the client:
+
+```ts
+// Before
+const plan = db.sql.raw`SELECT id, email FROM users WHERE id = ${1}`
+  .returnsRow({ id: users.columns.id, email: users.columns.email })
+  .build();
+
+// After
+const plan = db.raw.sql`SELECT id, email FROM users WHERE id = ${1}`
+  .returnsRow({ id: users.columns.id, email: users.columns.email })
+  .build();
+```
+
+Everything after the template is unchanged: the terminators, the row specs they take, the plans
+they build, and splicing a row-returning statement into another template.
+
+The client's `raw` property changes shape in the same move. It was the expression tag you could
+call directly; it is now the lane, whose `sql` key holds the statement tag:
+
+```ts
+// Before: `raw` is a tag
+const upper = db.raw`UPPER(${email})`.returns('pg/text@1');
+
+// After, inside a builder callback — where fragments belong
+const rows = db.sql.public.users
+  .select((f, fns) => ({ upper: fns.raw`UPPER(${f.email})`.returns('pg/text@1') }))
+  .build();
+
+// After, from the lane, for a fragment you hold on its own
+const upper = db.raw.sql`UPPER(${email})`.returns('pg/text@1');
+```
+
+The detector looks for the old address and for `raw` used as a tag. It skips the receiver `fns`
+exactly, including `x.fns.raw`, because that is a fragment call site and needs no change. A
+receiver that merely ends in those letters, such as `myfns.raw`, still matches. So does a
+builder callback that names its functions object something else. Check whether the receiver is
+a client before you change anything.
+
+## `raw-is-no-longer-a-reserved-namespace`
+
+8.0.0-rc.2 and 8.0.0-rc.3 refused a contract whose storage declared a namespace named `raw`, because that was
+the key the SQL surface answered with the raw tag:
+
+```text
+ORM.NAMESPACE_RESERVED: The SQL surface exposes the raw statement tag as "db.raw", so a storage
+namespace named "raw" cannot be reached through it. Rename the namespace in the schema.
+```
+
+That constraint is gone. `db.sql` is a namespace map and nothing else, and the lane is composed
+by the client rather than derived from your contract, so the two cannot collide.
+
+If you renamed a namespace to get past the error, you may rename it back:
+
+```prisma
+model Event {
+  id String @id
+  @@schema("raw")
+}
+```
+
+Its tables are then reachable as `db.sql.raw.<table>`, like any other namespace. Re-emit the
+contract, and plan the rename against the database as you would any other namespace rename —
+the physical schema carries the old name until a plan moves it. Renaming back is optional; the
+name you moved to stays valid.


### PR DESCRIPTION
First of five PRs in this stack. TML-3214 moves the whole-query raw entrypoint out of the SQL builder and into a facade lane: `db.sql.raw` becomes `db.raw.sql`.

This PR adds the new lane. It does not remove the old address yet, so both work during the stack.

- `RawLane<C>` and `createRawLane()` live in sql-builder.
- The postgres and sqlite facades build the lane at client construction, with the same codec inferer and contract the tag already uses.
- Tests cover the lane through the static contexts and a full call site typed through `db.raw.sql`.
- This PR also adds the 8.0.0-rc.3 → rc.4 upgrade entries for the whole stack. They sit in this bottom PR so every PR above inherits them in its diff against main.

The facades' old `raw` key was the contract-free expression tag. It had no consumers outside two shape assertions in tests. Fragment authors keep `fns.raw`; expression typing is also available through the lane tag's `.returns()`.

Refs: TML-3214

https://claude.ai/code/session_01NnNjsNcPMtbJZhnZz5Zzbe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a raw SQL lane exposed through `client.raw.sql`.
  * Added contract-aware row decoding, affected-count result typing, and public raw-lane support for PostgreSQL and SQLite.

* **Breaking Changes**
  * Updated whole-query raw SQL usage from `db.sql.raw` to `db.raw.sql`.
  * The `raw` property is now an object containing the `sql` tag.

* **Documentation**
  * Added upgrade guidance, including raw SQL composition and removal of the reserved `raw` namespace.

* **Tests**
  * Added coverage for raw query execution, metadata, parameters, row types, and mutations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->