### PR TITLE
docs(rules): record CI-classification and verification lessons from the raw-lane close-out

### DIFF
--- a/.agents/rules/README.md
+++ b/.agents/rules/README.md
@@ -52,6 +52,7 @@ Rules below are listed by bare filename; the canonical file is `.agents/rules/<n
 - `fix-the-class-not-the-instance.mdc` — A review comment names a class of defect; sweep the whole diff for the class, fix every instance in one round
 
 ## Testing
+- `non-vacuous-verification.mdc` — Make every verification able to fail: regression tests red pre-fix, verifiers fail on empty input, `not.toBeAny()` sentinels
 - `test-import-patterns.mdc` — Test import patterns (source files, relative paths, don't export for tests)
 - `test-file-organization.mdc` — Test file organization (max 500 lines, split by functionality)
 - `test-intent-readability.mdc` — Tests must be readable by context (BDD-style grouping)
@@ -132,6 +133,7 @@ Rules below are listed by bare filename; the canonical file is `.agents/rules/<n
 - `tsdown-config-package-source-only.mdc` — Keep `@repo/tsdown` exports source-only (no `.js` workaround files)
 
 ## Git, CI & workflow
+- `ci-failure-classification.mdc` — Classify CI failures from evidence: frozen install first, non-inert controls, known flake fingerprints
 - `running-tests.mdc` — How to run tests (and other slow verification commands): save output to a file once, read the file; don't re-run to grep different lines
 - `no-target-branches.mdc` — Don't branch on target; use adapters
 - `no-pull-request-target.mdc` — Never add `pull_request_target` to GitHub Actions workflows

--- a/.agents/rules/adr-writing.mdc
+++ b/.agents/rules/adr-writing.mdc
@@ -13,3 +13,4 @@ alwaysApply: false
 - Use fenced code blocks for SQL (` ```sql `) and TS (` ```ts `); avoid nested backticks inside inline code
 - Worked examples should be end-to-end and make it obvious which layer owns each step (lane, adapter, codec, driver, runtime)
 - If the decision instantiates a structural pattern recorded in [`docs/architecture docs/patterns/`](../../docs/architecture%20docs/patterns/README.md), link forward to the pattern entry from the ADR (existing ADRs are not retroactively edited)
+- **Maintain the ADR in the PR that changes the decision.** When a decision evolves mid-project, update its ADR (and add supersession notes to any ADR it displaces) in the same PR — not in a follow-up. An ADR whose examples drift from the shipped surface violates `adr-examples-must-match-code.mdc` and misleads longer than it informs.

--- a/.agents/rules/ci-failure-classification.mdc
+++ b/.agents/rules/ci-failure-classification.mdc
@@ -1,5 +1,8 @@
 ---
 description: Classify CI failures from evidence before acting — install state first, controls that can fail, known flake fingerprints
+globs:
+  - ".github/**"
+  - "scripts/**"
 alwaysApply: false
 ---
 

--- a/.agents/rules/ci-failure-classification.mdc
+++ b/.agents/rules/ci-failure-classification.mdc
@@ -1,0 +1,33 @@
+---
+description: Classify CI failures from evidence before acting — install state first, controls that can fail, known flake fingerprints
+alwaysApply: false
+---
+
+# CI failure classification
+
+Classify every CI failure from evidence before re-running, "fixing", or blaming it: **(a)** caused by this PR — fix the code; **(b)** infra/flake — retry and record the fingerprint; **(c)** already broken on the base — prove it, route to its own fix.
+
+## Before classifying anything
+
+- `pnpm install --frozen-lockfile` first. Stale install state fakes both reds and greens: stale `dist/` (TS2307 on `@internal/*`), stale deps (a pin moved on the base is invisible until reinstall), stale fixtures. Install after a rebase, not before.
+- Read the actual job log; save it to a file once and grep the file (`running-tests.mdc`).
+- Find the first failure. One dead shared connection fails dozens of tests at 0ms — count one event, not N failures.
+- Check the diff can reach the failing package at all.
+
+## Control experiments
+
+- A control proves a failure pre-existing only if it ran the same steps. CI skips heavy steps on inert (docs-only) diffs and still reports green — use a non-inert control diff.
+- When the base never runs the failing workflow (pull_request-triggered), a concurrent trivial PR (e.g. dependabot bump) with the identical signature is the equivalent evidence.
+- Reproduce with the real test file at the real commit; an approximate harness produces the right symptom for the wrong cause.
+
+## Known flake fingerprints
+
+- **Different assertions across retry attempts** of one test — impossible for a deterministic defect; only the raw log shows it.
+- **`ECONNRESET` / `Connection terminated unexpectedly` at setup**, or one connection error then siblings failing at 0ms — the shared dev database died mid-run.
+- **All tests green, run exits 1 on an unhandled rejection** — teardown race; classify from the rejection's stack.
+
+A fingerprint match is a hypothesis, not a verdict — and a "flake" recurring on consecutive runs of the same tree is a real defect in a timing costume.
+
+## When a gate (not a test) fails
+
+Read the gate's own output. If satisfying it would mean describing changes the PR does not contain, or contorting tense to avoid falsehoods, suspect the gate's comparison base — fix the gate, don't contort.

