### PR TITLE
TML-3102: warn at emit when PSL Json resolves to native json on postgres

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ This directory contains the primary documentation for the repository.
 - [Mongo Pipeline Builder](./reference/Mongo%20Pipeline%20Builder.md) — typed builder for MongoDB aggregation pipelines, reads, writes, and find-and-modify
 - [`migration graph --tree` rendering](./reference/migration-graph-rendering.md) — condensed annotated-tree rendering for offline migration topology
 - [Why Prisma Next only supports externally-managed native Postgres enums](./reference/postgres-native-enums.md) — the rewrite/atomicity costs behind managed native enums being create/add-value-only
+- [Porting a Prisma 7 schema: `Json` vs `Jsonb` on Postgres](./reference/porting-prisma-7-schemas.md) — PSL `Json` binds native `json`; Prisma ORM's `Json` meant `jsonb` — write `Jsonb` when porting
 - [CLI Style Guide](./CLI%20Style%20Guide.md) — CLI UX conventions
 
 ## Working with AI agents

--- a/docs/reference/porting-prisma-7-schemas.md
+++ b/docs/reference/porting-prisma-7-schemas.md
@@ -1,0 +1,9 @@
+# Porting a Prisma 7 schema: `Json` vs `Jsonb` on Postgres
+
+In Prisma ORM (Prisma 7 and earlier), the `Json` scalar mapped to the Postgres `jsonb` column type. In Prisma 8 PSL, `Json` binds to the native `json` column type, and `jsonb` has its own scalar: `Jsonb`.
+
+A `schema.prisma` copied from Prisma 7 therefore emits `json` columns where the original database had `jsonb`. Emit and check both pass; only `db verify` against the live database catches the mismatch. If you meant `jsonb` — which every Prisma 7 `Json` field did — write `Jsonb`.
+
+`contract emit` warns about this: every bare `Json` field on the postgres target reports `PN_PSL_JSON_NATIVE_JSON`, batched into one summary when a schema has many such fields. The warning is advisory and never fails the build; if a native `json` column is what you want, keep the `Json` spelling.
+
+SQLite and MongoDB `Json` bindings are unaffected. The TypeScript authoring surface (`field.json()`) already means `jsonb` and is unaffected.

--- a/docs/reference/porting-prisma-7-schemas.md
+++ b/docs/reference/porting-prisma-7-schemas.md
@@ -2,8 +2,8 @@
 
 In Prisma ORM (Prisma 7 and earlier), the `Json` scalar mapped to the Postgres `jsonb` column type. In Prisma 8 PSL, `Json` binds to the native `json` column type, and `jsonb` has its own scalar: `Jsonb`.
 
-A `schema.prisma` copied from Prisma 7 therefore emits `json` columns where the original database had `jsonb`. Emit and check both pass; only `db verify` against the live database catches the mismatch. If you meant `jsonb` — which every Prisma 7 `Json` field did — write `Jsonb`.
+A `schema.prisma` copied from Prisma 7 therefore emits `json` columns where the original database had `jsonb`. If you meant `jsonb` — which every Prisma 7 `Json` field did — write `Jsonb`.
 
-`contract emit` warns about this: every bare `Json` field on the postgres target reports `PN_PSL_JSON_NATIVE_JSON`, batched into one summary when a schema has many such fields. The warning is advisory and never fails the build; if a native `json` column is what you want, keep the `Json` spelling.
+`contract emit` flags this: every bare `Json` field on the postgres target reports the advisory `PN_PSL_JSON_NATIVE_JSON`, batched into one summary when a schema has many such fields, and `db verify` confirms the resulting mismatch against the live database. The warning never fails the build; if a native `json` column is what you want, keep the `Json` spelling. A named-type alias (`types { Meta = Json }`) is treated as a deliberate single-site choice and does not warn.
 
 SQLite and MongoDB `Json` bindings are unaffected. The TypeScript authoring surface (`field.json()`) already means `jsonb` and is unaffected.

