### PR TITLE
chore(release): publish prisma stable releases on prev

### DIFF
--- a/scripts/ci/publish.ts
+++ b/scripts/ci/publish.ts
@@ -811,8 +811,9 @@ async function publishPackages(
       const pkgDir = path.dirname(pkg.path)
 
       const newVersion = prismaVersion
+      const packageTag = pkgName === 'prisma' && tag === 'latest' ? 'prev' : tag
 
-      console.log(`\nPublishing ${magenta(`${pkgName}@${newVersion}`)} ${dim(`on ${tag}`)}`)
+      console.log(`\nPublishing ${magenta(`${pkgName}@${newVersion}`)} ${dim(`on ${packageTag}`)}`)
 
       // Why is this needed?
       // Was introduced in the first version of this script on Apr 14, 2020
@@ -860,7 +861,7 @@ async function publishPackages(
           publishEnv.NODE_AUTH_TOKEN = prismaBotNpmToken
         }
 
-        await run(pkgDir, `pnpm publish --no-git-checks --access public --tag ${tag}`, dryRun, false, publishEnv)
+        await run(pkgDir, `pnpm publish --no-git-checks --access public --tag ${packageTag}`, dryRun, false, publishEnv)
       }
     }
   }


### PR DESCRIPTION
## Summary

- publish the `prisma` package under `prev` when the release tag is `latest`
- preserve all other dist-tags for `prisma`
- leave publishing behavior unchanged for every other package

## Validation

- `pnpm exec eslint scripts/ci/publish.ts` (0 errors; existing warnings only)
- `git diff --check`
- no tests run (publish script has no tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the npm distribution tag used when publishing the Prisma package, ensuring it uses the appropriate `prev` tag instead of `latest`.
  * Updated publishing logs to accurately reflect the tag applied to each package.
  * Other packages continue using their requested distribution tags, helping ensure releases are published and identified consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->