### PR TITLE
docs(skills): correct the upgrade-entry validation recipe after executing it (TML-3223)

### DIFF
--- a/skills-contrib/record-upgrade-instructions/SKILL.md
+++ b/skills-contrib/record-upgrade-instructions/SKILL.md
@@ -86,7 +86,7 @@ For each PR that hits one or both signals, walk these steps in order.
 
 5. **Author any colocated scripts.** Scripts are portable — TypeScript (run via `pnpm exec tsx`), shell (`*.sh`), codemods (`jscodeshift`-style `*.codemod.cjs`), whichever fits the change. Scripts must not require network access, environment variables, or any input beyond the consumer's filesystem and the script's bundled assets. If the same script applies to both substrates (cross-audience case), **copy** it into both packages' directories — symlinks do not survive npm publish, and a hard dependency between the two packages is forbidden.
 
-6. **Validate the entry by execution** (see *Validation by execution* below for the concrete recipe). The acceptance criterion is the matching substrate's test suite green after the entry application, and the resulting substrate diff matching the PR-branch state.
+6. **Validate the entry by execution** (see *Validation by execution* below for the concrete recipe). The acceptance criterion is the matching substrate's test suite green after the entry application, and the resulting substrate state matching `<head>` outside the substrate's test directories.
 
 7. **Commit on the PR branch** (see *PR commit shape* below for what the commit must include).
 
@@ -108,7 +108,7 @@ The substrate's own tests are the PR author's work, not the entry's. An entry tr
 1. Check out `<head>`, which has the framework change applied.
 2. Revert `examples/` to its pre-PR state (`git restore --source=<base> -- examples/`).
 3. Run the entry against the reverted substrate — invoke any colocated script(s) per the entry's `script:` reference, then walk the prose body of `instructions.md` if the entry has additional instructions.