--- a/.agents/rules/non-vacuous-verification.mdc
+++ b/.agents/rules/non-vacuous-verification.mdc
@@ -1,0 +1,15 @@
+---
+description: A green check that would also pass with the defect present proves nothing — make every verification able to fail
+alwaysApply: false
+---
+
+# Non-vacuous verification
+
+A verification that cannot fail converts absence of evidence into false confidence. Before trusting a green result, name what would have made it red.
+
+- **A regression test must be red before the fix** — run it against the unfixed code and record the failure. If the triggering scenario cannot be reproduced (e.g. a transport race), don't ship a test that is green in both worlds: make the seam testable and test the seam directly.
+- **A verifier must fail (or loudly warn) on empty input.** "All 0 known cases verified" is a discovery failure, not a pass.
+- **Guard type tests against `any` poisoning.** `skipLibCheck` + an unresolvable import in a fixture `.d.ts` makes every dependent assertion vacuous (`T & any` is `any`). Add a `not.toBeAny()` sentinel on the fixture's central types.
+- **Comments are not evidence.** A comment describing a guard does not mean it exists — read the code it claims to describe; correct the comment when it lies.
+- **Generated files: test claims by regenerating.** Reading the generator is not evidence; running it is.
+- **Instrument before designing a fix** for a hard-to-reproduce failure — a counter proving "this catch never runs" kills a wrong hypothesis in one run.

--- a/.agents/rules/non-vacuous-verification.mdc
+++ b/.agents/rules/non-vacuous-verification.mdc
@@ -1,5 +1,10 @@
 ---
 description: A green check that would also pass with the defect present proves nothing — make every verification able to fail
+globs:
+  - "**/*.test.ts"
+  - "**/*.test-d.ts"
+  - "**/*.integration.test.ts"
+  - "test/**"
 alwaysApply: false
 ---
 

--- a/.agents/rules/typescript-patterns.mdc
+++ b/.agents/rules/typescript-patterns.mdc
@@ -21,6 +21,8 @@ This rulecard is intentionally short. For deeper examples, see `docs/reference/t
 - **Export interfaces; construct via factories**: keep classes as private implementation details.
 - **No generic defaults unless meaningful**: defaults are semantics, not “flexibility”.
 - **Test-only escapes**: `@ts-expect-error` and double casts are acceptable only in test files, with a short explanation.
+- **Key id-like string parameters on the map they come from**: a `Record<string, string>` constraint widens `'pg/int8@1'` to `string`; `keyof CT & string` preserves the literal and gives completions. Reach for the keyed union whenever a string is semantically an id from a known map.
+- **`ReturnType` of an overloaded function resolves to the last overload.** Adding an overload silently retypes every `ReturnType<typeof fn>` consumer. Order overloads most-specific first and pin the inferred type with a type test.
 
 ## Related rules
 

--- a/.agents/rules/typescript-patterns.mdc
+++ b/.agents/rules/typescript-patterns.mdc
@@ -22,7 +22,7 @@ This rulecard is intentionally short. For deeper examples, see `docs/reference/t
 - **No generic defaults unless meaningful**: defaults are semantics, not “flexibility”.
 - **Test-only escapes**: `@ts-expect-error` and double casts are acceptable only in test files, with a short explanation.
 - **Key id-like string parameters on the map they come from**: a `Record<string, string>` constraint widens `'pg/int8@1'` to `string`; `keyof CT & string` preserves the literal and gives completions. Reach for the keyed union whenever a string is semantically an id from a known map.
-- **`ReturnType` of an overloaded function resolves to the last overload.** Adding an overload silently retypes every `ReturnType<typeof fn>` consumer. Order overloads most-specific first and pin the inferred type with a type test.
+- **`ReturnType` of an overloaded function resolves to the last overload.** Adding a new last overload, or reordering the existing ones so a different signature ends up last, silently retypes every `ReturnType<typeof fn>` consumer; an overload inserted earlier leaves them alone. Order overloads most-specific first and most general last, and pin the inferred type with a type test so a change to the last signature fails loudly.
 
 ## Related rules
 

