### PR TITLE
fix(cli): migration graph --dot draws the DOT as a human block, un-redding main

### DIFF
--- a/packages/1-framework/3-tooling/cli/src/orm/migration/graph.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/migration/graph.ts
@@ -39,7 +39,10 @@ interface MigrationGraphDotResult extends MigrationGraphJsonResult {
 
 /**
  * The tree is a drawing for a reader; the DOT document is a graph description
- * for another program, so it is the one thing here that belongs on stdout.
+ * for another program, so it is also the stdout payload. It appears in both
+ * surfaces because the engine treats the payload as a mirror of the human
+ * output: on one shared screen it suppresses the stdout copy, so the human
+ * block is what keeps `--dot` visible there, while split sinks receive both.
  */
 function graphPresentations(inputs: {
   readonly document: MigrationGraphJsonResult | MigrationGraphDotResult;
@@ -63,6 +66,7 @@ function graphPresentations(inputs: {
         ],
       },
       ...(tree === undefined ? [] : [{ kind: 'drawing' as const, lines: toneDrawing(tree) }]),
+      ...(dot === undefined ? [] : [{ kind: 'drawing' as const, lines: dot.split('\n') }]),
       ...(legend === undefined ? [] : [{ kind: 'drawing' as const, lines: toneDrawing(legend) }]),
     ],
     ...(dot === undefined ? {} : { stdout: () => dot.split('\n') }),

--- a/packages/1-framework/3-tooling/cli/test/orm/migration-graph.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/orm/migration-graph.test.ts
@@ -173,6 +173,25 @@ describe('migration graph', () => {
     expect(run.exitCode).toBe(0);
     expect(run.presented?.presentation.stdout?.[0]).toBe('digraph migrations {');
     expect(run.presented?.presentation.stdout?.join('\n')).toContain(MIGRATION_DIR);
+    expect(run.stdout).toContain('digraph migrations {');
+  });
+
+  it('draws the DOT as a human block, so one shared screen still shows it', async () => {
+    const dir = await projectDir();
+    await seedMigration(join(dir, 'migrations'));
+
+    const run = await harness(ormConfig()).run(['migration', 'graph', '--dot'], {
+      cwd: dir,
+      isTty: { stdout: true, stderr: true },
+    });
+    const drawing = run.presented?.presentation.human.at(-1);
+
+    expect(run.exitCode).toBe(0);
+    expect(drawing?.kind).toBe('drawing');
+    expect(JSON.stringify(drawing)).toContain('digraph migrations {');
+    expect(stripAnsi(run.stderr)).toContain('digraph migrations {');
+    expect(run.stdout).toBe('');
+    expect(run.presented?.presentation.stdout?.[0]).toBe('digraph migrations {');
   });
 
   it('carries the DOT text on the json result alongside the graph document', async () => {

--- a/test/integration/test/cli-journeys/migration-graph-dot.e2e.test.ts
+++ b/test/integration/test/cli-journeys/migration-graph-dot.e2e.test.ts
@@ -3,9 +3,11 @@
  *
  * DOT is not a `--format` value — the engine reserves that flag — so `--dot`
  * stays a command-owned boolean and the old precedence quirk goes away: in
- * human mode the DOT text is the command's stdout payload, and in json mode
- * (which a non-TTY stdout selects) the result carries the DOT alongside the
- * graph document instead of replacing it.
+ * human mode the DOT text is both a human block and the stdout payload. On one
+ * shared screen the engine suppresses the stdout mirror and the human block is
+ * what the reader sees; with split sinks stdout carries the raw DOT too. In
+ * json mode (which a non-TTY stdout selects) the result carries the DOT
+ * alongside the graph document instead of replacing it.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -22,7 +24,7 @@ import {
 withTempDir(({ createTempDir }) => {
   describe('migration graph — DOT output', () => {
     it(
-      'puts DOT on stdout in human mode and on the result in json mode',
+      'shows DOT on the human screen and carries it on the json result',
       async () => {
         const ctx: JourneyContext = setupJourney({ createTempDir });
 
@@ -36,7 +38,11 @@ withTempDir(({ createTempDir }) => {
         expect(human.presented?.presentation.stdout?.[0], 'DOT preamble').toBe(
           'digraph migrations {',
         );
-        expect(human.stdout, 'DOT reaches stdout').toContain('digraph migrations {');
+        // Both streams are TTYs here — one shared screen — so the engine
+        // suppresses the stdout mirror and the human block is the copy the
+        // reader sees, on stderr.
+        expect(human.stderr, 'DOT reaches the reader').toContain('digraph migrations {');
+        expect(human.stdout, 'stdout mirror suppressed on one screen').toBe('');
 
         // Piping selects json, and the DOT rides the result rather than
         // shadowing it: a caller that asked for json never receives DOT where


### PR DESCRIPTION
## What broke

8.0.0-rc.2 shipped with `migration graph --dot` printing no DOT on a terminal, and main has been red on `test/integration/test/cli-journeys/migration-graph-dot.e2e.test.ts` since the release merge (#30049) — silently, because integration tests were not a required check at the time.

@prisma/cli-engine 0.1.1 treats a command's stdout payload as a mirror of the human output and suppresses it when stdout and stderr are one screen (`isTty.stdout && isTty.stderr && outputStreamsShareDevice !== false`). For `--dot` the payload was the only copy of the DOT text, so a terminal showed nothing, and piping switches the engine to json mode, so there was no stream shape that produced raw DOT.

## The fix

`graphPresentations` now also emits the DOT as a human `drawing` block. That makes the stdout payload a genuine mirror, so the engine's suppression rule is correct in every shape:

- one shared screen: the human block shows the DOT on stderr, the stdout mirror is suppressed
- split sinks (stdout terminal, stderr elsewhere): stdout carries the raw DOT and stderr the human copy
- json mode: unchanged — the result envelope carries `dot` alongside the graph document

## Tests

- `packages/1-framework/3-tooling/cli/test/orm/migration-graph.test.ts`: new case pinning the one-shared-screen shape (human block present, stderr shows DOT, stdout empty, payload still declared); the split-shape case now also asserts the raw DOT actually reaches stdout.
- `test/integration/test/cli-journeys/migration-graph-dot.e2e.test.ts`: the red journey now asserts the new contract and passes.

Verified locally: cli package suite (1421 tests), the DOT journey (3 tests), `pnpm typecheck`, `pnpm lint` — all green.

## Follow-up not in this PR

`runtimeFromProcess` still never sets `Runtime.outputStreamsShareDevice`, so two genuinely separate terminals are treated as one screen. Upstream prisma/prisma-cli#198 makes the field required, which will force that decision here when the next engine version is adopted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved migration graph `--dot` output in human-readable mode.
  * DOT diagrams now appear in the human presentation while remaining available through the existing standard output format.
  * Clarified command documentation describing how DOT output is presented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->