### PR TITLE
fix(language-server): recognize connection errors from any copy of vscode-jsonrpc (TML-3222)

### DIFF
--- a/packages/1-framework/3-tooling/language-server/src/guarded-connection.ts
+++ b/packages/1-framework/3-tooling/language-server/src/guarded-connection.ts
@@ -1,4 +1,4 @@
-import { type Connection, ConnectionError } from 'vscode-languageserver';
+import { type Connection, ConnectionError, ConnectionErrors } from 'vscode-languageserver';
 
 /**
  * Wraps a connection so that an outbound call the client is no longer there to
@@ -45,12 +45,36 @@ function guardCalls<Target extends object>(target: Target): Target {
   });
 }
 
+/**
+ * Whether an error says the connection is gone.
+ *
+ * The identity check is the fast path. It misses when the error comes from a
+ * second copy of `vscode-jsonrpc` in the dependency tree, whose
+ * `ConnectionError` is a different class carrying the same shape, so the code
+ * is what decides: `Closed`, `Disposed` and `AlreadyListening` are the whole
+ * range, and no other error jsonrpc throws carries a numeric `code` in it.
+ */
+function isConnectionGone(error: unknown): error is ConnectionError {
+  if (error instanceof ConnectionError) {
+    return true;
+  }
+  if (!(error instanceof Error) || !('code' in error)) {
+    return false;
+  }
+  const { code } = error;
+  return (
+    code === ConnectionErrors.Closed ||
+    code === ConnectionErrors.Disposed ||
+    code === ConnectionErrors.AlreadyListening
+  );
+}
+
 function whileConnected(send: () => unknown): unknown {
   let sent: unknown;
   try {
     sent = send();
   } catch (error) {
-    if (error instanceof ConnectionError) {
+    if (isConnectionGone(error)) {
       // Sends return promises, so a caller that awaits or chains a swallowed
       // one must get a promise back, not a bare `undefined`.
       return Promise.resolve(undefined);

--- a/packages/1-framework/3-tooling/language-server/test/guarded-connection.test.ts
+++ b/packages/1-framework/3-tooling/language-server/test/guarded-connection.test.ts
@@ -107,6 +107,24 @@ describe('guardedConnection', () => {
     ).resolves.toBeUndefined();
   });
 
+  // A second copy of `vscode-jsonrpc` in the tree throws its own
+  // `ConnectionError` class, so the error carries the shape but not the
+  // identity of the one this module imports.
+  class ForeignConnectionError extends Error {
+    readonly code = 2;
+  }
+
+  it('drops a send the connection refused from another copy of the transport', () => {
+    const console = {
+      error: () => {
+        throw new ForeignConnectionError('Connection is disposed.');
+      },
+    };
+    const guarded = guardedConnection({ console } as unknown as Connection);
+
+    expect(() => guarded.console.error('late log')).not.toThrow();
+  });
+
   it('lets an error that is not the connection leaving through', () => {
     const connection = guardedConnection(serverConnection(new PassThrough(), discardingWriter()));
 

--- a/packages/1-framework/3-tooling/language-server/test/server.test.ts
+++ b/packages/1-framework/3-tooling/language-server/test/server.test.ts
@@ -419,12 +419,11 @@ function startHarness(
     getDocumentAst: (uri) => server.getDocumentAst(uri),
     getProjectSymbolTable: (uri) => server.getProjectSymbolTable(uri),
     dispose: () => {
-      // Dispose the server first: this sets its `disposed` flag before the
-      // transport dies, so an in-flight `publish` rejection is swallowed by
-      // the guard in `publishSafely` instead of being logged through a
-      // connection that the client has already torn down (which would throw
-      // "Connection is disposed" inside a fire-and-forget notification and
-      // surface as an unhandled rejection).
+      // Dispose the server first, so its connection is gone before the
+      // transport dies. Sends made after that point — an in-flight `publish`
+      // reporting diagnostics, or `publishSafely` logging a failure — go
+      // through the guarded connection, which drops a send the connection
+      // refuses rather than letting it throw inside a fire-and-forget call.
       server.dispose();
       client.dispose();
       clientToServer.end();


### PR DESCRIPTION
TML-3222. Two consecutive merge-queue runs for #30075 failed with every test passing (1157 files, 15314 tests) plus one unhandled rejection: `Error: Connection is disposed.` escaping from the language-server suite during teardown.

## Root cause

`guardedConnection` already wraps every outbound send and swallows failures after the client is gone — but it recognized a connection failure with `error instanceof ConnectionError`. The tree resolves three copies of `vscode-jsonrpc` (9.0.1, 8.2.1, 8.2.0). `instanceof` compares class identity, not shape, so a `ConnectionError` thrown by a copy other than the one this module imports fails the check. The guard then rethrows it inside a fire-and-forget call, and the run fails with an unhandled rejection while every test is green.

Proven: the three copies exist, the predicate was identity-based, and a same-shape error from a foreign class escapes the guard with exactly the message and serialized `{ code: 2 }` (`ConnectionErrors.Disposed`) that CI reported. Inferred, not observed: that CI's install layout is what routes the throw through a second copy. The fix is correct either way — a class that can arrive from any copy needs a shape check.

## What changes

- `isConnectionGone` type predicate in `guarded-connection.ts`: `instanceof` stays as the fast path; the fallback matches an `Error` whose numeric `code` is one of the three `ConnectionErrors` members (`Closed`, `Disposed`, `AlreadyListening` — the whole enum).
- Regression test: a send that throws a `ConnectionError`-shaped error from a foreign class must be dropped. Red on the previous predicate with the exact CI failure text; the existing negative case (errors that are not the connection still propagate) stays green, so the widening cannot swallow everything.
- The test harness's dispose comment claimed a `disposed` flag in the server that never existed; it now describes the real mechanism (the guarded connection).

## Verification

- New test red pre-fix (`'Error: Connection is disposed.' was thrown`), green post-fix; guard suite 7/7.
- Full language-server package suite: 260 tests pass; lint and typecheck clean; workspace typecheck 168/168.

Unblocks #30075, which this flake bounced from the merge queue twice.

https://claude.ai/code/session_01NnNjsNcPMtbJZhnZz5Zzbe


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of language server connections that close or are disposed unexpectedly.
  * Prevented harmless late diagnostic updates and logging attempts from producing unnecessary errors after shutdown.
  * Preserved propagation of unrelated connection failures.

* **Tests**
  * Added coverage for connection errors originating from different compatible JSON-RPC implementations.
 

<!-- end of auto-generated comment: release notes by coderabbit.ai -->