### PR TITLE
A release sweep needs the transition directory, not a fresh declaration

### DIFF
--- a/scripts/check-upgrade-coverage.mjs
+++ b/scripts/check-upgrade-coverage.mjs
@@ -340,9 +340,12 @@ function canonicalJson(value) {
   return JSON.stringify(value);
 }
 
-/** The manifest with every dependency *version* blanked; names are kept. */
-function manifestShapeIgnoringVersions(text) {
+/** The manifest with every dependency *version* blanked; names are kept.
+ *  With `ignoreOwnVersion`, the package's own `version` field is blanked
+ *  too — the shape a release sweep produces. */
+export function manifestShapeIgnoringVersions(text, ignoreOwnVersion = false) {
   const parsed = JSON.parse(text);
+  if (ignoreOwnVersion && typeof parsed.version === 'string') parsed.version = '';
   for (const map of DEPENDENCY_MAPS) {
     const deps = parsed[map];
     if (deps !== null && typeof deps === 'object' && !Array.isArray(deps)) {
@@ -361,7 +364,7 @@ function manifestShapeIgnoringVersions(text) {
  * a name appearing or disappearing can signal an API change, so it still wants
  * a human to say so.
  */
-function isTranslationIrrelevant(repoRoot, prev, head, path) {
+function isTranslationIrrelevant(repoRoot, prev, head, path, ignoreOwnVersion = false) {
   const before = tryReadFileAtRef(repoRoot, prev, path);
   const after = tryReadFileAtRef(repoRoot, head, path);
   // An added or deleted file is a structural change, not a version move.
@@ -369,7 +372,10 @@ function isTranslationIrrelevant(repoRoot, prev, head, path) {
 
   if (basename(path) === 'package.json') {
     try {
-      return manifestShapeIgnoringVersions(before) === manifestShapeIgnoringVersions(after);
+      return (
+        manifestShapeIgnoringVersions(before, ignoreOwnVersion) ===
+        manifestShapeIgnoringVersions(after, ignoreOwnVersion)
+      );
     } catch {
       return false;
     }
@@ -532,6 +538,13 @@ export function runCheck({ repoRoot, head, prev }) {
       (path) => !isTranslationIrrelevant(repoRoot, prev, head, path),
     );
     if (substrateDiff.length === 0) continue;
+    // A release sweep — every remaining substrate file differs only in
+    // version fields — keeps the coverage rule in force (the transition
+    // directory must exist), but demands no fresh per-PR declaration:
+    // the sweep declares nothing an earlier PR has not already recorded.
+    const sweepOnly = substrateDiff.every((path) =>
+      isTranslationIrrelevant(repoRoot, prev, head, path, true),
+    );
     for (const transition of coverageChain) {
       const requiredDir = `${skillPkg}/upgrades/${transition}`;
       if (!existsSync(`${repoRoot}/${requiredDir}`)) {
@@ -549,6 +562,7 @@ export function runCheck({ repoRoot, head, prev }) {
       // deliberate intent is recorded per PR, not just per transition
       // directory creation.
       const instructionsPath = `${skillPkg}/upgrades/${transition}/instructions.md`;
+      if (sweepOnly && !changedPaths.has(instructionsPath)) continue;
       if (!changedPaths.has(instructionsPath)) {
         violations.push({
           rule: 'per-pr-declaration',

--- a/scripts/check-upgrade-coverage.test.mjs
+++ b/scripts/check-upgrade-coverage.test.mjs
@@ -11,6 +11,7 @@ import {
   comparePrecedence,
   coverageTransitionChain,
   inFlightTransitionLabel,
+  manifestShapeIgnoringVersions,
   parseChangesFrontmatter,
   parseTransitionFromPath,
   parseVersion,
@@ -1057,6 +1058,77 @@ describe('check-upgrade-coverage — dependency-only substrate diffs need no dec
       `${JSON.stringify({ name: 'demo', scripts: { build: 'vite build' }, devDependencies: { vite: '^8.1.4' } }, null, 2)}\n`,
     );
     commitAll('head — scripts added');
+    const result = runScript(['--prev', prev, '--head', 'HEAD']);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /per-pr-declaration/);
+  });
+});
+
+describe('manifestShapeIgnoringVersions', () => {
+  const manifest = (version, deps) =>
+    JSON.stringify({ name: 'fixture', version, dependencies: deps });
+
+  it('a release sweep compares equal only when the own version is ignored', () => {
+    const before = manifest('8.0.0-rc.3', { '@prisma/orm-postgres': 'workspace:8.0.0-rc.3' });
+    const after = manifest('8.0.0-rc.4', { '@prisma/orm-postgres': 'workspace:8.0.0-rc.4' });
+    assert.notEqual(manifestShapeIgnoringVersions(before), manifestShapeIgnoringVersions(after));
+    assert.equal(
+      manifestShapeIgnoringVersions(before, true),
+      manifestShapeIgnoringVersions(after, true),
+    );
+  });
+
+  it('an added dependency compares unequal — a new name can signal an API change', () => {
+    const before = manifest('1.0.0', {});
+    const after = manifest('1.0.0', { 'left-pad': '^1.0.0' });
+    assert.notEqual(manifestShapeIgnoringVersions(before), manifestShapeIgnoringVersions(after));
+  });
+
+  it('a changed script compares unequal even when versions are ignored', () => {
+    const before = JSON.stringify({ name: 'fixture', version: '1.0.0', scripts: { emit: 'a' } });
+    const after = JSON.stringify({ name: 'fixture', version: '2.0.0', scripts: { emit: 'b' } });
+    assert.notEqual(
+      manifestShapeIgnoringVersions(before, true),
+      manifestShapeIgnoringVersions(after, true),
+    );
+  });
+});
+
+describe('check-upgrade-coverage — release sweep per-PR declaration', () => {
+  it('a version-only sweep needs the transition directory but no fresh declaration', () => {
+    writePackageJson('8.0.0-rc.3');
+    writeRepoFile('examples/demo/package.json', '{"name":"demo","version":"8.0.0-rc.3"}\n');
+    writeRepoFile(
+      'skills/prisma-next-upgrade/upgrades/8.0.0-rc.3-to-8.0.0-rc.4/instructions.md',
+      '---\nfrom: "8.0.0-rc.3"\nto: "8.0.0-rc.4"\nchanges: []\n---\n',
+    );
+    commitAll('prev, directory already recorded by an earlier PR');
+    const prev = git('rev-parse', 'HEAD');
+
+    writePackageJson('8.0.0-rc.4');
+    writeRepoFile('examples/demo/package.json', '{"name":"demo","version":"8.0.0-rc.4"}\n');
+    commitAll('bump to 8.0.0-rc.4');
+
+    const result = runScript(['--prev', prev, '--head', 'HEAD']);
+    assert.equal(result.status, 0, `expected exit 0; stderr=${result.stderr}`);
+  });
+
+  it('a sweep with a real substrate change still demands the declaration', () => {
+    writePackageJson('8.0.0-rc.3');
+    writeRepoFile('examples/demo/package.json', '{"name":"demo","version":"8.0.0-rc.3"}\n');
+    writeRepoFile('examples/demo/src/main.ts', 'export const a = 1;\n');
+    writeRepoFile(
+      'skills/prisma-next-upgrade/upgrades/8.0.0-rc.3-to-8.0.0-rc.4/instructions.md',
+      '---\nfrom: "8.0.0-rc.3"\nto: "8.0.0-rc.4"\nchanges: []\n---\n',
+    );
+    commitAll('prev');
+    const prev = git('rev-parse', 'HEAD');
+
+    writePackageJson('8.0.0-rc.4');
+    writeRepoFile('examples/demo/package.json', '{"name":"demo","version":"8.0.0-rc.4"}\n');
+    writeRepoFile('examples/demo/src/main.ts', 'export const a = 2;\n');
+    commitAll('bump with substrate change');
+
     const result = runScript(['--prev', prev, '--head', 'HEAD']);
     assert.notEqual(result.status, 0);
     assert.match(result.stderr, /per-pr-declaration/);


### PR DESCRIPTION
Every release-bump PR failed `check:upgrade-coverage`'s `per-pr-declaration` rule, because the version sweep rewrites the `version` field of every manifest under `examples/` and `packages/3-extensions/`, and the dependency-only exemption deliberately leaves that field visible (the `coverage` rule uses it to force the transition directory to exist on release PRs — there is a fixture test pinning that).

The two rules now read the diff differently: `coverage` is unchanged, and `per-pr-declaration` is skipped when every substrate file in the diff differs only in version fields — a sweep declares nothing an earlier PR has not already recorded. Two new fixture tests pin the split: a pure sweep passes when the directory exists; a sweep plus a real substrate change still demands the declaration. 78/78 script tests pass.

Unblocks the rc.4 release PR (#30066), which currently fails this rule despite #30058 having already recorded the real rc.3→rc.4 entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release-sweep validation to recognize version-only updates without requiring unnecessary declarations.
  - Continued requiring transition details when changes affect dependencies, scripts, or other release behavior.
  - Ensured existing instruction files remain valid when no substantive release changes are detected.

- **Tests**
  - Added coverage for version-only manifest changes.
  - Added checks confirming that dependency and script changes still trigger the appropriate release requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->