--- a/packages/1-framework/1-core/framework-components/src/exports/authoring.ts
+++ b/packages/1-framework/1-core/framework-components/src/exports/authoring.ts
@@ -1,6 +1,7 @@
 export type {
   AuthoringArgRef,
   AuthoringArgumentDescriptor,
+  AuthoringBareSpellingWarning,
   AuthoringColumnDefaultTemplate,
   AuthoringContributions,
   AuthoringDiagnosticSink,

--- a/packages/1-framework/1-core/framework-components/src/shared/framework-authoring.ts
+++ b/packages/1-framework/1-core/framework-components/src/shared/framework-authoring.ts
@@ -126,12 +126,10 @@ export interface AuthoringTypeConstructorDescriptor {
 }
 
 /**
- * Declarative bare-spelling advisory a type constructor carries so the
- * target can flag a spelling whose storage binding diverges from what its
- * users historically meant. Field resolution mints an
- * {@link AuthoringWarning} from it: `message` completes
- * `field "<Model>.<field>" <message>`; `summary` follows the
- * AuthoringWarning group-summary contract (plural noun phrase first, e.g.
+ * Declarative bare-spelling advisory a type constructor carries so the target can flag a spelling
+ * whose storage binding diverges from what its users historically meant. Field resolution mints an
+ * {@link AuthoringWarning} from it: `message` completes `field "<Model>.<field>" <message>`;
+ * `summary` follows the AuthoringWarning group-summary contract (plural noun phrase first, e.g.
  * `fields are typed <spelling>. <remediation>`).
  */
 export interface AuthoringBareSpellingWarning {
@@ -919,13 +917,10 @@ export function collectScalarTypeConstructors(
     if (!isAuthoringTypeConstructorDescriptor(value)) continue;
     if (value.entityRefArg !== undefined) continue;
     if (value.args?.some((arg) => arg.optional !== true)) continue;
-    const output = instantiateAuthoringTypeConstructor(value, []);
-    result.set(
-      name,
-      value.bareSpellingWarning === undefined
-        ? output
-        : { ...output, bareSpellingWarning: value.bareSpellingWarning },
-    );
+    result.set(name, {
+      ...instantiateAuthoringTypeConstructor(value, []),
+      ...ifDefined('bareSpellingWarning', value.bareSpellingWarning),
+    });
   }
   return result;
 }

--- a/packages/1-framework/1-core/framework-components/src/shared/framework-authoring.ts
+++ b/packages/1-framework/1-core/framework-components/src/shared/framework-authoring.ts
@@ -121,6 +121,23 @@ export interface AuthoringTypeConstructorDescriptor {
   readonly output: AuthoringStorageTypeTemplate;
   /** Present when one of this constructor's positional arguments names another document-local entity instead of carrying a literal value. Absent for ordinary literal-argument constructors. */
   readonly entityRefArg?: AuthoringTypeConstructorEntityRef;
+  /** Advisory minted once per schema field that resolves this constructor via its bare type-name spelling; explicit constructor calls stay silent. */
+  readonly bareSpellingWarning?: AuthoringBareSpellingWarning;
+}
+
+/**
+ * Declarative bare-spelling advisory a type constructor carries so the
+ * target can flag a spelling whose storage binding diverges from what its
+ * users historically meant. Field resolution mints an
+ * {@link AuthoringWarning} from it: `message` completes
+ * `field "<Model>.<field>" <message>`; `summary` follows the
+ * AuthoringWarning group-summary contract (plural noun phrase first, e.g.
+ * `fields are typed <spelling>. <remediation>`).
+ */
+export interface AuthoringBareSpellingWarning {
+  readonly code: string;
+  readonly message: string;
+  readonly summary: string;
 }
 
 export interface AuthoringColumnDefaultTemplateLiteral {
@@ -876,6 +893,7 @@ export interface ScalarTypeConstructorOutput {
   readonly codecId: string;
   readonly nativeType: string;
   readonly typeParams?: Record<string, unknown>;
+  readonly bareSpellingWarning?: AuthoringBareSpellingWarning;
 }
 
 /**
@@ -901,7 +919,13 @@ export function collectScalarTypeConstructors(
     if (!isAuthoringTypeConstructorDescriptor(value)) continue;
     if (value.entityRefArg !== undefined) continue;
     if (value.args?.some((arg) => arg.optional !== true)) continue;
-    result.set(name, instantiateAuthoringTypeConstructor(value, []));
+    const output = instantiateAuthoringTypeConstructor(value, []);
+    result.set(
+      name,
+      value.bareSpellingWarning === undefined
+        ? output
+        : { ...output, bareSpellingWarning: value.bareSpellingWarning },
+    );
   }
   return result;
 }

--- a/packages/1-framework/1-core/framework-components/test/framework-components.authoring.test.ts
+++ b/packages/1-framework/1-core/framework-components/test/framework-components.authoring.test.ts
@@ -898,6 +898,30 @@ describe('collectScalarTypeConstructors', () => {
     });
   });
 
+  it('carries a declared bareSpellingWarning into the scalar view; entries without one stay bare', () => {
+    const warning = {
+      code: 'PN_TEST_LEGACY_SPELLING',
+      message: 'is typed "Legacy". Write "Modern" instead.',
+      summary: 'fields are typed "Legacy". Write "Modern" instead.',
+    };
+    const namespace = {
+      Legacy: {
+        kind: 'typeConstructor',
+        output: { codecId: 'test/text@1', nativeType: 'text' },
+        bareSpellingWarning: warning,
+      },
+      Modern: { kind: 'typeConstructor', output: { codecId: 'test/text@1', nativeType: 'text' } },
+    } satisfies AuthoringTypeNamespace;
+
+    const scalars = collectScalarTypeConstructors(namespace);
+    expect(scalars.get('Legacy')).toEqual({
+      codecId: 'test/text@1',
+      nativeType: 'text',
+      bareSpellingWarning: warning,
+    });
+    expect(scalars.get('Modern')).toEqual({ codecId: 'test/text@1', nativeType: 'text' });
+  });
+
   it('applies a template default in bare form, same as the zero-arg call', () => {
     const Defaulted = {
       kind: 'typeConstructor',

--- a/packages/2-sql/1-core/contract/test/emit-warning-spy.ts
+++ b/packages/2-sql/1-core/contract/test/emit-warning-spy.ts
@@ -1,0 +1,20 @@
+import { afterAll, afterEach, beforeAll, type MockInstance, vi } from 'vitest';
+
+/**
+ * Spies `process.emitWarning` for one suite. The spy is installed in `beforeAll` rather than at
+ * collection time because suites in one run share the global: stacked collection-time spies let
+ * one suite's restore discard the next suite's instrumentation.
+ */
+export function useEmitWarningSpy(): () => MockInstance<typeof process.emitWarning> {
+  let spy: MockInstance<typeof process.emitWarning>;
+  beforeAll(() => {
+    spy = vi.spyOn(process, 'emitWarning').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    spy.mockClear();
+  });
+  afterAll(() => {
+    spy.mockRestore();
+  });
+  return () => spy;
+}

--- a/packages/2-sql/2-authoring/contract-psl/src/interpreter.ts
+++ b/packages/2-sql/2-authoring/contract-psl/src/interpreter.ts
@@ -22,6 +22,7 @@ import type {
   AuthoringModelAttributeLoweringOutput,
   AuthoringPslBlockDescriptorNamespace,
   AuthoringWarning,
+  AuthoringWarningSink,
   PslExtensionBlock,
 } from '@internal/framework-components/authoring';
 import {
@@ -657,6 +658,8 @@ interface BuildModelNodeInput {
   readonly modelAttributesByName: ReadonlyMap<string, AuthoringModelAttributeDescriptor>;
   /** The target's default namespace id — the lowering context's `namespaceId` fallback for a model with no explicit PSL namespace. */
   readonly defaultNamespaceId: string;
+  /** Per-build sink for non-fatal authoring warnings minted during field resolution. */
+  readonly warnings: AuthoringWarningSink;
 }
 
 interface BuildModelNodeResult {
@@ -716,6 +719,7 @@ function buildModelNodeFromPsl(input: BuildModelNodeInput): BuildModelNodeResult
     ...ifDefined('namespaceId', modelNamespaceId),
     ...ifDefined('namespaceExtensionEntities', namespaceExtensionEntitiesForModel),
     ...ifDefined('codecLookup', input.codecLookup),
+    warnings: input.warnings,
   });
 
   const inlineIdFields = resolvedFields.filter((field) => field.isId);
@@ -2422,6 +2426,7 @@ export function interpretPslDocumentToSqlContract(
       ...ifDefined('codecLookup', input.codecLookup),
       modelAttributesByName,
       defaultNamespaceId,
+      warnings: authoringWarnings,
     });
     modelNodes.push(
       namespaceId !== undefined ? { ...result.modelNode, namespaceId } : result.modelNode,

--- a/packages/2-sql/2-authoring/contract-psl/src/interpreter.ts
+++ b/packages/2-sql/2-authoring/contract-psl/src/interpreter.ts
@@ -660,6 +660,12 @@ interface BuildModelNodeInput {
   readonly defaultNamespaceId: string;
   /** Per-build sink for non-fatal authoring warnings minted during field resolution. */
   readonly warnings: AuthoringWarningSink;
+  /**
+   * The model's resolved namespace id from its own `ModelNamespaceEntry` — unlike the bare-name
+   * keyed `modelNamespaceIds` map, this stays correct when two namespaces declare same-named
+   * models.
+   */
+  readonly namespaceId: string | undefined;
 }
 
 interface BuildModelNodeResult {
@@ -691,7 +697,7 @@ function relationAttributeDeclaresOwningSide(relationAttribute: ResolvedAttribut
 function buildModelNodeFromPsl(input: BuildModelNodeInput): BuildModelNodeResult {
   const { model, mapping, sourceId, diagnostics } = input;
   const tableName = mapping.tableName;
-  const modelNamespaceId = input.modelNamespaceIds.get(model.name);
+  const modelNamespaceId = input.namespaceId;
   const namespaceExtensionEntitiesForModel =
     modelNamespaceId !== undefined
       ? input.namespaceExtensionEntities?.get(modelNamespaceId)
@@ -720,6 +726,7 @@ function buildModelNodeFromPsl(input: BuildModelNodeInput): BuildModelNodeResult
     ...ifDefined('namespaceExtensionEntities', namespaceExtensionEntitiesForModel),
     ...ifDefined('codecLookup', input.codecLookup),
     warnings: input.warnings,
+    defaultNamespaceId: input.defaultNamespaceId,
   });
 
   const inlineIdFields = resolvedFields.filter((field) => field.isId);
@@ -2427,6 +2434,7 @@ export function interpretPslDocumentToSqlContract(
       modelAttributesByName,
       defaultNamespaceId,
       warnings: authoringWarnings,
+      namespaceId,
     });
     modelNodes.push(
       namespaceId !== undefined ? { ...result.modelNode, namespaceId } : result.modelNode,

--- a/packages/2-sql/2-authoring/contract-psl/src/psl-column-resolution.ts
+++ b/packages/2-sql/2-authoring/contract-psl/src/psl-column-resolution.ts
@@ -62,9 +62,8 @@ export type ColumnDescriptor = {
    */
   readonly valueSet?: ValueSetRef;
   /**
-   * Advisory the contributing type constructor declares for its bare
-   * type-name spelling (carried through the scalar view by
-   * `collectScalarTypeConstructors`). Field resolution mints one
+   * Advisory the contributing type constructor declares for its bare type-name spelling (carried
+   * through the scalar view by `collectScalarTypeConstructors`). Field resolution mints one
    * AuthoringWarning per model field resolved via that bare spelling.
    */
   readonly bareSpellingWarning?: AuthoringBareSpellingWarning;

--- a/packages/2-sql/2-authoring/contract-psl/src/psl-column-resolution.ts
+++ b/packages/2-sql/2-authoring/contract-psl/src/psl-column-resolution.ts
@@ -5,6 +5,7 @@ import type {
   ValueSetRef,
 } from '@internal/contract/types';
 import type {
+  AuthoringBareSpellingWarning,
   AuthoringContributions,
   AuthoringEntityTypeDescriptor,
   AuthoringEntityTypeNamespace,
@@ -60,6 +61,13 @@ export type ColumnDescriptor = {
    * unset.
    */
   readonly valueSet?: ValueSetRef;
+  /**
+   * Advisory the contributing type constructor declares for its bare
+   * type-name spelling (carried through the scalar view by
+   * `collectScalarTypeConstructors`). Field resolution mints one
+   * AuthoringWarning per model field resolved via that bare spelling.
+   */
+  readonly bareSpellingWarning?: AuthoringBareSpellingWarning;
 };
 
 export function toNamedTypeFieldDescriptor(

--- a/packages/2-sql/2-authoring/contract-psl/src/psl-field-resolution.ts
+++ b/packages/2-sql/2-authoring/contract-psl/src/psl-field-resolution.ts
@@ -4,7 +4,10 @@ import type {
   ColumnDefaultLiteralInputValue,
   ExecutionMutationDefaultPhases,
 } from '@internal/contract/types';
-import type { AuthoringContributions } from '@internal/framework-components/authoring';
+import type {
+  AuthoringContributions,
+  AuthoringWarningSink,
+} from '@internal/framework-components/authoring';
 import type { CodecLookup } from '@internal/framework-components/codec';
 import type { CapabilityMatrix } from '@internal/framework-components/components';
 import type {
@@ -161,6 +164,8 @@ export interface CollectResolvedFieldsInput {
   readonly namespaceExtensionEntities?: Readonly<Record<string, Readonly<Record<string, unknown>>>>;
   /** Codec-id-keyed descriptor lookup — forwarded to `resolveFieldTypeDescriptor` for entity-ref type-constructor resolution (e.g. `pg.enum(Ref)`). */
   readonly codecLookup?: CodecLookup;
+  /** Sink for non-fatal advisories minted here (e.g. a bare type spelling whose descriptor declares `bareSpellingWarning`). */
+  readonly warnings?: AuthoringWarningSink;
 }
 
 const BUILTIN_FIELD_ATTRIBUTE_NAMES: ReadonlySet<string> = new Set([
@@ -409,6 +414,7 @@ export function collectResolvedFields(input: CollectResolvedFieldsInput): Resolv
     namespaceId,
     namespaceExtensionEntities,
     codecLookup,
+    warnings,
   } = input;
   const resolvedFields: ResolvedField[] = [];
   const valueObjectStorageTypeName = authoringContributions?.valueObjectStorageType;
@@ -549,6 +555,24 @@ export function collectResolvedFields(input: CollectResolvedFieldsInput): Resolv
 
     if (!descriptor) {
       continue;
+    }
+
+    // Only a bare type-name spelling triggers the descriptor's advisory: an
+    // explicit constructor call is a deliberate choice, and value-object
+    // storage resolution never came from the user's spelling.
+    if (
+      descriptor.bareSpellingWarning !== undefined &&
+      field.typeConstructor === undefined &&
+      !isValueObjectField
+    ) {
+      const advisory = descriptor.bareSpellingWarning;
+      const item = `field "${model.name}.${field.name}"`;
+      warnings?.push({
+        code: advisory.code,
+        message: `${item} ${advisory.message}`,
+        item,
+        summary: advisory.summary,
+      });
     }
 
     // Field presets are complete declarations: the preset names its own codec

--- a/packages/2-sql/2-authoring/contract-psl/src/psl-field-resolution.ts
+++ b/packages/2-sql/2-authoring/contract-psl/src/psl-field-resolution.ts
@@ -165,7 +165,9 @@ export interface CollectResolvedFieldsInput {
   /** Codec-id-keyed descriptor lookup — forwarded to `resolveFieldTypeDescriptor` for entity-ref type-constructor resolution (e.g. `pg.enum(Ref)`). */
   readonly codecLookup?: CodecLookup;
   /** Sink for non-fatal advisories minted here (e.g. a bare type spelling whose descriptor declares `bareSpellingWarning`). */
-  readonly warnings?: AuthoringWarningSink;
+  readonly warnings: AuthoringWarningSink;
+  /** The target's default namespace id — warning labels qualify the model name only outside it. */
+  readonly defaultNamespaceId: string | undefined;
 }
 
 const BUILTIN_FIELD_ATTRIBUTE_NAMES: ReadonlySet<string> = new Set([
@@ -415,6 +417,7 @@ export function collectResolvedFields(input: CollectResolvedFieldsInput): Resolv
     namespaceExtensionEntities,
     codecLookup,
     warnings,
+    defaultNamespaceId,
   } = input;
   const resolvedFields: ResolvedField[] = [];
   const valueObjectStorageTypeName = authoringContributions?.valueObjectStorageType;
@@ -566,8 +569,12 @@ export function collectResolvedFields(input: CollectResolvedFieldsInput): Resolv
       !isValueObjectField
     ) {
       const advisory = descriptor.bareSpellingWarning;
-      const item = `field "${model.name}.${field.name}"`;
-      warnings?.push({
+      const modelLabel =
+        namespaceId === undefined || namespaceId === defaultNamespaceId
+          ? model.name
+          : `${namespaceId}.${model.name}`;
+      const item = `field "${modelLabel}.${field.name}"`;
+      warnings.push({
         code: advisory.code,
         message: `${item} ${advisory.message}`,
         item,

--- a/packages/2-sql/2-authoring/contract-psl/test/interpreter.bare-spelling-warning.test.ts
+++ b/packages/2-sql/2-authoring/contract-psl/test/interpreter.bare-spelling-warning.test.ts
@@ -7,16 +7,9 @@
  */
 import type { AuthoringTypeNamespace } from '@internal/framework-components/authoring';
 import { collectScalarTypeConstructors } from '@internal/framework-components/authoring';
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  describe,
-  expect,
-  it,
-  type MockInstance,
-  vi,
-} from 'vitest';
+import { ifDefined } from '@internal/utils/defined';
+import { describe, expect, it } from 'vitest';
+import { useEmitWarningSpy } from '../../../1-core/contract/test/emit-warning-spy';
 import { createTestSqlNamespace } from '../../../1-core/contract/test/test-support';
 import { interpretPslDocumentToSqlContract } from '../src/interpreter';
 import {
@@ -43,20 +36,6 @@ const authoringTypes = {
 
 const scalarColumnDescriptors = collectScalarTypeConstructors(authoringTypes);
 
-function useEmitWarningSpy(): () => MockInstance<typeof process.emitWarning> {
-  let spy: MockInstance<typeof process.emitWarning>;
-  beforeAll(() => {
-    spy = vi.spyOn(process, 'emitWarning').mockImplementation(() => {});
-  });
-  afterEach(() => {
-    spy.mockClear();
-  });
-  afterAll(() => {
-    spy.mockRestore();
-  });
-  return () => spy;
-}
-
 describe('bare-spelling advisory at PSL lowering', () => {
   const builtinControlMutationDefaults = createBuiltinLikeControlMutationDefaults();
   const emitWarning = useEmitWarningSpy();
@@ -71,7 +50,7 @@ describe('bare-spelling advisory at PSL lowering', () => {
         entityTypes: {},
         type: authoringTypes,
         field: {},
-        ...(valueObjectStorageType !== undefined ? { valueObjectStorageType } : {}),
+        ...ifDefined('valueObjectStorageType', valueObjectStorageType),
       },
       composedExtensionContracts: new Map(),
       controlMutationDefaults: builtinControlMutationDefaults,
@@ -137,6 +116,41 @@ model User {
 
     expect(result.ok).toBe(true);
     expect(legacyWarningCalls()).toEqual([]);
+  });
+
+  it('a named-type alias over an advisory type does not warn — the alias declaration is a deliberate single-site choice', () => {
+    const result = interpret(`types {
+  Meta = Legacy
+}
+
+model Doc {
+  id Int @id
+  meta Meta
+}`);
+
+    expect(result.ok).toBe(true);
+    expect(legacyWarningCalls()).toEqual([]);
+  });
+
+  it('models outside the default namespace qualify the warning item with their namespace', () => {
+    const result = interpret(`namespace audit {
+  model Doc {
+    id Int @id
+    meta Legacy
+  }
+}
+
+model Doc {
+  id Int @id
+  meta Legacy
+}`);
+
+    expect(result.ok).toBe(true);
+    const messages = legacyWarningCalls().map((c) => String(c[0]));
+    expect(messages.sort()).toEqual([
+      'field "Doc.meta" is typed "Legacy". Write "Modern" instead.',
+      'field "audit.Doc.meta" is typed "Legacy". Write "Modern" instead.',
+    ]);
   });
 
   it('a type without the advisory never warns', () => {

--- a/packages/2-sql/2-authoring/contract-psl/test/interpreter.bare-spelling-warning.test.ts
+++ b/packages/2-sql/2-authoring/contract-psl/test/interpreter.bare-spelling-warning.test.ts
@@ -1,0 +1,152 @@
+/**
+ * A type constructor may declare a `bareSpellingWarning` advisory. PSL
+ * lowering mints one AuthoringWarning per model field that resolves the
+ * constructor via its bare type-name spelling; explicit constructor calls
+ * and value-object storage resolution stay silent. Warnings surface through
+ * the shared per-build flush (`process.emitWarning`).
+ */
+import type { AuthoringTypeNamespace } from '@internal/framework-components/authoring';
+import { collectScalarTypeConstructors } from '@internal/framework-components/authoring';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+import { createTestSqlNamespace } from '../../../1-core/contract/test/test-support';
+import { interpretPslDocumentToSqlContract } from '../src/interpreter';
+import {
+  createBuiltinLikeControlMutationDefaults,
+  postgresScalarAuthoringTypes,
+  postgresTarget,
+  symbolTableInputFromParseArgs,
+} from './fixtures';
+
+const LEGACY_WARNING = {
+  code: 'PN_TEST_LEGACY_SPELLING',
+  message: 'is typed "Legacy". Write "Modern" instead.',
+  summary: 'fields are typed "Legacy". Write "Modern" instead.',
+} as const;
+
+const authoringTypes = {
+  ...postgresScalarAuthoringTypes,
+  Legacy: {
+    kind: 'typeConstructor',
+    output: { codecId: 'pg/json@1', nativeType: 'json' },
+    bareSpellingWarning: LEGACY_WARNING,
+  },
+} satisfies AuthoringTypeNamespace;
+
+const scalarColumnDescriptors = collectScalarTypeConstructors(authoringTypes);
+
+function useEmitWarningSpy(): () => MockInstance<typeof process.emitWarning> {
+  let spy: MockInstance<typeof process.emitWarning>;
+  beforeAll(() => {
+    spy = vi.spyOn(process, 'emitWarning').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    spy.mockClear();
+  });
+  afterAll(() => {
+    spy.mockRestore();
+  });
+  return () => spy;
+}
+
+describe('bare-spelling advisory at PSL lowering', () => {
+  const builtinControlMutationDefaults = createBuiltinLikeControlMutationDefaults();
+  const emitWarning = useEmitWarningSpy();
+
+  function interpret(schema: string, valueObjectStorageType?: string) {
+    const document = symbolTableInputFromParseArgs({ schema, sourceId: 'schema.prisma' });
+    return interpretPslDocumentToSqlContract({
+      ...document,
+      target: postgresTarget,
+      scalarColumnDescriptors,
+      authoringContributions: {
+        entityTypes: {},
+        type: authoringTypes,
+        field: {},
+        ...(valueObjectStorageType !== undefined ? { valueObjectStorageType } : {}),
+      },
+      composedExtensionContracts: new Map(),
+      controlMutationDefaults: builtinControlMutationDefaults,
+      createNamespace: createTestSqlNamespace,
+      capabilities: { sql: { scalarList: true } },
+    });
+  }
+
+  function legacyWarningCalls() {
+    return emitWarning().mock.calls.filter(
+      ([, options]) => (options as { code?: string } | undefined)?.code === LEGACY_WARNING.code,
+    );
+  }
+
+  it('a bare spelling warns once per field, naming the field', () => {
+    const result = interpret(`model Doc {
+  id Int @id
+  meta Legacy
+  extra Legacy?
+}`);
+
+    expect(result.ok).toBe(true);
+    const messages = legacyWarningCalls().map((c) => String(c[0]));
+    expect(messages).toEqual([
+      'field "Doc.meta" is typed "Legacy". Write "Modern" instead.',
+      'field "Doc.extra" is typed "Legacy". Write "Modern" instead.',
+    ]);
+  });
+
+  it('a bare list spelling warns too', () => {
+    const result = interpret(`model Doc {
+  id Int @id
+  metas Legacy[]
+}`);
+
+    expect(result.ok).toBe(true);
+    const messages = legacyWarningCalls().map((c) => String(c[0]));
+    expect(messages).toEqual(['field "Doc.metas" is typed "Legacy". Write "Modern" instead.']);
+  });
+
+  it('an explicit constructor call does not warn', () => {
+    const result = interpret(`model Doc {
+  id Int @id
+  meta Legacy()
+}`);
+
+    expect(result.ok).toBe(true);
+    expect(legacyWarningCalls()).toEqual([]);
+  });
+
+  it('value-object storage resolving through an advisory-carrying type does not warn', () => {
+    const result = interpret(
+      `type Address {
+  street String
+}
+
+model User {
+  id Int @id
+  address Address
+}`,
+      'Legacy',
+    );
+
+    expect(result.ok).toBe(true);
+    expect(legacyWarningCalls()).toEqual([]);
+  });
+
+  it('a type without the advisory never warns', () => {
+    const result = interpret(`model Doc {
+  id Int @id
+  meta Jsonb
+  data Json
+}`);
+
+    expect(result.ok).toBe(true);
+    expect(legacyWarningCalls()).toEqual([]);
+  });
+});

--- a/packages/3-extensions/postgres/test/scalar-type-parity.test.ts
+++ b/packages/3-extensions/postgres/test/scalar-type-parity.test.ts
@@ -74,7 +74,11 @@ describe('postgres scalar types derived from the unified namespace', () => {
       Inet: { codecId: 'pg/inet@1', nativeType: 'inet' },
       Decimal: { codecId: 'pg/numeric@1', nativeType: 'numeric' },
       DateTime: { codecId: 'pg/timestamptz@1', nativeType: 'timestamptz' },
-      Json: { codecId: 'pg/json@1', nativeType: 'json' },
+      Json: {
+        codecId: 'pg/json@1',
+        nativeType: 'json',
+        bareSpellingWarning: expect.objectContaining({ code: 'PN_PSL_JSON_NATIVE_JSON' }),
+      },
       Jsonb: { codecId: 'pg/jsonb@1', nativeType: 'jsonb' },
       Bytes: { codecId: 'pg/bytea@1', nativeType: 'bytea' },
       VarChar: { codecId: 'sql/varchar@1', nativeType: 'character varying' },

--- a/packages/3-targets/3-targets/postgres/test/psl-policy-map-authoring.test.ts
+++ b/packages/3-targets/3-targets/postgres/test/psl-policy-map-authoring.test.ts
@@ -12,16 +12,8 @@ import { assembleAuthoringContributions } from '@internal/framework-components/c
 import { buildSymbolTable } from '@internal/psl-parser';
 import { parse } from '@internal/psl-parser/syntax';
 import { interpretPslDocumentToSqlContract } from '@internal/sql-contract-psl';
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  describe,
-  expect,
-  it,
-  type MockInstance,
-  vi,
-} from 'vitest';
+import { describe, expect, it } from 'vitest';
+import { useEmitWarningSpy } from '../../../../2-sql/1-core/contract/test/emit-warning-spy';
 import {
   postgresAuthoringEntityTypes,
   postgresAuthoringModelAttributes,
@@ -98,26 +90,6 @@ function publicNamespace(result: ReturnType<typeof interpret>): PostgresSchema {
   expect(result.ok).toBe(true);
   if (!result.ok) throw new Error('interpretation failed');
   return result.value.storage.namespaces['public'] as PostgresSchema;
-}
-
-/**
- * Spies `process.emitWarning` for one suite. The spy is installed in
- * `beforeAll` rather than at collection time because the suites in this file
- * share the global: stacked collection-time spies let one suite's restore
- * discard the next suite's instrumentation.
- */
-function useEmitWarningSpy(): () => MockInstance<typeof process.emitWarning> {
-  let spy: MockInstance<typeof process.emitWarning>;
-  beforeAll(() => {
-    spy = vi.spyOn(process, 'emitWarning').mockImplementation(() => {});
-  });
-  afterEach(() => {
-    spy.mockClear();
-  });
-  afterAll(() => {
-    spy.mockRestore();
-  });
-  return () => spy;
 }
 
 describe('@@map lowers an exact-named policy', () => {

--- a/packages/3-targets/6-adapters/postgres/src/core/control-mutation-defaults.ts
+++ b/packages/3-targets/6-adapters/postgres/src/core/control-mutation-defaults.ts
@@ -1,6 +1,9 @@
 import type { ExecutionMutationDefaultValue } from '@internal/contract/types';
 import { timestampNowControlDescriptor } from '@internal/family-sql/control';
-import type { AuthoringTypeNamespace } from '@internal/framework-components/authoring';
+import type {
+  AuthoringBareSpellingWarning,
+  AuthoringTypeNamespace,
+} from '@internal/framework-components/authoring';
 import type {
   ControlMutationDefaultEntry,
   DefaultFunctionLoweringContext,
@@ -151,6 +154,15 @@ const postgresDefaultFunctionRegistryEntries = [
   ],
 ] satisfies ReadonlyArray<readonly [string, ControlMutationDefaultEntry]>;
 
+const JSON_SPELLING_CAUSE =
+  'typed "Json", which binds to the Postgres native "json" column type. Prisma ORM\'s "Json" meant "jsonb" — write "Jsonb" to get';
+
+const jsonBareSpellingWarning: AuthoringBareSpellingWarning = {
+  code: 'PN_PSL_JSON_NATIVE_JSON',
+  message: `is ${JSON_SPELLING_CAUSE} a "jsonb" column.`,
+  summary: `fields are ${JSON_SPELLING_CAUSE} "jsonb" columns.`,
+};
+
 /**
  * The base PSL scalars as zero-arg type constructors in the unified authoring
  * channel, with explicit `nativeType` values pinned to the codec manifests
@@ -191,15 +203,7 @@ export const postgresScalarAuthoringTypes = {
   Json: {
     kind: 'typeConstructor',
     output: { codecId: 'pg/json@1', nativeType: 'json' },
-    // Prisma ORM's `Json` meant jsonb; here bare `Json` binds native json,
-    // so a ported schema silently changes the physical column type.
-    bareSpellingWarning: {
-      code: 'PN_PSL_JSON_NATIVE_JSON',
-      message:
-        'is typed "Json", which binds to the Postgres native "json" column type. Prisma ORM\'s "Json" meant "jsonb" — write "Jsonb" to get a "jsonb" column.',
-      summary:
-        'fields are typed "Json", which binds to the Postgres native "json" column type. Prisma ORM\'s "Json" meant "jsonb" — write "Jsonb" to get "jsonb" columns.',
-    },
+    bareSpellingWarning: jsonBareSpellingWarning,
   },
   Jsonb: {
     kind: 'typeConstructor',

--- a/packages/3-targets/6-adapters/postgres/src/core/control-mutation-defaults.ts
+++ b/packages/3-targets/6-adapters/postgres/src/core/control-mutation-defaults.ts
@@ -191,6 +191,15 @@ export const postgresScalarAuthoringTypes = {
   Json: {
     kind: 'typeConstructor',
     output: { codecId: 'pg/json@1', nativeType: 'json' },
+    // Prisma ORM's `Json` meant jsonb; here bare `Json` binds native json,
+    // so a ported schema silently changes the physical column type.
+    bareSpellingWarning: {
+      code: 'PN_PSL_JSON_NATIVE_JSON',
+      message:
+        'is typed "Json", which binds to the Postgres native "json" column type. Prisma ORM\'s "Json" meant "jsonb" — write "Jsonb" to get a "jsonb" column.',
+      summary:
+        'fields are typed "Json", which binds to the Postgres native "json" column type. Prisma ORM\'s "Json" meant "jsonb" — write "Jsonb" to get "jsonb" columns.',
+    },
   },
   Jsonb: {
     kind: 'typeConstructor',

--- a/packages/3-targets/6-adapters/postgres/test/control-mutation-defaults.test.ts
+++ b/packages/3-targets/6-adapters/postgres/test/control-mutation-defaults.test.ts
@@ -291,8 +291,6 @@ describe('postgresScalarAuthoringTypes', () => {
       expect(namespace[name]).toEqual({
         kind: 'typeConstructor',
         output: { codecId, nativeType: codecLookup.targetTypesFor(codecId)?.[0] },
-        // Json is the one scalar whose binding diverges from Prisma ORM
-        // (json here, jsonb there) — it alone carries the porting advisory.
         ...(name === 'Json'
           ? { bareSpellingWarning: expect.objectContaining({ code: 'PN_PSL_JSON_NATIVE_JSON' }) }
           : {}),

--- a/packages/3-targets/6-adapters/postgres/test/control-mutation-defaults.test.ts
+++ b/packages/3-targets/6-adapters/postgres/test/control-mutation-defaults.test.ts
@@ -291,6 +291,11 @@ describe('postgresScalarAuthoringTypes', () => {
       expect(namespace[name]).toEqual({
         kind: 'typeConstructor',
         output: { codecId, nativeType: codecLookup.targetTypesFor(codecId)?.[0] },
+        // Json is the one scalar whose binding diverges from Prisma ORM
+        // (json here, jsonb there) — it alone carries the porting advisory.
+        ...(name === 'Json'
+          ? { bareSpellingWarning: expect.objectContaining({ code: 'PN_PSL_JSON_NATIVE_JSON' }) }
+          : {}),
       });
     }
   });

--- a/packages/3-targets/6-adapters/postgres/test/psl-json-spelling-warning.test.ts
+++ b/packages/3-targets/6-adapters/postgres/test/psl-json-spelling-warning.test.ts
@@ -11,16 +11,8 @@ import { buildSymbolTable } from '@internal/psl-parser';
 import { parse } from '@internal/psl-parser/syntax';
 import { interpretPslDocumentToSqlContract } from '@internal/sql-contract-psl';
 import { postgresCreateNamespace } from '@internal/target-postgres/types';
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  describe,
-  expect,
-  it,
-  type MockInstance,
-  vi,
-} from 'vitest';
+import { describe, expect, it } from 'vitest';
+import { useEmitWarningSpy } from '../../../../2-sql/1-core/contract/test/emit-warning-spy';
 import { postgresAuthoringTypes } from '../src/core/control-mutation-defaults';
 
 const JSON_WARNING_CODE = 'PN_PSL_JSON_NATIVE_JSON';
@@ -61,20 +53,6 @@ function interpret(schema: string) {
     createNamespace: postgresCreateNamespace,
     capabilities: { sql: { scalarList: true } },
   });
-}
-
-function useEmitWarningSpy(): () => MockInstance<typeof process.emitWarning> {
-  let spy: MockInstance<typeof process.emitWarning>;
-  beforeAll(() => {
-    spy = vi.spyOn(process, 'emitWarning').mockImplementation(() => {});
-  });
-  afterEach(() => {
-    spy.mockClear();
-  });
-  afterAll(() => {
-    spy.mockRestore();
-  });
-  return () => spy;
 }
 
 describe('bare Json spelling advisory on the postgres target', () => {

--- a/packages/3-targets/6-adapters/postgres/test/psl-json-spelling-warning.test.ts
+++ b/packages/3-targets/6-adapters/postgres/test/psl-json-spelling-warning.test.ts
@@ -1,0 +1,154 @@
+/**
+ * PSL `Json` binds to the Postgres native "json" column type (`pg/json@1`),
+ * but Prisma ORM's `Json` meant `jsonb` — a schema ported from Prisma 7
+ * silently gets the wrong physical column type. The adapter's `Json` type
+ * constructor declares a bare-spelling advisory, so lowering a bare `Json`
+ * field warns at emit; `Jsonb` and explicit constructor calls stay silent,
+ * and many hits batch into one grouped summary per build.
+ */
+import { collectScalarTypeConstructors } from '@internal/framework-components/authoring';
+import { buildSymbolTable } from '@internal/psl-parser';
+import { parse } from '@internal/psl-parser/syntax';
+import { interpretPslDocumentToSqlContract } from '@internal/sql-contract-psl';
+import { postgresCreateNamespace } from '@internal/target-postgres/types';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+import { postgresAuthoringTypes } from '../src/core/control-mutation-defaults';
+
+const JSON_WARNING_CODE = 'PN_PSL_JSON_NATIVE_JSON';
+
+const postgresTarget = {
+  kind: 'target' as const,
+  familyId: 'sql' as const,
+  targetId: 'postgres' as const,
+  id: 'postgres',
+  version: '0.0.1',
+  capabilities: {},
+  defaultNamespaceId: 'public',
+};
+
+const scalarColumnDescriptors = collectScalarTypeConstructors(postgresAuthoringTypes);
+
+function interpret(schema: string) {
+  const { document, sourceFile } = parse(schema);
+  const { table: symbolTable, diagnostics } = buildSymbolTable({
+    document,
+    sourceFile,
+    pslBlockDescriptors: {},
+  });
+  expect(diagnostics).toEqual([]);
+  return interpretPslDocumentToSqlContract({
+    symbolTable,
+    sourceFile,
+    sourceId: 'schema.prisma',
+    target: postgresTarget,
+    scalarColumnDescriptors,
+    authoringContributions: {
+      entityTypes: {},
+      field: {},
+      type: postgresAuthoringTypes,
+      valueObjectStorageType: 'Jsonb',
+    },
+    composedExtensionContracts: new Map(),
+    createNamespace: postgresCreateNamespace,
+    capabilities: { sql: { scalarList: true } },
+  });
+}
+
+function useEmitWarningSpy(): () => MockInstance<typeof process.emitWarning> {
+  let spy: MockInstance<typeof process.emitWarning>;
+  beforeAll(() => {
+    spy = vi.spyOn(process, 'emitWarning').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    spy.mockClear();
+  });
+  afterAll(() => {
+    spy.mockRestore();
+  });
+  return () => spy;
+}
+
+describe('bare Json spelling advisory on the postgres target', () => {
+  const emitWarning = useEmitWarningSpy();
+
+  function jsonWarningCalls() {
+    return emitWarning().mock.calls.filter(
+      ([, options]) => (options as { code?: string } | undefined)?.code === JSON_WARNING_CODE,
+    );
+  }
+
+  it('a bare Json field warns at lowering, naming the field and the Jsonb fix', () => {
+    const result = interpret(`model User {
+  id Int @id
+  data Json
+}`);
+
+    expect(result.ok).toBe(true);
+    const calls = jsonWarningCalls();
+    expect(calls).toHaveLength(1);
+    expect(String(calls[0]?.[0])).toBe(
+      'field "User.data" is typed "Json", which binds to the Postgres native "json" column type. Prisma ORM\'s "Json" meant "jsonb" — write "Jsonb" to get a "jsonb" column.',
+    );
+  });
+
+  it('Jsonb does not warn', () => {
+    const result = interpret(`model User {
+  id Int @id
+  data Jsonb
+}`);
+
+    expect(result.ok).toBe(true);
+    expect(jsonWarningCalls()).toEqual([]);
+  });
+
+  it('an explicit Json() constructor call does not warn', () => {
+    const result = interpret(`model User {
+  id Int @id
+  data Json()
+}`);
+
+    expect(result.ok).toBe(true);
+    expect(jsonWarningCalls()).toEqual([]);
+  });
+
+  it('a value-object field storing as Jsonb does not warn', () => {
+    const result = interpret(`type Address {
+  street String
+}
+
+model User {
+  id Int @id
+  address Address
+}`);
+
+    expect(result.ok).toBe(true);
+    expect(jsonWarningCalls()).toEqual([]);
+  });
+
+  it('40 bare Json fields batch into ONE grouped warning listing every field', () => {
+    const fields = Array.from({ length: 40 }, (_, i) => `  data${i} Json`).join('\n');
+    const result = interpret(`model Blob {
+  id Int @id
+${fields}
+}`);
+
+    expect(result.ok).toBe(true);
+    const calls = jsonWarningCalls();
+    expect(calls).toHaveLength(1);
+    const message = String(calls[0]?.[0]);
+    expect(message).toMatch(
+      /^40 fields are typed "Json", which binds to the Postgres native "json" column type\. Prisma ORM's "Json" meant "jsonb" — write "Jsonb" to get "jsonb" columns\./,
+    );
+    expect(message).toContain('  - field "Blob.data0"');
+    expect(message).toContain('  - field "Blob.data39"');
+  });
+});

--- a/skills/prisma-8/references/contract.md
+++ b/skills/prisma-8/references/contract.md
@@ -120,6 +120,8 @@ model User {
 }
 ```
 
+**Porting from Prisma 7 (Postgres): `Json` now means native `json`, not `jsonb`.** Prisma ORM's `Json` mapped to `jsonb`; in Prisma 8 PSL write `Jsonb` for a `jsonb` column. A ported schema that keeps `Json` emits the wrong column type — `contract emit` warns (`PN_PSL_JSON_NATIVE_JSON`), and `db verify` catches it against a live database.
+
 Note: scalar lists (e.g. `String[]`) and implicit Prisma-ORM many-to-many (list nav on both sides without a join model) are rejected by the SQL interpreter — use a join model. Composite/embeddable types (`type Address { ... }` with `address Address` on a model) are supported: the interpreter lowers them to `valueObjects` in the domain and stores them as `jsonb` columns. See *Workflow — Value objects* below.
 
 ## Workflow — Edit a model / field / relation (TS builder)


### PR DESCRIPTION
Fixes [TML-3102](https://linear.app/prisma/issue/TML-3102). PSL `Json` binds to `pg/json@1` (native `json`), but Prisma ORM's `Json` meant `jsonb` — so a `schema.prisma` ported from Prisma 7 silently emits the wrong physical column type, and only `db verify` catches it. The binding is deliberate and stays; this PR makes the divergence visible at the moment the damage happens (`contract emit`) and documents it where the porting audience will actually read it.

## Emit-time warning

The PSL diagnostic model still has no warning severity, and this PR does not add one. Instead it uses the existing non-fatal `AuthoringWarning` channel (already flushed once per build, batched above five hits), via a new declarative hook:

- A type constructor can declare a `bareSpellingWarning` advisory (`framework-authoring.ts`). `collectScalarTypeConstructors` carries it into the scalar view, so the target-specific fact lives on the adapter's data table, not in family code (per the no-target-branches rule / ADR 223 pattern).
- PSL field resolution (`collectResolvedFields`) mints one `AuthoringWarning` per model field resolved via the bare type-name spelling. Explicit constructor calls (`Json()`) and value-object storage resolution stay silent. The sink is threaded interpreter → `buildModelNodeFromPsl` → `collectResolvedFields` into the same per-build batch as the index/check naming warnings.
- The postgres adapter declares the advisory on its `Json` entry. Nothing else declares one, so `Jsonb`, non-postgres targets, and the TS authoring path (already jsonb) are unaffected by construction.

Exact output for one field:

```
Warning: field "User.data" is typed "Json", which binds to the Postgres native "json" column type. Prisma ORM's "Json" meant "jsonb" — write "Jsonb" to get a "jsonb" column. [PN_PSL_JSON_NATIVE_JSON]
```

A schema with 40 `Json` fields produces ONE grouped warning (test-proven):

```
Warning: 40 fields are typed "Json", which binds to the Postgres native "json" column type. Prisma ORM's "Json" meant "jsonb" — write "Jsonb" to get "jsonb" columns.
  - field "Blob.data0"
  - field "Blob.data1"
  …
[PN_PSL_JSON_NATIVE_JSON]
```

## Tests

- `framework-components`: `collectScalarTypeConstructors` carries the advisory into the scalar view; entries without one stay unchanged.
- `sql-contract-psl` (`interpreter.bare-spelling-warning.test.ts`): generic mechanism — bare spelling warns once per field (incl. lists), explicit constructor calls don't, value-object storage through an advisory-carrying type doesn't, advisory-free types never warn.
- `adapter-postgres` (`psl-json-spelling-warning.test.ts`): real table + real interpreter — exact message text for `Json`, silence for `Jsonb` / `Json()` / value objects, and the 40-field single-grouped-warning case.
- Updated the two scalar-view pin tests to carry the new `Json` shape.

Verified with `pnpm build`, the framework-components and contract-psl suites, and `pnpm test:packages` (one unrelated 100ms-timeout flake in `planner.reconciliation.test.ts` under full parallel load; passes standalone).

## Porting docs

- New [`docs/reference/porting-prisma-7-schemas.md`](https://github.com/prisma/prisma/blob/tml-3102/json-native-json-warning/docs/reference/porting-prisma-7-schemas.md) (indexed from `docs/README.md`): what diverges, why, the one-word fix.
- `skills/prisma-8/references/contract.md`: a terse porting callout so agents doing Prisma 7 → 8 ports see it when editing PSL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added advisory warnings when bare PostgreSQL `Json` fields map to native `json`.
  * Warnings identify affected fields and recommend `Jsonb` for `jsonb` columns.
  * Multiple warnings are grouped into a single summary without failing builds.
  * Preserved warnings for named type aliases and qualified fields across namespaces.
* **Documentation**
  * Added Prisma 7 porting guidance and updated Prisma 8 reference documentation for `Json` versus `Jsonb`.
* **Tests**
  * Added coverage for scalar, list, explicit constructor, value-object, alias, and grouped-warning scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->