-4. Verify the resulting `examples/` directory matches the `<head>` state: `git status --porcelain -- examples/ ':(exclude)examples/*/test/**'` prints nothing. The entry has reproduced the patch `git diff <base>..<head> -- examples/` describes, so the working tree is back at `<head>` and the check is that nothing is left over — no modification, and no file the entry created along the way.
+4. Verify the resulting `examples/` directory matches the `<head>` state outside the substrate's test directories: `git status --porcelain -- examples/ ':(exclude)examples/*/test/**'` prints nothing. The entry has reproduced the patch `git diff <base>..<head> -- examples/ ':(exclude)examples/*/test/**'` describes, so those paths are back at `<head>` and the check is that nothing is left over — no modification, and no file the entry created along the way.
 5. Verify the touched example's test suite is green — `pnpm --filter <example-package> test` for each example the entry changed. The repo-wide `pnpm test:examples` also runs examples that need a database and a `.env` (`pnpm db:up`, then copy `.env.example`); run it only with those in place.
 
 If any of those checks fail, iterate on the entry. Do not merge. Classify a failure before you change anything, per `.agents/rules/ci-failure-classification.mdc`. A timeout or a connection error makes the environment a *candidate*, not a verdict — confirm that classification against the rule before you leave the entry alone.
@@ -118,7 +118,7 @@ If any of those checks fail, iterate on the entry. Do not merge. Classify a fail
 1. Check out `<head>`, which has the framework change applied.
 2. Revert `packages/3-extensions/` to its pre-PR state (`git restore --source=<base> -- packages/3-extensions/`).
 3. Run the entry against the reverted substrate.
-4. Verify the resulting `packages/3-extensions/` directory matches the `<head>` state: `git status --porcelain -- packages/3-extensions/ ':(exclude)packages/3-extensions/*/test/**'` prints nothing, the same check the user-skill flow makes against `examples/`.
+4. Verify the resulting `packages/3-extensions/` directory matches the `<head>` state outside the substrate's test directories: `git status --porcelain -- packages/3-extensions/ ':(exclude)packages/3-extensions/*/test/**'` prints nothing, the same check the user-skill flow makes against `examples/`. The patch the entry reproduces is `git diff <base>..<head> -- packages/3-extensions/ ':(exclude)packages/3-extensions/*/test/**'`.
 5. Verify the matching test suite is green: `pnpm test --filter='./packages/3-extensions/*'`.
 
 If any of those checks fail, iterate on the entry. Do not merge. Classify a failure before you change anything, as above.
@@ -130,7 +130,7 @@ This flow was last executed end to end on 2026-08-20, against the `8.0.0-rc.3-to
 The PR that introduces the breaking change must contain, in addition to the framework change itself:
 
 - **The new entry directory in each affected skill** — `<destination>/upgrades/<in-flight transition>/instructions.md` plus any colocated scripts (the in-flight transition being the one determined in step 1 of the authoring workflow).
-- **The post-instructions state of every affected substrate** — these substrates would have been left broken without the entry; the entry's effect on the substrate *is* the diff that brings them back to green. The `<head>` substrate state and the validation-by-execution output state must be identical.
+- **The post-instructions state of every affected substrate** — these substrates would have been left broken without the entry; the entry's effect on the substrate *is* the diff that brings them back to green. The `<head>` substrate state and the validation-by-execution output state must be identical outside the substrate's `test/` directories, which the entry neither writes nor updates.
 - **A reference in the PR description naming each entry directory** (e.g. *"Adds entries to `skills/prisma-next-upgrade/upgrades/0.7-to-0.8/` and `skills/prisma-8-extension-upgrade/upgrades/0.7-to-0.8/`."*).
 
 The human reviewer + the CI gate (`pnpm check:upgrade-coverage`) both check this shape, but the gate is **necessary-but-not-sufficient** — it only asserts that the in-flight transition *directory* exists, not that *this PR's* substrate diff has a matching `changes[]` entry. So a PR can have a real substrate diff, contribute no entry, and still pass the gate green whenever an earlier PR already created the transition directory. (This is exactly how a breaking change can ship undocumented: the directory was already there, so the gate stayed green.) The gap is load-bearing for the reviewer: **the human reviewer must verify that every substrate diff in the PR has a corresponding entry** — the gate will not catch a missing entry once the directory exists. The reviewer also catches the semantic case (entry exists but its prose / scripts don't match the framework change).
@@ -185,7 +185,7 @@ Both substrates are touched → both skill packages need entries.
 3. `skills/prisma-next-upgrade/upgrades/0.7-to-0.8/instructions.md` already exists (placeholder shipped with the initial mechanism PR). Append a `changes[]` entry — call it `migration-metadata-shape-update`. Same for `skills/prisma-8-extension-upgrade/upgrades/0.7-to-0.8/instructions.md`.
 4. The user-skill entry may be prose-only (e.g. "rename the imported type from `MigrationMetadata` to `MigrationManifest` in any consumer code"), since the user-facing fix is a simple rename.
 5. The extension-skill entry needs more work — the SPI changed shape, not just name. Author `skills/prisma-8-extension-upgrade/upgrades/0.7-to-0.8/update-migration-tools-imports.ts` and reference it from the entry's `script:` field. If the same transformation also applies to the example, copy the script into the user-skill cluster's directory too.
-6. Validate by execution: revert `packages/3-extensions/` to pre-PR → run the extension-skill entry → verify `pnpm test --filter='./packages/3-extensions/*'` green and diff matches PR-branch state. Then revert `examples/` to pre-PR → run the user-skill entry → verify `pnpm test:examples` green and diff matches.
+6. Validate by execution: revert `packages/3-extensions/` to pre-PR → run the extension-skill entry → verify `pnpm test --filter='./packages/3-extensions/*'` green and the non-test paths match `<head>`. Then revert `examples/` to pre-PR → run the user-skill entry → verify `pnpm test:examples` green and the non-test paths match.
 7. Commit on the PR branch with both entry directories, the colocated script(s), and the matching substrate post-state.
 
 ## Reference

--- a/skills-contrib/record-upgrade-instructions/SKILL.md
+++ b/skills-contrib/record-upgrade-instructions/SKILL.md
@@ -96,26 +96,29 @@ Before merging, every new entry runs against the corresponding in-repo substrate
 
 Workflow per entry (one of the two flows; both apply for cross-audience entries):
 
-`<target>` is the branch the PR targets. Validating an entry after its PR merged? Use the merge commit as the head and its mainline parent as the base: `git log --first-parent` names both.
+Two placeholders name the revisions the flow compares:
+
+- **Open PR** — `<head>` is the PR branch head, `<base>` is `origin/<target>`, where `<target>` is the branch the PR targets.
+- **Merged PR** — `<head>` is the merge commit, `<base>` is its mainline parent. `git log --first-parent` names both.
 
 The substrate's own tests are the PR author's work, not the entry's. An entry translates consumer code; it neither writes nor updates the tests this repo keeps beside that code. The checks below therefore exclude the substrate's `test/` directories — what they measure is whether the entry reproduces every source change.
 
 ### User-skill entry (against `examples/`)
 
-1. Check out the PR branch with the framework change applied.
-2. Revert `examples/` to its pre-PR state (`git restore --source=origin/<target> -- examples/`).
+1. Check out `<head>`, which has the framework change applied.
+2. Revert `examples/` to its pre-PR state (`git restore --source=<base> -- examples/`).
 3. Run the entry against the reverted substrate — invoke any colocated script(s) per the entry's `script:` reference, then walk the prose body of `instructions.md` if the entry has additional instructions.
-4. Verify the resulting `examples/` directory matches the PR-branch state: `git status --porcelain -- examples/ ':(exclude)examples/*/test/**'` prints nothing. The entry has reproduced the patch `git diff origin/<target>..HEAD -- examples/` describes, so the working tree is back at HEAD and the check is that nothing is left over — no modification, and no file the entry created along the way.
+4. Verify the resulting `examples/` directory matches the `<head>` state: `git status --porcelain -- examples/ ':(exclude)examples/*/test/**'` prints nothing. The entry has reproduced the patch `git diff <base>..<head> -- examples/` describes, so the working tree is back at `<head>` and the check is that nothing is left over — no modification, and no file the entry created along the way.
 5. Verify the touched example's test suite is green — `pnpm --filter <example-package> test` for each example the entry changed. The repo-wide `pnpm test:examples` also runs examples that need a database and a `.env` (`pnpm db:up`, then copy `.env.example`); run it only with those in place.
 
-If any of those checks fail, iterate on the entry. Do not merge. Classify a failure before you change anything: a timeout or a connection error is the environment, not the entry (`.agents/rules/ci-failure-classification.mdc`).
+If any of those checks fail, iterate on the entry. Do not merge. Classify a failure before you change anything, per `.agents/rules/ci-failure-classification.mdc`. A timeout or a connection error makes the environment a *candidate*, not a verdict — confirm that classification against the rule before you leave the entry alone.
 
 ### Extension-skill entry (against `packages/3-extensions/`)
 
-1. Check out the PR branch with the framework change applied.
-2. Revert `packages/3-extensions/` to its pre-PR state (`git restore --source=origin/<target> -- packages/3-extensions/`).
+1. Check out `<head>`, which has the framework change applied.
+2. Revert `packages/3-extensions/` to its pre-PR state (`git restore --source=<base> -- packages/3-extensions/`).
 3. Run the entry against the reverted substrate.
-4. Verify the resulting `packages/3-extensions/` directory matches the PR-branch state: `git status --porcelain -- packages/3-extensions/ ':(exclude)packages/3-extensions/*/test/**'` prints nothing, the same check the user-skill flow makes against `examples/`.
+4. Verify the resulting `packages/3-extensions/` directory matches the `<head>` state: `git status --porcelain -- packages/3-extensions/ ':(exclude)packages/3-extensions/*/test/**'` prints nothing, the same check the user-skill flow makes against `examples/`.
 5. Verify the matching test suite is green: `pnpm test --filter='./packages/3-extensions/*'`.
 
 If any of those checks fail, iterate on the entry. Do not merge. Classify a failure before you change anything, as above.
@@ -127,7 +130,7 @@ This flow was last executed end to end on 2026-08-20, against the `8.0.0-rc.3-to
 The PR that introduces the breaking change must contain, in addition to the framework change itself:
 
 - **The new entry directory in each affected skill** — `<destination>/upgrades/<in-flight transition>/instructions.md` plus any colocated scripts (the in-flight transition being the one determined in step 1 of the authoring workflow).
-- **The post-instructions state of every affected substrate** — these substrates would have been left broken without the entry; the entry's effect on the substrate *is* the diff that brings them back to green. The PR-branch substrate state and the validation-by-execution output state must be identical.
+- **The post-instructions state of every affected substrate** — these substrates would have been left broken without the entry; the entry's effect on the substrate *is* the diff that brings them back to green. The `<head>` substrate state and the validation-by-execution output state must be identical.
 - **A reference in the PR description naming each entry directory** (e.g. *"Adds entries to `skills/prisma-next-upgrade/upgrades/0.7-to-0.8/` and `skills/prisma-8-extension-upgrade/upgrades/0.7-to-0.8/`."*).
 
 The human reviewer + the CI gate (`pnpm check:upgrade-coverage`) both check this shape, but the gate is **necessary-but-not-sufficient** — it only asserts that the in-flight transition *directory* exists, not that *this PR's* substrate diff has a matching `changes[]` entry. So a PR can have a real substrate diff, contribute no entry, and still pass the gate green whenever an earlier PR already created the transition directory. (This is exactly how a breaking change can ship undocumented: the directory was already there, so the gate stayed green.) The gap is load-bearing for the reviewer: **the human reviewer must verify that every substrate diff in the PR has a corresponding entry** — the gate will not catch a missing entry once the directory exists. The reviewer also catches the semantic case (entry exists but its prose / scripts don't match the framework change).

--- a/skills-contrib/record-upgrade-instructions/SKILL.md
+++ b/skills-contrib/record-upgrade-instructions/SKILL.md
@@ -96,25 +96,31 @@ Before merging, every new entry runs against the corresponding in-repo substrate
 
 Workflow per entry (one of the two flows; both apply for cross-audience entries):
 
+`<target>` is the branch the PR targets. Validating an entry after its PR merged? Use the merge commit as the head and its mainline parent as the base: `git log --first-parent` names both.
+
+The substrate's own tests are the PR author's work, not the entry's. An entry translates consumer code; it neither writes nor updates the tests this repo keeps beside that code. The checks below therefore exclude the substrate's `test/` directories — what they measure is whether the entry reproduces every source change.
+
 ### User-skill entry (against `examples/`)
 
 1. Check out the PR branch with the framework change applied.
 2. Revert `examples/` to its pre-PR state (`git restore --source=origin/<target> -- examples/`).
 3. Run the entry against the reverted substrate — invoke any colocated script(s) per the entry's `script:` reference, then walk the prose body of `instructions.md` if the entry has additional instructions.
-4. Verify the resulting `examples/` directory matches the PR-branch state: `git status --porcelain -- examples/` prints nothing. The entry has reproduced the patch `git diff origin/<target>..HEAD -- examples/` describes, so the working tree is back at HEAD and the check is that nothing is left over — no modification, and no file the entry created along the way.
-5. Verify the matching test suite is green: `pnpm test:examples`.
+4. Verify the resulting `examples/` directory matches the PR-branch state: `git status --porcelain -- examples/ ':(exclude)examples/*/test/**'` prints nothing. The entry has reproduced the patch `git diff origin/<target>..HEAD -- examples/` describes, so the working tree is back at HEAD and the check is that nothing is left over — no modification, and no file the entry created along the way.
+5. Verify the touched example's test suite is green — `pnpm --filter <example-package> test` for each example the entry changed. The repo-wide `pnpm test:examples` also runs examples that need a database and a `.env` (`pnpm db:up`, then copy `.env.example`); run it only with those in place.
 
-If any of those checks fail, iterate on the entry. Do not merge.
+If any of those checks fail, iterate on the entry. Do not merge. Classify a failure before you change anything: a timeout or a connection error is the environment, not the entry (`.agents/rules/ci-failure-classification.mdc`).
 
 ### Extension-skill entry (against `packages/3-extensions/`)
 
 1. Check out the PR branch with the framework change applied.
 2. Revert `packages/3-extensions/` to its pre-PR state (`git restore --source=origin/<target> -- packages/3-extensions/`).
 3. Run the entry against the reverted substrate.
-4. Verify the resulting `packages/3-extensions/` directory matches the PR-branch state: `git status --porcelain -- packages/3-extensions/` prints nothing, the same check the user-skill flow makes against `examples/`.
+4. Verify the resulting `packages/3-extensions/` directory matches the PR-branch state: `git status --porcelain -- packages/3-extensions/ ':(exclude)packages/3-extensions/*/test/**'` prints nothing, the same check the user-skill flow makes against `examples/`.
 5. Verify the matching test suite is green: `pnpm test --filter='./packages/3-extensions/*'`.
 
-If any of those checks fail, iterate on the entry. Do not merge.
+If any of those checks fail, iterate on the entry. Do not merge. Classify a failure before you change anything, as above.
+
+This flow was last executed end to end on 2026-08-20, against the `8.0.0-rc.3-to-8.0.0-rc.4` raw-lane entries in both skills.
 
 ## PR commit shape
 

--- a/skills-contrib/record-upgrade-instructions/SKILL.md
+++ b/skills-contrib/record-upgrade-instructions/SKILL.md
@@ -101,7 +101,7 @@ Two placeholders name the revisions the flow compares:
 - **Open PR** — `<head>` is the PR branch head, `<base>` is `origin/<target>`, where `<target>` is the branch the PR targets.
 - **Merged PR** — `<head>` is the merge commit, `<base>` is its mainline parent. `git log --first-parent` names both.
 
-The substrate's own tests are the PR author's work, not the entry's. An entry translates consumer code; it neither writes nor updates the tests this repo keeps beside that code. The checks below therefore exclude the substrate's `test/` directories — what they measure is whether the entry reproduces every source change.
+The substrate's own tests are the PR author's work, not the entry's. An entry translates consumer code; it neither writes nor updates the tests this repo keeps beside that code. So the equality check below excludes the substrate's `test/` directories — what it measures is whether the entry reproduces every source change — and a companion check confirms the entry left those directories exactly as it found them.
 
 ### User-skill entry (against `examples/`)
 
@@ -109,7 +109,16 @@ The substrate's own tests are the PR author's work, not the entry's. An entry tr
 2. Revert `examples/` to its pre-PR state (`git restore --source=<base> -- examples/`).
 3. Run the entry against the reverted substrate — invoke any colocated script(s) per the entry's `script:` reference, then walk the prose body of `instructions.md` if the entry has additional instructions.
 4. Verify the resulting `examples/` directory matches the `<head>` state outside the substrate's test directories: `git status --porcelain -- examples/ ':(exclude)examples/*/test/**'` prints nothing. The entry has reproduced the patch `git diff <base>..<head> -- examples/ ':(exclude)examples/*/test/**'` describes, so those paths are back at `<head>` and the check is that nothing is left over — no modification, and no file the entry created along the way.
-5. Verify the touched example's test suite is green — `pnpm --filter <example-package> test` for each example the entry changed. The repo-wide `pnpm test:examples` also runs examples that need a database and a `.env` (`pnpm db:up`, then copy `.env.example`); run it only with those in place.
+5. Verify the entry left the test paths alone. Step 2 put them at `<base>` and a correct entry never touches them, so they must still be at `<base>`. Step 4 excludes those paths and cannot see a change there, so without this check an entry could mutate the tests to make step 6 pass:
+
+   ```bash
+   git diff --exit-code <base> -- 'examples/*/test/**'
+   git ls-files --others --exclude-standard -- 'examples/*/test/**'
+   ```
+
+   The first command must exit 0 (no tracked test file changed), the second must print nothing (the entry created no new test file).
+
+6. Verify the touched example's test suite is green — `pnpm --filter <example-package> test` for each example the entry changed. The repo-wide `pnpm test:examples` also runs examples that need a database and a `.env` (`pnpm db:up`, then copy `.env.example`); run it only with those in place.
 
 If any of those checks fail, iterate on the entry. Do not merge. Classify a failure before you change anything, per `.agents/rules/ci-failure-classification.mdc`. A timeout or a connection error makes the environment a *candidate*, not a verdict — confirm that classification against the rule before you leave the entry alone.
 
@@ -119,7 +128,14 @@ If any of those checks fail, iterate on the entry. Do not merge. Classify a fail
 2. Revert `packages/3-extensions/` to its pre-PR state (`git restore --source=<base> -- packages/3-extensions/`).
 3. Run the entry against the reverted substrate.
 4. Verify the resulting `packages/3-extensions/` directory matches the `<head>` state outside the substrate's test directories: `git status --porcelain -- packages/3-extensions/ ':(exclude)packages/3-extensions/*/test/**'` prints nothing, the same check the user-skill flow makes against `examples/`. The patch the entry reproduces is `git diff <base>..<head> -- packages/3-extensions/ ':(exclude)packages/3-extensions/*/test/**'`.
-5. Verify the matching test suite is green: `pnpm test --filter='./packages/3-extensions/*'`.
+5. Verify the entry left the test paths alone, the same companion check the user-skill flow makes, for the same reason:
+
+   ```bash
+   git diff --exit-code <base> -- 'packages/3-extensions/*/test/**'
+   git ls-files --others --exclude-standard -- 'packages/3-extensions/*/test/**'
+   ```
+
+6. Verify the matching test suite is green: `pnpm test --filter='./packages/3-extensions/*'`.
 
 If any of those checks fail, iterate on the entry. Do not merge. Classify a failure before you change anything, as above.
 
@@ -185,7 +201,7 @@ Both substrates are touched → both skill packages need entries.
 3. `skills/prisma-next-upgrade/upgrades/0.7-to-0.8/instructions.md` already exists (placeholder shipped with the initial mechanism PR). Append a `changes[]` entry — call it `migration-metadata-shape-update`. Same for `skills/prisma-8-extension-upgrade/upgrades/0.7-to-0.8/instructions.md`.
 4. The user-skill entry may be prose-only (e.g. "rename the imported type from `MigrationMetadata` to `MigrationManifest` in any consumer code"), since the user-facing fix is a simple rename.
 5. The extension-skill entry needs more work — the SPI changed shape, not just name. Author `skills/prisma-8-extension-upgrade/upgrades/0.7-to-0.8/update-migration-tools-imports.ts` and reference it from the entry's `script:` field. If the same transformation also applies to the example, copy the script into the user-skill cluster's directory too.
-6. Validate by execution: revert `packages/3-extensions/` to pre-PR → run the extension-skill entry → verify `pnpm test --filter='./packages/3-extensions/*'` green and the non-test paths match `<head>`. Then revert `examples/` to pre-PR → run the user-skill entry → verify `pnpm test:examples` green and the non-test paths match.
+6. Validate by execution: revert `packages/3-extensions/` to pre-PR → run the extension-skill entry → verify `pnpm test --filter='./packages/3-extensions/*'` green, the non-test paths matching `<head>`, and the test paths still at `<base>`. Then revert `examples/` to pre-PR → run the user-skill entry → verify `pnpm --filter <example-package> test` green for the touched example, with the same two path checks.
 7. Commit on the PR branch with both entry directories, the colocated script(s), and the matching substrate post-state.
 
 ## Reference


### PR DESCRIPTION
TML-3223, part 1. The "Validation by execution" recipe in `skills-contrib/record-upgrade-instructions/SKILL.md` had never been executed end to end. This PR records what executing it against the merged `8.0.0-rc.3-to-8.0.0-rc.4` raw-lane entries (both flows, in a scratch git clone) surfaced.

## The positive result

Both entries are correct. Detection matched exactly the files the stack changed (no false positives, no misses), and a literal replay reproduced every source hunk in both substrates. Nothing in the shipped transition content needed changing.

## Three recipe defects, fixed

1. **Step 4 was unsatisfiable for any PR that touches its substrate's tests.** The check demanded the substrate match HEAD, but substrate diffs carry the repo's own test updates and new test files — which no consumer-facing entry can or should replay (a consumer's project does not contain this repo's tests). The extension flow failed on five paths, every one a test file. Both flows now exclude `*/test/**` from the match check, with a paragraph stating why: the checks measure whether the entry reproduces every *source* change.
2. **Step 5 ran every example, including two that need a database and a `.env`,** so it failed on a clean checkout regardless of the entry. The flow now names the touched example's own suite (`pnpm --filter <example-package> test`) and states the prerequisites for the repo-wide run.
3. **The recipe assumed an unmerged PR branch.** For a merged entry there was no defined base. It now says: use the merge commit as head and its mainline parent as base, via `git log --first-parent`.

Both flows also gain one sentence: classify a failure before iterating on the entry — a timeout or connection error is the environment, not the entry (`ci-failure-classification.mdc`). The execution run hit exactly that: one 100ms-timeout test failure on a cold 70s import phase, passing 3/3 in isolation.

## The stamp

The section now records when the flow was last executed for real, so the next reader knows it is a tested recipe: 2026-08-20, against the rc.3→rc.4 entries in both skills.

Corrected checks were re-run against the real substrate after the fixes; both flows print nothing.

https://claude.ai/code/session_01NnNjsNcPMtbJZhnZz5Zzbe


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added explicit checks ensuring substrate test directories remain unchanged and contain no newly created files.
  * Updated user-skill validation guidance to run tests for each example.
  * Added equivalent test-path validation guidance for extensions.
  * Revised the worked example to demonstrate per-example test execution and the updated validation checks.
  * Clarified guidance for comparing revisions and restoring changes during validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->