### PR TITLE
contract emit survives a relative project root; init scaffolds definePrismaConfig

### DIFF
--- a/packages/1-framework/3-tooling/cli/src/commands/init/templates/code-templates.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/init/templates/code-templates.ts
@@ -301,10 +301,10 @@ export function configFile(
 ): string {
   const configEntrypoint = targetEntrypoint(target, 'config', resolveImportSpecifier);
   return `import 'dotenv/config';
-import { defineConfig } from '@prisma/cli-engine';
+import { definePrismaConfig } from '@prisma/cli-engine';
 import { defineConfig as ormConfig } from '${configEntrypoint}';
 
-export default defineConfig({
+export default definePrismaConfig({
   orm: ormConfig({
     contract: ${JSON.stringify(contractPath)},
     db: {

--- a/packages/1-framework/3-tooling/cli/src/commands/init/templates/quick-reference-mongo.md
+++ b/packages/1-framework/3-tooling/cli/src/commands/init/templates/quick-reference-mongo.md
@@ -42,10 +42,10 @@ If you use a framework like Next.js or Vite, the Prisma Next plugin will do this
 
 ```typescript
 import 'dotenv/config';
-import { defineConfig } from '@prisma/cli-engine';
+import { definePrismaConfig } from '@prisma/cli-engine';
 import { defineConfig as ormConfig } from '{{configEntrypoint}}';
 
-export default defineConfig({
+export default definePrismaConfig({
   orm: ormConfig({
     contract: './{{schemaPath}}',
     db: {

--- a/packages/1-framework/3-tooling/cli/src/commands/init/templates/quick-reference-postgres.md
+++ b/packages/1-framework/3-tooling/cli/src/commands/init/templates/quick-reference-postgres.md
@@ -40,10 +40,10 @@ If you use a framework like Next.js or Vite, the Prisma Next plugin will do this
 
 ```typescript
 import 'dotenv/config';
-import { defineConfig } from '@prisma/cli-engine';
+import { definePrismaConfig } from '@prisma/cli-engine';
 import { defineConfig as ormConfig } from '{{configEntrypoint}}';
 
-export default defineConfig({
+export default definePrismaConfig({
   orm: ormConfig({
     contract: './{{schemaPath}}',
     db: {

--- a/packages/1-framework/3-tooling/cli/src/utils/validate-contract-deps.ts
+++ b/packages/1-framework/3-tooling/cli/src/utils/validate-contract-deps.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module';
+import { resolve as resolvePath } from 'node:path';
 
 const IMPORT_PATTERN = /import\s+type\s+.*?\s+from\s+['"](@[^/]+\/[^/'"]+)/g;
 
@@ -21,7 +22,9 @@ export function validateContractDeps(
   projectRoot: string,
 ): ContractDepsValidation {
   const packages = extractPackageSpecifiers(dtsContent);
-  const resolve = createRequire(`${projectRoot}/package.json`);
+  // createRequire requires an absolute path; the project root arrives
+  // relative when the command is invoked with a relative --project.
+  const resolve = createRequire(resolvePath(projectRoot, 'package.json'));
 
   const missing: string[] = [];
   for (const pkg of packages) {

--- a/packages/1-framework/3-tooling/cli/test/commands/init/__snapshots__/templates.test.ts.snap
+++ b/packages/1-framework/3-tooling/cli/test/commands/init/__snapshots__/templates.test.ts.snap
@@ -79,10 +79,10 @@ Node-based Prisma Next projects expect Node.js 24 LTS or newer.
 
 exports[`templates > per-cell snapshots (FR5.4) > mongo + psl > configFile is stable 1`] = `
 "import 'dotenv/config';
-import { defineConfig } from '@prisma/cli-engine';
+import { definePrismaConfig } from '@prisma/cli-engine';
 import { defineConfig as ormConfig } from '@internal/mongo/config';
 
-export default defineConfig({
+export default definePrismaConfig({
   orm: ormConfig({
     contract: "./src/prisma/contract.prisma",
     db: {
@@ -161,10 +161,10 @@ If you use a framework like Next.js or Vite, the Prisma Next plugin will do this
 
 \`\`\`typescript
 import 'dotenv/config';
-import { defineConfig } from '@prisma/cli-engine';
+import { definePrismaConfig } from '@prisma/cli-engine';
 import { defineConfig as ormConfig } from '@internal/mongo/config';
 
-export default defineConfig({
+export default definePrismaConfig({
   orm: ormConfig({
     contract: './src/prisma/contract.prisma',
     db: {
@@ -262,10 +262,10 @@ model Post {
 
 exports[`templates > per-cell snapshots (FR5.4) > mongo + typescript > configFile is stable 1`] = `
 "import 'dotenv/config';
-import { defineConfig } from '@prisma/cli-engine';
+import { definePrismaConfig } from '@prisma/cli-engine';
 import { defineConfig as ormConfig } from '@internal/mongo/config';
 
-export default defineConfig({
+export default definePrismaConfig({
   orm: ormConfig({
     contract: "./src/prisma/contract.ts",
     db: {
@@ -355,10 +355,10 @@ If you use a framework like Next.js or Vite, the Prisma Next plugin will do this
 
 \`\`\`typescript
 import 'dotenv/config';
-import { defineConfig } from '@prisma/cli-engine';
+import { definePrismaConfig } from '@prisma/cli-engine';
 import { defineConfig as ormConfig } from '@internal/mongo/config';
 
-export default defineConfig({
+export default definePrismaConfig({
   orm: ormConfig({
     contract: './src/prisma/contract.ts',
     db: {
@@ -471,10 +471,10 @@ export const contract = defineContract(
 
 exports[`templates > per-cell snapshots (FR5.4) > postgres + psl > configFile is stable 1`] = `
 "import 'dotenv/config';
-import { defineConfig } from '@prisma/cli-engine';
+import { definePrismaConfig } from '@prisma/cli-engine';
 import { defineConfig as ormConfig } from '@internal/postgres/config';
 
-export default defineConfig({
+export default definePrismaConfig({
   orm: ormConfig({
     contract: "./src/prisma/contract.prisma",
     db: {
@@ -550,10 +550,10 @@ If you use a framework like Next.js or Vite, the Prisma Next plugin will do this
 
 \`\`\`typescript
 import 'dotenv/config';
-import { defineConfig } from '@prisma/cli-engine';
+import { definePrismaConfig } from '@prisma/cli-engine';
 import { defineConfig as ormConfig } from '@internal/postgres/config';
 
-export default defineConfig({
+export default definePrismaConfig({
   orm: ormConfig({
     contract: './src/prisma/contract.prisma',
     db: {
@@ -634,10 +634,10 @@ model Post {
 
 exports[`templates > per-cell snapshots (FR5.4) > postgres + typescript > configFile is stable 1`] = `
 "import 'dotenv/config';
-import { defineConfig } from '@prisma/cli-engine';
+import { definePrismaConfig } from '@prisma/cli-engine';
 import { defineConfig as ormConfig } from '@internal/postgres/config';
 
-export default defineConfig({
+export default definePrismaConfig({
   orm: ormConfig({
     contract: "./src/prisma/contract.ts",
     db: {
@@ -724,10 +724,10 @@ If you use a framework like Next.js or Vite, the Prisma Next plugin will do this
 
 \`\`\`typescript
 import 'dotenv/config';
-import { defineConfig } from '@prisma/cli-engine';
+import { definePrismaConfig } from '@prisma/cli-engine';
 import { defineConfig as ormConfig } from '@internal/postgres/config';
 
-export default defineConfig({
+export default definePrismaConfig({
   orm: ormConfig({
     contract: './src/prisma/contract.ts',
     db: {

--- a/packages/1-framework/3-tooling/cli/test/utils/validate-contract-deps.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/utils/validate-contract-deps.test.ts
@@ -1,3 +1,4 @@
+import { relative } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   extractPackageSpecifiers,
@@ -57,6 +58,15 @@ describe('validateContractDeps', () => {
     const result = validateContractDeps(dts, __dirname);
 
     expect(result.missing).toEqual(['@nonexistent-scope/fake-package']);
+  });
+
+  it('accepts a relative project root — createRequire needs an absolute path', () => {
+    const dts = `import type { Foo } from '@internal/contract/types';`;
+    const relativeRoot = relative(process.cwd(), __dirname);
+
+    const result = validateContractDeps(dts, `./${relativeRoot}`);
+
+    expect(result.missing).toEqual([]);
   });
 
   it('formats a warning message listing missing packages', () => {


### PR DESCRIPTION
Two of the three defects reported against the consolidated `8.0.0-rc.5` stack:

- **`contract emit` crashed after writing artifacts** when the project root was relative: `validateContractDeps()` built `createRequire()`'s argument from the root verbatim, and createRequire requires an absolute path (`The argument 'filename' must be … or absolute path string. Received './src/prisma/package.json'`). The root is resolved first now, with a regression test on a relative root.
- **init scaffolded the deprecated `defineConfig`**: templates and quick-references now import `definePrismaConfig`, the name engine 0.2.0 gives the config marker. Snapshots updated — the diff is purely the rename. All 1422 CLI package tests pass.

**Deliberately not done: dropping `dotenv` from the scaffold.** The report asked for it, but engine 0.2.0's config loader explicitly disables `.env` reading (`dotenv: false` in its c12 options), and init scaffolds a `.env` that the config reads through `process.env` — removing the `import 'dotenv/config'` line today would break the scaffold's own flow. If the intent is for the engine (or CLI startup) to load `.env` itself, that's an engine change to make first; flagging for a decision rather than guessing.

The third reported defect — `@prisma/composer-prisma-cloud@0.8.0` requiring `orm-toolchain@8.0.0-rc.1` — is composer-repo work and follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved project initialization templates with the correct Prisma configuration format.
  - Relative project paths are now handled correctly during dependency validation.

- **Tests**
  - Added coverage confirming dependency validation works with relative project roots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->