### PR TITLE
fix(language-server): canonicalize Windows file URIs

### DIFF
--- a/packages/1-framework/3-tooling/language-server/src/schema-inputs.ts
+++ b/packages/1-framework/3-tooling/language-server/src/schema-inputs.ts
@@ -1,4 +1,5 @@
-import { pathToFileURL } from 'node:url';
+import { normalize } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 export interface SchemaInputConfig {
   readonly contract?: {
@@ -21,12 +22,52 @@ export function hasPslInputs(config: SchemaInputConfig): boolean {
 
 export function resolveSchemaInputs(config: SchemaInputConfig): SchemaInputSet {
   const inputs = hasPslInputs(config) ? config.contract?.source.inputs : undefined;
-  const uris = new Set(inputs?.map((input) => pathToFileURL(input).toString()));
+  const uris = inputs?.map(configuredInputUri) ?? [];
+  const identities = new Set(uris.map(canonicalFileIdentity));
 
   return {
-    includes: (uri) => uris.has(uri),
+    includes: (uri) => identities.has(canonicalFileIdentity(uri)),
     uris: () => uris,
   };
+}
+
+function configuredInputUri(input: string): string {
+  if (isFileUri(input)) {
+    return input;
+  }
+  return pathToFileURL(input, { windows: isWindowsPlatform() }).toString();
+}
+
+function isFileUri(input: string): boolean {
+  try {
+    return new URL(input).protocol === 'file:';
+  } catch {
+    return false;
+  }
+}
+
+function canonicalFileIdentity(uri: string): string {
+  let url: URL;
+  try {
+    url = new URL(uri);
+  } catch {
+    return uri;
+  }
+  if (url.protocol !== 'file:') {
+    return uri;
+  }
+
+  try {
+    const windows = isWindowsPlatform();
+    const filePath = normalize(fileURLToPath(url, { windows }));
+    return windows ? filePath.toLowerCase() : filePath;
+  } catch {
+    return uri;
+  }
+}
+
+function isWindowsPlatform(): boolean {
+  return process.platform === 'win32';
 }
 
 export const emptySchemaInputSet: SchemaInputSet = {

--- a/packages/1-framework/3-tooling/language-server/test/schema-inputs.test.ts
+++ b/packages/1-framework/3-tooling/language-server/test/schema-inputs.test.ts
@@ -1,6 +1,12 @@
 import { pathToFileURL } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { resolveSchemaInputs, type SchemaInputConfig } from '../src/schema-inputs';
+
+afterEach(() => vi.restoreAllMocks());
+
+function useWindowsPlatform(): void {
+  vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+}
 
 function configWith(
   inputs: readonly string[] | undefined,
@@ -27,6 +33,64 @@ describe('resolveSchemaInputs', () => {
   it('treats every configured input as a schema, not just the first', () => {
     const set = resolveSchemaInputs(configWith(['/abs/a.psl', '/abs/b.psl', '/abs/c.psl']));
     expect(set.includes(pathToFileURL('/abs/c.psl').toString())).toBe(true);
+  });
+
+  it.each([
+    'file:///D:/project/next.prisma',
+    'file:///d:/project/next.prisma',
+    'file:///D%3A/project/next.prisma',
+    'file:///d%3A/project/next.prisma',
+  ])('matches equivalent Windows file URI %s', (uri) => {
+    useWindowsPlatform();
+    const set = resolveSchemaInputs(configWith(['D:\\project\\next.prisma']));
+    expect(set.includes(uri)).toBe(true);
+  });
+
+  it.each(['D:/project/next.prisma', 'D:\\project\\next.prisma'])(
+    'matches Windows configured path separators in %s',
+    (input) => {
+      useWindowsPlatform();
+      const set = resolveSchemaInputs(configWith([input]));
+      expect(set.includes('file:///d%3A/project/next.prisma')).toBe(true);
+    },
+  );
+
+  it('matches percent-encoded and differently-cased Windows paths', () => {
+    useWindowsPlatform();
+    const set = resolveSchemaInputs(configWith(['D:\\Project Files\\Schema #1.prisma']));
+    expect(set.includes('file:///d%3A/project%20files/schema%20%231.PRISMA')).toBe(true);
+  });
+
+  it('matches Windows UNC inputs', () => {
+    useWindowsPlatform();
+    const set = resolveSchemaInputs(configWith(['\\\\server\\share\\schema.prisma']));
+    expect([...set.uris()]).toEqual(['file://server/share/schema.prisma']);
+    expect(set.includes('file://SERVER/share/SCHEMA.prisma')).toBe(true);
+  });
+
+  it.runIf(process.platform !== 'win32')(
+    'uses POSIX semantics for Windows-shaped file URIs on non-Windows hosts',
+    () => {
+      const set = resolveSchemaInputs(configWith(['/D:/Project/Next.prisma']));
+      expect(set.includes('file:///d:/project/next.prisma')).toBe(false);
+    },
+  );
+
+  it('matches percent-encoded POSIX paths', () => {
+    const set = resolveSchemaInputs(configWith(['/abs/project files/schema #1%.prisma']));
+    expect(set.includes('file:///abs/project%20files/schema%20%231%25.prisma')).toBe(true);
+  });
+
+  it('preserves configured file URIs', () => {
+    const uri = 'file:///abs/project%20files/schema.prisma';
+    const set = resolveSchemaInputs(configWith([uri]));
+    expect([...set.uris()]).toEqual([uri]);
+    expect(set.includes('file:///abs/project%20files/./schema.prisma')).toBe(true);
+  });
+
+  it('does not treat non-file URIs as configured inputs', () => {
+    const set = resolveSchemaInputs(configWith(['/abs/schema.psl']));
+    expect(set.includes('untitled:next.prisma')).toBe(false);
   });
 
   it('excludes everything when inputs is absent', () => {

--- a/packages/1-framework/3-tooling/language-server/test/server.test.ts
+++ b/packages/1-framework/3-tooling/language-server/test/server.test.ts
@@ -15,6 +15,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   type ClientCapabilities,
   type CompletionItem,
+  CompletionItemKind,
   type CompletionList,
   CompletionRequest,
   createConnection,
@@ -729,6 +730,28 @@ describe('language server', { timeout: timeouts.databaseOperation }, () => {
       textEdit: { newText: 'model ' },
     });
     expect(items.find((item) => item.label === 'model')?.insertTextFormat).toBeUndefined();
+  });
+
+  it('returns Prisma 8 completions for a VS Code-shaped Windows document URI', async () => {
+    const platform = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    try {
+      const windowsDocumentUri = 'file:///d%3A/project/next.prisma';
+      harness = startHarness(async () => resolutionForInputs(['D:\\project\\next.prisma']));
+      await harness.initialize();
+      openDocument(harness, windowsDocumentUri, '// use prisma-next\n');
+      await harness.waitForDiagnostics(windowsDocumentUri);
+
+      const items = completionItems(
+        await requestCompletion(harness, windowsDocumentUri, { line: 1, character: 0 }),
+      );
+      expect(items.find((item) => item.label === 'namespace')).toMatchObject({
+        kind: CompletionItemKind.Keyword,
+        detail: 'PSL declaration keyword',
+      });
+      expect(items.map((item) => item.label)).not.toContain('datasource');
+    } finally {
+      platform.mockRestore();
+    }
   });
 
   it('returns declaration keyword snippets when the client supports snippets', async () => {


### PR DESCRIPTION
## Linked issue

n/a — small change

## At a glance

```ts
const set = resolveSchemaInputs(configWith(['D:\\project\\next.prisma']))
expect(set.includes('file:///d%3A/project/next.prisma')).toBe(true)
```

Previously, the configured URI and VS Code document URI were compared as serialized strings, so this Windows document was treated as outside the project.

## Decision

This PR ships canonical filesystem identities for language-server schema membership. Configured inputs keep their original file URIs for consumers, while membership compares decoded and normalized paths with case-insensitive Windows identities.

## Reviewer notes

- Windows path handling is selected only when `process.platform === 'win32'`; a Windows-shaped URI on Linux or macOS retains host filesystem semantics.
- Windows identities are case-folded across the complete normalized path; POSIX identities remain case-sensitive.
- The change is internal to project lookup and requires no configuration, API, or migration changes.

## How it fits together

1. Configured filesystem paths are converted using the current host's Node URL semantics, while configured `file:` URIs are preserved verbatim.
2. Each configured URI is decoded to a filesystem path and stored as a canonical identity.
3. Incoming document URIs pass through the same canonicalization before `SchemaInputSet.includes()` performs membership.
4. All project-scoped document features inherit the fix because completion, diagnostics, formatting, semantic tokens, folding, and artifact creation share that membership boundary.

## Behavior changes & evidence

- VS Code-shaped Windows URIs now resolve to configured Prisma 8 schemas across drive-letter case and encoded/unencoded drive colons. The implementation is in [`schema-inputs.ts`](packages/1-framework/3-tooling/language-server/src/schema-inputs.ts), with boundary coverage in [`schema-inputs.test.ts`](packages/1-framework/3-tooling/language-server/test/schema-inputs.test.ts).
- Completion now reaches the configured project for `file:///d%3A/...` documents and returns the Prisma 8 `namespace` declaration keyword without legacy `datasource`. The JSON-RPC path is covered in [`server.test.ts`](packages/1-framework/3-tooling/language-server/test/server.test.ts).
- Windows UNC paths, configured `file:` URIs, POSIX paths, Windows-shaped URIs on non-Windows hosts, percent-encoded characters, non-file URIs, and multi-file inputs retain host-appropriate behavior through the same boundary suite.

## Testing performed

- `pnpm --filter @internal/language-server... build`
- `pnpm exec vitest run test/schema-inputs.test.ts test/server.test.ts` — 112 tests passed
- `pnpm typecheck`
- `pnpm test` — 273 tests passed across 14 files
- `pnpm exec biome check src/schema-inputs.ts test/schema-inputs.test.ts test/server.test.ts --error-on-warnings`
- Pre-commit focused dependency lint

## Skill update

n/a — internal URI identity fix with no CLI, configuration, or public TypeScript surface change

## Alternatives considered

- Comparing normalized URI serialization would still couple file identity to URI-library encoding choices, so membership compares decoded filesystem paths instead.
- Preserving non-drive path casing would miss equivalent Windows paths whose directory or file-name casing differs, so the complete Windows identity is case-folded.
- An extension-specific workaround would leave diagnostics and other LSP features vulnerable, so canonicalization lives at the shared project-input boundary.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco).
- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and the change is scoped to one logical concern.
- [x] Tests are updated.
- [x] n/a — no Linear ticket exists; the PR uses the conventional small-fix title described in `CONTRIBUTING.md`.
- [x] The **Skill update** section above is filled in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema input matching across Windows and POSIX paths, including file URLs, drive-letter paths, UNC paths, casing differences, separators, and percent-encoding.
  * Preserved configured input order and retained non-file or invalid values when they cannot be normalized.
  * Improved language-server completions for Windows-style document URIs, including correct namespace metadata and filtering of unsupported keywords.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->