### PR TITLE
TML-3224: encode timestamptz parameters as UTC ISO strings

### DIFF
--- a/packages/3-targets/3-targets/postgres/src/core/codec-helpers.ts
+++ b/packages/3-targets/3-targets/postgres/src/core/codec-helpers.ts
@@ -262,8 +262,20 @@ export const pgTimestampDecodeJson = (json: JsonValue): Date => {
   return date;
 };
 
+/**
+ * Serializes a `timestamptz` parameter as the instant's UTC ISO-8601 string,
+ * bypassing the pg driver's own `Date` serialization (`dateToString`). That
+ * serializer writes the *local* wall clock (`getHours`..`getSeconds`) next to an
+ * offset suffix derived from `getTimezoneOffset()`, which is whole minutes.
+ * Zones whose historical rule is local mean time carry a seconds component
+ * (Europe/Berlin before 1893 is +00:53:28), so the wall clock includes seconds
+ * the suffix cannot express and the stored instant drifts by that remainder.
+ * A `Z`-suffixed UTC string has no such offset to lose.
+ */
+export const pgTimestamptzEncode = (value: Date): string => value.toISOString();
+
 export const pgTimestamptzEncodeJson = (value: Date): JsonValue =>
-  value.toISOString().replace(/Z$/, '+00:00');
+  pgTimestamptzEncode(value).replace(/Z$/, '+00:00');
 export const pgTimestamptzDecodeJson = (json: JsonValue): Date => {
   if (typeof json !== 'string') {
     throw postgresError(

--- a/packages/3-targets/3-targets/postgres/src/core/codecs.ts
+++ b/packages/3-targets/3-targets/postgres/src/core/codecs.ts
@@ -76,6 +76,7 @@ import {
   pgTimestampDecodeJson,
   pgTimestampEncodeJson,
   pgTimestamptzDecodeJson,
+  pgTimestamptzEncode,
   pgTimestamptzEncodeJson,
   pgUnboundedIntDecode,
   renderLength,
@@ -1149,11 +1150,11 @@ pgTimestampColumn satisfies ColumnHelperForStrict<PgTimestampDescriptor>;
 export class PgTimestamptzCodec extends CodecImpl<
   typeof PG_TIMESTAMPTZ_CODEC_ID,
   readonly ['equality', 'order'],
-  Date,
+  Date | string,
   Date
 > {
-  async encode(value: Date, _ctx: CodecCallContext): Promise<Date> {
-    return value;
+  async encode(value: Date, _ctx: CodecCallContext): Promise<string> {
+    return pgTimestamptzEncode(value);
   }
   async decode(wire: Date, _ctx: CodecCallContext): Promise<Date> {
     return wire;

--- a/packages/3-targets/3-targets/postgres/test/codecs-class.test.ts
+++ b/packages/3-targets/3-targets/postgres/test/codecs-class.test.ts
@@ -283,9 +283,9 @@ describe('codecs-class', () => {
       expect(codec.id).toBe(PG_TIMESTAMPTZ_CODEC_ID);
     });
 
-    it('round-trips Date values', async () => {
+    it('encodes the instant as a UTC ISO string and passes the parsed Date through on decode', async () => {
       const instant = new Date('2024-01-15T10:30:00Z');
-      expect(await codec.encode(instant, callCtx)).toBe(instant);
+      expect(await codec.encode(instant, callCtx)).toBe('2024-01-15T10:30:00.000Z');
       expect(await codec.decode(instant, callCtx)).toBe(instant);
     });
 

--- a/packages/3-targets/3-targets/postgres/test/codecs.test.ts
+++ b/packages/3-targets/3-targets/postgres/test/codecs.test.ts
@@ -161,13 +161,22 @@ describe('adapter-postgres codecs', () => {
 
   describe('timestamptz codec', () => {
     const timestamptzCodec = codecForScalar('timestamptz') as {
-      encode: (value: Date, ctx: SqlCodecCallContext) => Promise<Date>;
+      encode: (value: Date, ctx: SqlCodecCallContext) => Promise<string>;
       decode: (wire: Date, ctx: SqlCodecCallContext) => Promise<Date>;
     };
 
-    it('round-trips Date values', async () => {
+    it('encodes the instant as a UTC ISO string, independent of process timezone', async () => {
       const date = new Date('2024-01-15T10:30:00Z');
-      expect(await timestamptzCodec.encode(date, {})).toBe(date);
+      expect(await timestamptzCodec.encode(date, {})).toBe('2024-01-15T10:30:00.000Z');
+    });
+
+    it('encodes historical instants exactly (no local-mean-time offset rounding)', async () => {
+      const date = new Date('0120-01-01T00:00:00Z');
+      expect(await timestamptzCodec.encode(date, {})).toBe('0120-01-01T00:00:00.000Z');
+    });
+
+    it('passes the driver-parsed Date through on decode', async () => {
+      const date = new Date('2024-01-15T10:30:00Z');
       expect(await timestamptzCodec.decode(date, {})).toBe(date);
     });
   });


### PR DESCRIPTION
Writing `new Date('0120-01-01T00:00:00Z')` to a `timestamptz` column from a `TZ=Europe/Berlin` process stored `0120-01-01T00:00:28Z` — 28 seconds late. Same code, `TZ=UTC`: exact. This PR makes the `timestamptz` codec serialize the instant itself, so what gets stored no longer depends on the writer's timezone.

**Linear:** [TML-3224](https://linear.app/prisma-company/issue/TML-3224)

## The bug

It is on the write side, in how a JavaScript `Date` becomes a query parameter — not in the session and not in decoding (a direct `select` under both timezones shows the same session `TimeZone`, identical wire text, and a correct parse).

`pg/timestamptz@1.encode` handed the `Date` straight to the `pg` driver, whose `dateToString` writes the **local wall clock** (`getHours`/`getMinutes`/`getSeconds`) next to an offset suffix built from **`getTimezoneOffset()`, which is whole minutes**. For year 120, Europe/Berlin's rule is local mean time, `+00:53:28` — an offset with seconds. So the instant was serialized as:

```
0120-01-01T00:53:28+00:53
          └─ wall clock keeps the 28 s   └─ suffix cannot express them
```

Postgres reads that literally: 00:53:28 at +00:53 is `00:00:28Z`. Any zone whose historical rule carries seconds reproduces it; UTC — and therefore CI — cannot, which is why this only surfaced as a "local-only" red in `issues-28192-pg-historical-dates`.

## The fix

`encode` now returns `value.toISOString()` — a `Z`-suffixed UTC string with no offset to lose — through a new `pgTimestamptzEncode` helper whose doc comment records the mechanism. This mirrors the codec's existing JSON-lane encoder and the fix `pg/date@1` already received for the same `dateToString` cause. The codec's wire type widens to `Date | string`; decode is unchanged.

## Verification

- New unit tests pin the exact encoded string for a modern and a historical instant. They are timezone-independent and fail on the old pass-through (run red before the change).
- `@internal/target-postgres`: 1412 tests, lint, typecheck, build green. `@internal/adapter-postgres` and `@internal/sql-orm-client` tests and typecheck green; `integration-tests` typecheck green.
- End to end: the `issues-28192-pg-historical-dates` integration file run from a `TZ=Europe/Berlin` shell against the rebuilt package — 5 passed, 4 expected-fail (the pre-existing 2-digit-year `date` cases), 0 failed. No timezone pinning anywhere.

## Deliberately not in this PR

- The naive `pg/timestamp@1` codec's two lanes disagree on which wall clock a `Date` maps to (JSON lane: UTC components; parameter lane: local, via `dateToString`). Naive timestamps must not be implicitly forced to UTC; which wall clock they should use is a design decision, tracked in TML-3224's follow-up section.
- CI has no non-UTC leg, so it cannot catch this class; also noted on the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * PostgreSQL timestamp-with-time-zone values are now encoded as consistent UTC ISO-8601 strings.
  * Timestamp encoding accepts both `Date` values and date strings.
  * Decoding continues to return `Date` values, preserving existing behavior.
* **Tests**
  * Added coverage for timezone-independent encoding and historical dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->