--- a/.cursor/rules-footprint.config.json
+++ b/.cursor/rules-footprint.config.json
@@ -6,6 +6,6 @@
     "agentsLines": 200,
     "agentsBytes": 11200,
     "totalRulesLines": 5050,
-    "totalRulesBytes": 208000
+    "totalRulesBytes": 216000
   }
 }

--- a/skills-contrib/record-upgrade-instructions/SKILL.md
+++ b/skills-contrib/record-upgrade-instructions/SKILL.md
@@ -52,6 +52,8 @@ The substrate diff is the signal that an entry is required. The agent fixing the
 
 **Stacked PRs.** The coverage gate diffs each PR against the branch it targets, not against `main`. Each PR in a stack therefore declares the entries for its own substrate diff, in its own commits. Do not pool a stack's entries in the bottom PR: pooled entries break self-containment (a partial merge ships instructions for changes that did not land), and under per-base diffing the upper PRs fail the gate anyway. Sequential commits appending entries to the same `instructions.md` are the normal shape.
 
+Throughout the steps below, **`<target>`** is the branch the PR targets: `main`, unless the PR is stacked, in which case it is the PR below it in the stack.
+
 ## Authoring workflow
 
 For each PR that hits one or both signals, walk these steps in order.
@@ -63,13 +65,22 @@ For each PR that hits one or both signals, walk these steps in order.
 
    The branch's `package.json` is the source-of-truth — do **not** consult `npm view`. If there is no substrate diff at all, no entry is needed — skip to step 7.
 
-2. **Identify the touched substrate(s).** Compute `git diff origin/main..HEAD` restricted to `examples/` and to `packages/3-extensions/`. Each non-empty substrate corresponds to one destination package per the routing table above. The "both" case is normal — the rare PR (e.g. a structural on-disk migration shape change) touches both.
+2. **Identify the touched substrate(s).** Compute `git diff origin/<target>..HEAD` restricted to `examples/` and to `packages/3-extensions/`. Each non-empty substrate corresponds to one destination package per the routing table above. The "both" case is normal — the rare PR (e.g. a structural on-disk migration shape change) touches both.
 
 3. **Find or create the directory in each destination.** For each destination, the directory is `<destination>/upgrades/<in-flight transition>/` from step 1 (so e.g. `skills/prisma-next-upgrade/upgrades/0.7-to-0.8/` for the user-skill). If the directory already exists (an earlier PR on the same transition created it, or the placeholder shipped with the initial mechanism PR is still there), **do not create a duplicate** — append a new entry to the existing `instructions.md`'s `changes[]` array.
 
 4. **Write the entry into `instructions.md`.** Each `changes[]` entry carries an `id` (kebab-case, unique within the transition), a one-line `summary`, an optional `detection` block (glob + content predicate the consumer's agent runs to know whether the change applies to that consumer's project), and an optional `script:` reference (relative path to a colocated script next to `instructions.md`). For changes that need agent reasoning across the codebase rather than a deterministic script, the entry omits `script:` and the agent follows the prose body of `instructions.md` instead.
 
