### PR TITLE
Integration tests skip merge-queue groups and run nightly for the launch window

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,12 @@ jobs:
   test-integration:
     name: Integration Tests
     needs: [build, changes]
+    # Launch window (until ~2026-08-21): not run in merge-queue groups, so
+    # queue throughput is not spent on a check that no longer blocks the
+    # merge. Still runs on every PR, and nightly on main
+    # (integration-nightly.yml). Remove this condition after launch, when
+    # the check becomes required again.
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     env:
       TEST_TIMEOUT_MULTIPLIER: 2

--- a/.github/workflows/integration-nightly.yml
+++ b/.github/workflows/integration-nightly.yml
@@ -1,0 +1,49 @@
+name: Integration Nightly
+
+# While Integration Tests is not a required check (the launch window,
+# until ~2026-08-21), this nightly run on main is what keeps regressions
+# from sitting unnoticed — an unrequired check is how a red e2e sat
+# silently on main from rc.2 until #30057. Delete this workflow when the
+# check is required again.
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test-integration:
+    name: Integration Tests (nightly, main)
+    runs-on: ubuntu-latest
+    env:
+      TEST_TIMEOUT_MULTIPLIER: 2
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm build
+      - name: Run Integration tests
+        run: pnpm test:integration
+      - name: Check working tree is clean
+        run: pnpm check:clean-tree


### PR DESCRIPTION
Integration Tests is no longer a required check during the launch window (until ~2026-08-21). Two changes, both marked for removal when the requirement returns:

- The `test-integration` job in CI (PR) skips `merge_group` events — a queue group was spending ~30 minutes of runner time on a check that cannot block the merge. It still runs on every pull request, so the people who want the signal keep getting it.
- `integration-nightly.yml` runs the same job on `main` every night at 03:00 UTC (and on `workflow_dispatch`). An unrequired check is exactly how a red e2e sat silently on main from rc.2 until #30057 — the nightly run is what keeps regressions surfacing while nothing blocks on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Integration tests now run nightly on the main branch and can also be triggered manually.
  - Integration tests are skipped for merge queue validation events while continuing to run for pull requests and other supported events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->