### PR TITLE
feat!: retire the reserved raw namespace with the old address (TML-3214)

### DIFF
--- a/docs/reference/error-reference.md
+++ b/docs/reference/error-reference.md
@@ -521,10 +521,6 @@ The Mongo ORM client was asked to operate on a model name that is not in the con
 
 A mutation that expected the database to return a row got none — `create()`/`upsert()` read-back, MTI base or variant INSERT, or a nested create. The Prisma-classic analogue of P2025. Meta: `operation`, `model`, `tableName`, `phase`.
 
-### ORM.NAMESPACE_RESERVED
-
-The contract declares a storage namespace whose name the SQL surface reserves for itself, so every table in it would be unreachable through the builder while the type still promised them. `sql()` refuses such a contract at construction. One name is reserved: `raw`, the key the SQL DSL object answers with the whole-query raw statement tag (`db.sql.raw`, see [ADR 247](../architecture%20docs/adrs/ADR%20247%20-%20Whole-query%20raw%20SQL%20is%20the%20fragment%20mechanism%20at%20statement%20position.md)). Rename the namespace in the schema. Meta: `namespaceId`.
-
 ### ORM.OPERATION_UNSUPPORTED
 
 A valid ORM method was called in a configuration that does not support it: mutating an MTI variant collection with a method that requires `createAll()`, Mongo `upsert()` with dot-path field operations, or a Mongo mutation carrying windowing (`orderBy`/`skip`/`take`) or includes. Meta: `method`, `model`, `reason`, `field`.

--- a/examples/prisma-8-demo/src/queries/raw-query-demo.ts
+++ b/examples/prisma-8-demo/src/queries/raw-query-demo.ts
@@ -6,7 +6,7 @@ import { db } from '../prisma/db';
  * (see `raw-sql-demo.ts`, which drops raw *fragments* into a typed builder
  * query).
  *
- * `db.sql.raw` is the same tagged template, terminated differently:
+ * `db.raw.sql` is the same tagged template, terminated differently:
  *
  * - `.returnsRow(spec)` declares the result columns and yields a plan the
  *   runtime's `query()` streams decoded rows from.
