### PR TITLE
The init journey installs an engine that has definePrismaConfig

### DIFF
--- a/test/integration/test/cli-journeys/init-journey/harness.ts
+++ b/test/integration/test/cli-journeys/init-journey/harness.ts
@@ -491,12 +491,13 @@ function rewritePackageJsonForTarballs(dir: string, cell: CellId, tarballs: Pack
   };
   // No `prisma-next` devDependency: the standalone CLI package stopped
   // being published; journey steps invoke the workspace-built engine bin.
-  // `@prisma/cli-engine` is the scaffolded prisma.config.ts's defineConfig
-  // import, installed from the registry exactly as `init`'s own install
-  // would.
+  // `@prisma/cli-engine` is the scaffolded prisma.config.ts's
+  // definePrismaConfig import, installed from the registry exactly as
+  // `init`'s own install would. Must be an engine that has that export
+  // (0.2.0+), and should track what the workspace pins.
   pkg.devDependencies = {
     ...(pkg.devDependencies ?? {}),
-    '@prisma/cli-engine': '0.0.9',
+    '@prisma/cli-engine': '0.2.0',
     '@types/node': '^24.10.4',
     typescript: '^5.9.3',
   };


### PR DESCRIPTION
Follow-up to #30064: the init-journey harness pinned the scaffolded project's `@prisma/cli-engine` at 0.0.9 — an engine from before the `definePrismaConfig` rename — so all 20 journey emit/plan steps fail on main right now (`(0, _cliEngine.definePrismaConfig) is not a function`). The pin moves to 0.2.0, what the workspace pins. All 32 journey tests pass locally with the full workspace built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the scaffolded CLI engine development dependency to version 0.2.0.
  * Clarified the required `definePrismaConfig` export in generated project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->