### PR TITLE
fix(cli): contract emit accepts the relative contract path orm init scaffolds

### DIFF
--- a/packages/1-framework/3-tooling/cli/src/utils/validate-contract-deps.ts
+++ b/packages/1-framework/3-tooling/cli/src/utils/validate-contract-deps.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module';
+import { join, resolve as resolvePath } from 'pathe';
 
 const IMPORT_PATTERN = /import\s+type\s+.*?\s+from\s+['"](@[^/]+\/[^/'"]+)/g;
 
@@ -21,7 +22,9 @@ export function validateContractDeps(
   projectRoot: string,
 ): ContractDepsValidation {
   const packages = extractPackageSpecifiers(dtsContent);
-  const resolve = createRequire(`${projectRoot}/package.json`);
+  // createRequire accepts only absolute paths; a relative project root
+  // (a relative contract path in prisma.config.ts) resolves against cwd.
+  const resolve = createRequire(join(resolvePath(projectRoot), 'package.json'));
 
   const missing: string[] = [];
   for (const pkg of packages) {

--- a/packages/1-framework/3-tooling/cli/test/utils/validate-contract-deps.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/utils/validate-contract-deps.test.ts
@@ -1,3 +1,4 @@
+import { relative } from 'pathe';
 import { describe, expect, it } from 'vitest';
 import {
   extractPackageSpecifiers,
@@ -47,6 +48,14 @@ describe('validateContractDeps', () => {
     const dts = `import type { Foo } from '@internal/contract/types';`;
 
     const result = validateContractDeps(dts, __dirname);
+
+    expect(result.missing).toEqual([]);
+  });
+
+  it('accepts a relative project root, resolving it against the working directory', () => {
+    const dts = `import type { Foo } from '@internal/contract/types';`;
+
+    const result = validateContractDeps(dts, relative(process.cwd(), __dirname));
 
     expect(result.missing).toEqual([]);
   });


### PR DESCRIPTION
## Linked issue

Fixes the `contract emit` crash reported in prisma/prisma-cli#205. The issue was filed against the CLI repo, but the fix is purely in orm-toolchain, so it lands here.

## Summary

`contract emit` now works with the relative contract path that `orm init` scaffolds. Today the scaffold and the command its next steps tell users to run do not compose: `orm init` writes `contract: "./src/prisma/contract.prisma"`, and `contract emit` then crashes with `CLI.UNEXPECTED` / `ERR_INVALID_ARG_VALUE` ("Received './src/prisma/package.json'") after the emit itself has already succeeded.

Root cause: `validateContractDeps` derives its project root from the contract path and hands it straight to `node:module`'s `createRequire`, which accepts only absolute paths. The fix resolves the root against the working directory before `createRequire` sees it. That matches how `projectImportRoot` next door already treats a relative config path, and how the emit step treats the relative output paths.

## Testing performed

- New test in `validate-contract-deps.test.ts`: a relative project root resolves against the working directory. It fails before the fix with `ERR_INVALID_ARG_VALUE` and passes after.
- `pnpm test` in `packages/1-framework/3-tooling/cli`: 1422 passing. `pnpm typecheck` and biome: clean.
- End to end: an `orm init` scaffold with the default relative contract path completes `prisma contract emit` (`ok: true`, `contract.json` and `contract.d.ts` written) against this build of `@prisma/orm-toolchain`. The crash reproduces on the fully published stack (`prisma@8.0.0-rc.5` with `@prisma/orm-toolchain@8.0.0-rc.3`), so this is the last blocker in the default quickstart path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
