### PR TITLE
The sweep-only path still validates the existing upgrade record

### DIFF
--- a/scripts/check-upgrade-coverage.mjs
+++ b/scripts/check-upgrade-coverage.mjs
@@ -562,7 +562,26 @@ export function runCheck({ repoRoot, head, prev }) {
       // deliberate intent is recorded per PR, not just per transition
       // directory creation.
       const instructionsPath = `${skillPkg}/upgrades/${transition}/instructions.md`;
-      if (sweepOnly && !changedPaths.has(instructionsPath)) continue;
+      if (sweepOnly && !changedPaths.has(instructionsPath)) {
+        // No fresh declaration needed for a pure sweep — but the existing
+        // record must still be well-formed, or a bypassed earlier PR's
+        // malformed file rides through unexamined.
+        const raw = tryReadFileAtRef(repoRoot, head, instructionsPath);
+        const parsed = raw
+          ? parseChangesFrontmatter(raw)
+          : { ok: false, reason: 'file unreadable' };
+        if (!parsed.ok) {
+          violations.push({
+            rule: 'per-pr-declaration',
+            substrate,
+            instructionsPath,
+            malformed: true,
+            reason: parsed.reason,
+            sampleDiffPaths: substrateDiff.slice(0, 5),
+          });
+        }
+        continue;
+      }
       if (!changedPaths.has(instructionsPath)) {
         violations.push({
           rule: 'per-pr-declaration',

--- a/scripts/check-upgrade-coverage.test.mjs
+++ b/scripts/check-upgrade-coverage.test.mjs
@@ -1134,3 +1134,24 @@ describe('check-upgrade-coverage — release sweep per-PR declaration', () => {
     assert.match(result.stderr, /per-pr-declaration/);
   });
 });
+
+describe('check-upgrade-coverage — sweep path still validates the record', () => {
+  it('a pure sweep fails when the existing instructions file is malformed', () => {
+    writePackageJson('8.0.0-rc.3');
+    writeRepoFile('examples/demo/package.json', '{"name":"demo","version":"8.0.0-rc.3"}\n');
+    writeRepoFile(
+      'skills/prisma-next-upgrade/upgrades/8.0.0-rc.3-to-8.0.0-rc.4/instructions.md',
+      'no frontmatter at all\n',
+    );
+    commitAll('prev with a malformed record');
+    const prev = git('rev-parse', 'HEAD');
+
+    writePackageJson('8.0.0-rc.4');
+    writeRepoFile('examples/demo/package.json', '{"name":"demo","version":"8.0.0-rc.4"}\n');
+    commitAll('bump to 8.0.0-rc.4');
+
+    const result = runScript(['--prev', prev, '--head', 'HEAD']);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /per-pr-declaration/);
+  });
+});


### PR DESCRIPTION
Follow-up to #30068, raised by review on #30066: when a pure version sweep skips the fresh-declaration requirement, it must still read the existing `instructions.md` — otherwise a malformed record (possible only via a bypassed earlier PR, but bypasses happen, as this launch week shows) rides through unexamined. The sweep path now parses the record and reports a `per-pr-declaration` violation on a malformed one. One new fixture test; 79/79 pass.

Like #30068, the only check that exercises this is Lint (it runs the script test suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for release-sweep updates when existing upgrade instructions lack a new declaration.
  - Malformed or unreadable instruction metadata is now reported as a validation violation instead of being skipped.

- **Tests**
  - Added regression coverage for version-only updates with missing instruction metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->