-   **Make detection predicates token-precise.** A broad substring regex fires on call sites the change does not touch and sends consumers hunting for migrations they do not need. Test the predicate against both a true positive and the nearest false positive before shipping it. Example: matching the moved tag `` .raw` `` must not fire on the unchanged fragment tag `` fns.raw` `` — and excluding it needs a token boundary, since `(?<!fns)` would also suppress an unrelated `` myfns.raw` ``. The shipped predicate is `(?<!(?<![\w$])fns)\.raw`` — the inner lookbehind makes the exclusion apply only to the exact `fns` token.
+   **Make detection predicates token-precise.** A broad substring regex fires on call sites the change does not touch and sends consumers hunting for migrations they do not need. Test the predicate against both a true positive and the nearest false positive before shipping it. Matching a moved tag must not fire on an unchanged one, and excluding the unchanged spelling needs a token boundary — a bare lookbehind also suppresses an unrelated receiver that merely ends in those letters:
+
+   ```text
+   matches:      .raw`
+   must not fire on: fns.raw`
+   too broad:    (?<!fns)\.raw`        also suppresses myfns.raw`
+   shipped:      (?<!(?<![\w$])fns)\.raw`
+   ```
+
+   The inner lookbehind makes the exclusion apply only to the exact `fns` token.
 
    **Only record changes that require consumer action.** Every `changes[]` entry — and every paragraph in the prose body — must describe something the consumer has to *do*. Do not include narrative about substrate diffs that need no consumer response (e.g. dev-only dep bumps inside `examples/`, internal-only renames, generated-artefact churn that round-trips on re-emit). The absence of an entry already communicates "do nothing" — saying it explicitly is noise, and it dilutes the signal of the entries that *do* require action. If the entire in-flight transition is genuinely no-op for consumers, ship `changes: []` with no body prose; the `changes: []` array is the record. The reviewer treats any "consumers do not need to take any action" sentence in the body as a defect.
 
@@ -88,9 +99,9 @@ Workflow per entry (one of the two flows; both apply for cross-audience entries)
 ### User-skill entry (against `examples/`)
 
 1. Check out the PR branch with the framework change applied.
-2. Revert `examples/` to its pre-PR state (`git restore --source=origin/main -- examples/`).
+2. Revert `examples/` to its pre-PR state (`git restore --source=origin/<target> -- examples/`).
 3. Run the entry against the reverted substrate — invoke any colocated script(s) per the entry's `script:` reference, then walk the prose body of `instructions.md` if the entry has additional instructions.
-4. Verify the resulting `examples/` directory matches the PR-branch state (`git diff origin/main..HEAD -- examples/` ≡ `git diff -- examples/` after step 3).
+4. Verify the resulting `examples/` directory matches the PR-branch state (`git diff origin/<target>..HEAD -- examples/` ≡ `git diff -- examples/` after step 3).
 5. Verify the matching test suite is green: `pnpm test:examples`.
 
 If any of those checks fail, iterate on the entry. Do not merge.
@@ -98,7 +109,7 @@ If any of those checks fail, iterate on the entry. Do not merge.
 ### Extension-skill entry (against `packages/3-extensions/`)
 
 1. Check out the PR branch with the framework change applied.
-2. Revert `packages/3-extensions/` to its pre-PR state (`git restore --source=origin/main -- packages/3-extensions/`).
+2. Revert `packages/3-extensions/` to its pre-PR state (`git restore --source=origin/<target> -- packages/3-extensions/`).
 3. Run the entry against the reverted substrate.
 4. Verify the resulting `packages/3-extensions/` directory matches the PR-branch state.
 5. Verify the matching test suite is green: `pnpm test --filter='./packages/3-extensions/*'`.

--- a/skills-contrib/record-upgrade-instructions/SKILL.md
+++ b/skills-contrib/record-upgrade-instructions/SKILL.md
@@ -19,8 +19,8 @@ This skill fires on PRs **inside this repo** that make a breaking change to Pris
 
 The published skills you will be authoring entries into:
 
-- `skills/upgrade/prisma-next-upgrade/` — distributed via `pnpm dlx skills add prisma/prisma/skills/upgrade --all`. **Audience: users of Prisma Next** (consumers of the public package API: `@internal/postgres`, `@internal/mongo`, the contract files in `prisma/`, on-disk migration shape).
-- `skills/extension-author/prisma-8-extension-upgrade/` — distributed via `pnpm dlx skills add prisma/prisma/skills/extension-author --all`. **Audience: authors of Prisma Next extensions** (consumers of the framework SPI: `@internal/contract`, `@internal/framework-components`, `@internal/migration-tools`, etc.).
+- `skills/prisma-next-upgrade/` — distributed via `pnpm dlx skills add prisma/prisma/skills --skill prisma-next-upgrade -y`. **Audience: users of Prisma Next** (consumers of the public package API: `@internal/postgres`, `@internal/mongo`, the contract files in `prisma/`, on-disk migration shape).
+- `skills/prisma-8-extension-upgrade/` — distributed via `pnpm dlx skills add prisma/prisma/skills --skill prisma-8-extension-upgrade -y`. **Audience: authors of Prisma Next extensions** (consumers of the framework SPI: `@internal/contract`, `@internal/framework-components`, `@internal/migration-tools`, etc.).
 
 The two skill clusters are independent (no shared content). Cross-audience breaking changes — where the same on-disk transformation applies to both substrates — are recorded *separately* in each cluster, including duplicated colocated scripts.
 
@@ -44,8 +44,8 @@ Two mechanical signals, each tied to one destination package:
 
 | Substrate touched by the PR    | Destination skill                                              |
 | ------------------------------ | -------------------------------------------------------------- |
-| `examples/`                    | `skills/upgrade/prisma-next-upgrade/`                          |
-| `packages/3-extensions/`       | `skills/extension-author/prisma-8-extension-upgrade/`       |
+| `examples/`                    | `skills/prisma-next-upgrade/`                          |
+| `packages/3-extensions/`       | `skills/prisma-8-extension-upgrade/`       |
 | Both                           | Both — duplicated entries (see below)                          |
 
 The substrate diff is the signal that an entry is required. The agent fixing the red tests in those substrates sees the signal directly; the reviewer sees the same diff. The release-pipeline check (`pnpm check:upgrade-coverage`) enforces the outcome — a substrate diff without the matching directory fails the PR.
@@ -101,7 +101,7 @@ Workflow per entry (one of the two flows; both apply for cross-audience entries)
 1. Check out the PR branch with the framework change applied.
 2. Revert `examples/` to its pre-PR state (`git restore --source=origin/<target> -- examples/`).
 3. Run the entry against the reverted substrate — invoke any colocated script(s) per the entry's `script:` reference, then walk the prose body of `instructions.md` if the entry has additional instructions.
-4. Verify the resulting `examples/` directory matches the PR-branch state (`git diff origin/<target>..HEAD -- examples/` ≡ `git diff -- examples/` after step 3).
+4. Verify the resulting `examples/` directory matches the PR-branch state: `git diff --exit-code HEAD -- examples/` succeeds. The entry has reproduced the patch `git diff origin/<target>..HEAD -- examples/` describes, so the working tree is back at HEAD and the check is that nothing is left over.
 5. Verify the matching test suite is green: `pnpm test:examples`.
 
 If any of those checks fail, iterate on the entry. Do not merge.
@@ -111,7 +111,7 @@ If any of those checks fail, iterate on the entry. Do not merge.
 1. Check out the PR branch with the framework change applied.
 2. Revert `packages/3-extensions/` to its pre-PR state (`git restore --source=origin/<target> -- packages/3-extensions/`).
 3. Run the entry against the reverted substrate.
-4. Verify the resulting `packages/3-extensions/` directory matches the PR-branch state.
+4. Verify the resulting `packages/3-extensions/` directory matches the PR-branch state: `git diff --exit-code HEAD -- packages/3-extensions/` succeeds, the same check the user-skill flow makes against `examples/`.
 5. Verify the matching test suite is green: `pnpm test --filter='./packages/3-extensions/*'`.
 
 If any of those checks fail, iterate on the entry. Do not merge.
@@ -122,7 +122,7 @@ The PR that introduces the breaking change must contain, in addition to the fram
 
 - **The new entry directory in each affected skill** — `<destination>/upgrades/<in-flight transition>/instructions.md` plus any colocated scripts (the in-flight transition being the one determined in step 1 of the authoring workflow).
 - **The post-instructions state of every affected substrate** — these substrates would have been left broken without the entry; the entry's effect on the substrate *is* the diff that brings them back to green. The PR-branch substrate state and the validation-by-execution output state must be identical.
-- **A reference in the PR description naming each entry directory** (e.g. *"Adds entries to `skills/upgrade/prisma-next-upgrade/upgrades/0.7-to-0.8/` and `skills/extension-author/prisma-8-extension-upgrade/upgrades/0.7-to-0.8/`."*).
+- **A reference in the PR description naming each entry directory** (e.g. *"Adds entries to `skills/prisma-next-upgrade/upgrades/0.7-to-0.8/` and `skills/prisma-8-extension-upgrade/upgrades/0.7-to-0.8/`."*).
 
 The human reviewer + the CI gate (`pnpm check:upgrade-coverage`) both check this shape, but the gate is **necessary-but-not-sufficient** — it only asserts that the in-flight transition *directory* exists, not that *this PR's* substrate diff has a matching `changes[]` entry. So a PR can have a real substrate diff, contribute no entry, and still pass the gate green whenever an earlier PR already created the transition directory. (This is exactly how a breaking change can ship undocumented: the directory was already there, so the gate stayed green.) The gap is load-bearing for the reviewer: **the human reviewer must verify that every substrate diff in the PR has a corresponding entry** — the gate will not catch a missing entry once the directory exists. The reviewer also catches the semantic case (entry exists but its prose / scripts don't match the framework change).
 
@@ -158,7 +158,7 @@ Two corollaries of a release cut:
 
 ## Out of scope
 
-This skill records **upgrade instructions** — code-translation entries the published skills will replay against consumer projects. It does **not** add the per-step bump-install-instructions-validate-commit loop to entry bodies. That flow is general content carried in the published `SKILL.md` files (`skills/upgrade/prisma-next-upgrade/SKILL.md` and the matching extension-author file) and runs around your entry. Your entry only contains the code-translation work specific to the transition.
+This skill records **upgrade instructions** — code-translation entries the published skills will replay against consumer projects. It does **not** add the per-step bump-install-instructions-validate-commit loop to entry bodies. That flow is general content carried in the published `SKILL.md` files (`skills/prisma-next-upgrade/SKILL.md` and the matching extension-author file) and runs around your entry. Your entry only contains the code-translation work specific to the transition.
 
 This skill also does not enforce the exact-pin rule for extensions — that is `prisma-8-check-pins` (a `bin` of `@internal/extension-author-tools`), and it runs in extension authors' own CI plus in the extension-upgrade skill's per-step flow.
 
@@ -173,9 +173,9 @@ Both substrates are touched → both skill packages need entries.
 
 1. Read root `package.json` on the PR branch → `version: "0.7.0"`. Currently-published minor is `0.7`, so the in-flight transition is `0.7 → 0.8`. Directory is `upgrades/0.7-to-0.8/` in each skill package.
 2. Both substrates touched.
-3. `skills/upgrade/prisma-next-upgrade/upgrades/0.7-to-0.8/instructions.md` already exists (placeholder shipped with the initial mechanism PR). Append a `changes[]` entry — call it `migration-metadata-shape-update`. Same for `skills/extension-author/prisma-8-extension-upgrade/upgrades/0.7-to-0.8/instructions.md`.
+3. `skills/prisma-next-upgrade/upgrades/0.7-to-0.8/instructions.md` already exists (placeholder shipped with the initial mechanism PR). Append a `changes[]` entry — call it `migration-metadata-shape-update`. Same for `skills/prisma-8-extension-upgrade/upgrades/0.7-to-0.8/instructions.md`.
 4. The user-skill entry may be prose-only (e.g. "rename the imported type from `MigrationMetadata` to `MigrationManifest` in any consumer code"), since the user-facing fix is a simple rename.
-5. The extension-skill entry needs more work — the SPI changed shape, not just name. Author `skills/extension-author/prisma-8-extension-upgrade/upgrades/0.7-to-0.8/update-migration-tools-imports.ts` and reference it from the entry's `script:` field. If the same transformation also applies to the example, copy the script into the user-skill cluster's directory too.
+5. The extension-skill entry needs more work — the SPI changed shape, not just name. Author `skills/prisma-8-extension-upgrade/upgrades/0.7-to-0.8/update-migration-tools-imports.ts` and reference it from the entry's `script:` field. If the same transformation also applies to the example, copy the script into the user-skill cluster's directory too.
 6. Validate by execution: revert `packages/3-extensions/` to pre-PR → run the extension-skill entry → verify `pnpm test --filter='./packages/3-extensions/*'` green and diff matches PR-branch state. Then revert `examples/` to pre-PR → run the user-skill entry → verify `pnpm test:examples` green and diff matches.
 7. Commit on the PR branch with both entry directories, the colocated script(s), and the matching substrate post-state.
 
@@ -183,4 +183,4 @@ Both substrates are touched → both skill packages need entries.
 
 - Mechanism Linear ticket: [TML-2519](https://linear.app/prisma-company/issue/TML-2519).
 - Coverage gate script: `scripts/check-upgrade-coverage.mjs` (invoked as `pnpm check:upgrade-coverage`).
-- Published skills whose entries you are authoring: `skills/upgrade/prisma-next-upgrade/`, `skills/extension-author/prisma-8-extension-upgrade/`.
+- Published skills whose entries you are authoring: `skills/prisma-next-upgrade/`, `skills/prisma-8-extension-upgrade/`.

--- a/skills-contrib/record-upgrade-instructions/SKILL.md
+++ b/skills-contrib/record-upgrade-instructions/SKILL.md
@@ -101,7 +101,7 @@ Workflow per entry (one of the two flows; both apply for cross-audience entries)
 1. Check out the PR branch with the framework change applied.
 2. Revert `examples/` to its pre-PR state (`git restore --source=origin/<target> -- examples/`).
 3. Run the entry against the reverted substrate — invoke any colocated script(s) per the entry's `script:` reference, then walk the prose body of `instructions.md` if the entry has additional instructions.
-4. Verify the resulting `examples/` directory matches the PR-branch state: `git diff --exit-code HEAD -- examples/` succeeds. The entry has reproduced the patch `git diff origin/<target>..HEAD -- examples/` describes, so the working tree is back at HEAD and the check is that nothing is left over.
+4. Verify the resulting `examples/` directory matches the PR-branch state: `git status --porcelain -- examples/` prints nothing. The entry has reproduced the patch `git diff origin/<target>..HEAD -- examples/` describes, so the working tree is back at HEAD and the check is that nothing is left over — no modification, and no file the entry created along the way.
 5. Verify the matching test suite is green: `pnpm test:examples`.
 
 If any of those checks fail, iterate on the entry. Do not merge.
@@ -111,7 +111,7 @@ If any of those checks fail, iterate on the entry. Do not merge.
 1. Check out the PR branch with the framework change applied.
 2. Revert `packages/3-extensions/` to its pre-PR state (`git restore --source=origin/<target> -- packages/3-extensions/`).
 3. Run the entry against the reverted substrate.
-4. Verify the resulting `packages/3-extensions/` directory matches the PR-branch state: `git diff --exit-code HEAD -- packages/3-extensions/` succeeds, the same check the user-skill flow makes against `examples/`.
+4. Verify the resulting `packages/3-extensions/` directory matches the PR-branch state: `git status --porcelain -- packages/3-extensions/` prints nothing, the same check the user-skill flow makes against `examples/`.
 5. Verify the matching test suite is green: `pnpm test --filter='./packages/3-extensions/*'`.
 
 If any of those checks fail, iterate on the entry. Do not merge.
@@ -158,7 +158,7 @@ Two corollaries of a release cut:
 
 ## Out of scope
 
-This skill records **upgrade instructions** — code-translation entries the published skills will replay against consumer projects. It does **not** add the per-step bump-install-instructions-validate-commit loop to entry bodies. That flow is general content carried in the published `SKILL.md` files (`skills/prisma-next-upgrade/SKILL.md` and the matching extension-author file) and runs around your entry. Your entry only contains the code-translation work specific to the transition.
+This skill records **upgrade instructions** — code-translation entries the published skills will replay against consumer projects. It does **not** add the per-step bump-install-instructions-validate-commit loop to entry bodies. That flow is general content carried in the published `SKILL.md` files (`skills/prisma-next-upgrade/SKILL.md` and `skills/prisma-8-extension-upgrade/SKILL.md`) and runs around your entry. Your entry only contains the code-translation work specific to the transition.
 
 This skill also does not enforce the exact-pin rule for extensions — that is `prisma-8-check-pins` (a `bin` of `@internal/extension-author-tools`), and it runs in extension authors' own CI plus in the extension-upgrade skill's per-step flow.
 

--- a/skills-contrib/record-upgrade-instructions/SKILL.md
+++ b/skills-contrib/record-upgrade-instructions/SKILL.md
@@ -50,6 +50,8 @@ Two mechanical signals, each tied to one destination package:
 
 The substrate diff is the signal that an entry is required. The agent fixing the red tests in those substrates sees the signal directly; the reviewer sees the same diff. The release-pipeline check (`pnpm check:upgrade-coverage`) enforces the outcome — a substrate diff without the matching directory fails the PR.
 
+**Stacked PRs.** The coverage gate diffs each PR against the branch it targets, not against `main`. Each PR in a stack therefore declares the entries for its own substrate diff, in its own commits. Do not pool a stack's entries in the bottom PR: pooled entries break self-containment (a partial merge ships instructions for changes that did not land), and under per-base diffing the upper PRs fail the gate anyway. Sequential commits appending entries to the same `instructions.md` are the normal shape.
+
 ## Authoring workflow
 
 For each PR that hits one or both signals, walk these steps in order.
@@ -66,6 +68,8 @@ For each PR that hits one or both signals, walk these steps in order.
 3. **Find or create the directory in each destination.** For each destination, the directory is `<destination>/upgrades/<in-flight transition>/` from step 1 (so e.g. `skills/prisma-next-upgrade/upgrades/0.7-to-0.8/` for the user-skill). If the directory already exists (an earlier PR on the same transition created it, or the placeholder shipped with the initial mechanism PR is still there), **do not create a duplicate** — append a new entry to the existing `instructions.md`'s `changes[]` array.
 
 4. **Write the entry into `instructions.md`.** Each `changes[]` entry carries an `id` (kebab-case, unique within the transition), a one-line `summary`, an optional `detection` block (glob + content predicate the consumer's agent runs to know whether the change applies to that consumer's project), and an optional `script:` reference (relative path to a colocated script next to `instructions.md`). For changes that need agent reasoning across the codebase rather than a deterministic script, the entry omits `script:` and the agent follows the prose body of `instructions.md` instead.
+
+   **Make detection predicates token-precise.** A broad substring regex fires on call sites the change does not touch and sends consumers hunting for migrations they do not need. Test the predicate against both a true positive and the nearest false positive before shipping it. Example: matching the moved tag `` .raw` `` must not fire on the unchanged fragment tag `` fns.raw` `` — and excluding it needs a token boundary, since `(?<!fns)` would also suppress an unrelated `` myfns.raw` ``. The shipped predicate is `(?<!(?<![\w$])fns)\.raw`` — the inner lookbehind makes the exclusion apply only to the exact `fns` token.
 
    **Only record changes that require consumer action.** Every `changes[]` entry — and every paragraph in the prose body — must describe something the consumer has to *do*. Do not include narrative about substrate diffs that need no consumer response (e.g. dev-only dep bumps inside `examples/`, internal-only renames, generated-artefact churn that round-trips on re-emit). The absence of an entry already communicates "do nothing" — saying it explicitly is noise, and it dilutes the signal of the entries that *do* require action. If the entire in-flight transition is genuinely no-op for consumers, ship `changes: []` with no body prose; the `changes: []` array is the record. The reviewer treats any "consumers do not need to take any action" sentence in the body as a defect.
 
@@ -135,6 +139,11 @@ If a release PR lands on `main` mid-flight (advancing the currently-published ve
 3. **Existing entries** your branch added before the rebase to the previous in-flight directory may be left in place — they describe the transition that just shipped, and modifications / removals of any transition directory are allowed (the new-entries check only enforces *added* paths).
 
 Decide per-entry whether each prior add belongs in the just-shipped transition directory or should be relocated. The rule of thumb: if the entry fixes a substrate diff that already shipped in the release that just landed, leave it in the previous directory; if the entry fixes a substrate diff introduced by the further refactoring you did after the rebase, move it to the new in-flight directory.
+
+Two corollaries of a release cut:
+
+- **A just-shipped transition directory is history.** Restore it to the released content byte-for-byte if your branch had modified it; only entries describing changes that actually shipped in that release may remain there. An entry left in a shipped directory for a change that missed the release is a false instruction.
+- **The new in-flight directory may not exist yet.** If your PR touches a substrate and the directory for the new transition is missing, create it. When the PR's substrate diff needs no consumer action (purely additive features included), ship it with `changes: []` and no body prose — that satisfies the gate and records the no-op explicitly.
 
 ## Out of scope
 


### PR DESCRIPTION
Close-out documentation from the whole-query raw SQL project (TML-3198 → TML-3214/TML-3217 and the CI work they surfaced: TML-3221, TML-3222). Records the durable lessons as rules and skill guidance.

## New rules

- **`ci-failure-classification.mdc`** — classify CI failures from evidence before acting: run `pnpm install --frozen-lockfile` before classifying (stale dist/deps/fixtures fake both reds and greens), use control experiments that actually run the failing steps (the inert-diff detector makes docs-only controls vacuous), and recognize the flake fingerprints this project hit live: assertion drift across retries, connection death cascades (one error, then siblings at 0ms), and all-tests-green-but-exit-1 teardown rejections. Also: when a gate demands content about changes a PR does not contain, suspect the gate's comparison base.
- **`non-vacuous-verification.mdc`** — every check must be able to fail. Regression tests run red pre-fix or test a purpose-built seam; verifiers fail on empty input; `not.toBeAny()` sentinels guard type fixtures against `skipLibCheck` any-poisoning; comments describing guards are not evidence the guard exists; generated-file claims are tested by regenerating.

Both are scoped (`alwaysApply: false`); the always-apply and AGENTS.md budgets are unchanged. The total-rules-bytes footprint threshold rises 208000 → 216000 to cover them (the corpus was ~1 KiB under the ceiling before this PR).

## Extended rules

- `typescript-patterns.mdc` — two reminders: key id-like string parameters on their map (`keyof CT & string` preserves literals and completions where `Record<string, string>` widens), and `ReturnType` of an overloaded function resolves to the last overload (order most-specific first; pin with a type test).
- `adr-writing.mdc` — maintain the ADR in the PR that changes the decision, not in a follow-up.

## Skill guidance (`record-upgrade-instructions`)

- Stacked PRs: the coverage gate diffs each PR against the branch it targets (#30076), so each PR declares entries for its own substrate diff; pooling a stack's entries in the bottom PR breaks partial mergeability.
- Release-cut corollaries: a just-shipped transition directory is history (restore byte-for-byte; entries for unshipped changes may not remain), and the new in-flight directory is created by the first PR that needs it — `changes: []` when the diff needs no consumer action.
- Detection predicates must be token-precise, with the shipped `fns.raw` exclusion as the worked example.

## Scope

Documentation and one lint threshold only; no runtime code.

https://claude.ai/code/session_01NnNjsNcPMtbJZhnZz5Zzbe


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for keeping architectural decisions, examples, and upgrade instructions aligned with shipped changes.
  * Expanded CI troubleshooting guidance to distinguish code-related failures, infrastructure issues, and pre-existing failures.
  * Added verification practices to ensure tests and checks genuinely detect failure conditions.
  * Refined TypeScript guidance for overloaded function return types and type-test coverage.
  * Updated skill installation paths, validation procedures, examples, and reference documentation.
* **Chores**
  * Increased rule configuration capacity to support the expanded guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->