### PR TITLE
ci: judge each PR against the branch it targets, not main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,11 +79,18 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          # `check:upgrade-coverage` diffs HEAD against `origin/main`; needs
-          # enough history for `git diff origin/main..HEAD` to resolve.
+          # The per-PR gates diff HEAD against the branch this PR targets;
+          # needs enough history for `git diff origin/<base>..HEAD` to resolve.
           fetch-depth: 0
-      - name: Fetch base branch (origin/main)
-        run: git fetch --no-tags origin main:refs/remotes/origin/main
+      # A stacked PR targets the branch below it, not main, so the gates have
+      # to diff against that branch: judged against main, every PR in a stack
+      # carries the whole stack's diff and must repeat work its parent already
+      # declared. `github.base_ref` is empty outside pull_request events
+      # (merge_group, push), where main is the right comparison.
+      - name: Fetch the base branch this PR targets
+        env:
+          BASE: ${{ github.base_ref || 'main' }}
+        run: git fetch --no-tags origin "$BASE:refs/remotes/origin/$BASE"
       - uses: ./.github/actions/setup
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -127,11 +134,15 @@ jobs:
       - name: Lint publishability matches the directory layout
         run: pnpm lint:publishability
       - name: Check upgrade-instruction coverage
-        run: pnpm check:upgrade-coverage --mode pr
+        env:
+          BASE: ${{ github.base_ref || 'main' }}
+        run: pnpm check:upgrade-coverage --mode pr --prev "origin/$BASE"
       - name: Check error-reference completeness
         run: pnpm check:error-reference
       - name: Check release notes
-        run: pnpm check:release-notes --mode pr
+        env:
+          BASE: ${{ github.base_ref || 'main' }}
+        run: pnpm check:release-notes --mode pr --prev "origin/$BASE"
 
   fixtures:
     name: Fixtures

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,11 +82,6 @@ jobs:
           # The per-PR gates diff HEAD against the branch this PR targets;
           # needs enough history for `git diff origin/<base>..HEAD` to resolve.
           fetch-depth: 0
-      # A stacked PR targets the branch below it, not main, so the gates have
-      # to diff against that branch: judged against main, every PR in a stack
-      # carries the whole stack's diff and must repeat work its parent already
-      # declared. `github.base_ref` is empty outside pull_request events
-      # (merge_group, push), where main is the right comparison.
       - name: Fetch the base branch this PR targets
         env:
           BASE: ${{ github.base_ref || 'main' }}


### PR DESCRIPTION
TML-3221. The lint job's per-PR gates (`check:upgrade-coverage --mode pr`, `check:release-notes --mode pr`) always diffed against `origin/main`. For a stacked PR, which targets the branch below it, that comparison sees the whole stack's diff in every PR. Each intermediate PR then fails unless it repeats declarations its parent already carries — so the stack-wide content had to ride the bottom commit, which breaks self-containment: merging the stack partially would ship declarations for changes that did not land.

## What changes

- The lint job now fetches and diffs against the branch the PR targets: `github.base_ref`, falling back to `main` where `base_ref` is empty (`merge_group`, `push`), which is also where main is the right comparison.
- Both gates get `--prev "origin/$BASE"`. The scripts already accept `--prev`; only the workflow hardcoded main.
- Comments on the checkout and fetch steps now describe the base-branch behavior.

## Effect on stacked PRs

Each PR is judged on its own diff. A PR that changes `examples/` declares its own upgrade instructions; a PR that does not, declares nothing. Entries no longer need to pool in the bottom commit.

Window derivation is unchanged for the common case: a stacked base carries the same root version as the head, so the coverage check derives the same in-flight transition window it derived against main. If the base is ahead of the head (the base took a release cut the PR has not rebased onto), the check fails with an explicit "rebase" instruction instead of a silent wrong-window comparison.

## Validation

- `pnpm lint:workflows` passes.
- Local mirror run on a real stacked pair from the raw-lane stack: diffing the second PR against main passes only by inheriting the first PR's declarations; diffing it against its actual base correctly demands the second PR's own declaration. That demand is the fix working.

https://claude.ai/code/session_01NnNjsNcPMtbJZhnZz5Zzbe


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated validation so changes are evaluated against the appropriate target branch.
  * Aligned coverage and release-note checks to use the same relevant baseline.
  * This provides more accurate pull request feedback and helps prevent misleading validation results when working from branches other than the default branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->