@@ -30,7 +30,7 @@ const post = db.sql.public.post;
  * codec directly and reads back as a `bigint`.
  */
 export async function rawQueryReport(limit = 10, runtime?: Runtime) {
-  const plan = db.sql.raw`
+  const plan = db.raw.sql`
     SELECT u.id, u.email, count(p.id) AS "postCount"
     FROM "user" u
     LEFT JOIN "post" p ON p."userId" = u.id
@@ -56,7 +56,7 @@ export async function rawQueryReport(limit = 10, runtime?: Runtime) {
  * which answers with the statement's row count rather than a row stream.
  */
 export async function rawQueryBumpViews(kind = 'admin', runtime?: Runtime) {
-  const plan = db.sql.raw`
+  const plan = db.raw.sql`
     UPDATE "post"
     SET "viewCount" = "viewCount" + 1
     WHERE "userId" IN (SELECT id FROM "user" WHERE kind = ${kind})
@@ -75,7 +75,7 @@ export async function rawQueryBumpViews(kind = 'admin', runtime?: Runtime) {
  * describes the inner statement; the outer template declares its own.
  */
 export async function rawQueryActiveAuthors(minPosts = 1, runtime?: Runtime) {
-  const authorsWithPosts = db.sql.raw`
+  const authorsWithPosts = db.raw.sql`
     SELECT p."userId" AS "userId", count(*) AS "postCount"
     FROM "post" p
     GROUP BY p."userId"
@@ -85,7 +85,7 @@ export async function rawQueryActiveAuthors(minPosts = 1, runtime?: Runtime) {
     postCount: 'pg/int8@1',
   });
 
-  const plan = db.sql.raw`
+  const plan = db.raw.sql`
     WITH active AS (${authorsWithPosts})
     SELECT u.email, active."postCount"
     FROM active
@@ -110,7 +110,7 @@ export async function rawQueryActiveAuthors(minPosts = 1, runtime?: Runtime) {
  * and is rejected as an interpolation.
  */
 export async function rawQueryPromoteAndList(titleTerm: string, runtime?: Runtime) {
-  const promoted = db.sql.raw`
+  const promoted = db.raw.sql`
     UPDATE "post"
     SET priority = 'high'
     WHERE title ILIKE ${`%${titleTerm}%`} AND priority <> 'high'
@@ -121,7 +121,7 @@ export async function rawQueryPromoteAndList(titleTerm: string, runtime?: Runtim
     userId: post.columns.userId,
   });
 
-  const plan = db.sql.raw`
+  const plan = db.raw.sql`
     WITH promoted AS (${promoted})
     SELECT promoted.title, u.email
     FROM promoted

--- a/examples/prisma-8-demo/test/codec-id-ergonomics.types.test-d.ts
+++ b/examples/prisma-8-demo/test/codec-id-ergonomics.types.test-d.ts
@@ -10,13 +10,13 @@ import { expectTypeOf, test } from 'vitest';
 import { db } from '../src/prisma/db';
 
 test('a contract-bound fragment keeps its codec id literal', () => {
-  const expr = db.sql.raw`now()`.returns('pg/timestamptz@1');
+  const expr = db.raw.sql`now()`.returns('pg/timestamptz@1');
   expectTypeOf(expr.returnType.codecId).toEqualTypeOf<'pg/timestamptz@1'>();
 });
 
 test('a contract-bound fragment rejects an id the contract does not carry', () => {
   // @ts-expect-error — unknown codec id
-  db.sql.raw`now()`.returns('pg/nope@1');
+  db.raw.sql`now()`.returns('pg/nope@1');
 });
 
 test('a prepared declaration rejects an id the contract does not carry', async () => {

--- a/packages/2-sql/4-lanes/sql-builder/src/exports/types.ts
+++ b/packages/2-sql/4-lanes/sql-builder/src/exports/types.ts
@@ -11,5 +11,6 @@ export type {
 } from '../types/db';
 export type { GroupedQuery } from '../types/grouped-query';
 export type { DeleteQuery, InsertQuery, UpdateQuery } from '../types/mutation-query';
+export type { ContractRawTag, RawLane, RawTagFor } from '../types/raw-query';
 export type { SelectQuery } from '../types/select-query';
 export type { TableProxy } from '../types/table-proxy';

--- a/packages/2-sql/4-lanes/sql-builder/src/runtime/index.ts
+++ b/packages/2-sql/4-lanes/sql-builder/src/runtime/index.ts
@@ -2,4 +2,5 @@ export type { Db } from '../types/db';
 export { ExpressionImpl } from './expression-impl';
 export { createFieldProxy } from './field-proxy';
 export { createAggregateFunctions, createFunctions } from './functions';
+export { createRawLane, type RawLaneOptions } from './raw-lane';
 export { type SqlOptions, sql } from './sql';

--- a/packages/2-sql/4-lanes/sql-builder/src/runtime/raw-lane.ts
+++ b/packages/2-sql/4-lanes/sql-builder/src/runtime/raw-lane.ts
@@ -1,0 +1,33 @@
+import type { Contract } from '@internal/contract/types';
+import type { SqlStorage } from '@internal/sql-contract/types';
+import { createRawSql, type RawCodecInferer } from '@internal/sql-relational-core/expression';
+import type { ExecutionContext } from '@internal/sql-relational-core/query-lane-context';
+import { blindCast } from '@internal/utils/casts';
+import type { TableProxyContract } from '../types/db';
+import type { RawLane, RawTagFor } from '../types/raw-query';
+
+export interface RawLaneOptions<C extends Contract<SqlStorage> & TableProxyContract> {
+  readonly context: ExecutionContext<C>;
+  readonly rawCodecInferer: RawCodecInferer;
+}
+
+/**
+ * Builds the raw lane a client exposes as `db.raw`.
+ *
+ * The tag binds the adapter's codec inferer and the contract here, once. An
+ * authoring site then carries only its template, its row spec, and a
+ * terminator.
+ *
+ * The row type is phantom: no value holds it. The target-agnostic tag types it
+ * as `unknown`, and the contract says what each declared column decodes to.
+ */
+export function createRawLane<C extends Contract<SqlStorage> & TableProxyContract>(
+  options: RawLaneOptions<C>,
+): RawLane<C> {
+  const tag = blindCast<
+    RawTagFor<C>,
+    'the row type is phantom, so no value can prove it. The builder is the same one either way. Only the contract says what the declared columns decode to'
+  >(createRawSql(options.rawCodecInferer, { contract: options.context.contract }));
+
+  return Object.freeze({ sql: tag });
+}

--- a/packages/2-sql/4-lanes/sql-builder/src/runtime/sql.ts
+++ b/packages/2-sql/4-lanes/sql-builder/src/runtime/sql.ts
@@ -1,17 +1,12 @@
 import type { Contract } from '@internal/contract/types';
 import type { SqlStorage } from '@internal/sql-contract/types';
-import { createRawSql, type RawCodecInferer } from '@internal/sql-relational-core/expression';
+import type { RawCodecInferer } from '@internal/sql-relational-core/expression';
 import type { ExecutionContext } from '@internal/sql-relational-core/query-lane-context';
 import { blindCast } from '@internal/utils/casts';
-import { structuredError } from '@internal/utils/structured-error';
 import type { Db, TableProxyContract } from '../types/db';
-import type { RawTagFor } from '../types/raw-query';
 import type { BuilderContext } from './builder-base';
 import { resolveTableInNamespace } from './resolve-table';
 import { TableProxyImpl } from './table-proxy-impl';
-
-/** The key `raw`, which the SQL surface answers with the raw statement tag; no storage namespace may claim it. */
-const RAW_TAG_KEY = 'raw';
 
 export interface SqlOptions<C extends Contract<SqlStorage> & TableProxyContract> {
   readonly context: ExecutionContext<C>;
@@ -35,36 +30,12 @@ export function sql<C extends Contract<SqlStorage> & TableProxyContract>(
 
   const { storage } = context.contract;
 
-  // `db.raw` is the whole-query raw tag, so a namespace of that name would be
-  // unreachable through the surface while still typing as one. Refuse the
-  // contract here rather than answering `undefined` for every table in it.
-  if (Object.hasOwn(storage.namespaces, RAW_TAG_KEY)) {
-    throw structuredError(
-      'ORM.NAMESPACE_RESERVED',
-      `The SQL surface exposes the raw statement tag as "db.${RAW_TAG_KEY}", so a storage namespace named "${RAW_TAG_KEY}" cannot be reached through it. Rename the namespace in the schema.`,
-      { meta: { namespaceId: RAW_TAG_KEY } },
-    );
-  }
-
-  // Bound once, here: the tag carries the adapter's codec inferer and the
-  // contract its plans are stamped from, so an authoring site states neither.
-  // The row type each terminator mints is phantom — the contract resolves what
-  // a declared column decodes to, which the target-agnostic tag types as
-  // `unknown`.
-  const raw = blindCast<
-    RawTagFor<C>,
-    'the row type a raw plan carries is phantom: the same builder mints it, and only the contract states what its declared columns decode to'
-  >(createRawSql(rawCodecInferer, { contract: context.contract }));
-
   return new Proxy(
     blindCast<Db<C>, 'the handler answers every property; the target is an empty carrier'>({}),
     {
       get(_target, prop: string | symbol) {
         if (typeof prop !== 'string') {
           return undefined;
-        }
-        if (prop === RAW_TAG_KEY) {
-          return raw;
         }
         if (!Object.hasOwn(storage.namespaces, prop)) {
           return undefined;

--- a/packages/2-sql/4-lanes/sql-builder/src/types/db.ts
+++ b/packages/2-sql/4-lanes/sql-builder/src/types/db.ts
@@ -1,5 +1,4 @@
 import type { StorageTable } from '@internal/sql-contract/types';
-import type { RawTagFor } from './raw-query';
 import type { TableProxy } from './table-proxy';
 
 export type CapabilitiesBase = Record<string, Record<string, boolean>>;
@@ -81,16 +80,13 @@ export type Namespace<
 };
 
 /**
- * The contract-bound SQL surface: one facet per storage namespace, plus the
- * raw tag for statements the builders do not express.
+ * The contract-bound SQL surface: one facet per storage namespace, and nothing
+ * else.
  *
- * `raw` sits beside the namespace facets because a whole-query raw statement
- * is a peer of the table proxies, not something reached through one — it names
- * its own tables. The tag binds the adapter's codec inferer and the contract
- * once, here, so an authoring site carries only its template and row spec.
+ * A namespace may be named anything the database allows, `raw` included. The
+ * client carries whole-query raw statements on its own lane, `db.raw.sql`.
+ * This map does not reach that lane.
  */
 export type Db<C extends TableProxyContract> = {
   readonly [Ns in keyof C['storage']['namespaces'] & string]: Namespace<C, Ns>;
-} & {
-  readonly raw: RawTagFor<C>;
 };

--- a/packages/2-sql/4-lanes/sql-builder/src/types/raw-query.ts
+++ b/packages/2-sql/4-lanes/sql-builder/src/types/raw-query.ts
@@ -122,7 +122,7 @@ export interface ContractRawBuilder<CodecTypes extends Record<string, { readonly
   affectedCount(): RawAffectedCountQuery;
 }
 
-/** The contract-bound raw tag, as `db.raw` exposes it. */
+/** The contract-bound raw tag, as `db.raw.sql` exposes it. */
 export type ContractRawTag<CodecTypes extends Record<string, { readonly output: unknown }>> = (
   strings: TemplateStringsArray,
   ...values: RawSqlInterpolation[]
@@ -130,3 +130,17 @@ export type ContractRawTag<CodecTypes extends Record<string, { readonly output: 
 
 /** The raw tag for a contract, with its codec-type map already applied. */
 export type RawTagFor<C extends TableProxyContract> = ContractRawTag<ExtractCodecTypes<C>>;
+
+/**
+ * The raw lane, addressed as `db.raw`. It holds the whole-query statement tag
+ * under `sql`.
+ *
+ * Editors key their SQL highlighting on that name, and a raw plan's
+ * `lane: 'raw'` already uses it.
+ *
+ * The lane is one key wide on purpose. Anything else raw authoring needs can
+ * join it later, without moving the address again.
+ */
+export type RawLane<C extends TableProxyContract> = {
+  readonly sql: RawTagFor<C>;
+};

--- a/packages/2-sql/4-lanes/sql-builder/test/runtime/raw-query.test.ts
+++ b/packages/2-sql/4-lanes/sql-builder/test/runtime/raw-query.test.ts
@@ -8,6 +8,7 @@ import type { ExecutionContext } from '@internal/sql-relational-core/query-lane-
 import { describe, expect, it } from 'vitest';
 import { createTestSqlNamespace } from '../../../../1-core/contract/test/test-support';
 import type { BuilderContext } from '../../src/runtime/builder-base';
+import { createRawLane } from '../../src/runtime/raw-lane';
 import { sql } from '../../src/runtime/sql';
 import { TableProxyImpl } from '../../src/runtime/table-proxy-impl';
 import { contract as contractJson } from '../fixtures/contract';
@@ -23,6 +24,15 @@ const stubBase = {
   types: {},
   applyMutationDefaults: () => [],
 };
+
+function rawLane() {
+  return createRawLane({
+    context: { ...stubBase, contract: sqlContract } as unknown as ExecutionContext<
+      typeof sqlContract
+    >,
+    rawCodecInferer: { inferCodec: () => 'pg/int4@1' },
+  });
+}
 
 function db() {
   return sql({
@@ -49,10 +59,10 @@ describe('contract-bound raw statements', () => {
   // Reads as the surface is meant to be used: one template, one row spec
   // mixing contract columns with a computed column, one terminator.
   it('builds a plan whose row spec resolves both entry forms', () => {
-    const d = db();
-    const users = d.public.users;
+    const d = rawLane();
+    const users = db().public.users;
 
-    const plan = d.raw`
+    const plan = d.sql`
       SELECT u.id, u.email, count(p.id) AS post_count
       FROM users u JOIN posts p ON p.user_id = u.id
       WHERE u.invited_by_id = ${1}
@@ -82,7 +92,7 @@ describe('contract-bound raw statements', () => {
   });
 
   it('binds interpolated values through the adapter inferer', () => {
-    const plan = db().raw`SELECT id FROM users WHERE id = ${7}`
+    const plan = rawLane().sql`SELECT id FROM users WHERE id = ${7}`
       .returnsRow({ id: 'pg/int4@1' })
       .build();
 
@@ -93,18 +103,20 @@ describe('contract-bound raw statements', () => {
   });
 
   it('builds an affected-count plan from a mutation template', () => {
-    const plan = db().raw`UPDATE users SET name = ${'Ada'} WHERE id = ${1}`.affectedCount().build();
+    const plan = rawLane().sql`UPDATE users SET name = ${'Ada'} WHERE id = ${1}`
+      .affectedCount()
+      .build();
 
     expect((plan.ast as RawQueryAst).result).toEqual({ kind: 'affected-count' });
   });
 
   it('splices a row-returning statement into another template', () => {
-    const d = db();
-    const invited = d.raw`SELECT id FROM users WHERE invited_by_id = ${1}`.returnsRow({
-      id: d.public.users.columns.id,
+    const d = rawLane();
+    const invited = d.sql`SELECT id FROM users WHERE invited_by_id = ${1}`.returnsRow({
+      id: db().public.users.columns.id,
     });
 
-    const plan = d.raw`WITH invited AS (${invited}) SELECT count(*) AS n FROM invited`
+    const plan = d.sql`WITH invited AS (${invited}) SELECT count(*) AS n FROM invited`
       .returnsRow({ n: 'pg/int8@1' })
       .build();
 
@@ -114,7 +126,7 @@ describe('contract-bound raw statements', () => {
   });
 });
 
-describe('reserved surface keys', () => {
+describe('a storage namespace named raw', () => {
   // Authored through the contract builder so the namespace is one the emitter
   // could really produce: the target pack's default namespace names it.
   const rawNamespaceContract = defineContract(
@@ -148,26 +160,27 @@ describe('reserved surface keys', () => {
       }) as const,
   ) as FrameworkContract<SqlStorage>;
 
-  it('refuses a contract whose storage claims the raw tag key', () => {
-    expect(() =>
-      sql({
-        context: { ...stubBase, contract: rawNamespaceContract } as unknown as ExecutionContext<
-          typeof rawNamespaceContract
-        >,
-        rawCodecInferer: { inferCodec: () => 'pg/text@1' },
-      }),
-    ).toThrow(/namespace named "raw" cannot be reached/);
+  it('is reachable like any other namespace', () => {
+    const db = sql({
+      context: { ...stubBase, contract: rawNamespaceContract } as unknown as ExecutionContext<
+        typeof rawNamespaceContract
+      >,
+      rawCodecInferer: { inferCodec: () => 'pg/text@1' },
+    });
+
+    expect(db['raw']?.['Note']?.columns['id']).toEqual({ codecId: 'pg/text@1', nullable: false });
   });
 
-  it('names the collision in a structured envelope', () => {
-    expect(() =>
-      sql({
-        context: { ...stubBase, contract: rawNamespaceContract } as unknown as ExecutionContext<
-          typeof rawNamespaceContract
-        >,
-        rawCodecInferer: { inferCodec: () => 'pg/text@1' },
-      }),
-    ).toThrow(expect.objectContaining({ code: 'ORM.NAMESPACE_RESERVED' }));
+  it('builds a query against its tables', () => {
+    const db = sql({
+      context: { ...stubBase, contract: rawNamespaceContract } as unknown as ExecutionContext<
+        typeof rawNamespaceContract
+      >,
+      rawCodecInferer: { inferCodec: () => 'pg/text@1' },
+    });
+    const plan = db['raw']?.['Note']?.select('id').build();
+
+    expect(plan?.ast.kind).toBe('select');
   });
 });
 

--- a/packages/2-sql/4-lanes/sql-builder/test/types/raw-query.types.test-d.ts
+++ b/packages/2-sql/4-lanes/sql-builder/test/types/raw-query.types.test-d.ts
@@ -9,15 +9,16 @@ import type { ResultType } from '@internal/framework-components/runtime';
 import type { SqlStatementStats } from '@internal/sql-relational-core/ast';
 import type { AffectedCount } from '@internal/sql-relational-core/expression';
 import { expectTypeOf, test } from 'vitest';
-import type { Db } from '../../src/exports/types';
+import type { Db, RawLane } from '../../src/exports/types';
 import type { Contract } from '../fixtures/generated/contract';
 
 declare const db: Db<Contract>;
+declare const raw: RawLane<Contract>;
 
 const users = db.public.users;
 
 test('a contract column reference inherits its output type', () => {
-  const plan = db.raw`SELECT id, email FROM users`
+  const plan = raw.sql`SELECT id, email FROM users`
     .returnsRow({ id: users.columns.id, email: users.columns.email })
     .build();
   type Row = ResultType<typeof plan>;
@@ -28,7 +29,7 @@ test('a contract column reference inherits its output type', () => {
 });
 
 test('a nullable contract column reference resolves to a nullable type', () => {
-  const plan = db.raw`SELECT invited_by_id FROM users`
+  const plan = raw.sql`SELECT invited_by_id FROM users`
     .returnsRow({ invited_by_id: users.columns.invited_by_id })
     .build();
   type Row = ResultType<typeof plan>;
@@ -37,7 +38,7 @@ test('a nullable contract column reference resolves to a nullable type', () => {
 });
 
 test('an explicit codec id resolves through the contract codec-type map', () => {
-  const plan = db.raw`SELECT count(*) AS order_count FROM posts`
+  const plan = raw.sql`SELECT count(*) AS order_count FROM posts`
     .returnsRow({ order_count: 'pg/int8@1' })
     .build();
   type Row = ResultType<typeof plan>;
@@ -46,7 +47,7 @@ test('an explicit codec id resolves through the contract codec-type map', () => 
 });
 
 test('an explicit entry declaring nullability widens its resolved type', () => {
-  const plan = db.raw`SELECT max(views) AS top FROM posts`
+  const plan = raw.sql`SELECT max(views) AS top FROM posts`
     .returnsRow({ top: { codecId: 'pg/int4@1', nullable: true } })
     .build();
   type Row = ResultType<typeof plan>;
@@ -55,7 +56,7 @@ test('an explicit entry declaring nullability widens its resolved type', () => {
 });
 
 test('a mixed spec resolves each entry by its own form', () => {
-  const plan = db.raw`
+  const plan = raw.sql`
     SELECT u.id, u.email, count(p.id) AS post_count
     FROM users u JOIN posts p ON p.user_id = u.id
     GROUP BY u.id, u.email
@@ -75,7 +76,7 @@ test('a mixed spec resolves each entry by its own form', () => {
 });
 
 test('an affected-count statement mints a branded statement-stats plan', () => {
-  const plan = db.raw`UPDATE users SET name = ${'Ada'} WHERE id = ${1}`.affectedCount().build();
+  const plan = raw.sql`UPDATE users SET name = ${'Ada'} WHERE id = ${1}`.affectedCount().build();
   type Row = ResultType<typeof plan>;
 
   // The brand is what tells this plan apart from a row spec that happens to
@@ -86,12 +87,12 @@ test('an affected-count statement mints a branded statement-stats plan', () => {
 });
 
 test('a row-returning statement interpolates into another template', () => {
-  const invited = db.raw`SELECT id, email FROM users WHERE invited_by_id = ${1}`.returnsRow({
+  const invited = raw.sql`SELECT id, email FROM users WHERE invited_by_id = ${1}`.returnsRow({
     id: users.columns.id,
     email: users.columns.email,
   });
 
-  const plan = db.raw`WITH invited AS (${invited}) SELECT count(*) AS n FROM invited`
+  const plan = raw.sql`WITH invited AS (${invited}) SELECT count(*) AS n FROM invited`
     .returnsRow({ n: 'pg/int8@1' })
     .build();
   type Row = ResultType<typeof plan>;
@@ -100,15 +101,15 @@ test('a row-returning statement interpolates into another template', () => {
 });
 
 test('an affected-count statement is rejected as an interpolation', () => {
-  const bump = db.raw`UPDATE users SET name = ${'Ada'}`.affectedCount();
+  const bump = raw.sql`UPDATE users SET name = ${'Ada'}`.affectedCount();
 
   // @ts-expect-error — only row-returning raw statements embed into a template
-  db.raw`WITH bumped AS (${bump}) SELECT 1`.returnsRow({ one: 'pg/int4@1' });
+  raw.sql`WITH bumped AS (${bump}) SELECT 1`.returnsRow({ one: 'pg/int4@1' });
 });
 
 test('an unterminated template has no build()', () => {
   // @ts-expect-error — the template builds only through a terminator
-  db.raw`SELECT 1`.build();
+  raw.sql`SELECT 1`.build();
 });
 
 test('a column reference from the table proxy carries the contract codec id', () => {
@@ -119,7 +120,7 @@ test('a column reference from the table proxy carries the contract codec id', ()
 
 test('a __proto__ column is rejected on the contract-typed tag too', () => {
   // @ts-expect-error — a __proto__ key never survives as a row column
-  db.raw`SELECT 1 AS "__proto__"`.returnsRow({ __proto__: 'pg/int4@1' });
+  raw.sql`SELECT 1 AS "__proto__"`.returnsRow({ __proto__: 'pg/int4@1' });
 });
 
 test('a constructor column cannot be declared against the contract codec map', () => {
@@ -128,5 +129,5 @@ test('a constructor column cannot be declared against the contract codec map', (
   // The rejection is the compiler's, not a rule this surface imposes: the
   // contract-free tag takes the same spec and carries the column through.
   // @ts-expect-error — the codec id cannot stay literal under this key
-  db.raw`SELECT 1 AS "constructor"`.returnsRow({ constructor: 'pg/int4@1' });
+  raw.sql`SELECT 1 AS "constructor"`.returnsRow({ constructor: 'pg/int4@1' });
 });

--- a/packages/3-extensions/postgres/src/runtime/postgres.ts
+++ b/packages/3-extensions/postgres/src/runtime/postgres.ts
@@ -4,10 +4,10 @@ import type { Contract } from '@internal/contract/types';
 import postgresDriver from '@internal/driver-postgres/runtime';
 import { instantiateExecutionStack } from '@internal/framework-components/execution';
 import { sql as sqlBuilder } from '@internal/sql-builder/runtime';
-import type { Db } from '@internal/sql-builder/types';
+import type { Db, RawLane } from '@internal/sql-builder/types';
 import type { ExtractCodecTypes, SqlStorage } from '@internal/sql-contract/types';
 import { orm as ormBuilder } from '@internal/sql-orm-client';
-import type { CodecTypesBase, RawSqlTag } from '@internal/sql-relational-core/expression';
+import type { CodecTypesBase } from '@internal/sql-relational-core/expression';
 import type { SqlQueryPlan } from '@internal/sql-relational-core/plan';
 import type {
   BindSiteParams,
@@ -58,7 +58,7 @@ export interface PostgresClient<TContract extends Contract<SqlStorage>> {
   readonly orm: OrmClient<TContract>;
   readonly enums: NamespacedEnums<TContract>;
   readonly nativeEnums: NamespacedNativeEnums<TContract>;
-  readonly raw: RawSqlTag;
+  readonly raw: RawLane<TContract>;
   readonly context: ExecutionContext<TContract>;
   readonly contract: TContract;
   readonly stack: SqlExecutionStackWithDriver<PostgresTargetId>;

--- a/packages/3-extensions/postgres/src/static/postgres-static.ts
+++ b/packages/3-extensions/postgres/src/static/postgres-static.ts
@@ -1,11 +1,10 @@
 import postgresAdapter from '@internal/adapter-postgres/runtime';
 import { buildNamespacedEnums, type NamespacedEnums } from '@internal/contract/enum-accessor';
 import type { Contract } from '@internal/contract/types';
-import { sql } from '@internal/sql-builder/runtime';
-import type { Db } from '@internal/sql-builder/types';
+import { createRawLane, sql } from '@internal/sql-builder/runtime';
+import type { Db, RawLane } from '@internal/sql-builder/types';
 import type { SqlStorage } from '@internal/sql-contract/types';
-import type { RawCodecInferer, RawSqlTag } from '@internal/sql-relational-core/expression';
-import { createRawSql } from '@internal/sql-relational-core/expression';
+import type { RawCodecInferer } from '@internal/sql-relational-core/expression';
 import type { ExecutionContext, SqlRuntimeExtensionDescriptor } from '@internal/sql-runtime';
 import { createExecutionContext, createSqlExecutionStack } from '@internal/sql-runtime';
 import postgresTarget, { PostgresContractSerializer } from '@internal/target-postgres/runtime';
@@ -19,7 +18,7 @@ export interface PostgresStaticContext<TContract extends Contract<SqlStorage>> {
   readonly enums: NamespacedEnums<TContract>;
   readonly nativeEnums: NamespacedNativeEnums<TContract>;
   readonly sql: Db<TContract>;
-  readonly raw: RawSqlTag;
+  readonly raw: RawLane<TContract>;
 }
 
 export function buildPostgresStaticContext<TContract extends Contract<SqlStorage>>(
@@ -27,7 +26,7 @@ export function buildPostgresStaticContext<TContract extends Contract<SqlStorage
   rawCodecInferer: RawCodecInferer,
 ): PostgresStaticContext<TContract> {
   const sqlDb: Db<TContract> = sql<TContract>({ context, rawCodecInferer });
-  const raw: RawSqlTag = createRawSql(rawCodecInferer);
+  const raw: RawLane<TContract> = createRawLane<TContract>({ context, rawCodecInferer });
   const enums = Object.freeze(buildNamespacedEnums<TContract>(context.contract.domain));
   const nativeEnums = blindCast<
     NamespacedNativeEnums<TContract>,

--- a/packages/3-extensions/postgres/test/postgres.static.test.ts
+++ b/packages/3-extensions/postgres/test/postgres.static.test.ts
@@ -41,9 +41,10 @@ describe('postgresStatic({ contractJson })', () => {
     expect(typeof result.sql).toBe('object');
   });
 
-  it('raw is a tagged template function', () => {
+  it('raw is the lane holding the statement tag', () => {
     const result = postgresStatic<typeof contract>({ contractJson: contract });
-    expect(typeof result.raw).toBe('function');
+    expect(typeof result.raw).toBe('object');
+    expect(typeof result.raw.sql).toBe('function');
   });
 
   it('enums matches what buildNamespacedEnums produces', () => {

--- a/packages/3-extensions/postgres/test/raw-lane.test.ts
+++ b/packages/3-extensions/postgres/test/raw-lane.test.ts
@@ -1,0 +1,50 @@
+import { validateSqlContractFully } from '@internal/sql-contract/validators';
+import { type ParamRef, RawQueryAst } from '@internal/sql-relational-core/ast';
+import { describe, expect, it } from 'vitest';
+import postgresStatic from '../src/static/postgres-static';
+import type { Contract } from './fixtures/generated/contract';
+import contractJson from './fixtures/generated/contract.json' with { type: 'json' };
+
+const contract = validateSqlContractFully<Contract>(contractJson);
+const db = () => postgresStatic<Contract>({ contractJson: contract });
+
+/** Interpolated values ride the node's param refs. A plan lists them once lowered. */
+const paramValues = (ast: RawQueryAst): unknown[] =>
+  ast.collectParamRefs().map((ref) => (ref as ParamRef).value);
+
+describe('the raw lane on the client', () => {
+  it('builds a plan from a template the way a caller writes one', () => {
+    const client = db();
+    const users = client.sql.public.users;
+
+    const plan = client.raw.sql`SELECT id, email FROM users WHERE invited_by_id = ${1}`
+      .returnsRow({ id: users.columns.id, email: users.columns.email })
+      .build();
+
+    expect(plan.ast).toBeInstanceOf(RawQueryAst);
+    expect(plan.meta.lane).toBe('raw');
+    expect(plan.meta.target).toBe('postgres');
+    expect(paramValues(plan.ast as RawQueryAst)).toEqual([1]);
+  });
+
+  it('carries the declared columns onto the node', () => {
+    const plan = db().raw.sql`SELECT count(*) AS n FROM users`
+      .returnsRow({ n: 'pg/int8@1' })
+      .build();
+    const ast = plan.ast as RawQueryAst;
+
+    expect(ast.result).toEqual({
+      kind: 'rows',
+      columns: { n: { codecId: 'pg/int8@1', nullable: false } },
+    });
+  });
+
+  it('builds an affected-count plan from the mutation terminator', () => {
+    const plan = db().raw.sql`UPDATE users SET name = ${'Ada'} WHERE id = ${1}`
+      .affectedCount()
+      .build();
+
+    expect((plan.ast as RawQueryAst).result).toEqual({ kind: 'affected-count' });
+    expect(paramValues(plan.ast as RawQueryAst)).toEqual(['Ada', 1]);
+  });
+});

--- a/packages/3-extensions/postgres/test/raw-lane.types.test-d.ts
+++ b/packages/3-extensions/postgres/test/raw-lane.types.test-d.ts
@@ -1,0 +1,48 @@
+/**
+ * Type-test: the raw lane, authored from the client the way a caller reaches
+ * it. Each spec entry goes through `db.raw.sql`, and the contract resolves
+ * what every declared column decodes to.
+ */
+
+import type { ResultType } from '@internal/framework-components/runtime';
+import type { AffectedCount } from '@internal/sql-relational-core/expression';
+import type { SqlQueryPlan } from '@internal/sql-relational-core/plan';
+import { expectTypeOf, test } from 'vitest';
+import type { PostgresClient } from '../src/runtime/postgres';
+import type { Contract } from './fixtures/generated/contract';
+
+declare const db: PostgresClient<Contract>;
+
+test('a row spec resolves each column through the contract codec map', () => {
+  const users = db.sql.public.users;
+
+  const plan = db.raw.sql`
+    SELECT u.id, u.email, count(p.id) AS post_count
+    FROM users u JOIN posts p ON p.user_id = u.id
+    WHERE u.invited_by_id = ${1}
+    GROUP BY u.id, u.email
+  `
+    .returnsRow({
+      id: users.columns.id,
+      email: users.columns.email,
+      post_count: 'pg/int8@1',
+    })
+    .build();
+  type Row = ResultType<typeof plan>;
+
+  expectTypeOf<Row['id']>().toEqualTypeOf<number>();
+  expectTypeOf<Row['email']>().toEqualTypeOf<string>();
+  expectTypeOf<Row['post_count']>().toEqualTypeOf<bigint>();
+  expectTypeOf<keyof Row>().toEqualTypeOf<'id' | 'email' | 'post_count'>();
+});
+
+test('the affected-count terminator builds the branded row', () => {
+  const plan = db.raw.sql`UPDATE users SET name = ${'Ada'} WHERE id = ${1}`.affectedCount().build();
+
+  expectTypeOf(plan).toEqualTypeOf<SqlQueryPlan<AffectedCount>>();
+});
+
+test('an unknown codec id is rejected at the lane', () => {
+  // @ts-expect-error — 'pg/nope@1' is not a key of the contract's codec map
+  db.raw.sql`SELECT 1 AS one`.returnsRow({ one: 'pg/nope@1' });
+});

--- a/packages/3-extensions/sqlite/src/runtime/sqlite.ts
+++ b/packages/3-extensions/sqlite/src/runtime/sqlite.ts
@@ -5,10 +5,10 @@ import sqliteDriver from '@internal/driver-sqlite/runtime';
 import { instantiateExecutionStack } from '@internal/framework-components/execution';
 import { UNBOUND_NAMESPACE_ID } from '@internal/framework-components/ir';
 import { sql as sqlBuilder } from '@internal/sql-builder/runtime';
-import type { Db } from '@internal/sql-builder/types';
+import type { Db, RawLane } from '@internal/sql-builder/types';
 import type { ExtractCodecTypes, SqlStorage } from '@internal/sql-contract/types';
 import { orm as ormBuilder } from '@internal/sql-orm-client';
-import type { CodecTypesBase, RawSqlTag } from '@internal/sql-relational-core/expression';
+import type { CodecTypesBase } from '@internal/sql-relational-core/expression';
 import type { SqlQueryPlan } from '@internal/sql-relational-core/plan';
 import type {
   BindSiteParams,
@@ -70,7 +70,7 @@ export interface SqliteClient<TContract extends Contract<SqlStorage>> {
   readonly sql: UnboundSql<TContract>;
   readonly orm: UnboundOrm<TContract>;
   readonly enums: SqliteStaticContext<TContract>['enums'];
-  readonly raw: RawSqlTag;
+  readonly raw: RawLane<TContract>;
   readonly context: ExecutionContext<TContract>;
   readonly contract: TContract;
   readonly stack: SqlExecutionStackWithDriver<SqliteTargetId>;

--- a/packages/3-extensions/sqlite/src/static/sqlite-static.ts
+++ b/packages/3-extensions/sqlite/src/static/sqlite-static.ts
@@ -2,11 +2,10 @@ import sqliteAdapter from '@internal/adapter-sqlite/runtime';
 import { buildNamespacedEnums, type NamespacedEnums } from '@internal/contract/enum-accessor';
 import type { Contract } from '@internal/contract/types';
 import { UNBOUND_NAMESPACE_ID } from '@internal/framework-components/ir';
-import { sql } from '@internal/sql-builder/runtime';
-import type { Db } from '@internal/sql-builder/types';
+import { createRawLane, sql } from '@internal/sql-builder/runtime';
+import type { Db, RawLane } from '@internal/sql-builder/types';
 import type { SqlStorage } from '@internal/sql-contract/types';
-import type { RawCodecInferer, RawSqlTag } from '@internal/sql-relational-core/expression';
-import { createRawSql } from '@internal/sql-relational-core/expression';
+import type { RawCodecInferer } from '@internal/sql-relational-core/expression';
 import type { ExecutionContext, SqlRuntimeExtensionDescriptor } from '@internal/sql-runtime';
 import { createExecutionContext, createSqlExecutionStack } from '@internal/sql-runtime';
 import sqliteTarget, { SqliteContractSerializer } from '@internal/target-sqlite/runtime';
@@ -24,7 +23,7 @@ export interface SqliteStaticContext<TContract extends Contract<SqlStorage>> {
   readonly contract: TContract;
   readonly enums: UnboundEnums<TContract>;
   readonly sql: UnboundSql<TContract>;
-  readonly raw: RawSqlTag;
+  readonly raw: RawLane<TContract>;
 }
 
 export function buildSqliteStaticContext<TContract extends Contract<SqlStorage>>(
@@ -37,7 +36,7 @@ export function buildSqliteStaticContext<TContract extends Contract<SqlStorage>>
     UnboundSql<TContract>,
     'Db<TContract> indexed by a literal key widens NsId to string; TableProxy is invariant in NsId via insert()/update() parameter positions, so the indexed-access type cannot be proven to match the literal-keyed Namespace without this cast'
   >(sqlNamespace);
-  const raw: RawSqlTag = createRawSql(rawCodecInferer);
+  const raw: RawLane<TContract> = createRawLane<TContract>({ context, rawCodecInferer });
   const enums = Object.freeze(buildNamespacedEnums<TContract>(context.contract.domain))[
     UNBOUND_NAMESPACE_ID
   ];

--- a/packages/3-extensions/sqlite/test/sqlite.static.test.ts
+++ b/packages/3-extensions/sqlite/test/sqlite.static.test.ts
@@ -57,9 +57,10 @@ describe('sqliteStatic({ contractJson })', () => {
     expect(typeof result.sql).toBe('object');
   });
 
-  it('raw is a tagged template function', () => {
+  it('raw is the lane holding the statement tag', () => {
     const result = sqliteStatic<typeof contract>({ contractJson: contract });
-    expect(typeof result.raw).toBe('function');
+    expect(typeof result.raw).toBe('object');
+    expect(typeof result.raw.sql).toBe('function');
   });
 
   it('SqliteStaticContext type exposes context, contract, enums, sql, raw', () => {

--- a/skills/prisma-8-extension-upgrade/upgrades/8.0.0-rc.3-to-8.0.0-rc.4/instructions.md
+++ b/skills/prisma-8-extension-upgrade/upgrades/8.0.0-rc.3-to-8.0.0-rc.4/instructions.md
@@ -1,0 +1,97 @@
+---
+from: "8.0.0-rc.3"
+to: "8.0.0-rc.4"
+changes:
+  - id: facades-compose-the-raw-lane
+    summary: |
+      A facade no longer gets the whole-query raw tag from the builder. `Db<C>` is a pure
+      namespace map now, so the `raw` key it used to answer is gone, and the tag is composed at
+      client build instead.
+
+      Build it with `createRawLane({ context, rawCodecInferer })` from
+      `@internal/sql-builder/runtime`, typed `RawLane<TContract>` from
+      `@internal/sql-builder/types`, and expose it as your client's `raw`. Callers then write
+      ``client.raw.sql`SELECT ...` ``. A client that binds per role or per scope builds one lane
+      per bound context, the way it already builds one `sql` per context. A static context —
+      the no-runtime shape that returns `context`, `contract` and `sql` — builds one too and
+      returns it as `raw`.
+
+      If your `raw` property was the contract-free expression tag (`createRawSql(inferer)`), it
+      changes shape from a callable to `{ sql }`. That breaks your own surface, so note it in
+      your release.
+    detection:
+      glob: "**/*.{ts,mts,cts}"
+      regex:
+        - 'createRawSql\('
+        - 'RawSqlTag'
+        # `fns.raw` is a fragment call site and is deliberately excluded:
+        # fragments are unchanged by this release.
+        - '(?<!(?<![\w$])fns)\.raw`'
+      anyMatch: true
+  - id: reserved-raw-namespace-check-removed
+    summary: |
+      `sql()` no longer refuses a contract whose storage declares a namespace named `raw`, and
+      `ORM.NAMESPACE_RESERVED` leaves the error catalogue. Nothing raises the code now, so drop
+      any branch that matched it: a test asserting the refusal, a doc listing the code, an
+      error mapping of your own.
+    detection:
+      glob: "**/*.{ts,mts,cts,md}"
+      contains:
+        - "ORM.NAMESPACE_RESERVED"
+      anyMatch: true
+---
+
+# 8.0.0-rc.3 → 8.0.0-rc.4 — Extension-author upgrade instructions
+
+## `facades-compose-the-raw-lane`
+
+`Db<C>` is a namespace map and nothing else, so a facade composes the whole-query raw tag itself
+and exposes it as the raw lane:
+
+```ts
+import { createRawLane, sql } from '@internal/sql-builder/runtime';
+import type { Db, RawLane } from '@internal/sql-builder/types';
+
+const sqlDb: Db<TContract> = sql<TContract>({ context, rawCodecInferer });
+const raw: RawLane<TContract> = createRawLane<TContract>({ context, rawCodecInferer });
+```
+
+Callers reach the tag at `client.raw.sql`. A client that binds per role or per scope builds one
+lane per bound context, exactly as it already builds one `sql` per context.
+
+A static context does the same. If your facade ships a no-runtime surface — the shape that
+returns `context`, `contract`, `sql` and friends without opening a connection — build the lane
+there too and return it as `raw`:
+
+```ts
+export interface YourStaticContext<TContract extends Contract<SqlStorage>> {
+  readonly sql: Db<TContract>;
+  readonly raw: RawLane<TContract>;
+  // …context, contract, enums
+}
+
+const raw: RawLane<TContract> = createRawLane<TContract>({ context, rawCodecInferer });
+```
+
+Its `raw` property changes type from the contract-free tag to `RawLane<TContract>`, the same
+change the connected client makes, so a consumer reads both surfaces the same way.
+
+Two shapes change for your consumers. Anyone who wrote ``client.sql.raw`...` `` writes
+``client.raw.sql`...` ``. Anyone who called `client.raw` as an expression tag calls
+`client.raw.sql`...`.returns(codecId)` instead, or `fns.raw` inside a builder callback. Both are
+breaking changes to your own surface, so note them in your release.
+
+The detector looks for `createRawSql(`, `RawSqlTag`, and `raw` used as a tag. It skips the
+receiver `fns` exactly, including `x.fns.raw`, because that is a fragment call site and needs no
+change. A receiver that merely ends in those letters, such as `myfns.raw`, still matches, as
+does a functions object aliased to another name.
+
+## `reserved-raw-namespace-check-removed`
+
+`sql()` used to refuse a contract whose storage declared a namespace named `raw`, raising
+`ORM.NAMESPACE_RESERVED` at client construction. The check is gone with the constraint it
+enforced: the lane is composed by the client, not answered by the namespace map, so no contract
+can shadow it.
+
+Drop any branch that matched the code — a test asserting the refusal, an error mapping, a doc
+that lists it. The code no longer exists in the catalogue, and nothing raises it.

--- a/skills/prisma-next-upgrade/upgrades/8.0.0-rc.3-to-8.0.0-rc.4/instructions.md
+++ b/skills/prisma-next-upgrade/upgrades/8.0.0-rc.3-to-8.0.0-rc.4/instructions.md
@@ -1,0 +1,117 @@
+---
+from: "8.0.0-rc.3"
+to: "8.0.0-rc.4"
+changes:
+  - id: raw-moves-to-its-own-lane
+    summary: |
+      Whole-query raw SQL moves address: ``db.sql.raw`SELECT ...` `` becomes
+      ``db.raw.sql`SELECT ...` ``. Everything after the template is unchanged.
+      `.returnsRow(spec)`, `.affectedCount()`, `.returns(codecId)`, and splicing a
+      row-returning statement into another template all behave as they did.
+
+      The client's `raw` property changes shape in the same move. It was a tagged template you
+      could call directly for an expression fragment. It is now the raw lane, an object whose
+      `sql` key holds the statement tag.
+
+      An author who called `db.raw` as a fragment tag has two replacements. Use `fns.raw`
+      inside a builder callback, which is where fragments belong. Or terminate the lane's tag
+      with `.returns(codecId)` for the same expression, now bound to the contract.
+    detection:
+      glob: "**/*.{ts,tsx,mts,cts}"
+      regex:
+        # The old whole-query address, on any receiver.
+        - '\.sql\.raw`'
+        # The client tag being repurposed. `fns.raw` is a fragment call site and
+        # is deliberately excluded: fragments are unchanged by this release.
+        - '(?<!(?<![\w$])fns)\.raw`'
+      anyMatch: true
+  - id: raw-is-no-longer-a-reserved-namespace
+    summary: |
+      A storage namespace named `raw` is allowed again. 8.0.0-rc.2 and 8.0.0-rc.3 refused such a contract when
+      the client was built, with `ORM.NAMESPACE_RESERVED`, because the SQL surface answered
+      `db.sql.raw` with the raw tag. The tag has moved to `db.raw.sql`, so nothing a contract
+      declares can collide with it.
+
+      If you renamed a namespace to get past that error, you may rename it back:
+      `@@schema("raw")` is an ordinary name, reachable as `db.sql.raw.<table>`. Re-emit the
+      contract afterwards, then plan the rename against the database as you would any other
+      namespace rename. The physical schema keeps the name it has until a plan moves it.
+      Renaming back is optional: a namespace you renamed away stays valid.
+    detection:
+      glob: "**/*.{prisma,json}"
+      contains:
+        - "ORM.NAMESPACE_RESERVED"
+        - '@@schema("raw")'
+      anyMatch: true
+---
+
+# 8.0.0-rc.3 → 8.0.0-rc.4 — User upgrade instructions
+
+## `raw-moves-to-its-own-lane`
+
+Whole-query raw SQL has its own front door. The tag that sat inside the namespace map is now a
+lane on the client:
+
+```ts
+// Before
+const plan = db.sql.raw`SELECT id, email FROM users WHERE id = ${1}`
+  .returnsRow({ id: users.columns.id, email: users.columns.email })
+  .build();
+
+// After
+const plan = db.raw.sql`SELECT id, email FROM users WHERE id = ${1}`
+  .returnsRow({ id: users.columns.id, email: users.columns.email })
+  .build();
+```
+
+Everything after the template is unchanged: the terminators, the row specs they take, the plans
+they build, and splicing a row-returning statement into another template.
+
+The client's `raw` property changes shape in the same move. It was the expression tag you could
+call directly; it is now the lane, whose `sql` key holds the statement tag:
+
+```ts
+// Before: `raw` is a tag
+const upper = db.raw`UPPER(${email})`.returns('pg/text@1');
+
+// After, inside a builder callback — where fragments belong
+const rows = db.sql.public.users
+  .select((f, fns) => ({ upper: fns.raw`UPPER(${f.email})`.returns('pg/text@1') }))
+  .build();
+
+// After, from the lane, for a fragment you hold on its own
+const upper = db.raw.sql`UPPER(${email})`.returns('pg/text@1');
+```
+
+The detector looks for the old address and for `raw` used as a tag. It skips the receiver `fns`
+exactly, including `x.fns.raw`, because that is a fragment call site and needs no change. A
+receiver that merely ends in those letters, such as `myfns.raw`, still matches. So does a
+builder callback that names its functions object something else. Check whether the receiver is
+a client before you change anything.
+
+## `raw-is-no-longer-a-reserved-namespace`
+
+8.0.0-rc.2 and 8.0.0-rc.3 refused a contract whose storage declared a namespace named `raw`, because that was
+the key the SQL surface answered with the raw tag:
+
+```text
+ORM.NAMESPACE_RESERVED: The SQL surface exposes the raw statement tag as "db.raw", so a storage
+namespace named "raw" cannot be reached through it. Rename the namespace in the schema.
+```
+
+That constraint is gone. `db.sql` is a namespace map and nothing else, and the lane is composed
+by the client rather than derived from your contract, so the two cannot collide.
+
+If you renamed a namespace to get past the error, you may rename it back:
+
+```prisma
+model Event {
+  id String @id
+  @@schema("raw")
+}
+```
+
+Its tables are then reachable as `db.sql.raw.<table>`, like any other namespace. Re-emit the
+contract, and plan the rename against the database as you would any other namespace rename —
+the physical schema carries the old name until a plan moves it. Renaming back is optional; the
+name you moved to stays valid.


### PR DESCRIPTION
Second of five. The new address exists (PR 1), so this PR removes the old one and the collision machinery it needed.

- The `raw` key leaves `Db<C>` and the proxy. `Db<C>` is a plain namespace map again.
- `RAW_TAG_KEY`, the construction-time guard, `ORM.NAMESPACE_RESERVED`, and its error-reference entry are deleted.
- The guard test now proves the opposite: a contract with a storage namespace named `raw` builds and queries through `db.sql.raw.<table>`.
- Demo spellings update here so this commit builds and passes on its own.

Mostly deletions: 71 added, 94 removed.

Refs: TML-3214

https://claude.ai/code/session_01NnNjsNcPMtbJZhnZz5Zzbe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Raw SQL queries are now accessed through the dedicated `raw.sql` interface.
  * Storage namespaces named `raw` are now supported without restriction.
* **Bug Fixes**
  * Updated raw SQL examples and type checks to use the current access pattern.
  * Preserved query composition, parameter binding, type inference, and execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->