### PR TITLE
Init stops touching agent skills; the family-level prisma init owns skills setup

### DIFF
--- a/docs/reference/error-reference.md
+++ b/docs/reference/error-reference.md
@@ -143,9 +143,9 @@ The code was raised by the commander `init` (deleted in the S5 cutover), whose c
 
 ### CLI.INIT_SKILL_INSTALL_FAILED
 
-Retired. `prisma orm init` used to fetch the agent skills from GitHub with `skills add`, and raised this at exit `6` when that fetch failed. The skills now ship inside the `@prisma/orm-*` packages a project installs, and init copies them into the agent directories by running `prisma skills sync` once, then writes a `postinstall` script that repeats the sync on every later install.
+Retired. `prisma orm init` used to fetch the agent skills from GitHub with `skills add`, and raised this at exit `6` when that fetch failed. The skills now ship inside the `@prisma/orm-*` packages a project installs, and init copies them into the agent directories by running `prisma skills sync` once at scaffold time.
 
-A sync that fails no longer fails anything: init warns and names the command to re-run, the postinstall retries on the next install, and every `prisma` command reports skills that no longer match the installed packages. Init exits `4` or `5` now — there is no exit `6`, and nothing raises this code.
+A sync that fails no longer fails anything: init warns and names the command to re-run, and every `prisma` command reports skills that no longer match the installed packages — that staleness notice is what keeps the copies current, naming the sync command to run. Init exits `4` or `5` now — there is no exit `6`, and nothing raises this code.
 
 ### CLI.INIT_STRICT_PROBE_WITHOUT_PROBE
 

--- a/docs/reference/error-reference.md
+++ b/docs/reference/error-reference.md
@@ -8,7 +8,7 @@ Exit codes (CLI): an expected structured failure exits `2`, a user abort exits `
 
 Some codes are not failures to run at all. `db verify`, `db sign` and `migration check` answer a question about the project, and a bad answer is still an answer: they finish, report their findings as diagnostics on a successful envelope, and exit `4`. Exit `2` is reserved for the cases where those commands could not do the job — an unknown `--space`, a migration reference that resolves to nothing, an unreachable database, a contract that has not been emitted. Every entry whose code can arrive on one of those runs says so and names the command. Each of those commands declares the numbers it can exit with, and its `--help` text spells out what each one means.
 
-A command may also **complete with findings**: it ran to its end and has a result to report, and the problems it found ride that result as diagnostics carrying the codes on this page. Those runs exit with a documented per-command code in the `4`–`99` band rather than `2`, and the entry below says so. `prisma orm init` is the case today: its scaffold is on disk whatever happens next, so a failed dependency install, contract emit, or agent-skill install is a finding on a completed run at exit `4`, `5` or `6`.
+A command may also **complete with findings**: it ran to its end and has a result to report, and the problems it found ride that result as diagnostics carrying the codes on this page. Those runs exit with a documented per-command code in the `4`–`99` band rather than `2`, and the entry below says so. `prisma orm init` is the case today: its scaffold is on disk whatever happens next, so a failed dependency install or contract emit is a finding on a completed run at exit `4` or `5`.
 
 Codes that predate the dotted scheme were renamed at 0.16; the full old→new crosswalk (`PN-DOMAIN-NNNN` → `NAMESPACE.SUBCODE`) is in [ADR 239](../architecture%20docs/adrs/ADR%20239%20-%20Errors%20are%20structural%20envelopes%20with%20dotted%20namespace%20codes.md).
 
@@ -143,9 +143,9 @@ The code was raised by the commander `init` (deleted in the S5 cutover), whose c
 
 ### CLI.INIT_SKILL_INSTALL_FAILED
 
-During `prisma orm init`, the project-level skills install failed after a successful dependency install and emit. Init runs `skills add` through the project's package manager — `pnpm dlx skills@latest add prisma/prisma/skills#v<version> --agent cursor claude-code codex windsurf --skill prisma-8 -y` — for the one `prisma-8` skill (upgrading folded into it, so there are no longer separate always-latest upgrade installs). The project itself is complete without the skills; the user can fix the underlying issue (network, registry, PATH) and install manually, or re-run with `--skip-skills`. `init` completes with this as a finding and exits 6. Meta: `filesWritten`, plus `skillInstall` (the attempted command, the manager, its exit code and the tail of its stderr).
+Retired. `prisma orm init` used to fetch the agent skills from GitHub with `skills add`, and raised this at exit `6` when that fetch failed. The skills now ship inside the `@prisma/orm-*` packages a project installs, and init copies them into the agent directories by running `prisma skills sync` once, then writes a `postinstall` script that repeats the sync on every later install.
 
-This GitHub-fetching install is being replaced: the skill now ships inside the `@prisma/orm-*` tarballs and `prisma skills sync` copies it out of the installed package, so init will stop shelling out to `skills add` and this failure path retires with it.
+A sync that fails no longer fails anything: init warns and names the command to re-run, the postinstall retries on the next install, and every `prisma` command reports skills that no longer match the installed packages. Init exits `4` or `5` now — there is no exit `6`, and nothing raises this code.
 
 ### CLI.INIT_STRICT_PROBE_WITHOUT_PROBE
 

--- a/docs/reference/error-reference.md
+++ b/docs/reference/error-reference.md
@@ -143,9 +143,7 @@ The code was raised by the commander `init` (deleted in the S5 cutover), whose c
 
 ### CLI.INIT_SKILL_INSTALL_FAILED
 
-Retired. `prisma orm init` used to fetch the agent skills from GitHub with `skills add`, and raised this at exit `6` when that fetch failed. The skills now ship inside the `@prisma/orm-*` packages a project installs, and init copies them into the agent directories by running `prisma skills sync` once at scaffold time.
-
-A sync that fails no longer fails anything: init warns and names the command to re-run, and every `prisma` command reports skills that no longer match the installed packages — that staleness notice is what keeps the copies current, naming the sync command to run. Init exits `4` or `5` now — there is no exit `6`, and nothing raises this code.
+Retired. `prisma orm init` used to fetch the agent skills from GitHub with `skills add`, and raised this at exit `6` when that fetch failed. The skills now ship inside the `@prisma/orm-*` packages a project installs, and `orm init` no longer touches them at all: skills setup belongs to the family-level `prisma init` command, and `prisma skills sync` copies the skills out of the installed packages whenever it runs. Init exits `4` or `5` now — there is no exit `6`, and nothing raises this code.
 
 ### CLI.INIT_STRICT_PROBE_WITHOUT_PROBE
 

--- a/docs/reference/error-reference.md
+++ b/docs/reference/error-reference.md
@@ -143,7 +143,7 @@ The code was raised by the commander `init` (deleted in the S5 cutover), whose c
 
 ### CLI.INIT_SKILL_INSTALL_FAILED
 
-Retired. `prisma orm init` used to fetch the agent skills from GitHub with `skills add`, and raised this at exit `6` when that fetch failed. The skills now ship inside the `@prisma/orm-*` packages a project installs, and `orm init` no longer touches them at all: skills setup belongs to the family-level `prisma init` command, and `prisma skills sync` copies the skills out of the installed packages whenever it runs. Init exits `4` or `5` now — there is no exit `6`, and nothing raises this code.
+Retired. `prisma orm init` used to fetch the agent skills from GitHub with `skills add`, and raised this at exit `6` when that fetch failed. The skills now ship inside the `@prisma/orm-*` packages a project installs, and `orm init` no longer touches them at all: skills setup belongs to the family-level `prisma init` command, and `prisma skills sync` copies the skills out of the installed packages whenever it runs. Init's remaining failure exits are `4` (dependency install failed) and `5` (contract emission failed); there is no exit `6`, and nothing raises this code.
 
 ### CLI.INIT_STRICT_PROBE_WITHOUT_PROBE
 

