### PR TITLE
Base agent worktrees on freshly fetched origin/main

### DIFF
--- a/.claude/scripts/worktree-create.mjs
+++ b/.claude/scripts/worktree-create.mjs
@@ -12,7 +12,9 @@ const cwd = input.cwd;
 
 const dir = resolve(cwd, '.claude/worktrees', name);
 
-execSync(`git worktree add -b "worktree/${name}" "${dir}" HEAD`, {
+execSync('git fetch origin main', { stdio: 'ignore', cwd });
+
+execSync(`git worktree add -b "worktree/${name}" "${dir}" origin/main`, {
   stdio: 'ignore',
   cwd,
 });

--- a/.claude/scripts/worktree-create.mjs
+++ b/.claude/scripts/worktree-create.mjs
@@ -12,7 +12,10 @@ const cwd = input.cwd;
 
 const dir = resolve(cwd, '.claude/worktrees', name);
 
-execSync('git fetch origin main', { stdio: 'ignore', cwd });
+execSync('git fetch origin +main:refs/remotes/origin/main', {
+  stdio: 'ignore',
+  cwd,
+});
 
 execSync(`git worktree add -b "worktree/${name}" "${dir}" origin/main`, {
   stdio: 'ignore',


### PR DESCRIPTION
The WorktreeCreate hook created every agent worktree from the main checkout's HEAD, with no fetch. That checkout is routinely stale (nothing pulls it), so agent sessions regularly started one or more commits behind origin/main and analyzed or built against outdated code.

The hook now runs `git fetch origin main` and branches the worktree from `origin/main` instead of `HEAD`. If the fetch fails (for example offline), worktree creation fails loudly instead of silently starting from a stale base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Worktrees are now created from the latest `origin/main`, ensuring new branches start with up-to-date code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->