--- a/packages/1-framework/3-tooling/cli/src/commands/init/detect-package-manager.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/init/detect-package-manager.ts
@@ -23,8 +23,8 @@ function isPackageManager(name: string): name is PackageManager {
  *  2. **`getUserAgent()`** — parses `npm_config_user_agent`, the env var
  *     every PM sets when it spawns a script. This catches the
  *     bare-directory case where there's no project to walk up to but the
- *     user invoked us via `pnpm dlx @prisma/cli@next orm init` / `bunx
- *     @prisma/cli@next orm init` / `yarn dlx …`. Same signal used by every
+ *     user invoked us via `pnpm dlx prisma@next orm init` / `bunx
+ *     prisma@next orm init` / `yarn dlx …`. Same signal used by every
  *     `create-*` tool in the ecosystem (`create-vite`, `create-next-app`,
  *     `create-astro`, `@antfu/ni`, …).
  *

--- a/packages/1-framework/3-tooling/cli/src/commands/init/hygiene-gitattributes.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/init/hygiene-gitattributes.ts
@@ -6,7 +6,7 @@ import type { TargetId } from './templates/code-templates';
  * [`.gitattributes`](../../../../../../../../.gitattributes):
  *
  * - **Today**: `contract.json`, `contract.d.ts` are emitted on every
- *   `prisma-cli contract emit`. Marking them `linguist-generated`
+ *   `prisma contract emit`. Marking them `linguist-generated`
  *   keeps GitHub's diff stats honest and collapses the file in code
  *   review by default.
  * - **Forward-looking**: `ops.json`, `migration.json` are not yet emitted

--- a/packages/1-framework/3-tooling/cli/src/commands/init/hygiene-gitignore.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/init/hygiene-gitignore.ts
@@ -10,6 +10,23 @@
 export const REQUIRED_GITIGNORE_ENTRIES: readonly string[] = ['node_modules/', 'dist/', '.env'];
 
 /**
+ * The skill copies `prisma skills sync` maintains in each agent harness's
+ * skill directory. They are derived from the lockfile the way `node_modules`
+ * is — a teammate's first install recreates them — so committing them would
+ * only invite drift between what the tree says and what is installed.
+ *
+ * Each entry names the one directory sync manages, not the harness directory
+ * around it: a project's own hand-written skills live as siblings there and
+ * must stay tracked.
+ */
+export const SYNCED_SKILL_GITIGNORE_ENTRIES: readonly string[] = [
+  '.claude/skills/prisma-8/',
+  '.cursor/skills/prisma-8/',
+  '.agents/skills/prisma-8/',
+  '.windsurf/skills/prisma-8/',
+];
+
+/**
  * Idempotent `.gitignore` merge (FR3.3 / FR9.3). Returns the new file
  * content given the existing content (or `undefined` if the file does
  * not yet exist). Adds only entries that are not already present and
@@ -26,9 +43,12 @@ export const REQUIRED_GITIGNORE_ENTRIES: readonly string[] = ['node_modules/', '
  * every required entry). The caller can use this to decide whether to
  * include `.gitignore` in `filesWritten`.
  */
-export function mergeGitignore(existing: string | undefined): string | null {
+export function mergeGitignore(
+  existing: string | undefined,
+  required: readonly string[] = REQUIRED_GITIGNORE_ENTRIES,
+): string | null {
   if (existing === undefined) {
-    return `${REQUIRED_GITIGNORE_ENTRIES.join('\n')}\n`;
+    return `${required.join('\n')}\n`;
   }
 
   const present = new Set(
@@ -38,7 +58,7 @@ export function mergeGitignore(existing: string | undefined): string | null {
       .filter((line) => line.length > 0 && !line.startsWith('#')),
   );
 
-  const missing = REQUIRED_GITIGNORE_ENTRIES.filter((entry) => !present.has(entry));
+  const missing = required.filter((entry) => !present.has(entry));
   if (missing.length === 0) {
     return null;
   }

--- a/packages/1-framework/3-tooling/cli/src/commands/init/hygiene-gitignore.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/init/hygiene-gitignore.ts
@@ -26,12 +26,9 @@ export const REQUIRED_GITIGNORE_ENTRIES: readonly string[] = ['node_modules/', '
  * every required entry). The caller can use this to decide whether to
  * include `.gitignore` in `filesWritten`.
  */
-export function mergeGitignore(
-  existing: string | undefined,
-  required: readonly string[] = REQUIRED_GITIGNORE_ENTRIES,
-): string | null {
+export function mergeGitignore(existing: string | undefined): string | null {
   if (existing === undefined) {
-    return `${required.join('\n')}\n`;
+    return `${REQUIRED_GITIGNORE_ENTRIES.join('\n')}\n`;
   }
 
   const present = new Set(
@@ -41,7 +38,7 @@ export function mergeGitignore(
       .filter((line) => line.length > 0 && !line.startsWith('#')),
   );
 
-  const missing = required.filter((entry) => !present.has(entry));
+  const missing = REQUIRED_GITIGNORE_ENTRIES.filter((entry) => !present.has(entry));
   if (missing.length === 0) {
     return null;
   }

--- a/packages/1-framework/3-tooling/cli/src/commands/init/hygiene-gitignore.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/init/hygiene-gitignore.ts
@@ -10,23 +10,6 @@
 export const REQUIRED_GITIGNORE_ENTRIES: readonly string[] = ['node_modules/', 'dist/', '.env'];
 
 /**
- * The skill copies `prisma skills sync` maintains in each agent harness's
- * skill directory. They are derived from the lockfile the way `node_modules`
- * is — a teammate's first install recreates them — so committing them would
- * only invite drift between what the tree says and what is installed.
- *
- * Each entry names the one directory sync manages, not the harness directory
- * around it: a project's own hand-written skills live as siblings there and
- * must stay tracked.
- */
-export const SYNCED_SKILL_GITIGNORE_ENTRIES: readonly string[] = [
-  '.claude/skills/prisma-8/',
-  '.cursor/skills/prisma-8/',
-  '.agents/skills/prisma-8/',
-  '.windsurf/skills/prisma-8/',
-];
-
-/**
  * Idempotent `.gitignore` merge (FR3.3 / FR9.3). Returns the new file
  * content given the existing content (or `undefined` if the file does
  * not yet exist). Adds only entries that are not already present and

--- a/packages/1-framework/3-tooling/cli/src/commands/init/hygiene-package-scripts.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/init/hygiene-package-scripts.ts
@@ -3,7 +3,7 @@ import { blindCast } from '@internal/utils/casts';
 /**
  * The package.json `scripts` entries `init` adds idempotently (FR3.5).
  * The script *name* mirrors the CLI subcommand path (`contract:emit` →
- * `prisma-cli contract emit`) so the script is greppable: a user
+ * `prisma contract emit`) so the script is greppable: a user
  * encountering `npm run contract:emit` in CI logs can navigate
  * straight to the equivalent CLI invocation.
  *
@@ -16,7 +16,7 @@ export interface RequiredScript {
 }
 
 export const REQUIRED_SCRIPTS: readonly RequiredScript[] = [
-  { name: 'contract:emit', command: 'prisma-cli contract emit' },
+  { name: 'contract:emit', command: 'prisma contract emit' },
 ];
 
 /**

--- a/packages/1-framework/3-tooling/cli/src/commands/init/hygiene-package-scripts.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/init/hygiene-package-scripts.ts
@@ -19,22 +19,6 @@ export const REQUIRED_SCRIPTS: readonly RequiredScript[] = [
   { name: 'contract:emit', command: 'prisma contract emit' },
 ];
 
-/**
- * Keeps the agent skills matching the installed packages: every install and
- * every upgrade re-copies them out of the packages they ship in. The script
- * lives in the user's own manifest rather than in a Prisma package because
- * dependency lifecycle scripts are blocked by default under pnpm 10+, bun and
- * Deno, and by any `ignore-scripts` policy.
- *
- * `|| exit 0` covers the environments where the `prisma` binary is not there
- * at all — a production install with no development dependencies, most of all.
- * Skills are a development aid, so their absence must never fail an install.
- */
-export const SKILLS_SYNC_SCRIPT: RequiredScript = {
-  name: 'postinstall',
-  command: 'prisma skills sync || exit 0',
-};
-
 export interface PackageScriptsMergeResult {
   /**
    * The new package.json content. `null` when no changes are required

--- a/packages/1-framework/3-tooling/cli/src/commands/init/hygiene-package-scripts.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/init/hygiene-package-scripts.ts
@@ -19,6 +19,22 @@ export const REQUIRED_SCRIPTS: readonly RequiredScript[] = [
   { name: 'contract:emit', command: 'prisma-cli contract emit' },
 ];
 
+/**
+ * Keeps the agent skills matching the installed packages: every install and
+ * every upgrade re-copies them out of the packages they ship in. The script
+ * lives in the user's own manifest rather than in a Prisma package because
+ * dependency lifecycle scripts are blocked by default under pnpm 10+, bun and
+ * Deno, and by any `ignore-scripts` policy.
+ *
+ * `|| exit 0` covers the environments where the `prisma` binary is not there
+ * at all — a production install with no development dependencies, most of all.
+ * Skills are a development aid, so their absence must never fail an install.
+ */
+export const SKILLS_SYNC_SCRIPT: RequiredScript = {
+  name: 'postinstall',
+  command: 'prisma skills sync || exit 0',
+};
+
 export interface PackageScriptsMergeResult {
   /**
    * The new package.json content. `null` when no changes are required

--- a/packages/1-framework/3-tooling/cli/src/commands/init/output.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/init/output.ts
@@ -80,14 +80,6 @@ export function buildNextSteps(options: {
   readonly contractEmitted: boolean;
   readonly emitCommand: string;
   readonly schemaPath: string;
-  /**
-   * Whether the project-level Prisma Next skill sync actually ran
-   * and succeeded during this `init`. When false (the user passed
-   * `--skip-skills`, so the sync was skipped), the
-   * "registered with your agent runtime" step is omitted — the skip is
-   * already surfaced in the warnings array with a manual-install hint.
-   */
-  readonly skillRegistered: boolean;
 }): string[] {
   const steps: string[] = [];
   let stepNumber = 1;
@@ -111,10 +103,8 @@ export function buildNextSteps(options: {
     push(`Edit your schema at ${options.schemaPath}, then re-run \`${options.emitCommand}\`.`);
   }
   push('Open prisma-next.md for a quick reference on how to write your first typed query.');
-  if (options.skillRegistered) {
-    push(
-      'Prisma Next skills are registered with your agent runtime — open the project in your IDE and ask the agent to add a model, run a query, or plan a migration.',
-    );
-  }
+  push(
+    'Working with a coding agent? Run `prisma init` in this project to set up the Prisma agent skills.',
+  );
   return steps;
 }

--- a/packages/1-framework/3-tooling/cli/src/commands/init/output.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/init/output.ts
@@ -81,9 +81,9 @@ export function buildNextSteps(options: {
   readonly emitCommand: string;
   readonly schemaPath: string;
   /**
-   * Whether the project-level Prisma Next skills install actually ran
+   * Whether the project-level Prisma Next skill sync actually ran
    * and succeeded during this `init`. When false (the user passed
-   * `--skip-skills`, so the install was skipped), the
+   * `--skip-skills`, so the sync was skipped), the
    * "registered with your agent runtime" step is omitted — the skip is
    * already surfaced in the warnings array with a manual-install hint.
    */

--- a/packages/1-framework/3-tooling/cli/src/commands/init/skill-sources.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/init/skill-sources.ts
@@ -1,43 +1,8 @@
-import type { PackageManager } from './detect-package-manager';
-
-/**
- * The agent skills ship inside the packages they describe — the `prisma-8`
- * skill travels in the `@prisma/orm-*` tarball a project installs — so init
- * no longer fetches them from anywhere. `prisma skills sync` copies them out
- * of the installed packages into the agent harnesses' skill directories;
- * init runs it once at scaffold time, and the CLI's staleness check points
- * the user back at it when the copies fall behind the installed packages.
- *
- * The package driven here is `prisma`, the same specifier init adds as a
- * development dependency: it is the package that carries the `prisma` binary
- * every piece of advice below names.
- */
-export const SKILLS_SYNC_PACKAGE = 'prisma@next';
-
-export const SKILLS_SYNC_ARGS: readonly string[] = ['skills', 'sync'];
-
-/**
- * The sync invocation as the user would type it, for the advice init prints
- * when it skips the sync or the sync fails. This runs the `prisma` binary the
- * project already has as a development dependency rather than fetching a
- * fresh copy: the installed one is the version the project pinned, and it
- * needs no network. Deno has no local-bin runner, so it names the package.
- */
-export function formatSkillSyncCommand(pm: PackageManager): string {
-  const command = ['prisma', ...SKILLS_SYNC_ARGS].join(' ');
-  switch (pm) {
-    case 'pnpm':
-      return `pnpm exec ${command}`;
-    case 'yarn':
-      return `yarn exec ${command}`;
-    case 'bun':
-      return `bun run ${command}`;
-    case 'deno':
-      return `deno run -A npm:${command}`;
-    case 'npm':
-      return `npm exec ${command}`;
-  }
-}
+// The agent skills ship inside the packages they describe — the `prisma-8`
+// skill travels in the `@prisma/orm-*` tarball a project installs — so init
+// no longer fetches or installs them from anywhere. Skills setup belongs to
+// the family-level `prisma init` command; the only skill work left in
+// `orm init` is deleting the retired directories below.
 
 // -------------------------------------------------------------------
 // Legacy file cleanup
@@ -73,9 +38,8 @@ export const RETIRED_SKILL_NAMES = [
 ] as const;
 
 /**
- * The project-level skill directories the agent harnesses read, and the ones
- * `prisma skills sync` writes into: Claude Code, Cursor, Codex (`.agents`),
- * and Windsurf.
+ * The project-level skill directories the agent harnesses read: Claude Code,
+ * Cursor, Codex (`.agents`), and Windsurf.
  */
 export const AGENT_SKILL_ROOTS = [
   '.claude/skills',
@@ -86,7 +50,7 @@ export const AGENT_SKILL_ROOTS = [
 
 /**
  * Every directory a retired skill may occupy in a consumer project. Init
- * deletes each (recursively) before running the sync.
+ * deletes each (recursively) on every run.
  */
 export function legacySkillDirs(): readonly string[] {
   return AGENT_SKILL_ROOTS.flatMap((root) => RETIRED_SKILL_NAMES.map((name) => `${root}/${name}`));

--- a/packages/1-framework/3-tooling/cli/src/commands/init/skill-sources.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/init/skill-sources.ts
@@ -7,33 +7,34 @@ import type { PackageManager } from './detect-package-manager';
  * of the installed packages into the agent harnesses' skill directories, and
  * the `postinstall` script init writes re-runs it on every later install.
  *
- * The package driven here is the unified CLI at the same specifier init adds
- * as a development dependency, so the sync runs at the version the project
- * just pinned.
+ * The package driven here is `prisma`, the same specifier init adds as a
+ * development dependency: it is the package that carries the `prisma` binary
+ * the postinstall script and every piece of advice below name.
  */
-export const SKILLS_SYNC_PACKAGE = '@prisma/cli@next';
+export const SKILLS_SYNC_PACKAGE = 'prisma@next';
 
 export const SKILLS_SYNC_ARGS: readonly string[] = ['skills', 'sync'];
 
 /**
  * The sync invocation as the user would type it, for the advice init prints
- * when it skips the sync or the sync fails. `npx`/`pnpm dlx`/`bunx` are
- * interchangeable to the user; we pick the variant that matches the rest of
- * the install step so a project consistently uses one runner.
+ * when it skips the sync or the sync fails. This runs the `prisma` binary the
+ * project already has as a development dependency rather than fetching a
+ * fresh copy: the installed one is the version the project pinned, and it
+ * needs no network. Deno has no local-bin runner, so it names the package.
  */
 export function formatSkillSyncCommand(pm: PackageManager): string {
-  const args = [SKILLS_SYNC_PACKAGE, ...SKILLS_SYNC_ARGS];
+  const command = ['prisma', ...SKILLS_SYNC_ARGS].join(' ');
   switch (pm) {
     case 'pnpm':
-      return `pnpm dlx ${args.join(' ')}`;
+      return `pnpm exec ${command}`;
     case 'yarn':
-      return `yarn dlx ${args.join(' ')}`;
+      return `yarn exec ${command}`;
     case 'bun':
-      return `bunx ${args.join(' ')}`;
+      return `bun run ${command}`;
     case 'deno':
-      return `deno run -A npm:${args.join(' ')}`;
+      return `deno run -A npm:${command}`;
     case 'npm':
-      return `npx ${args.join(' ')}`;
+      return `npm exec ${command}`;
   }
 }
 

--- a/packages/1-framework/3-tooling/cli/src/commands/init/skill-sources.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/init/skill-sources.ts
@@ -4,12 +4,13 @@ import type { PackageManager } from './detect-package-manager';
  * The agent skills ship inside the packages they describe — the `prisma-8`
  * skill travels in the `@prisma/orm-*` tarball a project installs — so init
  * no longer fetches them from anywhere. `prisma skills sync` copies them out
- * of the installed packages into the agent harnesses' skill directories, and
- * the `postinstall` script init writes re-runs it on every later install.
+ * of the installed packages into the agent harnesses' skill directories;
+ * init runs it once at scaffold time, and the CLI's staleness check points
+ * the user back at it when the copies fall behind the installed packages.
  *
  * The package driven here is `prisma`, the same specifier init adds as a
  * development dependency: it is the package that carries the `prisma` binary
- * the postinstall script and every piece of advice below name.
+ * every piece of advice below names.
  */
 export const SKILLS_SYNC_PACKAGE = 'prisma@next';
 

--- a/packages/1-framework/3-tooling/cli/src/commands/init/skill-sources.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/init/skill-sources.ts
@@ -1,157 +1,28 @@
-import { ifDefined } from '@internal/utils/defined';
-import { version as cliVersion } from '../../../package.json' with { type: 'json' };
 import type { PackageManager } from './detect-package-manager';
 
 /**
- * Default base for the GitHub-URL form `<owner>/<repo>` consumed by
- * upstream `skills add`. Each `SkillSource` joins this base with its
- * own subpath (and optional `#ref` for version-pinned clusters).
- */
-export const DEFAULT_SKILL_BASE = 'prisma/prisma';
-
-/**
- * One skill install inside the Prisma Next monorepo. The CLI emits
- * one `skills add <base>/<subpath>[#ref] --agent ... --skill <name> -y`
- * invocation per source during `init`. Every skill lives directly
- * under the `skills/` subpath; the explicit `--skill` name keeps a
- * pinned install from capturing sibling skills with a different ref
- * policy.
+ * The agent skills ship inside the packages they describe — the `prisma-8`
+ * skill travels in the `@prisma/orm-*` tarball a project installs — so init
+ * no longer fetches them from anywhere. `prisma skills sync` copies them out
+ * of the installed packages into the agent harnesses' skill directories, and
+ * the `postinstall` script init writes re-runs it on every later install.
  *
- * `ref` semantics:
- * - `cli`: pin to the CLI's own package version (lockstep with the
- *   skills' SPI). Used for the consolidated usage skill
- *   (`skills/prisma-8`), which describes the public package API
- *   and is pinned to the version of `@internal/*` currently
- *   installed in the consumer's project.
- * - `null`: no ref. The skill is installed from whatever `main` holds.
- *   No source uses this today: upgrading is a branch of the `prisma-8`
- *   skill, which is version-pinned like the rest of it.
+ * The package driven here is the unified CLI at the same specifier init adds
+ * as a development dependency, so the sync runs at the version the project
+ * just pinned.
  */
-export interface SkillSource {
-  readonly subpath: string;
-  readonly skill: string;
-  readonly ref: 'cli' | null;
-  readonly description: string;
-}
+export const SKILLS_SYNC_PACKAGE = '@prisma/cli@next';
 
-export const DEFAULT_SKILL_SOURCES: readonly SkillSource[] = [
-  {
-    subpath: 'skills',
-    skill: 'prisma-8',
-    ref: 'cli',
-    description: 'usage skill (version-locked to installed Prisma Next)',
-  },
-];
+export const SKILLS_SYNC_ARGS: readonly string[] = ['skills', 'sync'];
 
 /**
- * Test-only escape hatch for pinning the install base to a local
- * checkout. Production runs leave this unset, so installs always use
- * `DEFAULT_SKILL_BASE`.
- *
- * When set to an absolute filesystem path (typical for tests), the
- * `#ref` fragment is dropped — local-path mode in upstream's CLI does
- * not accept refs, and the local clone has whatever content the test
- * checked into it anyway. When set to anything else (e.g. a fork name
- * `myuser/prisma`), the ref policy is preserved.
+ * The sync invocation as the user would type it, for the advice init prints
+ * when it skips the sync or the sync fails. `npx`/`pnpm dlx`/`bunx` are
+ * interchangeable to the user; we pick the variant that matches the rest of
+ * the install step so a project consistently uses one runner.
  */
-function resolveAgentSkillBase(env: SkillInstallEnv): string {
-  const override = env['PRISMA_NEXT_SKILLS_BASE']?.trim();
-  return override && override.length > 0 ? override : DEFAULT_SKILL_BASE;
-}
-
-/**
- * The environment the base override is read from. The commander shell reads
- * `process.env`; the engine command reads `ctx.env`, which is the only
- * environment a handler is allowed to see.
- */
-export type SkillInstallEnv = Readonly<Record<string, string | undefined>>;
-
-function isLocalPath(base: string): boolean {
-  return base.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(base);
-}
-
-/** Agent slugs accepted by the upstream `skills add --agent` flag. */
-export type SkillAgent = 'cursor' | 'claude-code' | 'codex' | 'windsurf';
-
-/**
- * Agents passed to every project-level init install. Upstream `skills add`
- * is the source of truth for per-agent install behaviour; the CLI lists
- * every supported runtime on one invocation and delegates the rest.
- */
-export const DEFAULT_SKILL_AGENTS: readonly SkillAgent[] = [
-  'cursor',
-  'claude-code',
-  'codex',
-  'windsurf',
-];
-
-/**
- * Build the `<base>/<subpath>[#ref]` URL the `skills` CLI will
- * resolve. Exported for unit tests so the per-source format can be
- * asserted without going through the full install loop.
- */
-export function formatSkillSourceUrl(
-  source: SkillSource,
-  env: SkillInstallEnv = process.env,
-): string {
-  const base = resolveAgentSkillBase(env);
-  const url = `${base}/${source.subpath}`;
-  if (source.ref === null) return url;
-  if (isLocalPath(base)) return url;
-  if (source.ref === 'cli') return `${url}#v${cliVersion}`;
-  return url;
-}
-
-/**
- * The skill-install command for one source, formatted for the
- * project's detected package manager. `npx`/`pnpm dlx`/`bunx` are
- * interchangeable to the user; we pick the variant that matches the
- * rest of the install step so a single project consistently uses one
- * runner.
- *
- * `--agent` takes space-separated slugs on one flag; the explicit
- * `--skill <name>` and `-y` skip the multi-select prompts a
- * non-interactive scaffold step cannot show.
- *
- * Exported for unit tests so the per-PM dispatch can be asserted
- * without a live subprocess.
- */
-export function formatSkillInstallCommand(args: {
-  readonly pm: PackageManager;
-  readonly source: SkillSource;
-  readonly agents?: readonly SkillAgent[];
-  /** The environment the base override is read from; the engine command has its own. */
-  readonly env?: SkillInstallEnv;
-}): string {
-  const agents = args.agents ?? DEFAULT_SKILL_AGENTS;
-  const cliArgs = [
-    'skills@latest',
-    'add',
-    formatSkillSourceUrl(args.source, args.env),
-    '--agent',
-    ...agents,
-    '--skill',
-    args.source.skill,
-    '-y',
-  ];
-  return formatPackageManagerCommand(args.pm, cliArgs);
-}
-
-/**
- * Ordered skill-install commands for one init run. This is both what the
- * commander shell runs and what either shell tells the user to run when the
- * install is skipped or fails — the commands need no scaffold and no `init`.
- */
-export function resolveProjectSkillInstallCommands(
-  pm: PackageManager,
-  env?: SkillInstallEnv,
-): readonly string[] {
-  return DEFAULT_SKILL_SOURCES.map((source) =>
-    formatSkillInstallCommand({ pm, source, ...ifDefined('env', env) }),
-  );
-}
-
-function formatPackageManagerCommand(pm: PackageManager, args: readonly string[]): string {
+export function formatSkillSyncCommand(pm: PackageManager): string {
+  const args = [SKILLS_SYNC_PACKAGE, ...SKILLS_SYNC_ARGS];
   switch (pm) {
     case 'pnpm':
       return `pnpm dlx ${args.join(' ')}`;
@@ -171,16 +42,15 @@ function formatPackageManagerCommand(pm: PackageManager, args: readonly string[]
 // -------------------------------------------------------------------
 
 /**
- * Skill directories that predate the consolidated `prisma-8` skill:
- * the per-workflow usage cluster (including the renamed
+ * Skill directories that predate the consolidated `prisma-8` skill: the
+ * per-workflow usage cluster (including the renamed
  * `prisma-8-migration-review` spelling it briefly shipped under), the
- * pre-rename spellings of the consolidated skill and the
- * extension-author upgrade skill, any hand-rolled `prisma-next` stub,
- * and the two standalone upgrade skills that folded into the
- * `prisma-8` router. Projects initialised before the consolidation carry these as
- * sibling directories in each agent's install root; left in place
- * they compete with the current skills for activation, so init
- * removes them on every run.
+ * pre-rename spellings of the consolidated skill and the extension-author
+ * upgrade skill, any hand-rolled `prisma-next` stub, and the two standalone
+ * upgrade skills that folded into the `prisma-8` router. Projects initialised
+ * before those changes carry these as sibling directories in each agent's
+ * install root; left in place they compete with the current skill for
+ * activation, so init removes them on every run.
  */
 export const RETIRED_SKILL_NAMES = [
   'prisma-next',
@@ -201,26 +71,21 @@ export const RETIRED_SKILL_NAMES = [
 ] as const;
 
 /**
- * Project-level install roots the upstream `skills` CLI uses for the
- * agents in `DEFAULT_SKILL_AGENTS`: cursor and codex install into
- * `.agents/skills`, claude-code into `.claude/skills`, windsurf into
- * `.windsurf/skills`.
+ * The project-level skill directories the agent harnesses read, and the ones
+ * `prisma skills sync` writes into: Claude Code, Cursor, Codex (`.agents`),
+ * and Windsurf.
  */
-export const AGENT_SKILL_ROOTS = ['.agents/skills', '.claude/skills', '.windsurf/skills'] as const;
+export const AGENT_SKILL_ROOTS = [
+  '.claude/skills',
+  '.cursor/skills',
+  '.agents/skills',
+  '.windsurf/skills',
+] as const;
 
 /**
- * Every directory a retired per-workflow skill may occupy in a
- * consumer project. Init deletes each (recursively) before running the
- * skill install. Names that are also in `DEFAULT_SKILL_SOURCES` are
- * excluded so a list mistake can never delete a skill init installs
- * (or one `--skip-skills` preserves) — see TML-2637.
+ * Every directory a retired skill may occupy in a consumer project. Init
+ * deletes each (recursively) before running the sync.
  */
-export function legacySkillDirs(
-  retired: readonly string[] = RETIRED_SKILL_NAMES,
-  sources: readonly SkillSource[] = DEFAULT_SKILL_SOURCES,
-): readonly string[] {
-  const installed = new Set<string>(sources.map((source) => source.skill));
-  return AGENT_SKILL_ROOTS.flatMap((root) =>
-    retired.filter((name) => !installed.has(name)).map((name) => `${root}/${name}`),
-  );
+export function legacySkillDirs(): readonly string[] {
+  return AGENT_SKILL_ROOTS.flatMap((root) => RETIRED_SKILL_NAMES.map((name) => `${root}/${name}`));
 }

--- a/packages/1-framework/3-tooling/cli/src/commands/init/templates/quick-reference-mongo.md
+++ b/packages/1-framework/3-tooling/cli/src/commands/init/templates/quick-reference-mongo.md
@@ -112,6 +112,6 @@ The ORM covers the common cases. For the rest, two escape hatches are designed i
 
 If this project lives inside a pnpm workspace, a few things are worth knowing:
 
-- **Catalogs.** When the workspace's `pnpm-workspace.yaml` defines a `catalogs` entry for `@prisma/cli` or `{{pkg}}`, pnpm uses the catalog version everywhere — `init` does too. If you wanted the published `latest` instead, update or remove the catalog entry, then re-run `pnpm install`.
-- **`pnpm dlx`.** `pnpm dlx @prisma/cli@next init …` works in any directory. Inside a workspace, pnpm still resolves dependencies through the workspace's catalog/overrides rather than the registry; expect the installed Prisma Next packages to reflect the workspace's catalog rather than `latest`.
+- **Catalogs.** When the workspace's `pnpm-workspace.yaml` defines a `catalogs` entry for `prisma` or `{{pkg}}`, pnpm uses the catalog version everywhere — `init` does too. If you wanted the published `latest` instead, update or remove the catalog entry, then re-run `pnpm install`.
+- **`pnpm dlx`.** `pnpm dlx prisma@next orm init …` works in any directory. Inside a workspace, pnpm still resolves dependencies through the workspace's catalog/overrides rather than the registry; expect the installed Prisma Next packages to reflect the workspace's catalog rather than `latest`.
 - **`pnpm` → `npm` fallback.** If `pnpm` ever fails to install Prisma Next with a `workspace:*` or `catalog:` resolution error (a leak in a published artefact), `init` falls back to `npm install` and surfaces a warning. Once the offending package republishes a clean version you can switch back with `pnpm install`.

--- a/packages/1-framework/3-tooling/cli/src/commands/init/templates/quick-reference-postgres.md
+++ b/packages/1-framework/3-tooling/cli/src/commands/init/templates/quick-reference-postgres.md
@@ -91,6 +91,6 @@ You can customize how your environment variables are loaded by changing or remov
 
 If this project lives inside a pnpm workspace, a few things are worth knowing:
 
-- **Catalogs.** When the workspace's `pnpm-workspace.yaml` defines a `catalogs` entry for `@prisma/cli` or `{{pkg}}`, pnpm uses the catalog version everywhere — `init` does too. If you wanted the published `latest` instead, update or remove the catalog entry, then re-run `pnpm install`.
-- **`pnpm dlx`.** `pnpm dlx @prisma/cli@next init …` works in any directory. Inside a workspace, pnpm still resolves dependencies through the workspace's catalog/overrides rather than the registry; expect the installed Prisma Next packages to reflect the workspace's catalog rather than `latest`.
+- **Catalogs.** When the workspace's `pnpm-workspace.yaml` defines a `catalogs` entry for `prisma` or `{{pkg}}`, pnpm uses the catalog version everywhere — `init` does too. If you wanted the published `latest` instead, update or remove the catalog entry, then re-run `pnpm install`.
+- **`pnpm dlx`.** `pnpm dlx prisma@next orm init …` works in any directory. Inside a workspace, pnpm still resolves dependencies through the workspace's catalog/overrides rather than the registry; expect the installed Prisma Next packages to reflect the workspace's catalog rather than `latest`.
 - **`pnpm` → `npm` fallback.** If `pnpm` ever fails to install Prisma Next with a `workspace:*` or `catalog:` resolution error (a leak in a published artefact), `init` falls back to `npm install` and surfaces a warning. Once the offending package republishes a clean version you can switch back with `pnpm install`.

--- a/packages/1-framework/3-tooling/cli/src/commands/init/templates/quick-reference.ts
+++ b/packages/1-framework/3-tooling/cli/src/commands/init/templates/quick-reference.ts
@@ -43,7 +43,7 @@ export function quickReferenceMd(
     pkg,
     configEntrypoint: targetEntrypoint(target, 'config', resolveImportSpecifier),
     schemaSample: schemaSample(target, authoring, resolveImportSpecifier),
-    requirements: requirementsBlock(target),
+    requirements: requirementsBlock(target, pkgRun),
   };
   const templateFile = `quick-reference-${target}.md`;
   return renderTemplate(templateFile, variables, vars);
@@ -60,7 +60,7 @@ export function quickReferenceMd(
  * shouldn't ship Mongo's `db.runCommand` (and vice versa) just because
  * we couldn't be bothered to branch.
  */
-function requirementsBlock(target: TargetId): string {
+function requirementsBlock(target: TargetId, pkgRun: string): string {
   const label = TARGET_LABEL[target];
   const minVersion = MIN_SERVER_VERSION[target];
   const verifyCommand =
@@ -69,6 +69,6 @@ function requirementsBlock(target: TargetId): string {
     '## Requirements',
     '',
     `- **${label} ${minVersion} or newer.** Older servers are not supported. Run ${verifyCommand} against your server to verify.`,
-    '- The CLI never connects to your database without explicit consent. Pass `--probe-db` to `prisma orm init` if you want `init` to verify the server version itself.',
+    `- The CLI never connects to your database without explicit consent. Pass \`--probe-db\` to \`${pkgRun} orm init\` if you want \`init\` to verify the server version itself.`,
   ].join('\n');
 }

--- a/packages/1-framework/3-tooling/cli/src/orm/init-blocks.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/init-blocks.ts
@@ -43,7 +43,6 @@ function scaffoldTree(document: InitOutput): Block {
 export function buildInitNextActions(inputs: {
   readonly contractEmitted: boolean;
   readonly schemaPath: string;
-  readonly skillRegistered: boolean;
 }): readonly NextAction[] {
   const actions: NextAction[] = [
     chooseAction('Set DATABASE_URL in your environment (export it or add it to .env)'),
@@ -58,13 +57,9 @@ export function buildInitNextActions(inputs: {
   actions.push(
     chooseAction('Open prisma-next.md for a quick reference on writing your first typed query'),
   );
-  if (inputs.skillRegistered) {
-    actions.push(
-      chooseAction(
-        'Prisma Next skills are registered with your agent runtime — ask it to add a model, run a query, or plan a migration',
-      ),
-    );
-  }
+  actions.push(
+    runCommandAction('Set up the Prisma agent skills for your coding agent', 'prisma init'),
+  );
   return actions;
 }
 

--- a/packages/1-framework/3-tooling/cli/src/orm/init-diagnostics.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/init-diagnostics.ts
@@ -3,7 +3,7 @@ import type { CliStructuredError, Diagnostic, NextAction } from '@prisma/cli-eng
 import { chooseAction, runCommandAction } from '../utils/next-actions';
 
 /** The invocation that finishes what a failed `init` phase started. */
-export const EMIT_COMMAND = 'prisma-cli contract emit';
+export const EMIT_COMMAND = 'prisma contract emit';
 
 /**
  * The command's own record of a phase that failed after the scaffold was

--- a/packages/1-framework/3-tooling/cli/src/orm/init-diagnostics.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/init-diagnostics.ts
@@ -61,26 +61,3 @@ export function emitFailedFinding(cause: string, filesWritten: readonly string[]
     meta: { filesWritten, cause },
   });
 }
-
-/**
- * An agent-skill install failed; the project itself is complete without it.
- * The remedy is the skill-install commands themselves, which run against any
- * directory — advising a re-run of `init` would put the user's schema at risk
- * to fix something `init` no longer needs to be involved in.
- */
-export function skillInstallFailedFinding(
-  failure: CliStructuredError,
-  filesWritten: readonly string[],
-  skillCommands: readonly string[],
-): Diagnostic {
-  return initFinding('CLI.INIT_SKILL_INSTALL_FAILED', 'Failed to install Prisma Next skills', {
-    why: failure.why ?? failure.message,
-    nextActions: [
-      ...failure.nextActions,
-      ...skillCommands.map((command) =>
-        runCommandAction('Install the Prisma Next skills', command),
-      ),
-    ],
-    meta: { filesWritten, skillInstall: failure.meta ?? {} },
-  });
-}

--- a/packages/1-framework/3-tooling/cli/src/orm/init-emit.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/init-emit.ts
@@ -9,7 +9,7 @@ const STDERR_TAIL_LINES = 20;
 /**
  * Test-only seam for the manifest resolution, mirroring probe-db's
  * `requireFromBaseDir`: vitest wraps `createRequire` so resolution never
- * fails under test even when the project has no `@prisma/cli` installed.
+ * fails under test even when the project has no `prisma` installed.
  * Production callers omit it.
  */
 export interface EmitOverrides {
@@ -18,7 +18,7 @@ export interface EmitOverrides {
 
 /**
  * Emits the contract for the project `init` has just scaffolded, by spawning
- * the project-local `prisma-cli` binary the install step put into
+ * the project-local `prisma` binary the install step put into
  * `node_modules`. That binary and the installed `defineConfig` come from the
  * same registry release, so the config loader that evaluates
  * `prisma.config.ts` always matches the config format it was written
@@ -38,7 +38,7 @@ export async function emitScaffoldedContract(
       result.exitCode === null
         ? `was killed by signal ${result.signal ?? 'unknown'}`
         : `exited with code ${result.exitCode}`;
-    throw new Error(`\`prisma-cli contract emit\` ${cause}: ${redactSecrets(tail(output))}`);
+    throw new Error(`\`prisma contract emit\` ${cause}: ${redactSecrets(tail(output))}`);
   }
 }
 
@@ -49,10 +49,10 @@ function resolveProjectBin(cwd: string, overrides: EmitOverrides): string {
       createRequire(join(baseDir, 'package.json')).resolve(specifier));
   let manifestPath: string;
   try {
-    manifestPath = resolveFromBaseDir(cwd, '@prisma/cli/package.json');
+    manifestPath = resolveFromBaseDir(cwd, 'prisma/package.json');
   } catch (error) {
     throw new Error(
-      `\`@prisma/cli\` is not installed in this project (resolved from ${cwd}; cause: ${causeMessage(error)})`,
+      `\`prisma\` is not installed in this project (resolved from ${cwd}; cause: ${causeMessage(error)})`,
     );
   }
   let manifest: unknown;
@@ -60,7 +60,7 @@ function resolveProjectBin(cwd: string, overrides: EmitOverrides): string {
     manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
   } catch (error) {
     throw new Error(
-      `the installed @prisma/cli manifest at ${manifestPath} is not valid JSON: ${causeMessage(error)}`,
+      `the installed prisma manifest at ${manifestPath} is not valid JSON: ${causeMessage(error)}`,
     );
   }
   const bin =
@@ -69,11 +69,11 @@ function resolveProjectBin(cwd: string, overrides: EmitOverrides): string {
     typeof bin === 'string'
       ? bin
       : bin !== null && typeof bin === 'object'
-        ? Reflect.get(bin, 'prisma-cli')
+        ? Reflect.get(bin, 'prisma')
         : undefined;
   if (typeof binEntry !== 'string') {
     throw new Error(
-      `the installed @prisma/cli package at ${dirname(manifestPath)} declares no \`prisma-cli\` bin`,
+      `the installed prisma package at ${dirname(manifestPath)} declares no \`prisma\` bin`,
     );
   }
   return join(dirname(manifestPath), binEntry);
@@ -100,7 +100,7 @@ function runCaptured(
       stderr += chunk.toString('utf-8');
     });
     child.on('error', (error) => {
-      reject(new Error(`could not run the project-local prisma-cli binary: ${error.message}`));
+      reject(new Error(`could not run the project-local prisma binary: ${error.message}`));
     });
     child.on('close', (code, signal) => {
       resolve({ exitCode: code, signal, stdout, stderr });

--- a/packages/1-framework/3-tooling/cli/src/orm/init-inputs.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/init-inputs.ts
@@ -26,7 +26,6 @@ export interface InitFlagValues {
   readonly probeDb: boolean;
   readonly strictProbe: boolean;
   readonly skipInstall: boolean;
-  readonly skipSkills: boolean;
   readonly keepPreviousFacade: boolean;
 }
 
@@ -47,7 +46,6 @@ export interface ResolvedInitInputs {
    * user kept it.
    */
   readonly removePreviousFacade: string | null;
-  readonly installProjectSkill: boolean;
 }
 
 const REQUIRED_FLAG_PROMPTS = new Set(['target', 'authoring']);
@@ -252,6 +250,5 @@ export async function resolveInitInputs(ctx: {
     strictProbe: flags.strictProbe,
     reinit,
     removePreviousFacade,
-    installProjectSkill: !flags.skipSkills,
   };
 }

--- a/packages/1-framework/3-tooling/cli/src/orm/init-packages.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/init-packages.ts
@@ -5,7 +5,6 @@ import type { CliStructuredError } from '@prisma/cli-engine/protocol';
 import { join } from 'pathe';
 import { isRecognisedPnpmResolutionError } from '../commands/init/pnpm-fallback';
 import { redactSecrets } from '../commands/init/redact-secrets';
-import { SKILLS_SYNC_ARGS, SKILLS_SYNC_PACKAGE } from '../commands/init/skill-sources';
 
 /** What one install pair produced, and which manager finished it. */
 export interface InstallOutcome {
@@ -13,7 +12,7 @@ export interface InstallOutcome {
   readonly failure: CliStructuredError | undefined;
   /**
    * The manager override that succeeded, when the pnpm fallback fired. The
-   * agent-skill install reuses it: driving `pnpm dlx` right after `pnpm add`
+   * follow-up engine install reuses it: driving pnpm right after `pnpm add`
    * failed to resolve a workspace specifier would fail the same way.
    */
   readonly manager: PackageManagerId | undefined;
@@ -146,25 +145,4 @@ export async function installProjectDependencies(ctx: {
   // npm bypassed pnpm's resolver, so the workspace catalog is not what ended
   // up installed — saying otherwise alongside the fallback would contradict it.
   return { failure: undefined, manager: 'npm', warnings: [fallbackWarning(failure)] };
-}
-
-/**
- * Copies the agent skills out of the packages that just installed into the
- * project's agent-harness directories, by running the unified CLI's own
- * `skills sync`. Sync exits 0 when there is nothing to do, so a failure here
- * is the run itself failing — a missing runner, an unreachable registry —
- * rather than a project with no skills to sync.
- */
-export async function syncAgentSkills(ctx: {
-  readonly packages: PackageOperations;
-  readonly cwd: string;
-  readonly manager: PackageManagerId | undefined;
-}): Promise<CliStructuredError | undefined> {
-  const result = await ctx.packages.run({
-    package: SKILLS_SYNC_PACKAGE,
-    args: SKILLS_SYNC_ARGS,
-    cwd: ctx.cwd,
-    ...ifDefined('manager', ctx.manager),
-  });
-  return result.ok ? undefined : result.failure;
 }

--- a/packages/1-framework/3-tooling/cli/src/orm/init-packages.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/init-packages.ts
@@ -5,12 +5,7 @@ import type { CliStructuredError } from '@prisma/cli-engine/protocol';
 import { join } from 'pathe';
 import { isRecognisedPnpmResolutionError } from '../commands/init/pnpm-fallback';
 import { redactSecrets } from '../commands/init/redact-secrets';
-import {
-  DEFAULT_SKILL_AGENTS,
-  DEFAULT_SKILL_SOURCES,
-  formatSkillSourceUrl,
-  type SkillInstallEnv,
-} from '../commands/init/skill-sources';
+import { SKILLS_SYNC_ARGS, SKILLS_SYNC_PACKAGE } from '../commands/init/skill-sources';
 
 /** What one install pair produced, and which manager finished it. */
 export interface InstallOutcome {
@@ -153,31 +148,23 @@ export async function installProjectDependencies(ctx: {
   return { failure: undefined, manager: 'npm', warnings: [fallbackWarning(failure)] };
 }
 
-function skillArgs(url: string, skill: string): readonly string[] {
-  return ['add', url, '--agent', ...DEFAULT_SKILL_AGENTS, '--skill', skill, '-y'];
-}
-
 /**
- * Registers every Prisma Next skill with the agent runtimes, in order. The
- * first failure stops the loop: the user opted into Prisma Next by running
- * `init`, and a half-installed skill set leaves the project ambiguous.
+ * Copies the agent skills out of the packages that just installed into the
+ * project's agent-harness directories, by running the unified CLI's own
+ * `skills sync`. Sync exits 0 when there is nothing to do, so a failure here
+ * is the run itself failing — a missing runner, an unreachable registry —
+ * rather than a project with no skills to sync.
  */
-export async function installAgentSkills(ctx: {
+export async function syncAgentSkills(ctx: {
   readonly packages: PackageOperations;
   readonly cwd: string;
-  readonly env: SkillInstallEnv;
   readonly manager: PackageManagerId | undefined;
 }): Promise<CliStructuredError | undefined> {
-  for (const source of DEFAULT_SKILL_SOURCES) {
-    const result = await ctx.packages.run({
-      package: 'skills@latest',
-      args: skillArgs(formatSkillSourceUrl(source, ctx.env), source.skill),
-      cwd: ctx.cwd,
-      ...ifDefined('manager', ctx.manager),
-    });
-    if (!result.ok) {
-      return result.failure;
-    }
-  }
-  return undefined;
+  const result = await ctx.packages.run({
+    package: SKILLS_SYNC_PACKAGE,
+    args: SKILLS_SYNC_ARGS,
+    cwd: ctx.cwd,
+    ...ifDefined('manager', ctx.manager),
+  });
+  return result.ok ? undefined : result.failure;
 }

--- a/packages/1-framework/3-tooling/cli/src/orm/init-packages.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/init-packages.ts
@@ -75,7 +75,7 @@ function retriedWarning(failure: CliStructuredError): string {
 /**
  * The engine dependency spec a fresh scaffold installs. The scaffolded
  * `prisma.config.ts` imports `defineConfig` from `@prisma/cli-engine`, and the
- * installed `@prisma/cli` names the exact engine version it runs against — so
+ * installed `prisma` names the exact engine version it runs against — so
  * the spec is read from the manifest the install just placed, never guessed
  * from a dist-tag (whose `latest` has lagged that version before and broken
  * the very next command). A CLI without a readable engine entry falls back to
@@ -84,7 +84,7 @@ function retriedWarning(failure: CliStructuredError): string {
 export function engineDevDependencySpec(cwd: string): string {
   try {
     const manifest: unknown = JSON.parse(
-      readFileSync(join(cwd, 'node_modules', '@prisma', 'cli', 'package.json'), 'utf-8'),
+      readFileSync(join(cwd, 'node_modules', 'prisma', 'package.json'), 'utf-8'),
     );
     if (typeof manifest === 'object' && manifest !== null) {
       for (const field of ['dependencies', 'peerDependencies'] as const) {

--- a/packages/1-framework/3-tooling/cli/src/orm/init-scaffold.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/init-scaffold.ts
@@ -13,11 +13,16 @@ import {
   mergeGitattributes,
   requiredGitattributesLines,
 } from '../commands/init/hygiene-gitattributes';
-import { mergeGitignore } from '../commands/init/hygiene-gitignore';
+import {
+  mergeGitignore,
+  REQUIRED_GITIGNORE_ENTRIES,
+  SYNCED_SKILL_GITIGNORE_ENTRIES,
+} from '../commands/init/hygiene-gitignore';
 import {
   ensureEsmModuleType,
   mergePackageScripts,
   REQUIRED_SCRIPTS,
+  SKILLS_SYNC_SCRIPT,
 } from '../commands/init/hygiene-package-scripts';
 import { findStaleArtifacts, removeDependency } from '../commands/init/reinit-cleanup';
 import { legacySkillDirs } from '../commands/init/skill-sources';
@@ -243,9 +248,16 @@ function planScaffold(ctx: {
     files.push({ path: 'tsconfig.json', content: defaultTsConfig() });
   }
 
+  // The synced skill copies are only this project's business when init is the
+  // one putting them there; `--skip-skills` leaves both the sync and the lines
+  // that would describe its output out of the project.
+  const gitignoreEntries = inputs.installProjectSkill
+    ? [...REQUIRED_GITIGNORE_ENTRIES, ...SYNCED_SKILL_GITIGNORE_ENTRIES]
+    : REQUIRED_GITIGNORE_ENTRIES;
   const gitignorePath = join(cwd, '.gitignore');
   const nextGitignore = mergeGitignore(
     existsSync(gitignorePath) ? readFileSync(gitignorePath, 'utf-8') : undefined,
+    gitignoreEntries,
   );
   if (nextGitignore !== null) {
     files.push({ path: '.gitignore', content: nextGitignore });
@@ -288,7 +300,7 @@ function planScaffold(ctx: {
     }
     const { content: withScripts, warnings: scriptWarnings } = mergePackageScripts(
       working,
-      REQUIRED_SCRIPTS,
+      inputs.installProjectSkill ? [...REQUIRED_SCRIPTS, SKILLS_SYNC_SCRIPT] : REQUIRED_SCRIPTS,
     );
     if (withScripts !== null) {
       working = withScripts;

--- a/packages/1-framework/3-tooling/cli/src/orm/init-scaffold.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/init-scaffold.ts
@@ -183,7 +183,7 @@ function planScaffold(ctx: {
   const configContractPath = isAbsolute(inputs.schemaPath)
     ? inputs.schemaPath
     : `./${inputs.schemaPath}`;
-  const runPrefix = formatRunCommand(packageManager, 'prisma-cli', '').trimEnd();
+  const runPrefix = formatRunCommand(packageManager, 'prisma', '').trimEnd();
 
   const files: FileEntry[] = [
     {

--- a/packages/1-framework/3-tooling/cli/src/orm/init-scaffold.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/init-scaffold.ts
@@ -13,17 +13,8 @@ import {
   mergeGitattributes,
   requiredGitattributesLines,
 } from '../commands/init/hygiene-gitattributes';
-import {
-  mergeGitignore,
-  REQUIRED_GITIGNORE_ENTRIES,
-  SYNCED_SKILL_GITIGNORE_ENTRIES,
-} from '../commands/init/hygiene-gitignore';
-import {
-  ensureEsmModuleType,
-  mergePackageScripts,
-  REQUIRED_SCRIPTS,
-  SKILLS_SYNC_SCRIPT,
-} from '../commands/init/hygiene-package-scripts';
+import { mergeGitignore } from '../commands/init/hygiene-gitignore';
+import { ensureEsmModuleType, mergePackageScripts } from '../commands/init/hygiene-package-scripts';
 import { findStaleArtifacts, removeDependency } from '../commands/init/reinit-cleanup';
 import { legacySkillDirs } from '../commands/init/skill-sources';
 import {
@@ -248,16 +239,9 @@ function planScaffold(ctx: {
     files.push({ path: 'tsconfig.json', content: defaultTsConfig() });
   }
 
-  // The synced skill copies are only this project's business when init is the
-  // one putting them there; `--skip-skills` leaves both the sync and the lines
-  // that would describe its output out of the project.
-  const gitignoreEntries = inputs.installProjectSkill
-    ? [...REQUIRED_GITIGNORE_ENTRIES, ...SYNCED_SKILL_GITIGNORE_ENTRIES]
-    : REQUIRED_GITIGNORE_ENTRIES;
   const gitignorePath = join(cwd, '.gitignore');
   const nextGitignore = mergeGitignore(
     existsSync(gitignorePath) ? readFileSync(gitignorePath, 'utf-8') : undefined,
-    gitignoreEntries,
   );
   if (nextGitignore !== null) {
     files.push({ path: '.gitignore', content: nextGitignore });
@@ -298,10 +282,7 @@ function planScaffold(ctx: {
         changed = true;
       }
     }
-    const { content: withScripts, warnings: scriptWarnings } = mergePackageScripts(
-      working,
-      inputs.installProjectSkill ? [...REQUIRED_SCRIPTS, SKILLS_SYNC_SCRIPT] : REQUIRED_SCRIPTS,
-    );
+    const { content: withScripts, warnings: scriptWarnings } = mergePackageScripts(working);
     if (withScripts !== null) {
       working = withScripts;
       changed = true;

--- a/packages/1-framework/3-tooling/cli/src/orm/init.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/init.ts
@@ -147,8 +147,8 @@ export const createInitCommand = (injected: InitCommandDependencies) =>
       // The CLI the scaffolded scripts run is `prisma`, the unified CLI's
       // published name, whose v8 line publishes under the `next` dist-tag (the
       // `prisma-next` shim is no longer published). It is the package that
-      // carries the `prisma` binary, which is what the scaffolded scripts and
-      // the postinstall skills sync invoke. `@prisma/cli-engine` — the config file's
+      // carries the `prisma` binary, which is what the scaffolded scripts
+      // invoke. `@prisma/cli-engine` — the config file's
       // defineConfig import — is deliberately absent here: the CLI declares it
       // as an exact peer, so it installs in a second step at the version the
       // just-installed CLI names. Under moduleResolution 'bundler' the
@@ -317,12 +317,11 @@ export const createInitCommand = (injected: InitCommandDependencies) =>
         if (failure === undefined) {
           skillRegistered = true;
         } else {
-          // A failed first sync is not a failed init: the postinstall script
-          // this run wrote re-runs the sync on the next install, and every
-          // `prisma` command reports skills that do not match the installed
-          // packages. The project converges without anyone doing anything.
+          // A failed first sync is not a failed init: every `prisma` command
+          // reports skills that do not match the installed packages, so the
+          // user is pointed back at the sync the next time they run anything.
           warn(
-            `Could not sync the Prisma Next agent skills: ${failure.why ?? failure.message}\nThe postinstall script will retry on the next install, or run it now: \`${syncCommand}\``,
+            `Could not sync the Prisma Next agent skills: ${failure.why ?? failure.message}\nRun it again: \`${syncCommand}\``,
           );
         }
       } else {

--- a/packages/1-framework/3-tooling/cli/src/orm/init.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/init.ts
@@ -144,16 +144,18 @@ export const createInitCommand = (injected: InitCommandDependencies) =>
       }
 
       const deps = [targetPackageName(inputs.target, scaffold.resolveImportSpecifier), 'dotenv'];
-      // The CLI the scaffolded scripts run is the unified `@prisma/cli`, whose
-      // v8 line publishes under the `next` dist-tag (the `prisma-next` shim is
-      // no longer published). `@prisma/cli-engine` — the config file's
+      // The CLI the scaffolded scripts run is `prisma`, the unified CLI's
+      // published name, whose v8 line publishes under the `next` dist-tag (the
+      // `prisma-next` shim is no longer published). It is the package that
+      // carries the `prisma` binary, which is what the scaffolded scripts and
+      // the postinstall skills sync invoke. `@prisma/cli-engine` — the config file's
       // defineConfig import — is deliberately absent here: the CLI declares it
       // as an exact peer, so it installs in a second step at the version the
       // just-installed CLI names. Under moduleResolution 'bundler' the
       // scaffolded files reference process.env, which only typechecks with
       // Node's ambient types present; a project that already pins @types/node
       // keeps its own major.
-      const cliDevDeps = ['@prisma/cli@next'];
+      const cliDevDeps = ['prisma@next'];
       const devDeps: string[] = scaffold.hasTypesNode ? cliDevDeps : [...cliDevDeps, '@types/node'];
 
       const findings: Diagnostic[] = [];
@@ -270,7 +272,7 @@ export const createInitCommand = (injected: InitCommandDependencies) =>
       } else {
         extraActions.push(
           chooseAction(
-            `Install the project dependencies with your package manager: ${deps.join(', ')} (and ${devDeps.join(', ')} plus @prisma/cli-engine at the version @prisma/cli declares as its peer, as development dependencies)`,
+            `Install the project dependencies with your package manager: ${deps.join(', ')} (and ${devDeps.join(', ')} plus @prisma/cli-engine at the version prisma declares as its dependency, as development dependencies)`,
           ),
         );
       }

--- a/packages/1-framework/3-tooling/cli/src/orm/init.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/init.ts
@@ -14,24 +14,19 @@ import {
   type InstallStatus,
 } from '../commands/init/output';
 import { type ProbeOutcome, probeServerVersion } from '../commands/init/probe-db';
-import { resolveProjectSkillInstallCommands } from '../commands/init/skill-sources';
+import { formatSkillSyncCommand } from '../commands/init/skill-sources';
 import { targetPackageName } from '../commands/init/templates/code-templates';
 import { MIN_SERVER_VERSION } from '../commands/init/templates/env';
 import { chooseAction } from '../utils/next-actions';
 import { defineOrmCommand } from './define-command';
 import { buildInitNextActions, initPresentations } from './init-blocks';
-import {
-  EMIT_COMMAND,
-  emitFailedFinding,
-  installFailedFinding,
-  skillInstallFailedFinding,
-} from './init-diagnostics';
+import { EMIT_COMMAND, emitFailedFinding, installFailedFinding } from './init-diagnostics';
 import { emitScaffoldedContract } from './init-emit';
 import { resolveInitInputs } from './init-inputs';
 import {
   engineDevDependencySpec,
-  installAgentSkills,
   installProjectDependencies,
+  syncAgentSkills,
 } from './init-packages';
 import { resolveScaffoldPackageManager, scaffoldProject } from './init-scaffold';
 import { normalizeError } from './normalize-error';
@@ -40,7 +35,6 @@ import { normalizeError } from './normalize-error';
 const INIT_EXIT_CODES = {
   4: 'scaffold written; dependency install failed',
   5: 'scaffold written and installed; contract emit failed',
-  6: 'scaffold complete; agent-skill install failed',
 } as const;
 
 function probeWarning(
@@ -119,7 +113,7 @@ export const createInitCommand = (injected: InitCommandDependencies) =>
         }),
         strictProbe: flag.boolean({ brief: 'Treat a failed --probe-db as fatal' }),
         skipInstall: flag.boolean({ brief: 'Skip dependency installation and contract emission' }),
-        skipSkills: flag.boolean({ brief: 'Skip the Prisma Next agent-skill install' }),
+        skipSkills: flag.boolean({ brief: 'Skip the Prisma Next agent-skill sync' }),
         keepPreviousFacade: flag.boolean({
           brief: 'Keep the previous target package in package.json when switching targets',
         }),
@@ -169,7 +163,7 @@ export const createInitCommand = (injected: InitCommandDependencies) =>
       let contractEmitted = false;
       let skillRegistered = false;
 
-      const settle = (exitCode: 0 | 4 | 5 | 6) => {
+      const settle = (exitCode: 0 | 4 | 5) => {
         const installed = packagesInstalled === 'installed';
         const document: InitOutput = {
           ok: true,
@@ -306,30 +300,32 @@ export const createInitCommand = (injected: InitCommandDependencies) =>
         }
       }
 
-      // The skills install through the same manager the dependencies did, and
-      // needs no scaffold, so the commands stand alone: whether it is skipped or
-      // fails, what the user is told to run is the install itself — never `init`
+      // The sync runs through the same manager the dependencies did, and needs
+      // no scaffold, so the command stands alone: whether it is skipped or
+      // fails, what the user is told to run is the sync itself — never `init`
       // again, which would re-scaffold over the schema they have since written.
-      const skillCommands = resolveProjectSkillInstallCommands(
-        installedManager ?? packageManager,
-        ctx.env,
-      );
+      const syncCommand = formatSkillSyncCommand(installedManager ?? packageManager);
 
       if (inputs.installProjectSkill) {
-        const failure = await installAgentSkills({
+        const failure = await syncAgentSkills({
           packages: ctx.packages,
           cwd: ctx.cwd,
-          env: ctx.env,
           manager: installedManager,
         });
-        if (failure !== undefined) {
-          findings.push(skillInstallFailedFinding(failure, scaffold.filesWritten, skillCommands));
-          return settle(6);
+        if (failure === undefined) {
+          skillRegistered = true;
+        } else {
+          // A failed first sync is not a failed init: the postinstall script
+          // this run wrote re-runs the sync on the next install, and every
+          // `prisma` command reports skills that do not match the installed
+          // packages. The project converges without anyone doing anything.
+          warn(
+            `Could not sync the Prisma Next agent skills: ${failure.why ?? failure.message}\nThe postinstall script will retry on the next install, or run it now: \`${syncCommand}\``,
+          );
         }
-        skillRegistered = true;
       } else {
         warn(
-          `Skipped the Prisma Next agent-skill install (--skip-skills). To install them later, run: ${skillCommands.map((command) => `\`${command}\``).join(' && ')}`,
+          `Skipped the Prisma Next agent-skill sync (--skip-skills). To install them later, run: \`${syncCommand}\``,
         );
       }
 

--- a/packages/1-framework/3-tooling/cli/src/orm/init.ts
+++ b/packages/1-framework/3-tooling/cli/src/orm/init.ts
@@ -1,6 +1,5 @@
 import { ifDefined } from '@internal/utils/defined';
 import { docsUrlFor } from '@internal/utils/structured-error';
-import type { PackageManagerId } from '@prisma/cli-engine';
 import { flag } from '@prisma/cli-engine';
 import type { Diagnostic, NextAction } from '@prisma/cli-engine/protocol';
 import { CliStructuredError, notOk, ok } from '@prisma/cli-engine/protocol';
@@ -14,7 +13,6 @@ import {
   type InstallStatus,
 } from '../commands/init/output';
 import { type ProbeOutcome, probeServerVersion } from '../commands/init/probe-db';
-import { formatSkillSyncCommand } from '../commands/init/skill-sources';
 import { targetPackageName } from '../commands/init/templates/code-templates';
 import { MIN_SERVER_VERSION } from '../commands/init/templates/env';
 import { chooseAction } from '../utils/next-actions';
@@ -23,11 +21,7 @@ import { buildInitNextActions, initPresentations } from './init-blocks';
 import { EMIT_COMMAND, emitFailedFinding, installFailedFinding } from './init-diagnostics';
 import { emitScaffoldedContract } from './init-emit';
 import { resolveInitInputs } from './init-inputs';
-import {
-  engineDevDependencySpec,
-  installProjectDependencies,
-  syncAgentSkills,
-} from './init-packages';
+import { engineDevDependencySpec, installProjectDependencies } from './init-packages';
 import { resolveScaffoldPackageManager, scaffoldProject } from './init-scaffold';
 import { normalizeError } from './normalize-error';
 
@@ -85,7 +79,6 @@ export const createInitCommand = (injected: InitCommandDependencies) =>
         // biome-ignore lint/plugin/no-family-vocabulary: names a target on purpose — user-facing help showing what to pass to --target
         'orm init --target mongodb --authoring typescript --json',
         'orm init --skip-install',
-        'orm init --skip-skills',
         // biome-ignore lint/plugin/no-family-vocabulary: names a target on purpose — user-facing help showing what to pass to --target
         'orm init --target postgres --keep-previous-facade',
       ],
@@ -113,7 +106,6 @@ export const createInitCommand = (injected: InitCommandDependencies) =>
         }),
         strictProbe: flag.boolean({ brief: 'Treat a failed --probe-db as fatal' }),
         skipInstall: flag.boolean({ brief: 'Skip dependency installation and contract emission' }),
-        skipSkills: flag.boolean({ brief: 'Skip the Prisma Next agent-skill sync' }),
         keepPreviousFacade: flag.boolean({
           brief: 'Keep the previous target package in package.json when switching targets',
         }),
@@ -160,10 +152,8 @@ export const createInitCommand = (injected: InitCommandDependencies) =>
 
       const findings: Diagnostic[] = [];
       const extraActions: NextAction[] = [];
-      let installedManager: PackageManagerId | undefined;
       let packagesInstalled: InstallStatus = 'skipped';
       let contractEmitted = false;
-      let skillRegistered = false;
 
       const settle = (exitCode: 0 | 4 | 5) => {
         const installed = packagesInstalled === 'installed';
@@ -186,7 +176,6 @@ export const createInitCommand = (injected: InitCommandDependencies) =>
             contractEmitted,
             emitCommand: EMIT_COMMAND,
             schemaPath: inputs.schemaPath,
-            skillRegistered,
           }),
           warnings,
         };
@@ -217,7 +206,6 @@ export const createInitCommand = (injected: InitCommandDependencies) =>
                 ...buildInitNextActions({
                   contractEmitted,
                   schemaPath: inputs.schemaPath,
-                  skillRegistered,
                 }),
               ],
             }),
@@ -256,7 +244,6 @@ export const createInitCommand = (injected: InitCommandDependencies) =>
         }
         devDeps.push(engineSpec);
         packagesInstalled = 'installed';
-        installedManager = outcome.manager;
 
         const emitStep = 'Emit the contract';
         ctx.report({ kind: 'step-started', step: emitStep });
@@ -300,34 +287,6 @@ export const createInitCommand = (injected: InitCommandDependencies) =>
             ),
           );
         }
-      }
-
-      // The sync runs through the same manager the dependencies did, and needs
-      // no scaffold, so the command stands alone: whether it is skipped or
-      // fails, what the user is told to run is the sync itself — never `init`
-      // again, which would re-scaffold over the schema they have since written.
-      const syncCommand = formatSkillSyncCommand(installedManager ?? packageManager);
-
-      if (inputs.installProjectSkill) {
-        const failure = await syncAgentSkills({
-          packages: ctx.packages,
-          cwd: ctx.cwd,
-          manager: installedManager,
-        });
-        if (failure === undefined) {
-          skillRegistered = true;
-        } else {
-          // A failed first sync is not a failed init: every `prisma` command
-          // reports skills that do not match the installed packages, so the
-          // user is pointed back at the sync the next time they run anything.
-          warn(
-            `Could not sync the Prisma Next agent skills: ${failure.why ?? failure.message}\nRun it again: \`${syncCommand}\``,
-          );
-        }
-      } else {
-        warn(
-          `Skipped the Prisma Next agent-skill sync (--skip-skills). To install them later, run: \`${syncCommand}\``,
-        );
       }
 
       return settle(0);

--- a/packages/1-framework/3-tooling/cli/test/commands/init/__snapshots__/templates.test.ts.snap
+++ b/packages/1-framework/3-tooling/cli/test/commands/init/__snapshots__/templates.test.ts.snap
@@ -232,8 +232,8 @@ The ORM covers the common cases. For the rest, two escape hatches are designed i
 
 If this project lives inside a pnpm workspace, a few things are worth knowing:
 
-- **Catalogs.** When the workspace's \`pnpm-workspace.yaml\` defines a \`catalogs\` entry for \`@prisma/cli\` or \`@internal/mongo\`, pnpm uses the catalog version everywhere — \`init\` does too. If you wanted the published \`latest\` instead, update or remove the catalog entry, then re-run \`pnpm install\`.
-- **\`pnpm dlx\`.** \`pnpm dlx @prisma/cli@next init …\` works in any directory. Inside a workspace, pnpm still resolves dependencies through the workspace's catalog/overrides rather than the registry; expect the installed Prisma Next packages to reflect the workspace's catalog rather than \`latest\`.
+- **Catalogs.** When the workspace's \`pnpm-workspace.yaml\` defines a \`catalogs\` entry for \`prisma\` or \`@internal/mongo\`, pnpm uses the catalog version everywhere — \`init\` does too. If you wanted the published \`latest\` instead, update or remove the catalog entry, then re-run \`pnpm install\`.
+- **\`pnpm dlx\`.** \`pnpm dlx prisma@next orm init …\` works in any directory. Inside a workspace, pnpm still resolves dependencies through the workspace's catalog/overrides rather than the registry; expect the installed Prisma Next packages to reflect the workspace's catalog rather than \`latest\`.
 - **\`pnpm\` → \`npm\` fallback.** If \`pnpm\` ever fails to install Prisma Next with a \`workspace:*\` or \`catalog:\` resolution error (a leak in a published artefact), \`init\` falls back to \`npm install\` and surfaces a warning. Once the offending package republishes a clean version you can switch back with \`pnpm install\`.
 "
 `;
@@ -427,8 +427,8 @@ The ORM covers the common cases. For the rest, two escape hatches are designed i
 
 If this project lives inside a pnpm workspace, a few things are worth knowing:
 
-- **Catalogs.** When the workspace's \`pnpm-workspace.yaml\` defines a \`catalogs\` entry for \`@prisma/cli\` or \`@internal/mongo\`, pnpm uses the catalog version everywhere — \`init\` does too. If you wanted the published \`latest\` instead, update or remove the catalog entry, then re-run \`pnpm install\`.
-- **\`pnpm dlx\`.** \`pnpm dlx @prisma/cli@next init …\` works in any directory. Inside a workspace, pnpm still resolves dependencies through the workspace's catalog/overrides rather than the registry; expect the installed Prisma Next packages to reflect the workspace's catalog rather than \`latest\`.
+- **Catalogs.** When the workspace's \`pnpm-workspace.yaml\` defines a \`catalogs\` entry for \`prisma\` or \`@internal/mongo\`, pnpm uses the catalog version everywhere — \`init\` does too. If you wanted the published \`latest\` instead, update or remove the catalog entry, then re-run \`pnpm install\`.
+- **\`pnpm dlx\`.** \`pnpm dlx prisma@next orm init …\` works in any directory. Inside a workspace, pnpm still resolves dependencies through the workspace's catalog/overrides rather than the registry; expect the installed Prisma Next packages to reflect the workspace's catalog rather than \`latest\`.
 - **\`pnpm\` → \`npm\` fallback.** If \`pnpm\` ever fails to install Prisma Next with a \`workspace:*\` or \`catalog:\` resolution error (a leak in a published artefact), \`init\` falls back to \`npm install\` and surfaces a warning. Once the offending package republishes a clean version you can switch back with \`pnpm install\`.
 "
 `;
@@ -604,8 +604,8 @@ pnpm prisma migration status    # Show migration status
 
 If this project lives inside a pnpm workspace, a few things are worth knowing:
 
-- **Catalogs.** When the workspace's \`pnpm-workspace.yaml\` defines a \`catalogs\` entry for \`@prisma/cli\` or \`@internal/postgres\`, pnpm uses the catalog version everywhere — \`init\` does too. If you wanted the published \`latest\` instead, update or remove the catalog entry, then re-run \`pnpm install\`.
-- **\`pnpm dlx\`.** \`pnpm dlx @prisma/cli@next init …\` works in any directory. Inside a workspace, pnpm still resolves dependencies through the workspace's catalog/overrides rather than the registry; expect the installed Prisma Next packages to reflect the workspace's catalog rather than \`latest\`.
+- **Catalogs.** When the workspace's \`pnpm-workspace.yaml\` defines a \`catalogs\` entry for \`prisma\` or \`@internal/postgres\`, pnpm uses the catalog version everywhere — \`init\` does too. If you wanted the published \`latest\` instead, update or remove the catalog entry, then re-run \`pnpm install\`.
+- **\`pnpm dlx\`.** \`pnpm dlx prisma@next orm init …\` works in any directory. Inside a workspace, pnpm still resolves dependencies through the workspace's catalog/overrides rather than the registry; expect the installed Prisma Next packages to reflect the workspace's catalog rather than \`latest\`.
 - **\`pnpm\` → \`npm\` fallback.** If \`pnpm\` ever fails to install Prisma Next with a \`workspace:*\` or \`catalog:\` resolution error (a leak in a published artefact), \`init\` falls back to \`npm install\` and surfaces a warning. Once the offending package republishes a clean version you can switch back with \`pnpm install\`.
 "
 `;
@@ -779,8 +779,8 @@ pnpm prisma migration status    # Show migration status
 
 If this project lives inside a pnpm workspace, a few things are worth knowing:
 
-- **Catalogs.** When the workspace's \`pnpm-workspace.yaml\` defines a \`catalogs\` entry for \`@prisma/cli\` or \`@internal/postgres\`, pnpm uses the catalog version everywhere — \`init\` does too. If you wanted the published \`latest\` instead, update or remove the catalog entry, then re-run \`pnpm install\`.
-- **\`pnpm dlx\`.** \`pnpm dlx @prisma/cli@next init …\` works in any directory. Inside a workspace, pnpm still resolves dependencies through the workspace's catalog/overrides rather than the registry; expect the installed Prisma Next packages to reflect the workspace's catalog rather than \`latest\`.
+- **Catalogs.** When the workspace's \`pnpm-workspace.yaml\` defines a \`catalogs\` entry for \`prisma\` or \`@internal/postgres\`, pnpm uses the catalog version everywhere — \`init\` does too. If you wanted the published \`latest\` instead, update or remove the catalog entry, then re-run \`pnpm install\`.
+- **\`pnpm dlx\`.** \`pnpm dlx prisma@next orm init …\` works in any directory. Inside a workspace, pnpm still resolves dependencies through the workspace's catalog/overrides rather than the registry; expect the installed Prisma Next packages to reflect the workspace's catalog rather than \`latest\`.
 - **\`pnpm\` → \`npm\` fallback.** If \`pnpm\` ever fails to install Prisma Next with a \`workspace:*\` or \`catalog:\` resolution error (a leak in a published artefact), \`init\` falls back to \`npm install\` and surfaces a warning. Once the offending package republishes a clean version you can switch back with \`pnpm install\`.
 "
 `;

--- a/packages/1-framework/3-tooling/cli/test/commands/init/__snapshots__/templates.test.ts.snap
+++ b/packages/1-framework/3-tooling/cli/test/commands/init/__snapshots__/templates.test.ts.snap
@@ -116,7 +116,7 @@ This project is set up for MongoDB. Prisma Next also supports other databases.
 ## Requirements
 
 - **MongoDB 8.0 or newer.** Older servers are not supported. Run \`db.runCommand({ buildInfo: 1 })\` against your server to verify.
-- The CLI never connects to your database without explicit consent. Pass \`--probe-db\` to \`prisma orm init\` if you want \`init\` to verify the server version itself.
+- The CLI never connects to your database without explicit consent. Pass \`--probe-db\` to \`pnpm prisma orm init\` if you want \`init\` to verify the server version itself.
 
 ## Your data contract
 
@@ -300,7 +300,7 @@ This project is set up for MongoDB. Prisma Next also supports other databases.
 ## Requirements
 
 - **MongoDB 8.0 or newer.** Older servers are not supported. Run \`db.runCommand({ buildInfo: 1 })\` against your server to verify.
-- The CLI never connects to your database without explicit consent. Pass \`--probe-db\` to \`prisma orm init\` if you want \`init\` to verify the server version itself.
+- The CLI never connects to your database without explicit consent. Pass \`--probe-db\` to \`pnpm prisma orm init\` if you want \`init\` to verify the server version itself.
 
 ## Your data contract
 
@@ -510,7 +510,7 @@ This project is set up for PostgreSQL. Prisma Next also supports other databases
 ## Requirements
 
 - **PostgreSQL 15 or newer.** Older servers are not supported. Run \`SELECT version()\` against your server to verify.
-- The CLI never connects to your database without explicit consent. Pass \`--probe-db\` to \`prisma orm init\` if you want \`init\` to verify the server version itself.
+- The CLI never connects to your database without explicit consent. Pass \`--probe-db\` to \`pnpm prisma orm init\` if you want \`init\` to verify the server version itself.
 
 ## Your data contract
 
@@ -674,7 +674,7 @@ This project is set up for PostgreSQL. Prisma Next also supports other databases
 ## Requirements
 
 - **PostgreSQL 15 or newer.** Older servers are not supported. Run \`SELECT version()\` against your server to verify.
-- The CLI never connects to your database without explicit consent. Pass \`--probe-db\` to \`prisma orm init\` if you want \`init\` to verify the server version itself.
+- The CLI never connects to your database without explicit consent. Pass \`--probe-db\` to \`pnpm prisma orm init\` if you want \`init\` to verify the server version itself.
 
 ## Your data contract
 

--- a/packages/1-framework/3-tooling/cli/test/commands/init/__snapshots__/templates.test.ts.snap
+++ b/packages/1-framework/3-tooling/cli/test/commands/init/__snapshots__/templates.test.ts.snap
@@ -152,7 +152,7 @@ Your contract has two companion files in the same directory:
 - **\`contract.json\`** — this tells your application what models exist, just like \`package-lock.json\` tells your package manager what dependencies your project has
 - **\`contract.d.ts\`** — this powers autocomplete and type checking in your editor
 
-Commit both files to git. When you change your contract, run \`pnpm prisma-cli contract emit\` to update them.
+Commit both files to git. When you change your contract, run \`pnpm prisma contract emit\` to update them.
 
 If you use a framework like Next.js or Vite, the Prisma Next plugin will do this for you automatically.
 
@@ -188,9 +188,9 @@ You can customize how your environment variables are loaded by changing or remov
 ### Commands
 
 \`\`\`bash
-pnpm prisma-cli contract emit       # Update contract.json and contract.d.ts
-pnpm prisma-cli db init             # Create collections in the database
-pnpm prisma-cli migration status    # Show migration status
+pnpm prisma contract emit       # Update contract.json and contract.d.ts
+pnpm prisma db init             # Create collections in the database
+pnpm prisma migration status    # Show migration status
 \`\`\`
 
 ### Files
@@ -206,7 +206,7 @@ pnpm prisma-cli migration status    # Show migration status
 ### Workflow
 
 1. Edit [\`src/prisma/contract.prisma\`](src/prisma/contract.prisma) to add or change models.
-2. Run \`pnpm prisma-cli contract emit\` to regenerate the contract.
+2. Run \`pnpm prisma contract emit\` to regenerate the contract.
 3. Query your models — your IDE will autocomplete everything.
 
 ## Transactions and change streams (Mongo)
@@ -347,7 +347,7 @@ Your contract has two companion files in the same directory:
 - **\`contract.json\`** — this tells your application what models exist, just like \`package-lock.json\` tells your package manager what dependencies your project has
 - **\`contract.d.ts\`** — this powers autocomplete and type checking in your editor
 
-Commit both files to git. When you change your contract, run \`pnpm prisma-cli contract emit\` to update them.
+Commit both files to git. When you change your contract, run \`pnpm prisma contract emit\` to update them.
 
 If you use a framework like Next.js or Vite, the Prisma Next plugin will do this for you automatically.
 
@@ -383,9 +383,9 @@ You can customize how your environment variables are loaded by changing or remov
 ### Commands
 
 \`\`\`bash
-pnpm prisma-cli contract emit       # Update contract.json and contract.d.ts
-pnpm prisma-cli db init             # Create collections in the database
-pnpm prisma-cli migration status    # Show migration status
+pnpm prisma contract emit       # Update contract.json and contract.d.ts
+pnpm prisma db init             # Create collections in the database
+pnpm prisma migration status    # Show migration status
 \`\`\`
 
 ### Files
@@ -401,7 +401,7 @@ pnpm prisma-cli migration status    # Show migration status
 ### Workflow
 
 1. Edit [\`src/prisma/contract.ts\`](src/prisma/contract.ts) to add or change models.
-2. Run \`pnpm prisma-cli contract emit\` to regenerate the contract.
+2. Run \`pnpm prisma contract emit\` to regenerate the contract.
 3. Query your models — your IDE will autocomplete everything.
 
 ## Transactions and change streams (Mongo)
@@ -543,7 +543,7 @@ Your contract has two companion files in the same directory:
 - **\`contract.json\`** — this tells your application what models exist, just like \`package-lock.json\` tells your package manager what dependencies your project has
 - **\`contract.d.ts\`** — this powers autocomplete and type checking in your editor
 
-Commit both files to git. When you change your contract, run \`pnpm prisma-cli contract emit\` to update them.
+Commit both files to git. When you change your contract, run \`pnpm prisma contract emit\` to update them.
 
 If you use a framework like Next.js or Vite, the Prisma Next plugin will do this for you automatically.
 
@@ -579,9 +579,9 @@ You can customize how your environment variables are loaded by changing or remov
 ### Commands
 
 \`\`\`bash
-pnpm prisma-cli contract emit       # Update contract.json and contract.d.ts
-pnpm prisma-cli db init             # Create tables in the database
-pnpm prisma-cli migration status    # Show migration status
+pnpm prisma contract emit       # Update contract.json and contract.d.ts
+pnpm prisma db init             # Create tables in the database
+pnpm prisma migration status    # Show migration status
 \`\`\`
 
 ### Files
@@ -597,7 +597,7 @@ pnpm prisma-cli migration status    # Show migration status
 ### Workflow
 
 1. Edit [\`src/prisma/contract.prisma\`](src/prisma/contract.prisma) to add or change models.
-2. Run \`pnpm prisma-cli contract emit\` to regenerate the contract.
+2. Run \`pnpm prisma contract emit\` to regenerate the contract.
 3. Query your models — your IDE will autocomplete everything.
 
 ## Monorepo notes (pnpm workspaces)
@@ -718,7 +718,7 @@ Your contract has two companion files in the same directory:
 - **\`contract.json\`** — this tells your application what models exist, just like \`package-lock.json\` tells your package manager what dependencies your project has
 - **\`contract.d.ts\`** — this powers autocomplete and type checking in your editor
 
-Commit both files to git. When you change your contract, run \`pnpm prisma-cli contract emit\` to update them.
+Commit both files to git. When you change your contract, run \`pnpm prisma contract emit\` to update them.
 
 If you use a framework like Next.js or Vite, the Prisma Next plugin will do this for you automatically.
 
@@ -754,9 +754,9 @@ You can customize how your environment variables are loaded by changing or remov
 ### Commands
 
 \`\`\`bash
-pnpm prisma-cli contract emit       # Update contract.json and contract.d.ts
-pnpm prisma-cli db init             # Create tables in the database
-pnpm prisma-cli migration status    # Show migration status
+pnpm prisma contract emit       # Update contract.json and contract.d.ts
+pnpm prisma db init             # Create tables in the database
+pnpm prisma migration status    # Show migration status
 \`\`\`
 
 ### Files
@@ -772,7 +772,7 @@ pnpm prisma-cli migration status    # Show migration status
 ### Workflow
 
 1. Edit [\`src/prisma/contract.ts\`](src/prisma/contract.ts) to add or change models.
-2. Run \`pnpm prisma-cli contract emit\` to regenerate the contract.
+2. Run \`pnpm prisma contract emit\` to regenerate the contract.
 3. Query your models — your IDE will autocomplete everything.
 
 ## Monorepo notes (pnpm workspaces)

--- a/packages/1-framework/3-tooling/cli/test/commands/init/hygiene.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/commands/init/hygiene.test.ts
@@ -6,13 +6,11 @@ import {
 import {
   mergeGitignore,
   REQUIRED_GITIGNORE_ENTRIES,
-  SYNCED_SKILL_GITIGNORE_ENTRIES,
 } from '../../../src/commands/init/hygiene-gitignore';
 import {
   ensureEsmModuleType,
   mergePackageScripts,
   REQUIRED_SCRIPTS,
-  SKILLS_SYNC_SCRIPT,
 } from '../../../src/commands/init/hygiene-package-scripts';
 
 // ---------------------------------------------------------------------------
@@ -167,33 +165,6 @@ describe('mergeGitattributes (FR3.4)', () => {
   });
 });
 
-describe('the synced-skill gitignore entries', () => {
-  it('names one managed skill directory per harness, never the harness directory', () => {
-    expect(SYNCED_SKILL_GITIGNORE_ENTRIES).toEqual([
-      '.claude/skills/prisma-8/',
-      '.cursor/skills/prisma-8/',
-      '.agents/skills/prisma-8/',
-      '.windsurf/skills/prisma-8/',
-    ]);
-  });
-
-  it('appends them alongside the base entries when asked for', () => {
-    const result = mergeGitignore(undefined, [
-      ...REQUIRED_GITIGNORE_ENTRIES,
-      ...SYNCED_SKILL_GITIGNORE_ENTRIES,
-    ]);
-    expect(result).toContain('.claude/skills/prisma-8/');
-    expect(result).toContain('node_modules/');
-  });
-
-  it('leaves a project that already ignores them untouched', () => {
-    const existing = `${[...REQUIRED_GITIGNORE_ENTRIES, ...SYNCED_SKILL_GITIGNORE_ENTRIES].join('\n')}\n`;
-    expect(
-      mergeGitignore(existing, [...REQUIRED_GITIGNORE_ENTRIES, ...SYNCED_SKILL_GITIGNORE_ENTRIES]),
-    ).toBeNull();
-  });
-});
-
 // ---------------------------------------------------------------------------
 // FR3.5 — package.json#scripts merge with collision detection
 // ---------------------------------------------------------------------------
@@ -331,34 +302,5 @@ describe('ensureEsmModuleType (TML-2494)', () => {
     expect(content).not.toBeNull();
     const keys = Object.keys(JSON.parse(content ?? ''));
     expect(keys).toEqual(['name', 'type', 'version', 'dependencies']);
-  });
-});
-
-describe('the skills-sync postinstall script', () => {
-  it('runs sync on every install and never fails the install', () => {
-    expect(SKILLS_SYNC_SCRIPT).toEqual({
-      name: 'postinstall',
-      command: 'prisma skills sync || exit 0',
-    });
-  });
-
-  it('is merged like every other required script', () => {
-    const pkg = JSON.stringify({ name: 'app' }, null, 2);
-    const { content, warnings } = mergePackageScripts(pkg, [
-      ...REQUIRED_SCRIPTS,
-      SKILLS_SYNC_SCRIPT,
-    ]);
-    expect(warnings).toEqual([]);
-    expect(JSON.parse(content ?? '').scripts).toEqual({
-      'contract:emit': 'prisma contract emit',
-      postinstall: 'prisma skills sync || exit 0',
-    });
-  });
-
-  it("keeps a project's own postinstall and warns instead of overwriting it", () => {
-    const pkg = JSON.stringify({ name: 'app', scripts: { postinstall: 'patch-package' } }, null, 2);
-    const { content, warnings } = mergePackageScripts(pkg, [SKILLS_SYNC_SCRIPT]);
-    expect(content).toBeNull();
-    expect(warnings).toEqual([expect.stringContaining('postinstall')]);
   });
 });

--- a/packages/1-framework/3-tooling/cli/test/commands/init/hygiene.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/commands/init/hygiene.test.ts
@@ -205,7 +205,7 @@ describe('mergePackageScripts (FR3.5)', () => {
     expect(content).not.toBeNull();
     expect(warnings).toEqual([]);
     const parsed = JSON.parse(content ?? '');
-    expect(parsed.scripts).toEqual({ 'contract:emit': 'prisma-cli contract emit' });
+    expect(parsed.scripts).toEqual({ 'contract:emit': 'prisma contract emit' });
   });
 
   it('preserves existing user scripts and appends contract:emit', () => {
@@ -217,13 +217,13 @@ describe('mergePackageScripts (FR3.5)', () => {
     expect(parsed.scripts).toEqual({
       build: 'tsc',
       test: 'vitest',
-      'contract:emit': 'prisma-cli contract emit',
+      'contract:emit': 'prisma contract emit',
     });
   });
 
   it('returns null content when contract:emit is already correct (idempotent / FR9.3)', () => {
     const pkg = JSON.stringify(
-      { name: 'app', scripts: { 'contract:emit': 'prisma-cli contract emit' } },
+      { name: 'app', scripts: { 'contract:emit': 'prisma contract emit' } },
       null,
       2,
     );
@@ -243,7 +243,7 @@ describe('mergePackageScripts (FR3.5)', () => {
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toContain('"contract:emit"');
     expect(warnings[0]).toContain('./scripts/custom-emit.sh');
-    expect(warnings[0]).toContain('prisma-cli contract emit');
+    expect(warnings[0]).toContain('prisma contract emit');
   });
 
   it("preserves the user's key order (no reshuffle)", () => {
@@ -350,7 +350,7 @@ describe('the skills-sync postinstall script', () => {
     ]);
     expect(warnings).toEqual([]);
     expect(JSON.parse(content ?? '').scripts).toEqual({
-      'contract:emit': 'prisma-cli contract emit',
+      'contract:emit': 'prisma contract emit',
       postinstall: 'prisma skills sync || exit 0',
     });
   });

--- a/packages/1-framework/3-tooling/cli/test/commands/init/hygiene.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/commands/init/hygiene.test.ts
@@ -6,11 +6,13 @@ import {
 import {
   mergeGitignore,
   REQUIRED_GITIGNORE_ENTRIES,
+  SYNCED_SKILL_GITIGNORE_ENTRIES,
 } from '../../../src/commands/init/hygiene-gitignore';
 import {
   ensureEsmModuleType,
   mergePackageScripts,
   REQUIRED_SCRIPTS,
+  SKILLS_SYNC_SCRIPT,
 } from '../../../src/commands/init/hygiene-package-scripts';
 
 // ---------------------------------------------------------------------------
@@ -165,6 +167,33 @@ describe('mergeGitattributes (FR3.4)', () => {
   });
 });
 
+describe('the synced-skill gitignore entries', () => {
+  it('names one managed skill directory per harness, never the harness directory', () => {
+    expect(SYNCED_SKILL_GITIGNORE_ENTRIES).toEqual([
+      '.claude/skills/prisma-8/',
+      '.cursor/skills/prisma-8/',
+      '.agents/skills/prisma-8/',
+      '.windsurf/skills/prisma-8/',
+    ]);
+  });
+
+  it('appends them alongside the base entries when asked for', () => {
+    const result = mergeGitignore(undefined, [
+      ...REQUIRED_GITIGNORE_ENTRIES,
+      ...SYNCED_SKILL_GITIGNORE_ENTRIES,
+    ]);
+    expect(result).toContain('.claude/skills/prisma-8/');
+    expect(result).toContain('node_modules/');
+  });
+
+  it('leaves a project that already ignores them untouched', () => {
+    const existing = `${[...REQUIRED_GITIGNORE_ENTRIES, ...SYNCED_SKILL_GITIGNORE_ENTRIES].join('\n')}\n`;
+    expect(
+      mergeGitignore(existing, [...REQUIRED_GITIGNORE_ENTRIES, ...SYNCED_SKILL_GITIGNORE_ENTRIES]),
+    ).toBeNull();
+  });
+});
+
 // ---------------------------------------------------------------------------
 // FR3.5 — package.json#scripts merge with collision detection
 // ---------------------------------------------------------------------------
@@ -302,5 +331,34 @@ describe('ensureEsmModuleType (TML-2494)', () => {
     expect(content).not.toBeNull();
     const keys = Object.keys(JSON.parse(content ?? ''));
     expect(keys).toEqual(['name', 'type', 'version', 'dependencies']);
+  });
+});
+
+describe('the skills-sync postinstall script', () => {
+  it('runs sync on every install and never fails the install', () => {
+    expect(SKILLS_SYNC_SCRIPT).toEqual({
+      name: 'postinstall',
+      command: 'prisma skills sync || exit 0',
+    });
+  });
+
+  it('is merged like every other required script', () => {
+    const pkg = JSON.stringify({ name: 'app' }, null, 2);
+    const { content, warnings } = mergePackageScripts(pkg, [
+      ...REQUIRED_SCRIPTS,
+      SKILLS_SYNC_SCRIPT,
+    ]);
+    expect(warnings).toEqual([]);
+    expect(JSON.parse(content ?? '').scripts).toEqual({
+      'contract:emit': 'prisma-cli contract emit',
+      postinstall: 'prisma skills sync || exit 0',
+    });
+  });
+
+  it("keeps a project's own postinstall and warns instead of overwriting it", () => {
+    const pkg = JSON.stringify({ name: 'app', scripts: { postinstall: 'patch-package' } }, null, 2);
+    const { content, warnings } = mergePackageScripts(pkg, [SKILLS_SYNC_SCRIPT]);
+    expect(content).toBeNull();
+    expect(warnings).toEqual([expect.stringContaining('postinstall')]);
   });
 });

--- a/packages/1-framework/3-tooling/cli/test/commands/init/skill-sources.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/commands/init/skill-sources.test.ts
@@ -1,30 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
   AGENT_SKILL_ROOTS,
-  formatSkillSyncCommand,
   legacySkillDirs,
   RETIRED_SKILL_NAMES,
-  SKILLS_SYNC_ARGS,
-  SKILLS_SYNC_PACKAGE,
 } from '../../../src/commands/init/skill-sources';
 
-describe('the skills sync invocation', () => {
-  it('drives the package that carries the prisma bin', () => {
-    expect(SKILLS_SYNC_PACKAGE).toBe('prisma@next');
-    expect(SKILLS_SYNC_ARGS).toEqual(['skills', 'sync']);
-  });
-
-  it('advises the copy the project already installed, never a fresh one', () => {
-    expect(formatSkillSyncCommand('pnpm')).toBe('pnpm exec prisma skills sync');
-    expect(formatSkillSyncCommand('npm')).toBe('npm exec prisma skills sync');
-    expect(formatSkillSyncCommand('yarn')).toBe('yarn exec prisma skills sync');
-    expect(formatSkillSyncCommand('bun')).toBe('bun run prisma skills sync');
-    expect(formatSkillSyncCommand('deno')).toBe('deno run -A npm:prisma skills sync');
-  });
-});
-
 describe('legacy skill cleanup', () => {
-  it('covers every harness directory sync writes into', () => {
+  it('covers every harness directory the agents read', () => {
     expect(AGENT_SKILL_ROOTS).toEqual([
       '.claude/skills',
       '.cursor/skills',

--- a/packages/1-framework/3-tooling/cli/test/commands/init/skill-sources.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/commands/init/skill-sources.test.ts
@@ -9,17 +9,17 @@ import {
 } from '../../../src/commands/init/skill-sources';
 
 describe('the skills sync invocation', () => {
-  it('drives the unified CLI, which carries the sync command', () => {
-    expect(SKILLS_SYNC_PACKAGE).toBe('@prisma/cli@next');
+  it('drives the package that carries the prisma bin', () => {
+    expect(SKILLS_SYNC_PACKAGE).toBe('prisma@next');
     expect(SKILLS_SYNC_ARGS).toEqual(['skills', 'sync']);
   });
 
-  it('spells the runner the way each package manager does', () => {
-    expect(formatSkillSyncCommand('pnpm')).toBe('pnpm dlx @prisma/cli@next skills sync');
-    expect(formatSkillSyncCommand('npm')).toBe('npx @prisma/cli@next skills sync');
-    expect(formatSkillSyncCommand('yarn')).toBe('yarn dlx @prisma/cli@next skills sync');
-    expect(formatSkillSyncCommand('bun')).toBe('bunx @prisma/cli@next skills sync');
-    expect(formatSkillSyncCommand('deno')).toBe('deno run -A npm:@prisma/cli@next skills sync');
+  it('advises the copy the project already installed, never a fresh one', () => {
+    expect(formatSkillSyncCommand('pnpm')).toBe('pnpm exec prisma skills sync');
+    expect(formatSkillSyncCommand('npm')).toBe('npm exec prisma skills sync');
+    expect(formatSkillSyncCommand('yarn')).toBe('yarn exec prisma skills sync');
+    expect(formatSkillSyncCommand('bun')).toBe('bun run prisma skills sync');
+    expect(formatSkillSyncCommand('deno')).toBe('deno run -A npm:prisma skills sync');
   });
 });
 

--- a/packages/1-framework/3-tooling/cli/test/commands/init/skill-sources.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/commands/init/skill-sources.test.ts
@@ -1,29 +1,47 @@
-import { expectDefined } from '@repo/test-utils/typed-expectations';
 import { describe, expect, it } from 'vitest';
 import {
   AGENT_SKILL_ROOTS,
-  DEFAULT_SKILL_SOURCES,
+  formatSkillSyncCommand,
   legacySkillDirs,
   RETIRED_SKILL_NAMES,
+  SKILLS_SYNC_ARGS,
+  SKILLS_SYNC_PACKAGE,
 } from '../../../src/commands/init/skill-sources';
 
-describe('skill sources', () => {
-  it('never retires a skill name it currently installs', () => {
-    const installed = new Set<string>(DEFAULT_SKILL_SOURCES.map((source) => source.skill));
-    const overlap = RETIRED_SKILL_NAMES.filter((name) => installed.has(name));
-
-    expect(
-      overlap,
-      'a name in both lists would mark a skill init installs for deletion (TML-2637)',
-    ).toEqual([]);
+describe('the skills sync invocation', () => {
+  it('drives the unified CLI, which carries the sync command', () => {
+    expect(SKILLS_SYNC_PACKAGE).toBe('@prisma/cli@next');
+    expect(SKILLS_SYNC_ARGS).toEqual(['skills', 'sync']);
   });
 
-  it('legacySkillDirs excludes a retired name that is also installed, under every root', () => {
-    const [installed] = DEFAULT_SKILL_SOURCES;
-    expectDefined(installed);
+  it('spells the runner the way each package manager does', () => {
+    expect(formatSkillSyncCommand('pnpm')).toBe('pnpm dlx @prisma/cli@next skills sync');
+    expect(formatSkillSyncCommand('npm')).toBe('npx @prisma/cli@next skills sync');
+    expect(formatSkillSyncCommand('yarn')).toBe('yarn dlx @prisma/cli@next skills sync');
+    expect(formatSkillSyncCommand('bun')).toBe('bunx @prisma/cli@next skills sync');
+    expect(formatSkillSyncCommand('deno')).toBe('deno run -A npm:@prisma/cli@next skills sync');
+  });
+});
 
-    const dirs = legacySkillDirs([installed.skill, 'prisma-next-queries'], DEFAULT_SKILL_SOURCES);
+describe('legacy skill cleanup', () => {
+  it('covers every harness directory sync writes into', () => {
+    expect(AGENT_SKILL_ROOTS).toEqual([
+      '.claude/skills',
+      '.cursor/skills',
+      '.agents/skills',
+      '.windsurf/skills',
+    ]);
+  });
 
-    expect(dirs).toEqual(AGENT_SKILL_ROOTS.map((root) => `${root}/prisma-next-queries`));
+  it('retires the two standalone upgrade skills that folded into the router', () => {
+    expect(RETIRED_SKILL_NAMES).toContain('prisma-next-upgrade');
+    expect(RETIRED_SKILL_NAMES).toContain('prisma-8-extension-upgrade');
+  });
+
+  it('names one directory per harness root and retired skill', () => {
+    const dirs = legacySkillDirs();
+    expect(dirs).toHaveLength(AGENT_SKILL_ROOTS.length * RETIRED_SKILL_NAMES.length);
+    expect(dirs).toContain('.cursor/skills/prisma-next-upgrade');
+    expect(dirs).not.toContain('.claude/skills/prisma-8');
   });
 });

--- a/packages/1-framework/3-tooling/cli/test/commands/init/templates.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/commands/init/templates.test.ts
@@ -213,12 +213,7 @@ describe('templates', () => {
 
   describe('quickReferenceMd', () => {
     it('contains file locations for postgres', () => {
-      const md = quickReferenceMd(
-        'postgres',
-        'psl',
-        'src/prisma/contract.prisma',
-        'pnpm prisma-cli',
-      );
+      const md = quickReferenceMd('postgres', 'psl', 'src/prisma/contract.prisma', 'pnpm prisma');
 
       expect(md).toContain('src/prisma/contract.prisma');
       expect(md).toContain('src/prisma/contract.json');
@@ -227,12 +222,7 @@ describe('templates', () => {
     });
 
     it('contains postgres-specific content', () => {
-      const md = quickReferenceMd(
-        'postgres',
-        'psl',
-        'src/prisma/contract.prisma',
-        'pnpm prisma-cli',
-      );
+      const md = quickReferenceMd('postgres', 'psl', 'src/prisma/contract.prisma', 'pnpm prisma');
 
       expect(md).toContain('PostgreSQL');
       expect(md).toContain('@internal/postgres');
@@ -240,12 +230,7 @@ describe('templates', () => {
     });
 
     it('contains ORM query example for postgres', () => {
-      const md = quickReferenceMd(
-        'postgres',
-        'psl',
-        'src/prisma/contract.prisma',
-        'pnpm prisma-cli',
-      );
+      const md = quickReferenceMd('postgres', 'psl', 'src/prisma/contract.prisma', 'pnpm prisma');
 
       expect(md).toContain('db.orm.public.User');
       expect(md).toContain('.where(');
@@ -253,19 +238,14 @@ describe('templates', () => {
     });
 
     it('contains common commands', () => {
-      const md = quickReferenceMd(
-        'postgres',
-        'psl',
-        'src/prisma/contract.prisma',
-        'pnpm prisma-cli',
-      );
+      const md = quickReferenceMd('postgres', 'psl', 'src/prisma/contract.prisma', 'pnpm prisma');
 
       expect(md).toContain('contract emit');
       expect(md).toContain('db init');
     });
 
     it('contains mongo-specific content', () => {
-      const md = quickReferenceMd('mongo', 'psl', 'src/prisma/contract.prisma', 'pnpm prisma-cli');
+      const md = quickReferenceMd('mongo', 'psl', 'src/prisma/contract.prisma', 'pnpm prisma');
 
       expect(md).toContain('MongoDB');
       expect(md).toContain('@internal/mongo');
@@ -273,7 +253,7 @@ describe('templates', () => {
     });
 
     it('contains lazy ORM query example for mongo (no manual connect step)', () => {
-      const md = quickReferenceMd('mongo', 'psl', 'src/prisma/contract.prisma', 'pnpm prisma-cli');
+      const md = quickReferenceMd('mongo', 'psl', 'src/prisma/contract.prisma', 'pnpm prisma');
 
       expect(md).toContain('db.orm.users');
       expect(md).toContain('.where({ email:');
@@ -287,12 +267,7 @@ describe('templates', () => {
     // project does not silently lie about which servers it supports.
     describe('Requirements section (FR8.2)', () => {
       it('postgres: documents the minimum PostgreSQL version and only the postgres verify command', () => {
-        const md = quickReferenceMd(
-          'postgres',
-          'psl',
-          'src/prisma/contract.prisma',
-          'pnpm prisma-cli',
-        );
+        const md = quickReferenceMd('postgres', 'psl', 'src/prisma/contract.prisma', 'pnpm prisma');
 
         expect(md).toMatch(/## Requirements/);
         expect(md).toMatch(/PostgreSQL \d+ or newer/);
@@ -303,12 +278,7 @@ describe('templates', () => {
       });
 
       it('mongo: documents the minimum MongoDB version and only the mongo verify command', () => {
-        const md = quickReferenceMd(
-          'mongo',
-          'psl',
-          'src/prisma/contract.prisma',
-          'pnpm prisma-cli',
-        );
+        const md = quickReferenceMd('mongo', 'psl', 'src/prisma/contract.prisma', 'pnpm prisma');
 
         expect(md).toMatch(/## Requirements/);
         expect(md).toMatch(/MongoDB \d/);
@@ -319,26 +289,21 @@ describe('templates', () => {
       });
 
       it('mentions the --probe-db opt-in so users know init does not connect by default', () => {
-        const md = quickReferenceMd(
-          'postgres',
-          'psl',
-          'src/prisma/contract.prisma',
-          'pnpm prisma-cli',
-        );
+        const md = quickReferenceMd('postgres', 'psl', 'src/prisma/contract.prisma', 'pnpm prisma');
 
         expect(md).toContain('--probe-db');
       });
     });
 
     it('documents the replica-set requirement for transactions and change streams', () => {
-      const md = quickReferenceMd('mongo', 'psl', 'src/prisma/contract.prisma', 'pnpm prisma-cli');
+      const md = quickReferenceMd('mongo', 'psl', 'src/prisma/contract.prisma', 'pnpm prisma');
 
       expect(md).toContain('replica set');
       expect(md).toContain('TML-2313');
     });
 
     it('documents the escape hatches and steers users away from db.runtime() for mongo', () => {
-      const md = quickReferenceMd('mongo', 'psl', 'src/prisma/contract.prisma', 'pnpm prisma-cli');
+      const md = quickReferenceMd('mongo', 'psl', 'src/prisma/contract.prisma', 'pnpm prisma');
 
       expect(md).toContain('db.query');
       expect(md).toContain('mongoClient');
@@ -349,12 +314,7 @@ describe('templates', () => {
     // FR5.1: schema sample block differentiates by authoring.
     describe('schema sample (FR5.1)', () => {
       it('postgres + psl: shows a PSL `model { ... }` block', () => {
-        const md = quickReferenceMd(
-          'postgres',
-          'psl',
-          'src/prisma/contract.prisma',
-          'pnpm prisma-cli',
-        );
+        const md = quickReferenceMd('postgres', 'psl', 'src/prisma/contract.prisma', 'pnpm prisma');
 
         expect(md).toContain('```prisma');
         expect(md).toContain('model User');
@@ -367,7 +327,7 @@ describe('templates', () => {
           'postgres',
           'typescript',
           'src/prisma/contract.ts',
-          'pnpm prisma-cli',
+          'pnpm prisma',
         );
 
         expect(md).toContain('```typescript');
@@ -378,12 +338,7 @@ describe('templates', () => {
       });
 
       it('mongo + psl: shows a PSL `model { ... }` block', () => {
-        const md = quickReferenceMd(
-          'mongo',
-          'psl',
-          'src/prisma/contract.prisma',
-          'pnpm prisma-cli',
-        );
+        const md = quickReferenceMd('mongo', 'psl', 'src/prisma/contract.prisma', 'pnpm prisma');
 
         expect(md).toContain('```prisma');
         expect(md).toContain('model User');
@@ -392,12 +347,7 @@ describe('templates', () => {
       });
 
       it('mongo + typescript: shows a TS `defineContract` block (no PSL)', () => {
-        const md = quickReferenceMd(
-          'mongo',
-          'typescript',
-          'src/prisma/contract.ts',
-          'pnpm prisma-cli',
-        );
+        const md = quickReferenceMd('mongo', 'typescript', 'src/prisma/contract.ts', 'pnpm prisma');
 
         expect(md).toContain('```typescript');
         expect(md).toContain('defineContract');
@@ -546,9 +496,7 @@ describe('templates', () => {
         });
 
         it('quickReferenceMd is stable', () => {
-          expect(
-            quickReferenceMd(target, authoring, schemaPath, 'pnpm prisma-cli'),
-          ).toMatchSnapshot();
+          expect(quickReferenceMd(target, authoring, schemaPath, 'pnpm prisma')).toMatchSnapshot();
         });
       });
     }

--- a/packages/1-framework/3-tooling/cli/test/orm/init-emit.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/orm/init-emit.test.ts
@@ -20,26 +20,26 @@ afterEach(() => {
 });
 
 /**
- * Installs a fake `@prisma/cli` package into the project's `node_modules`,
+ * Installs a fake `prisma` package into the project's `node_modules`,
  * with a bin entry pointing at the given script — the shape the registry
  * package has, without the registry.
  */
 function installFakePrismaCli(
   binSource: string,
-  bin: string | Record<string, string> = { 'prisma-cli': './bin/prisma-cli.mjs' },
+  bin: string | Record<string, string> = { prisma: './bin/prisma.mjs' },
 ): void {
-  const packageDir = join(projectDir, 'node_modules/@prisma/cli');
+  const packageDir = join(projectDir, 'node_modules/prisma');
   mkdirSync(join(packageDir, 'bin'), { recursive: true });
   writeFileSync(
     join(packageDir, 'package.json'),
     JSON.stringify({
-      name: '@prisma/cli',
+      name: 'prisma',
       version: '0.0.0-test',
       type: 'module',
       bin,
     }),
   );
-  writeFileSync(join(packageDir, 'bin/prisma-cli.mjs'), binSource);
+  writeFileSync(join(packageDir, 'bin/prisma.mjs'), binSource);
 }
 
 async function emitFailure(): Promise<Error> {
@@ -54,7 +54,7 @@ async function emitFailure(): Promise<Error> {
 
 describe('emitScaffoldedContract', () => {
   it(
-    'runs the project-local prisma-cli bin with `contract emit` in the project directory',
+    'runs the project-local prisma bin with `contract emit` in the project directory',
     async () => {
       installFakePrismaCli(
         [
@@ -126,7 +126,7 @@ describe('emitScaffoldedContract', () => {
           "writeFileSync('emit-invocation.json', JSON.stringify({ argv: process.argv.slice(2) }));",
           '',
         ].join('\n'),
-        './bin/prisma-cli.mjs',
+        './bin/prisma.mjs',
       );
 
       await emitScaffoldedContract({ cwd: projectDir });
@@ -173,9 +173,9 @@ describe('emitScaffoldedContract', () => {
   );
 
   it(
-    'reports that @prisma/cli is not installed when resolution fails',
+    'reports that prisma is not installed when resolution fails',
     async () => {
-      // vitest wraps `createRequire` and resolves the workspace @prisma/cli
+      // vitest wraps `createRequire` and resolves the workspace prisma package
       // package from any directory, so a genuinely missing install cannot be
       // produced with real resolution here — the seam stands in for the
       // MODULE_NOT_FOUND a real Node process raises.
@@ -183,33 +183,33 @@ describe('emitScaffoldedContract', () => {
         { cwd: projectDir },
         {
           resolveFromBaseDir: () => {
-            throw new Error("Cannot find module '@prisma/cli/package.json'");
+            throw new Error("Cannot find module 'prisma/package.json'");
           },
         },
       ).catch((thrown: unknown) => thrown);
 
       expect(error).toBeInstanceOf(Error);
       const message = (error as Error).message;
-      expect(message).toMatch(/`@prisma\/cli` is not installed/);
+      expect(message).toMatch(/`prisma` is not installed/);
       expect(message).toContain(projectDir);
-      expect(message).toContain("Cannot find module '@prisma/cli/package.json'");
+      expect(message).toContain("Cannot find module 'prisma/package.json'");
     },
     timeouts.databaseOperation,
   );
 
   it(
-    'reports an installed @prisma/cli that declares no bin',
+    'reports an installed prisma that declares no bin',
     async () => {
-      const packageDir = join(projectDir, 'node_modules/@prisma/cli');
+      const packageDir = join(projectDir, 'node_modules/prisma');
       mkdirSync(packageDir, { recursive: true });
       writeFileSync(
         join(packageDir, 'package.json'),
-        JSON.stringify({ name: '@prisma/cli', version: '0.0.0-test' }),
+        JSON.stringify({ name: 'prisma', version: '0.0.0-test' }),
       );
 
       const error = await emitFailure();
 
-      expect(error.message).toMatch(/declares no `prisma-cli` bin/);
+      expect(error.message).toMatch(/declares no `prisma` bin/);
     },
     timeouts.databaseOperation,
   );

--- a/packages/1-framework/3-tooling/cli/test/orm/init-inputs.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/orm/init-inputs.test.ts
@@ -24,7 +24,6 @@ function flags(overrides: Partial<InitFlagValues> = {}): InitFlagValues {
     probeDb: false,
     strictProbe: false,
     skipInstall: true,
-    skipSkills: true,
     keepPreviousFacade: false,
     ...overrides,
   };

--- a/packages/1-framework/3-tooling/cli/test/orm/init-install.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/orm/init-install.test.ts
@@ -143,7 +143,7 @@ describe('init installs', () => {
   it(
     'announces each package-manager run as a step',
     async () => {
-      const run = await harness().run(scaffoldArgv('--skip-skills'), { cwd: projectDir });
+      const run = await harness().run(scaffoldArgv(), { cwd: projectDir });
 
       expect(run.events).toContainEqual(
         expect.objectContaining({
@@ -215,58 +215,14 @@ describe('init installs', () => {
   );
 
   it(
-    'completes at exit 0 when the skill sync fails, telling the user how to retry',
+    'runs no skills command — the family-level `prisma init` owns skills setup',
     async () => {
-      script = [
-        { exitCode: 0, stderr: '' },
-        { exitCode: 0, stderr: '' },
-        { exitCode: 0, stderr: '' },
-        { exitCode: 1, stderr: 'prisma: registry unreachable' },
-      ];
-
       const run = await harness().run(scaffoldArgv(), { cwd: projectDir });
 
       expect(run.exitCode).toBe(0);
-      expect(envelopeOf(run)).toMatchObject({ ok: true, exitCode: 0, diagnostics: [] });
-      expect(skillCalls()).toHaveLength(1);
-      expect(run.presented?.data).toMatchObject({
-        warnings: expect.arrayContaining([
-          expect.stringContaining('Could not sync the Prisma Next agent skills'),
-        ]),
-      });
-    },
-    timeouts.coldTransformImport,
-  );
-
-  it(
-    'sends a failed sync to the sync command, never back through init',
-    async () => {
-      script = [
-        { exitCode: 0, stderr: '' },
-        { exitCode: 0, stderr: '' },
-        { exitCode: 0, stderr: '' },
-        { exitCode: 1, stderr: 'prisma: registry unreachable' },
-      ];
-
-      const run = await harness().run(scaffoldArgv(), { cwd: projectDir });
-      const warnings = JSON.stringify(run.presented?.data);
-
-      expect(warnings).toContain('prisma skills sync');
-      expect(warnings).not.toContain('prisma-next init');
-    },
-    timeouts.coldTransformImport,
-  );
-
-  it(
-    'runs the skill sync once, through the unified CLI',
-    async () => {
-      await harness().run(scaffoldArgv(), { cwd: projectDir });
-
-      const first = skillCalls()[0];
-
-      expect(skillCalls()).toHaveLength(1);
-      expect(first).toMatchObject({ cwd: projectDir });
-      expect(first?.args).toEqual(expect.arrayContaining(['prisma@next', 'skills', 'sync']));
+      expect(skillCalls()).toEqual([]);
+      expect(calls).toHaveLength(3);
+      expect(JSON.stringify(run.presented?.data)).not.toContain('skills sync');
     },
     timeouts.coldTransformImport,
   );
@@ -277,7 +233,7 @@ describe('init installs', () => {
       async () => {
         script = [{ exitCode: 1, stderr: PNPM_WORKSPACE_LEAK }];
 
-        const run = await harness('pnpm').run(scaffoldArgv('--skip-skills'), { cwd: projectDir });
+        const run = await harness('pnpm').run(scaffoldArgv(), { cwd: projectDir });
 
         expect(run.exitCode).toBe(0);
         expect(calls.map((call) => `${call.file} ${call.args.join(' ')}`)).toEqual([
@@ -307,7 +263,7 @@ describe('init installs', () => {
           },
         ];
 
-        const run = await harness('pnpm').run(scaffoldArgv('--skip-skills'), { cwd: projectDir });
+        const run = await harness('pnpm').run(scaffoldArgv(), { cwd: projectDir });
         const warnings = run.presented?.data;
 
         expect(JSON.stringify(warnings)).not.toContain('hunter2');
@@ -315,18 +271,6 @@ describe('init installs', () => {
         expect(warnings).toMatchObject({
           warnings: expect.arrayContaining([expect.stringContaining('ERR_PNPM_WORKSPACE')]),
         });
-      },
-      timeouts.coldTransformImport,
-    );
-
-    it(
-      'drives the agent-skill sync with the manager that worked',
-      async () => {
-        script = [{ exitCode: 1, stderr: PNPM_WORKSPACE_LEAK }];
-
-        await harness('pnpm').run(scaffoldArgv(), { cwd: projectDir });
-
-        expect(skillCalls()[0]?.file).toBe('npx');
       },
       timeouts.coldTransformImport,
     );
@@ -381,11 +325,11 @@ describe('init installs', () => {
     );
   });
 
-  describe('the skip flags', () => {
+  describe('--skip-install', () => {
     it(
-      'installs nothing and emits nothing under --skip-install',
+      'installs nothing and emits nothing',
       async () => {
-        const run = await harness().run(scaffoldArgv('--skip-install', '--skip-skills'), {
+        const run = await harness().run(scaffoldArgv('--skip-install'), {
           cwd: projectDir,
         });
 
@@ -399,35 +343,6 @@ describe('init installs', () => {
         expect(run.presented?.presentation.next).toContainEqual(
           expect.objectContaining({ kind: 'run-command', command: 'prisma contract emit' }),
         );
-      },
-      timeouts.coldTransformImport,
-    );
-
-    it(
-      'still installs the agent skills when only the dependencies are skipped',
-      async () => {
-        const run = await harness().run(scaffoldArgv('--skip-install'), { cwd: projectDir });
-
-        expect(run.exitCode).toBe(0);
-        expect(skillCalls()).toHaveLength(1);
-      },
-      timeouts.coldTransformImport,
-    );
-
-    it(
-      'warns about the skipped skills under --skip-skills, naming the sync command',
-      async () => {
-        const run = await harness().run(scaffoldArgv('--skip-skills'), { cwd: projectDir });
-        const warnings = run.presented?.presentation.json;
-
-        expect(skillCalls()).toEqual([]);
-        expect(warnings).toMatchObject({
-          warnings: expect.arrayContaining([
-            expect.stringContaining('--skip-skills'),
-            expect.stringContaining('skills sync'),
-          ]),
-        });
-        expect(JSON.stringify(warnings)).not.toContain('prisma-next init --skip-install');
       },
       timeouts.coldTransformImport,
     );

--- a/packages/1-framework/3-tooling/cli/test/orm/init-install.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/orm/init-install.test.ts
@@ -72,7 +72,7 @@ function envelopeOf(run: { readonly json: readonly { readonly kind: string }[] }
 }
 
 function skillCalls(): readonly RunnerCall[] {
-  return calls.filter((call) => call.args.includes('skills@latest'));
+  return calls.filter((call) => call.args.includes('skills'));
 }
 
 describe('init installs', () => {
@@ -215,56 +215,50 @@ describe('init installs', () => {
   );
 
   it(
-    'completes at exit 6 when the agent-skill install fails',
+    'completes at exit 0 when the skill sync fails, telling the user how to retry',
     async () => {
       script = [
         { exitCode: 0, stderr: '' },
         { exitCode: 0, stderr: '' },
         { exitCode: 0, stderr: '' },
-        { exitCode: 1, stderr: 'skills: registry unreachable' },
+        { exitCode: 1, stderr: 'prisma: registry unreachable' },
       ];
 
       const run = await harness().run(scaffoldArgv(), { cwd: projectDir });
 
-      expect(run.exitCode).toBe(6);
-      expect(envelopeOf(run)).toMatchObject({
-        ok: true,
-        exitCode: 6,
-        diagnostics: [{ code: 'CLI.INIT_SKILL_INSTALL_FAILED', severity: 'error' }],
-      });
+      expect(run.exitCode).toBe(0);
+      expect(envelopeOf(run)).toMatchObject({ ok: true, exitCode: 0, diagnostics: [] });
       expect(skillCalls()).toHaveLength(1);
+      expect(run.presented?.data).toMatchObject({
+        warnings: expect.arrayContaining([
+          expect.stringContaining('Could not sync the Prisma Next agent skills'),
+        ]),
+      });
     },
     timeouts.coldTransformImport,
   );
 
   it(
-    'sends a failed skill install to the skill commands, never back through init',
+    'sends a failed sync to the sync command, never back through init',
     async () => {
       script = [
         { exitCode: 0, stderr: '' },
         { exitCode: 0, stderr: '' },
         { exitCode: 0, stderr: '' },
-        { exitCode: 1, stderr: 'skills: registry unreachable' },
+        { exitCode: 1, stderr: 'prisma: registry unreachable' },
       ];
 
       const run = await harness().run(scaffoldArgv(), { cwd: projectDir });
-      const finding = envelopeOf(run)?.diagnostics?.[0];
+      const warnings = JSON.stringify(run.presented?.data);
 
-      expect(finding?.nextActions).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            kind: 'run-command',
-            command: expect.stringContaining('skills@latest add'),
-          }),
-        ]),
-      );
-      expect(JSON.stringify(finding?.nextActions)).not.toContain('prisma-next init');
+      expect(warnings).toContain('skills sync');
+      expect(warnings).not.toContain('prisma-next init');
     },
     timeouts.coldTransformImport,
   );
 
   it(
-    'runs one skill install, naming the skill and the agents',
+    'runs the skill sync once, through the unified CLI',
     async () => {
       await harness().run(scaffoldArgv(), { cwd: projectDir });
 
@@ -272,10 +266,7 @@ describe('init installs', () => {
 
       expect(skillCalls()).toHaveLength(1);
       expect(first).toMatchObject({ cwd: projectDir });
-      expect(first?.args).toEqual(
-        expect.arrayContaining(['skills@latest', 'add', '--skill', 'prisma-8']),
-      );
-      expect(first?.args.at(-1)).toBe('-y');
+      expect(first?.args).toEqual(expect.arrayContaining(['@prisma/cli@next', 'skills', 'sync']));
     },
     timeouts.coldTransformImport,
   );
@@ -424,7 +415,7 @@ describe('init installs', () => {
     );
 
     it(
-      'warns about the skipped skills under --skip-skills, naming the install commands',
+      'warns about the skipped skills under --skip-skills, naming the sync command',
       async () => {
         const run = await harness().run(scaffoldArgv('--skip-skills'), { cwd: projectDir });
         const warnings = run.presented?.presentation.json;
@@ -433,7 +424,7 @@ describe('init installs', () => {
         expect(warnings).toMatchObject({
           warnings: expect.arrayContaining([
             expect.stringContaining('--skip-skills'),
-            expect.stringContaining('skills@latest add'),
+            expect.stringContaining('skills sync'),
           ]),
         });
         expect(JSON.stringify(warnings)).not.toContain('prisma-next init --skip-install');

--- a/packages/1-framework/3-tooling/cli/test/orm/init-install.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/orm/init-install.test.ts
@@ -79,12 +79,12 @@ describe('init installs', () => {
   it(
     'pins the engine to the exact version the installed @prisma/cli declares',
     async () => {
-      const cliManifestDir = join(projectDir, 'node_modules', '@prisma', 'cli');
+      const cliManifestDir = join(projectDir, 'node_modules', 'prisma');
       mkdirSync(cliManifestDir, { recursive: true });
       writeFileSync(
         join(cliManifestDir, 'package.json'),
         JSON.stringify({
-          name: '@prisma/cli',
+          name: 'prisma',
           version: '8.0.0-rc.4',
           dependencies: { '@prisma/cli-engine': '0.1.1' },
         }),
@@ -117,7 +117,7 @@ describe('init installs', () => {
         },
         {
           file: expect.any(String),
-          args: ['add', '-D', '@prisma/cli@next', '@types/node'],
+          args: ['add', '-D', 'prisma@next', '@types/node'],
           cwd: projectDir,
         },
         {
@@ -131,7 +131,7 @@ describe('init installs', () => {
         packagesInstalled: {
           status: 'installed',
           deps: ['@prisma/orm-postgres', 'dotenv'],
-          devDeps: ['@prisma/cli@next', '@types/node', '@prisma/cli-engine@next'],
+          devDeps: ['prisma@next', '@types/node', '@prisma/cli-engine@next'],
         },
         contractEmitted: true,
       });
@@ -251,7 +251,7 @@ describe('init installs', () => {
       const run = await harness().run(scaffoldArgv(), { cwd: projectDir });
       const warnings = JSON.stringify(run.presented?.data);
 
-      expect(warnings).toContain('skills sync');
+      expect(warnings).toContain('prisma skills sync');
       expect(warnings).not.toContain('prisma-next init');
     },
     timeouts.coldTransformImport,
@@ -266,7 +266,7 @@ describe('init installs', () => {
 
       expect(skillCalls()).toHaveLength(1);
       expect(first).toMatchObject({ cwd: projectDir });
-      expect(first?.args).toEqual(expect.arrayContaining(['@prisma/cli@next', 'skills', 'sync']));
+      expect(first?.args).toEqual(expect.arrayContaining(['prisma@next', 'skills', 'sync']));
     },
     timeouts.coldTransformImport,
   );
@@ -283,7 +283,7 @@ describe('init installs', () => {
         expect(calls.map((call) => `${call.file} ${call.args.join(' ')}`)).toEqual([
           'pnpm add @prisma/orm-postgres dotenv',
           'npm add @prisma/orm-postgres dotenv',
-          'npm add -D @prisma/cli@next @types/node',
+          'npm add -D prisma@next @types/node',
           'npm add -D @prisma/cli-engine@next',
         ]);
         expect(run.events).toContainEqual(
@@ -397,7 +397,7 @@ describe('init installs', () => {
           contractEmitted: false,
         });
         expect(run.presented?.presentation.next).toContainEqual(
-          expect.objectContaining({ kind: 'run-command', command: 'prisma-cli contract emit' }),
+          expect.objectContaining({ kind: 'run-command', command: 'prisma contract emit' }),
         );
       },
       timeouts.coldTransformImport,

--- a/packages/1-framework/3-tooling/cli/test/orm/init-install.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/orm/init-install.test.ts
@@ -320,7 +320,7 @@ describe('init installs', () => {
     );
 
     it(
-      'drives the agent-skill install with the manager that worked',
+      'drives the agent-skill sync with the manager that worked',
       async () => {
         script = [{ exitCode: 1, stderr: PNPM_WORKSPACE_LEAK }];
 

--- a/packages/1-framework/3-tooling/cli/test/orm/init-install.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/orm/init-install.test.ts
@@ -77,7 +77,7 @@ function skillCalls(): readonly RunnerCall[] {
 
 describe('init installs', () => {
   it(
-    'pins the engine to the exact version the installed @prisma/cli declares',
+    'pins the engine to the exact version the installed prisma package declares',
     async () => {
       const cliManifestDir = join(projectDir, 'node_modules', 'prisma');
       mkdirSync(cliManifestDir, { recursive: true });

--- a/packages/1-framework/3-tooling/cli/test/orm/init-prompts.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/orm/init-prompts.test.ts
@@ -11,7 +11,7 @@ import { createTestProjectDir } from '../utils/test-project-dir';
  * case here passes both skip flags, so no run needs a package-manager runner
  * and none is seeded.
  */
-const NO_PACKAGE_WORK = ['--skip-install', '--skip-skills'] as const;
+const NO_PACKAGE_WORK = ['--skip-install'] as const;
 
 let projectDir: string;
 

--- a/packages/1-framework/3-tooling/cli/test/orm/init-reinit.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/orm/init-reinit.test.ts
@@ -11,7 +11,7 @@ import { createTestProjectDir } from '../utils/test-project-dir';
  * the destructive act the consent token exists for. Both skip flags are
  * passed, so no run needs a package-manager runner and none is seeded.
  */
-const NO_PACKAGE_WORK = ['--skip-install', '--skip-skills'] as const;
+const NO_PACKAGE_WORK = ['--skip-install'] as const;
 
 const SCHEMA_PATH = 'src/prisma/contract.prisma';
 const HAND_WRITTEN_SCHEMA = 'model KeepMe {\n  id String @id\n}\n';

--- a/packages/1-framework/3-tooling/cli/test/orm/init-scaffold.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/orm/init-scaffold.test.ts
@@ -38,7 +38,7 @@ function scaffoldArgv(...extra: string[]): string[] {
   return ['orm', 'init', '--target', 'postgres', '--authoring', 'psl', ...extra];
 }
 
-const SKIP_ALL = ['--skip-install', '--skip-skills'] as const;
+const SKIP_ALL = ['--skip-install'] as const;
 
 /**
  * The emit step spawns the project-local `@prisma/cli` bin, which the mocked
@@ -257,7 +257,7 @@ describe('init scaffold', () => {
         );
         installFakeProjectLocalCli(projectDir);
 
-        const run = await harness().run(scaffoldArgv('--skip-skills'), { cwd: projectDir });
+        const run = await harness().run(scaffoldArgv(), { cwd: projectDir });
 
         expect(envelopeOf(run)).toMatchObject({ ok: true });
         expect(run.exitCode).toBe(0);
@@ -277,7 +277,7 @@ describe('init scaffold', () => {
           'utf-8',
         );
 
-        const run = await harness().run(scaffoldArgv('--skip-skills'), { cwd: projectDir });
+        const run = await harness().run(scaffoldArgv(), { cwd: projectDir });
 
         expect(run.presented?.data).toMatchObject({
           warnings: expect.arrayContaining([expect.stringContaining('catalog overrides detected')]),

--- a/packages/1-framework/3-tooling/cli/test/orm/init-scaffold.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/orm/init-scaffold.test.ts
@@ -154,6 +154,39 @@ describe('init scaffold', () => {
     );
   });
 
+  describe('the skill-sync wiring it writes', () => {
+    it(
+      'adds the postinstall script and gitignores the managed skill copies',
+      async () => {
+        const run = await harness().run(scaffoldArgv('--skip-install'), { cwd: projectDir });
+        const manifest = JSON.parse(readFileSync(join(projectDir, 'package.json'), 'utf-8'));
+        const gitignore = readFileSync(join(projectDir, '.gitignore'), 'utf-8');
+
+        expect(run.exitCode).toBe(0);
+        expect(manifest.scripts).toMatchObject({ postinstall: 'prisma skills sync || exit 0' });
+        expect(gitignore).toContain('.claude/skills/prisma-8/');
+        expect(gitignore).toContain('.cursor/skills/prisma-8/');
+        expect(gitignore).toContain('.agents/skills/prisma-8/');
+        expect(gitignore).toContain('.windsurf/skills/prisma-8/');
+      },
+      timeouts.coldTransformImport,
+    );
+
+    it(
+      'writes neither under --skip-skills',
+      async () => {
+        const run = await harness().run(scaffoldArgv(...SKIP_ALL), { cwd: projectDir });
+        const manifest = JSON.parse(readFileSync(join(projectDir, 'package.json'), 'utf-8'));
+        const gitignore = readFileSync(join(projectDir, '.gitignore'), 'utf-8');
+
+        expect(run.exitCode).toBe(0);
+        expect(manifest.scripts?.postinstall).toBeUndefined();
+        expect(gitignore).not.toContain('skills/prisma-8/');
+      },
+      timeouts.coldTransformImport,
+    );
+  });
+
   describe('the files it removes', () => {
     it(
       'deletes a retired agent-skill directory even on a first run, leaving installed skills alone under --skip-skills',

--- a/packages/1-framework/3-tooling/cli/test/orm/init-scaffold.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/orm/init-scaffold.test.ts
@@ -2,10 +2,8 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node
 import type { PackageManagerRunner } from '@prisma/cli-engine';
 import { createTestCli } from '@prisma/cli-engine/testing';
 import { timeouts } from '@repo/test-utils';
-import { expectDefined } from '@repo/test-utils/typed-expectations';
 import { join } from 'pathe';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { DEFAULT_SKILL_SOURCES } from '../../src/commands/init/skill-sources';
 import { BIN_COMMANDS, BIN_GROUPS } from '../../src/orm/cli';
 import { createTestProjectDir } from '../utils/test-project-dir';
 
@@ -172,14 +170,12 @@ describe('init scaffold', () => {
 
   describe('the files it removes', () => {
     it(
-      'deletes a retired agent-skill directory even on a first run, leaving installed skills alone under --skip-skills',
+      'deletes a retired agent-skill directory even on a first run, leaving an installed skill alone',
       async () => {
         const retired = join(projectDir, '.claude/skills/prisma-next-queries');
         mkdirSync(retired, { recursive: true });
         writeFileSync(join(retired, 'SKILL.md'), '# stale\n', 'utf-8');
-        const [firstSource] = DEFAULT_SKILL_SOURCES;
-        expectDefined(firstSource);
-        const installed = join(projectDir, `.agents/skills/${firstSource.skill}`);
+        const installed = join(projectDir, '.agents/skills/prisma-8');
         mkdirSync(installed, { recursive: true });
         writeFileSync(join(installed, 'SKILL.md'), '# installed\n', 'utf-8');
 

--- a/packages/1-framework/3-tooling/cli/test/orm/init-scaffold.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/orm/init-scaffold.test.ts
@@ -154,28 +154,11 @@ describe('init scaffold', () => {
     );
   });
 
-  describe('the skill-sync wiring it writes', () => {
+  describe('the skill-sync wiring it does not write', () => {
     it(
-      'adds the postinstall script and gitignores the managed skill copies',
+      'adds no postinstall script and no skill gitignore entries',
       async () => {
         const run = await harness().run(scaffoldArgv('--skip-install'), { cwd: projectDir });
-        const manifest = JSON.parse(readFileSync(join(projectDir, 'package.json'), 'utf-8'));
-        const gitignore = readFileSync(join(projectDir, '.gitignore'), 'utf-8');
-
-        expect(run.exitCode).toBe(0);
-        expect(manifest.scripts).toMatchObject({ postinstall: 'prisma skills sync || exit 0' });
-        expect(gitignore).toContain('.claude/skills/prisma-8/');
-        expect(gitignore).toContain('.cursor/skills/prisma-8/');
-        expect(gitignore).toContain('.agents/skills/prisma-8/');
-        expect(gitignore).toContain('.windsurf/skills/prisma-8/');
-      },
-      timeouts.coldTransformImport,
-    );
-
-    it(
-      'writes neither under --skip-skills',
-      async () => {
-        const run = await harness().run(scaffoldArgv(...SKIP_ALL), { cwd: projectDir });
         const manifest = JSON.parse(readFileSync(join(projectDir, 'package.json'), 'utf-8'));
         const gitignore = readFileSync(join(projectDir, '.gitignore'), 'utf-8');
 

--- a/packages/1-framework/3-tooling/cli/test/orm/init-scaffold.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/orm/init-scaffold.test.ts
@@ -46,18 +46,18 @@ const SKIP_ALL = ['--skip-install', '--skip-skills'] as const;
  * do not pass `--skip-install`.
  */
 function installFakeProjectLocalCli(dir: string): void {
-  const packageDir = join(dir, 'node_modules/@prisma/cli');
+  const packageDir = join(dir, 'node_modules/prisma');
   mkdirSync(join(packageDir, 'bin'), { recursive: true });
   writeFileSync(
     join(packageDir, 'package.json'),
     JSON.stringify({
-      name: '@prisma/cli',
+      name: 'prisma',
       version: '0.0.0-test',
       type: 'module',
-      bin: { 'prisma-cli': './bin/prisma-cli.mjs' },
+      bin: { prisma: './bin/prisma.mjs' },
     }),
   );
-  writeFileSync(join(packageDir, 'bin/prisma-cli.mjs'), '');
+  writeFileSync(join(packageDir, 'bin/prisma.mjs'), '');
 }
 
 function envelopeOf(run: { readonly json: readonly { readonly kind: string }[] }) {
@@ -278,7 +278,7 @@ describe('init scaffold', () => {
 
         expect(envelopeOf(run)).toMatchObject({ ok: true });
         expect(run.exitCode).toBe(0);
-        expect(calls[1]?.args).toEqual(['add', '-D', '@prisma/cli@next']);
+        expect(calls[1]?.args).toEqual(['add', '-D', 'prisma@next']);
         expect(calls[2]?.args).toEqual(['add', '-D', '@prisma/cli-engine@next']);
       },
       timeouts.coldTransformImport,

--- a/skills/README.md
+++ b/skills/README.md
@@ -20,7 +20,7 @@ Upgrading is a branch of the same skill rather than a separate one. [`references
 
 ## Install
 
-The skill arrives with the packages, and `prisma skills sync` copies it from the installed package into the agent directories at your project root (`.claude/skills/`, `.cursor/skills/`, `.agents/skills/`, `.windsurf/skills/`). `prisma orm init` runs that for you and adds a `postinstall` script so every later install and upgrade re-syncs:
+The skill arrives with the packages, and `prisma skills sync` copies it from the installed package into the agent directories at your project root (`.claude/skills/`, `.cursor/skills/`, `.agents/skills/`, `.windsurf/skills/`). `prisma orm init` runs that for you once at scaffold time:
 
 ```bash
 mkdir my-app && cd my-app

--- a/skills/README.md
+++ b/skills/README.md
@@ -24,7 +24,7 @@ The skill arrives with the packages, and `prisma skills sync` copies it from the
 
 ```bash
 mkdir my-app && cd my-app
-pnpm dlx @prisma/cli@next orm init
+pnpm dlx prisma@next orm init
 ```
 
 In an existing project, or after adding an agent runtime, run it directly:

--- a/skills/README.md
+++ b/skills/README.md
@@ -20,14 +20,7 @@ Upgrading is a branch of the same skill rather than a separate one. [`references
 
 ## Install
 
-The skill arrives with the packages, and `prisma skills sync` copies it from the installed package into the agent directories at your project root (`.claude/skills/`, `.cursor/skills/`, `.agents/skills/`, `.windsurf/skills/`). `prisma orm init` runs that for you once at scaffold time:
-
-```bash
-mkdir my-app && cd my-app
-pnpm dlx prisma@next orm init
-```
-
-In an existing project, or after adding an agent runtime, run it directly:
+The skill arrives with the packages, and `prisma skills sync` copies it from the installed package into the agent directories at your project root (`.claude/skills/`, `.cursor/skills/`, `.agents/skills/`, `.windsurf/skills/`). The family-level `prisma init` command sets the skills up for you; `prisma orm init` does not touch them. After adding an agent runtime, or to refresh the copies, run the sync directly:
 
 ```bash
 pnpm exec prisma skills sync

--- a/test/e2e/framework/test/init-emit-subprocess.test.ts
+++ b/test/e2e/framework/test/init-emit-subprocess.test.ts
@@ -1,13 +1,13 @@
 /**
  * Pins the init emit invariant end to end: the shipped bin's `init` command
- * emits the scaffolded contract by spawning the *project-local* `@prisma/cli`
+ * emits the scaffolded contract by spawning the *project-local* `prisma`
  * bin as a child process in the scaffold directory — never by loading the
  * project's config in-process with the running CLI's own loader. A revert to
  * in-process emit makes the fake project-local bin unnecessary, so its
  * sentinel file never appears and this suite fails.
  *
- * The project's `node_modules/@prisma/cli` is a fake package whose
- * `prisma-cli` bin records its argv and cwd; the package-manager install step
+ * The project's `node_modules/prisma` is a fake package whose
+ * `prisma` bin records its argv and cwd; the package-manager install step
  * is satisfied by a PATH shim `npm` that exits 0, so `init` reaches the emit
  * step without the network.
  */
@@ -61,18 +61,18 @@ afterEach(() => {
 });
 
 function installFakePrismaCli(binSource: string): void {
-  const packageDir = join(projectDir, 'node_modules', '@prisma', 'cli');
+  const packageDir = join(projectDir, 'node_modules', 'prisma');
   mkdirSync(join(packageDir, 'bin'), { recursive: true });
   writeFileSync(
     join(packageDir, 'package.json'),
     JSON.stringify({
-      name: '@prisma/cli',
+      name: 'prisma',
       version: '0.0.0-test',
       type: 'module',
-      bin: { 'prisma-cli': './bin/prisma-cli.mjs' },
+      bin: { prisma: './bin/prisma.mjs' },
     }),
   );
-  writeFileSync(join(packageDir, 'bin/prisma-cli.mjs'), binSource);
+  writeFileSync(join(packageDir, 'bin/prisma.mjs'), binSource);
 }
 
 interface InitRun {
@@ -121,9 +121,9 @@ function settledFrame(stdout: string): unknown {
   return JSON.parse(last ?? '');
 }
 
-describe('init emit through the project-local prisma-cli bin (process e2e)', () => {
+describe('init emit through the project-local prisma bin (process e2e)', () => {
   it(
-    'runs node_modules/@prisma/cli with `contract emit` as a child process in the scaffold directory',
+    'runs node_modules/prisma with `contract emit` as a child process in the scaffold directory',
     async () => {
       installFakePrismaCli(
         [
@@ -142,7 +142,7 @@ describe('init emit through the project-local prisma-cli bin (process e2e)', () 
       expect(invocation.argv).toEqual(['contract', 'emit']);
       expect(realpathSync(invocation.cwd)).toBe(realpathSync(projectDir));
       expect(realpathSync(invocation.script)).toBe(
-        realpathSync(join(projectDir, 'node_modules', '@prisma', 'cli', 'bin', 'prisma-cli.mjs')),
+        realpathSync(join(projectDir, 'node_modules', 'prisma', 'bin', 'prisma.mjs')),
       );
       expect(JSON.stringify(settledFrame(run.stdout))).toContain('"contractEmitted":true');
     },

--- a/test/e2e/framework/test/init-emit-subprocess.test.ts
+++ b/test/e2e/framework/test/init-emit-subprocess.test.ts
@@ -98,7 +98,6 @@ async function runInit(): Promise<InitRun> {
     '--schema-path',
     'prisma/contract.prisma',
     '--yes',
-    '--skip-skills',
     '--json',
   ];
   try {

--- a/test/integration/test/cli-journeys/init-journey/harness.ts
+++ b/test/integration/test/cli-journeys/init-journey/harness.ts
@@ -147,11 +147,9 @@ export async function createJourneyProject(
 
     const target = cell.target === 'mongo' ? 'mongodb' : 'postgres';
     // `--skip-skills` matters here: this journey verifies
-    // scaffold/install/emit/migrate only; skill registration is
-    // intentionally not exercised. Without the flag, project-level skill
-    // install pulls the `prisma/prisma/skills#v<cliVersion>` tag from
-    // GitHub, which does not exist for an in-development minor (the tag is
-    // only cut after publish), so every release-bump PR's CI goes red.
+    // scaffold/install/emit/migrate only; the skill sync is intentionally
+    // not exercised (it is covered by
+    // cli.init-skill-distribution.integration.test.ts).
     const initResult = await runNode(
       [
         CLI_BIN,

--- a/test/integration/test/cli-journeys/init-journey/harness.ts
+++ b/test/integration/test/cli-journeys/init-journey/harness.ts
@@ -146,10 +146,6 @@ export async function createJourneyProject(
     writeMinimalPackageJson(dir);
 
     const target = cell.target === 'mongo' ? 'mongodb' : 'postgres';
-    // `--skip-skills` matters here: this journey verifies
-    // scaffold/install/emit/migrate only; the skill sync is intentionally
-    // not exercised (it is covered by
-    // cli.init-skill-distribution.integration.test.ts).
     const initResult = await runNode(
       [
         CLI_BIN,
@@ -161,7 +157,6 @@ export async function createJourneyProject(
         cell.authoring,
         '--yes',
         '--skip-install',
-        '--skip-skills',
       ],
       dir,
     );

--- a/test/integration/test/cli.init-skill-distribution.integration.test.ts
+++ b/test/integration/test/cli.init-skill-distribution.integration.test.ts
@@ -57,6 +57,8 @@ function gitignoreOf(testDir: string): string {
   return readFileSync(join(testDir, '.gitignore'), 'utf8');
 }
 
+const SYNC_COMMAND = 'dlx prisma@next skills sync';
+
 const MANAGED_SKILL_PATHS = [
   '.claude/skills/prisma-8/',
   '.cursor/skills/prisma-8/',
@@ -80,7 +82,7 @@ describe('init skill distribution (offline integration, real CLI)', () => {
 
     expect(exitCode, stderr).toBe(0);
     const syncCommands = commands.filter((command) => command.includes('skills sync'));
-    expect(syncCommands).toEqual(['dlx @prisma/cli@next skills sync']);
+    expect(syncCommands).toEqual([SYNC_COMMAND]);
   });
 
   it('fetches no skills from GitHub any more', { timeout: 60_000 }, async () => {
@@ -89,6 +91,22 @@ describe('init skill distribution (offline integration, real CLI)', () => {
 
     expect(commands.filter((command) => command.includes('skills add'))).toEqual([]);
     expect(commands.filter((command) => command.includes('prisma/prisma'))).toEqual([]);
+  });
+
+  it('names one binary everywhere: the one it installed', { timeout: 60_000 }, async () => {
+    const { testDir, commands } = initProject();
+    testDirs.add(testDir);
+
+    // The postinstall and the emit script both name `prisma`, so the package
+    // that carries that bin is the one that has to be installed. Naming
+    // @prisma/cli here (bin `prisma-cli`) would leave both scripts calling a
+    // binary the project does not have, and `|| exit 0` would hide it.
+    expect(commands).toContain('add -D prisma@next @types/node');
+    expect(commands).toContain(SYNC_COMMAND);
+    expect(manifestOf(testDir).scripts).toMatchObject({
+      postinstall: 'prisma skills sync || exit 0',
+      'contract:emit': 'prisma contract emit',
+    });
   });
 
   it('leaves the wiring that keeps the skills current', { timeout: 60_000 }, async () => {
@@ -163,8 +181,8 @@ if (args[0] === 'add' || args[0] === 'install') {
 /**
  * The shim reports a successful install without fetching anything, so the
  * project it leaves behind has to contain what \`init\` reads next: init emits
- * by spawning the project-local \`prisma-cli\` binary it resolves through
- * \`@prisma/cli/package.json\`. Without this stub the emit step fails, init
+ * by spawning the project-local \`prisma\` binary it resolves through
+ * \`prisma/package.json\`. Without this stub the emit step fails, init
  * settles at exit 5, and the skill sync this file is about never runs.
  *
  * The binary only has to exit 0 — no assertion here reads the emitted
@@ -172,11 +190,11 @@ if (args[0] === 'add' || args[0] === 'install') {
  * and by test/e2e/framework/test/init-emit-subprocess.test.ts.
  */
 function materializePrismaCliStub(projectDir) {
-  const packageDir = path.join(projectDir, 'node_modules', '@prisma', 'cli');
+  const packageDir = path.join(projectDir, 'node_modules', 'prisma');
   fs.mkdirSync(packageDir, { recursive: true });
   fs.writeFileSync(
     path.join(packageDir, 'package.json'),
-    JSON.stringify({ name: '@prisma/cli', version: '0.0.0-test', bin: { 'prisma-cli': 'bin.mjs' } }),
+    JSON.stringify({ name: 'prisma', version: '0.0.0-test', bin: { prisma: 'bin.mjs' } }),
     'utf8',
   );
   fs.writeFileSync(path.join(packageDir, 'bin.mjs'), 'process.exit(0);\\n', 'utf8');

--- a/test/integration/test/cli.init-skill-distribution.integration.test.ts
+++ b/test/integration/test/cli.init-skill-distribution.integration.test.ts
@@ -9,13 +9,14 @@ const WORKSPACE_ROOT = resolve(import.meta.dirname, '../../..');
 const CLI_BIN = resolve(WORKSPACE_ROOT, 'packages/1-framework/3-tooling/cli/dist/bin.mjs');
 
 /**
- * What a consumer's project looks like after `init` where skills are
- * concerned: the skill tree ships inside the packages, and init's whole job
- * is to run the sync once so a fresh project starts current. Keeping the
- * copies current afterwards is the CLI's staleness check, not anything init
- * writes into the project. This exercises the real CLI bin as a subprocess
- * against a fake package manager, so the assertions are about the commands
- * init actually spawns and the files it actually writes.
+ * What a consumer's project looks like after `orm init` where skills are
+ * concerned: nothing. The skill tree ships inside the packages, and skills
+ * setup belongs to the family-level `prisma init` command — `orm init`
+ * neither fetches skills from GitHub nor runs `skills sync`. The one skill
+ * job it keeps is deleting retired skill directories. This exercises the
+ * real CLI bin as a subprocess against a fake package manager, so the
+ * assertions are about the commands init actually spawns and the files it
+ * actually writes.
  */
 function runEngineInit(
   testDir: string,
@@ -58,8 +59,6 @@ function gitignoreOf(testDir: string): string {
   return readFileSync(join(testDir, '.gitignore'), 'utf8');
 }
 
-const SYNC_COMMAND = 'dlx prisma@next skills sync';
-
 describe('init skill distribution (offline integration, real CLI)', () => {
   const testDirs = new Set<string>();
 
@@ -70,13 +69,12 @@ describe('init skill distribution (offline integration, real CLI)', () => {
     testDirs.clear();
   });
 
-  it('syncs the skills out of the installed packages, once', { timeout: 60_000 }, async () => {
+  it('runs no skills command at all', { timeout: 60_000 }, async () => {
     const { testDir, exitCode, stderr, commands } = initProject();
     testDirs.add(testDir);
 
     expect(exitCode, stderr).toBe(0);
-    const syncCommands = commands.filter((command) => command.includes('skills sync'));
-    expect(syncCommands).toEqual([SYNC_COMMAND]);
+    expect(commands.filter((command) => command.includes('skills'))).toEqual([]);
   });
 
   it('fetches no skills from GitHub any more', { timeout: 60_000 }, async () => {
@@ -96,7 +94,6 @@ describe('init skill distribution (offline integration, real CLI)', () => {
     // `prisma-cli`) would leave the script calling a binary the project does
     // not have.
     expect(commands).toContain('add -D prisma@next @types/node');
-    expect(commands).toContain(SYNC_COMMAND);
     expect(manifestOf(testDir).scripts).toMatchObject({
       'contract:emit': 'prisma contract emit',
     });
@@ -127,22 +124,14 @@ describe('init skill distribution (offline integration, real CLI)', () => {
     expect(exitCode, stderr).toBe(0);
     expect(existsSync(retired)).toBe(false);
   });
-
-  it('under --skip-skills, syncs nothing', { timeout: 60_000 }, async () => {
-    const { testDir, exitCode, stderr, commands } = initProject('--skip-skills');
-    testDirs.add(testDir);
-
-    expect(exitCode, stderr).toBe(0);
-    expect(commands.filter((command) => command.includes('skills'))).toEqual([]);
-  });
 });
 
 /**
- * Stand-in for the project's package manager. A real `pnpm dlx
- * prisma@next skills sync` would fetch from the npm registry, which an
- * offline test cannot do, so `pnpm` on `PATH` is replaced by a Node script
- * that logs every invocation, reports success, and leaves behind the part of
- * the "installed" project init reads next.
+ * Stand-in for the project's package manager. A real `pnpm add` would fetch
+ * from the npm registry, which an offline test cannot do, so `pnpm` on
+ * `PATH` is replaced by a Node script that logs every invocation, reports
+ * success, and leaves behind the part of the "installed" project init reads
+ * next.
  */
 function createFakeManagerHarness(testDir: string): {
   readonly fakeBinDir: string;
@@ -169,8 +158,8 @@ if (args[0] === 'add' || args[0] === 'install') {
  * The shim reports a successful install without fetching anything, so the
  * project it leaves behind has to contain what \`init\` reads next: init emits
  * by spawning the project-local \`prisma\` binary it resolves through
- * \`prisma/package.json\`. Without this stub the emit step fails, init
- * settles at exit 5, and the skill sync this file is about never runs.
+ * \`prisma/package.json\`. Without this stub the emit step fails and init
+ * settles at exit 5 instead of completing.
  *
  * The binary only has to exit 0 — no assertion here reads the emitted
  * contract, and the emit path itself is covered by the CLI's own unit tests

--- a/test/integration/test/cli.init-skill-distribution.integration.test.ts
+++ b/test/integration/test/cli.init-skill-distribution.integration.test.ts
@@ -10,11 +10,12 @@ const CLI_BIN = resolve(WORKSPACE_ROOT, 'packages/1-framework/3-tooling/cli/dist
 
 /**
  * What a consumer's project looks like after `init` where skills are
- * concerned: the skill tree ships inside the packages, so init's whole job is
- * to run the sync once and leave behind the wiring that keeps re-running it.
- * This exercises the real CLI bin as a subprocess against a fake package
- * manager, so the assertions are about the commands init actually spawns and
- * the files it actually writes.
+ * concerned: the skill tree ships inside the packages, and init's whole job
+ * is to run the sync once so a fresh project starts current. Keeping the
+ * copies current afterwards is the CLI's staleness check, not anything init
+ * writes into the project. This exercises the real CLI bin as a subprocess
+ * against a fake package manager, so the assertions are about the commands
+ * init actually spawns and the files it actually writes.
  */
 function runEngineInit(
   testDir: string,
@@ -59,13 +60,6 @@ function gitignoreOf(testDir: string): string {
 
 const SYNC_COMMAND = 'dlx prisma@next skills sync';
 
-const MANAGED_SKILL_PATHS = [
-  '.claude/skills/prisma-8/',
-  '.cursor/skills/prisma-8/',
-  '.agents/skills/prisma-8/',
-  '.windsurf/skills/prisma-8/',
-];
-
 describe('init skill distribution (offline integration, real CLI)', () => {
   const testDirs = new Set<string>();
 
@@ -97,28 +91,23 @@ describe('init skill distribution (offline integration, real CLI)', () => {
     const { testDir, commands } = initProject();
     testDirs.add(testDir);
 
-    // The postinstall and the emit script both name `prisma`, so the package
-    // that carries that bin is the one that has to be installed. Naming
-    // @prisma/cli here (bin `prisma-cli`) would leave both scripts calling a
-    // binary the project does not have, and `|| exit 0` would hide it.
+    // The emit script names `prisma`, so the package that carries that bin is
+    // the one that has to be installed. Naming @prisma/cli here (bin
+    // `prisma-cli`) would leave the script calling a binary the project does
+    // not have.
     expect(commands).toContain('add -D prisma@next @types/node');
     expect(commands).toContain(SYNC_COMMAND);
     expect(manifestOf(testDir).scripts).toMatchObject({
-      postinstall: 'prisma skills sync || exit 0',
       'contract:emit': 'prisma contract emit',
     });
   });
 
-  it('leaves the wiring that keeps the skills current', { timeout: 60_000 }, async () => {
+  it('writes no skills wiring into the project', { timeout: 60_000 }, async () => {
     const { testDir } = initProject();
     testDirs.add(testDir);
 
-    expect(manifestOf(testDir).scripts).toMatchObject({
-      postinstall: 'prisma skills sync || exit 0',
-    });
-    for (const path of MANAGED_SKILL_PATHS) {
-      expect(gitignoreOf(testDir)).toContain(path);
-    }
+    expect(manifestOf(testDir).scripts?.['postinstall']).toBeUndefined();
+    expect(gitignoreOf(testDir)).not.toContain('skills/prisma-8/');
   });
 
   it('removes skill directories the router replaced', { timeout: 60_000 }, async () => {
@@ -139,20 +128,18 @@ describe('init skill distribution (offline integration, real CLI)', () => {
     expect(existsSync(retired)).toBe(false);
   });
 
-  it('under --skip-skills, syncs nothing and writes no wiring', { timeout: 60_000 }, async () => {
+  it('under --skip-skills, syncs nothing', { timeout: 60_000 }, async () => {
     const { testDir, exitCode, stderr, commands } = initProject('--skip-skills');
     testDirs.add(testDir);
 
     expect(exitCode, stderr).toBe(0);
     expect(commands.filter((command) => command.includes('skills'))).toEqual([]);
-    expect(manifestOf(testDir).scripts?.['postinstall']).toBeUndefined();
-    expect(gitignoreOf(testDir)).not.toContain('skills/prisma-8/');
   });
 });
 
 /**
  * Stand-in for the project's package manager. A real `pnpm dlx
- * @prisma/cli@next skills sync` would fetch from the npm registry, which an
+ * prisma@next skills sync` would fetch from the npm registry, which an
  * offline test cannot do, so `pnpm` on `PATH` is replaced by a Node script
  * that logs every invocation, reports success, and leaves behind the part of
  * the "installed" project init reads next.

--- a/test/integration/test/cli.init-skill-distribution.integration.test.ts
+++ b/test/integration/test/cli.init-skill-distribution.integration.test.ts
@@ -1,55 +1,68 @@
-import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { delimiter as pathDelimiter } from 'node:path';
 import { join, resolve } from 'pathe';
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
-import { DEFAULT_SKILL_AGENTS } from '../../../packages/1-framework/3-tooling/cli/src/commands/init/skill-sources';
+import { afterEach, describe, expect, it } from 'vitest';
 import { createIntegrationTestDir } from './utils/cli-test-helpers';
 
 const WORKSPACE_ROOT = resolve(import.meta.dirname, '../../..');
-const SKILLS_BIN = resolve(WORKSPACE_ROOT, 'node_modules/.bin/skills');
 const CLI_BIN = resolve(WORKSPACE_ROOT, 'packages/1-framework/3-tooling/cli/dist/bin.mjs');
 
 /**
- * Runs the workspace-built engine bin's `init` as a real subprocess with the
- * fake package-manager harness on PATH, so every `pnpm add`/`pnpm dlx` the
- * engine's package capability spawns hits the shim.
+ * What a consumer's project looks like after `init` where skills are
+ * concerned: the skill tree ships inside the packages, so init's whole job is
+ * to run the sync once and leave behind the wiring that keeps re-running it.
+ * This exercises the real CLI bin as a subprocess against a fake package
+ * manager, so the assertions are about the commands init actually spawns and
+ * the files it actually writes.
  */
 function runEngineInit(
   testDir: string,
   env: Readonly<Record<string, string | undefined>>,
+  ...extraArgs: string[]
 ): { readonly exitCode: number; readonly stderr: string } {
   const result = spawnSync(
     process.execPath,
-    [CLI_BIN, 'orm', 'init', '--target', 'postgres', '--authoring', 'psl', '--yes'],
+    [CLI_BIN, 'orm', 'init', '--target', 'postgres', '--authoring', 'psl', '--yes', ...extraArgs],
     { cwd: testDir, encoding: 'utf8', env: { ...process.env, ...env } },
   );
   return { exitCode: result.status ?? 1, stderr: result.stderr ?? '' };
 }
 
-interface ParsedSkillMetadata {
-  readonly name: string;
+function initProject(...extraArgs: string[]): {
+  readonly testDir: string;
+  readonly exitCode: number;
+  readonly stderr: string;
+  readonly commands: readonly string[];
+} {
+  const testDir = createIntegrationTestDir();
+  writeFileSync(join(testDir, 'pnpm-lock.yaml'), '', 'utf8');
+  const { fakeBinDir, logPath } = createFakeManagerHarness(testDir);
+  const { exitCode, stderr } = runEngineInit(
+    testDir,
+    {
+      PATH: `${fakeBinDir}${pathDelimiter}${process.env['PATH'] ?? ''}`,
+      TEST_FAKE_DLX_LOG: logPath,
+    },
+    ...extraArgs,
+  );
+  return { testDir, exitCode, stderr, commands: readLoggedCommands(logPath) };
 }
 
-/**
- * Hermetic fixture: a sparse local clone of the tracked skill surfaces at
- * HEAD, built once per test file. The clone reflects what an external consumer
- * sees: tracked files only, no gitignored install targets like
- * `.agents/skills/`. Discovery against this fixture exercises the same
- * priority-dir traversal the upstream CLI does at consumer machines,
- * without any network round-trip.
- */
-let workspaceClone: string;
+function manifestOf(testDir: string): { readonly scripts?: Record<string, string> } {
+  return JSON.parse(readFileSync(join(testDir, 'package.json'), 'utf8'));
+}
 
-beforeAll(() => {
-  workspaceClone = makeWorkspaceClone();
-}, 30_000);
+function gitignoreOf(testDir: string): string {
+  return readFileSync(join(testDir, '.gitignore'), 'utf8');
+}
 
-afterAll(() => {
-  if (workspaceClone) {
-    rmSync(workspaceClone, { recursive: true, force: true });
-  }
-});
+const MANAGED_SKILL_PATHS = [
+  '.claude/skills/prisma-8/',
+  '.cursor/skills/prisma-8/',
+  '.agents/skills/prisma-8/',
+  '.windsurf/skills/prisma-8/',
+];
 
 describe('init skill distribution (offline integration, real CLI)', () => {
   const testDirs = new Set<string>();
@@ -61,107 +74,72 @@ describe('init skill distribution (offline integration, real CLI)', () => {
     testDirs.clear();
   });
 
-  it('invokes the shared skills source once per named skill and installs their union', {
-    timeout: 60_000,
-  }, async () => {
+  it('syncs the skills out of the installed packages, once', { timeout: 60_000 }, async () => {
+    const { testDir, exitCode, stderr, commands } = initProject();
+    testDirs.add(testDir);
+
+    expect(exitCode, stderr).toBe(0);
+    const syncCommands = commands.filter((command) => command.includes('skills sync'));
+    expect(syncCommands).toEqual(['dlx @prisma/cli@next skills sync']);
+  });
+
+  it('fetches no skills from GitHub any more', { timeout: 60_000 }, async () => {
+    const { testDir, commands } = initProject();
+    testDirs.add(testDir);
+
+    expect(commands.filter((command) => command.includes('skills add'))).toEqual([]);
+    expect(commands.filter((command) => command.includes('prisma/prisma'))).toEqual([]);
+  });
+
+  it('leaves the wiring that keeps the skills current', { timeout: 60_000 }, async () => {
+    const { testDir } = initProject();
+    testDirs.add(testDir);
+
+    expect(manifestOf(testDir).scripts).toMatchObject({
+      postinstall: 'prisma skills sync || exit 0',
+    });
+    for (const path of MANAGED_SKILL_PATHS) {
+      expect(gitignoreOf(testDir)).toContain(path);
+    }
+  });
+
+  it('removes skill directories the router replaced', { timeout: 60_000 }, async () => {
     const testDir = createIntegrationTestDir();
     testDirs.add(testDir);
     writeFileSync(join(testDir, 'pnpm-lock.yaml'), '', 'utf8');
+    const retired = join(testDir, '.agents', 'skills', 'prisma-next-upgrade');
+    mkdirSync(retired, { recursive: true });
+    writeFileSync(join(retired, 'SKILL.md'), '---\nname: prisma-next-upgrade\n---\n', 'utf8');
 
-    const { fakeBinDir, logPath } = createFakeDlxHarness(testDir);
-
+    const { fakeBinDir, logPath } = createFakeManagerHarness(testDir);
     const { exitCode, stderr } = runEngineInit(testDir, {
       PATH: `${fakeBinDir}${pathDelimiter}${process.env['PATH'] ?? ''}`,
-      PRISMA_NEXT_SKILLS_BASE: workspaceClone,
       TEST_FAKE_DLX_LOG: logPath,
-      INSTALL_INTERNAL_SKILLS: undefined,
-      SKILLS_AGENT_AUTO: 'cursor-cli',
     });
 
     expect(exitCode, stderr).toBe(0);
-
-    const loggedCommands = readLoggedCommands(logPath);
-    const agentFlags = (skill: string) =>
-      `--agent ${DEFAULT_SKILL_AGENTS.join(' ')} --skill ${skill} -y`;
-    expect(loggedCommands).toContain(
-      `dlx skills@latest add ${workspaceClone}/skills ${agentFlags('prisma-8')}`,
-    );
-
-    const installed = readInstalledSkillDirs(testDir);
-    const expected = readSkillNamesFrom(join(workspaceClone, 'skills'));
-    const expectedSorted = Array.from(new Set(expected)).sort();
-    expect(installed).toEqual(expectedSorted);
-    expect(installed.length).toBeGreaterThan(0);
-
-    const contributorNames = new Set(readContributorSkillNames());
-    const leaks = installed.filter((name) => contributorNames.has(name));
-    expect(leaks).toEqual([]);
+    expect(existsSync(retired)).toBe(false);
   });
 
-  it('subpath URL form is invoked verbatim (no implicit fallback to bare repo URL)', {
-    timeout: 60_000,
-  }, async () => {
-    const testDir = createIntegrationTestDir();
+  it('under --skip-skills, syncs nothing and writes no wiring', { timeout: 60_000 }, async () => {
+    const { testDir, exitCode, stderr, commands } = initProject('--skip-skills');
     testDirs.add(testDir);
-    writeFileSync(join(testDir, 'pnpm-lock.yaml'), '', 'utf8');
 
-    const { fakeBinDir, logPath } = createFakeDlxHarness(testDir);
-
-    runEngineInit(testDir, {
-      PATH: `${fakeBinDir}${pathDelimiter}${process.env['PATH'] ?? ''}`,
-      PRISMA_NEXT_SKILLS_BASE: workspaceClone,
-      TEST_FAKE_DLX_LOG: logPath,
-      SKILLS_AGENT_AUTO: 'cursor-cli',
-    });
-
-    const loggedCommands = readLoggedCommands(logPath);
-    const skillsAddCommands = loggedCommands.filter((c) => c.startsWith('dlx skills@latest add'));
-    // One shared source, one consolidated multi-agent install per named skill.
-    expect(skillsAddCommands).toHaveLength(1);
-    for (const command of skillsAddCommands) {
-      // Each call's source ends at the `skills` subpath before any
-      // flags. A bare repo URL (no `/skills`) would leak contributor
-      // skills via priority discovery of `.agents/skills/`; assert
-      // the subpath form here.
-      expect(command).toMatch(/\/skills(?:\s|$)/);
-      expect(command).toMatch(/--skill prisma-8 /);
-    }
+    expect(exitCode, stderr).toBe(0);
+    expect(commands.filter((command) => command.includes('skills'))).toEqual([]);
+    expect(manifestOf(testDir).scripts?.['postinstall']).toBeUndefined();
+    expect(gitignoreOf(testDir)).not.toContain('skills/prisma-8/');
   });
 });
 
 /**
- * Build a sparse local clone of the tracked skill surfaces at HEAD. Local
- * object sharing avoids copying repository history, and sparse checkout avoids
- * materialising thousands of unrelated tracked files.
+ * Stand-in for the project's package manager. A real `pnpm dlx
+ * @prisma/cli@next skills sync` would fetch from the npm registry, which an
+ * offline test cannot do, so `pnpm` on `PATH` is replaced by a Node script
+ * that logs every invocation, reports success, and leaves behind the part of
+ * the "installed" project init reads next.
  */
-function makeWorkspaceClone(): string {
-  const cloneRoot = join(
-    integrationTempRoot(),
-    `skills-clone-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-  );
-  mkdirSync(cloneRoot, { recursive: true });
-  execFileSync('git', ['clone', '--local', '--sparse', '-q', WORKSPACE_ROOT, cloneRoot]);
-  execFileSync('git', ['-C', cloneRoot, 'sparse-checkout', 'set', 'skills', 'skills-contrib']);
-  return cloneRoot;
-}
-
-function integrationTempRoot(): string {
-  return resolve(import.meta.dirname, '../.tmp');
-}
-
-/**
- * Stand-in for `pnpm dlx`. We can't run real `pnpm dlx skills@latest` from
- * an offline test (it would fetch from the npm registry on first run
- * in a fresh pnpm store), and we want to invoke the *real* `skills`
- * binary, not a re-implementation. So the harness replaces `pnpm` on
- * `PATH` with a Node script that:
- *   - logs every invocation (for assertions on the install URL form)
- *   - leaves behind the part of the "installed" project that init reads next
- *     (a stub `@prisma/cli` with a `prisma-cli` bin — see the shim body)
- *   - forwards `pnpm dlx skills@latest add <args>` to the workspace's
- *     `node_modules/.bin/skills` invoked from the consumer's cwd.
- */
-function createFakeDlxHarness(testDir: string): {
+function createFakeManagerHarness(testDir: string): {
   readonly fakeBinDir: string;
   readonly logPath: string;
 } {
@@ -173,20 +151,13 @@ function createFakeDlxHarness(testDir: string): {
     `#!/usr/bin/env node
 import fs from 'node:fs';
 import path from 'node:path';
-import { spawnSync } from 'node:child_process';
 
 const args = process.argv.slice(2);
 const cwd = process.cwd();
 const logPath = process.env.TEST_FAKE_DLX_LOG;
 
-if (args[0] === 'add' || args[0] === 'install' || args[0] === 'prisma-next') {
-  if (args[0] !== 'prisma-next') {
-    materializePrismaCliStub(cwd);
-  }
-  if (logPath) {
-    fs.appendFileSync(logPath, JSON.stringify({ cwd, args, status: 0 }) + '\\n', 'utf8');
-  }
-  process.exit(0);
+if (args[0] === 'add' || args[0] === 'install') {
+  materializePrismaCliStub(cwd);
 }
 
 /**
@@ -194,7 +165,7 @@ if (args[0] === 'add' || args[0] === 'install' || args[0] === 'prisma-next') {
  * project it leaves behind has to contain what \`init\` reads next: init emits
  * by spawning the project-local \`prisma-cli\` binary it resolves through
  * \`@prisma/cli/package.json\`. Without this stub the emit step fails, init
- * settles at exit 5, and the skill install this file is about never runs.
+ * settles at exit 5, and the skill sync this file is about never runs.
  *
  * The binary only has to exit 0 — no assertion here reads the emitted
  * contract, and the emit path itself is covered by the CLI's own unit tests
@@ -211,34 +182,6 @@ function materializePrismaCliStub(projectDir) {
   fs.writeFileSync(path.join(packageDir, 'bin.mjs'), 'process.exit(0);\\n', 'utf8');
 }
 
-if (args[0] === 'dlx' && (args[1] === 'skills' || args[1] === 'skills@latest') && args[2] === 'add') {
-  // Forward to the real CLI, scoped to the consumer cwd.
-  const skillsArgs = args.slice(2);
-  const result = spawnSync(${JSON.stringify(SKILLS_BIN)}, skillsArgs, {
-    cwd,
-    stdio: 'pipe',
-    env: { ...process.env, SKILLS_AGENT_AUTO: process.env.SKILLS_AGENT_AUTO || 'cursor-cli' },
-  });
-  if (logPath) {
-    fs.appendFileSync(
-      logPath,
-      JSON.stringify({
-        cwd,
-        args,
-        status: result.status,
-        stdout: result.stdout?.toString('utf8') ?? '',
-        stderr: result.stderr?.toString('utf8') ?? '',
-      }) + '\\n',
-      'utf8',
-    );
-  }
-  if (result.status !== 0) {
-    process.stderr.write(result.stderr ?? Buffer.from(''));
-    process.stdout.write(result.stdout ?? Buffer.from(''));
-  }
-  process.exit(result.status ?? 1);
-}
-
 if (logPath) {
   fs.appendFileSync(logPath, JSON.stringify({ cwd, args, status: 0 }) + '\\n', 'utf8');
 }
@@ -248,7 +191,6 @@ process.exit(0);
   );
   // Make the shim executable (POSIX) and provide a Windows shim for parity.
   // chmod is a no-op on Windows.
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { chmodSync } = require('node:fs');
   chmodSync(join(fakeBinDir, 'pnpm'), 0o755);
   writeFileSync(
@@ -266,64 +208,4 @@ function readLoggedCommands(logPath: string): readonly string[] {
     .filter((line) => line.length > 0)
     .map((line) => JSON.parse(line) as { readonly args: readonly string[] })
     .map((entry) => entry.args.join(' '));
-}
-
-function readInstalledSkillDirs(testDir: string): readonly string[] {
-  const root = join(testDir, '.agents', 'skills');
-  return readSkillDirNames(root);
-}
-
-function readSkillDirNames(root: string): readonly string[] {
-  if (!existsSync(root)) return [];
-  return readdirSync(root, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory() || entry.isSymbolicLink())
-    .map((entry) => entry.name)
-    .sort();
-}
-
-function readContributorSkillNames(): readonly string[] {
-  return readSkillNamesFrom(join(workspaceClone, 'skills-contrib'));
-}
-
-function readSkillNamesFrom(root: string): readonly string[] {
-  if (!existsSync(root)) return [];
-  const names: string[] = [];
-  for (const entry of readdirSync(root, { withFileTypes: true })) {
-    if (!entry.isDirectory()) continue;
-    const skillFile = join(root, entry.name, 'SKILL.md');
-    if (!existsSync(skillFile)) continue;
-    const metadata = parseSkillMetadata(skillFile);
-    if (metadata === null) continue;
-    names.push(sanitizeSkillDirName(metadata.name || entry.name));
-  }
-  return Array.from(new Set(names)).sort();
-}
-
-function parseSkillMetadata(skillFile: string): ParsedSkillMetadata | null {
-  const source = readFileSync(skillFile, 'utf8');
-  const normalized = source.replace(/\r\n/g, '\n');
-  if (!normalized.startsWith('---\n')) return null;
-  const end = normalized.indexOf('\n---\n', 4);
-  if (end === -1) return null;
-
-  const lines = normalized.slice(4, end).split('\n');
-  let name = '';
-  for (const line of lines) {
-    if (line.startsWith('name:')) {
-      name = line
-        .slice('name:'.length)
-        .trim()
-        .replace(/^['"]|['"]$/g, '');
-      break;
-    }
-  }
-  return { name };
-}
-
-function sanitizeSkillDirName(name: string): string {
-  const sanitized = name
-    .toLowerCase()
-    .replace(/[^a-z0-9._]+/g, '-')
-    .replace(/^[.-]+|[.-]+$/g, '');
-  return sanitized.substring(0, 255) || 'unnamed-skill';
 }


### PR DESCRIPTION
`prisma orm init` stops delivering agent skills entirely. The old GitHub fetch (`npx skills add`) is removed, and init does not run `prisma skills sync` either: skills setup belongs to the family-level `prisma init` command that ships in [prisma/prisma-cli#219](https://github.com/prisma/prisma-cli/pull/219).

> Operator ruling (Will Madden, 2026-08-21): `prisma orm init` must not run `skills sync` at scaffold time — the family-level `prisma init` owns skills setup. An earlier revision of this branch ran the sync once at scaffold time with a `--skip-skills` opt-out; both are removed.

Stacked on #30096 (the tarball packaging). Retarget to `main` after #30096 merges.

## What changed

- **Init runs no skills command at all.** `DEFAULT_SKILL_SOURCES`' GitHub invocations are gone and nothing replaced them: no `skills add`, no `skills sync`, no postinstall script, no skill gitignore entries. The `--skip-skills` flag is removed with the behavior it opted out of. Init's next-steps list carries one pointer: run `prisma init` in the project to set up the agent skills. The integration test asserts init spawns no skills command and fetches nothing from GitHub.
- **One binary everywhere.** The CLI dev dependency is `prisma@next` — the package that actually carries the `prisma` bin — and every string init writes or runs uses it: the engine-version probe, the emit spawn, the `contract:emit` script, next-actions, and the scaffold quick-reference. The integration test asserts one binary end to end.
- **The skill-install failure path is retired.** Exit code 6 and `skillInstallFailedFinding` are removed; `error-reference.md` updated.
- **Retired skill directories are still cleaned up.** Init keeps deleting the pre-`prisma-8` skill directories it finds in the agent harness roots.

## Notes for reviewers

- Existing projects are untouched: they keep `@prisma/cli` and `prisma-cli` scripts, which still work. Whether to ship a migration entry for them is a product decision left open deliberately.
- The repo-wide `prisma-cli` → `prisma` string rename (~10 `fix:` strings, root README) is deliberately not part of this change and needs its own owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `prisma orm init` now focuses on project setup and no longer installs or synchronizes agent skills.
  - Run `prisma init` to configure skills, or `prisma skills sync` to refresh them.
  - Contract emission now uses the project’s local `prisma` command.

- **Documentation**
  - Updated setup guidance, examples, error references, and quick references to use the current `prisma orm init` and `prisma` command syntax.
  - Removed obsolete skill-installation options and instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->